### PR TITLE
Link update messages to release notes

### DIFF
--- a/src/core/app/app_entry_runtime.zig
+++ b/src/core/app/app_entry_runtime.zig
@@ -350,11 +350,13 @@ fn runInteractiveWithDeps(comptime App: type, comptime cooperative: bool, alloc:
                 "resume",
                 handoff.session_id,
                 cli_surface.upgrade_relaunch_arg,
+                request.previousRevision() orelse "",
             };
+            const argv_slice = if (request.previousRevision() == null) argv[0..4] else argv[0..5];
             const replace_err = deps.replace_process(
                 deps.replace_ctx,
                 io_mod.getIo(),
-                .{ .argv = &argv },
+                .{ .argv = argv_slice },
             );
             writeUpgradeRelaunchFailure(deps, replace_err, handoff.session_id);
         } else {
@@ -620,11 +622,12 @@ const TestCapture = struct {
     resume_handoff_id: ?[]const u8 = null,
     raise_sigint_during_deinit: bool = false,
     upgrade_relaunch_path: ?[]const u8 = null,
+    upgrade_previous_revision: ?[]const u8 = null,
     replace_error: std.process.ReplaceError = error.InvalidExe,
     replace_calls: usize = 0,
     replace_arg_count: usize = 0,
-    replace_arg_bufs: [4][128]u8 = undefined,
-    replace_arg_lens: [4]usize = .{ 0, 0, 0, 0 },
+    replace_arg_bufs: [5][128]u8 = undefined,
+    replace_arg_lens: [5]usize = .{ 0, 0, 0, 0, 0 },
     fail_unexpected_format: bool = false,
 
     fn init(run_result: cli_surface.RunResult) TestCapture {
@@ -771,6 +774,10 @@ const TestApp = struct {
             .executable_path_len = path.len,
         };
         @memcpy(request.executable_path_buf[0..path.len], path);
+        if (active_capture.?.upgrade_previous_revision) |revision| {
+            @memcpy(request.previous_revision_buf[0..revision.len], revision);
+            request.previous_revision_len = @intCast(revision.len);
+        }
         return request;
     }
 
@@ -1008,6 +1015,30 @@ test "app entry relaunches only after teardown with the validated handoff" {
         "deinit",
         "stderr-attempt",
     });
+}
+
+test "app entry carries the previous revision through upgrade relaunch" {
+    const alloc = std.testing.allocator;
+    var capture = TestCapture.init(.{ .interactive = .{} });
+    defer capture.deinit();
+    capture.resume_handoff_id = "session-123";
+    capture.upgrade_relaunch_path = "/tmp/fx-upgraded";
+    capture.upgrade_previous_revision = "1111111111111111111111111111111111111111";
+
+    _ = try runWithDeps(
+        TestApp,
+        alloc,
+        &.{},
+        testConfig(),
+        capture.deps(),
+    );
+
+    try std.testing.expectEqual(@as(usize, 5), capture.replace_arg_count);
+    try std.testing.expectEqualStrings("--upgrade-relaunch", capture.replaceArg(3));
+    try std.testing.expectEqualStrings(
+        "1111111111111111111111111111111111111111",
+        capture.replaceArg(4),
+    );
 }
 
 test "app entry never relaunches without a validated handoff" {

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -53,6 +53,8 @@ const shell_runtime = @import("../../ui/shell_runtime.zig");
 const transcript_runtime = @import("../../ui/transcript/runtime.zig");
 const ui_input = @import("../../ui/input/runtime.zig");
 const ui_render = @import("../../ui/render.zig");
+const update_notes = @import("../upgrade/update_notes.zig");
+const update_target = @import("../upgrade/update_target.zig");
 
 const Allocator = std.mem.Allocator;
 
@@ -239,10 +241,40 @@ pub const ResumeHandoffIntent = enum {
     upgrade_requested,
 };
 
+const UpgradeNotice = struct {
+    version: []const u8,
+    channel: update_target.Channel,
+    previous_revision: []const u8,
+    revision: []const u8,
+};
+
 const ResumeNotice = union(enum) {
     session,
-    upgrade: []const u8,
+    upgrade: UpgradeNotice,
 };
+
+fn writeUpgradeNoticeBody(writer: *std.Io.Writer, upgrade: UpgradeNotice) !void {
+    try writer.writeAll("fx has been updated to ");
+    if (upgrade.channel == .dev and update_target.isValidRevision(upgrade.revision)) {
+        try writer.print("dev {s} (v{s})", .{
+            upgrade.revision[0..@min(upgrade.revision.len, 12)],
+            update_target.normalizeVersion(upgrade.version),
+        });
+    } else {
+        try writer.print("v{s}", .{update_target.normalizeVersion(upgrade.version)});
+    }
+    if (update_notes.destination(
+        upgrade.channel,
+        upgrade.version,
+        upgrade.previous_revision,
+        upgrade.revision,
+    )) |notes| {
+        try writer.writeByte('\n');
+        try update_notes.writeLabel(notes.kind, writer);
+        try writer.writeAll(": ");
+        try notes.writeUrl(writer);
+    }
+}
 
 pub const ResumeViewStage = union(enum) {
     none,
@@ -1643,8 +1675,16 @@ pub fn Runtime(comptime App: type) type {
         pub fn resumeRequestedSessionAfterUpgrade(
             app: *App,
             version: []const u8,
+            channel: update_target.Channel,
+            previous_revision: []const u8,
+            revision: []const u8,
         ) !void {
-            return resumeRequestedSessionWithNotice(app, .{ .upgrade = version });
+            return resumeRequestedSessionWithNotice(app, .{ .upgrade = .{
+                .version = version,
+                .channel = channel,
+                .previous_revision = previous_revision,
+                .revision = revision,
+            } });
         }
 
         fn resumeRequestedSessionWithNotice(
@@ -3572,17 +3612,16 @@ pub fn Runtime(comptime App: type) type {
                     .tone = .neutral,
                     .body = display_title,
                 }),
-                .upgrade => |version| {
-                    const body = try std.fmt.allocPrint(
-                        app.alloc,
-                        "fx has been updated to v{s}",
-                        .{version},
-                    );
-                    defer app.alloc.free(body);
+                .upgrade => |upgrade| {
+                    var body: std.Io.Writer.Allocating = .init(app.alloc);
+                    defer body.deinit();
+                    try writeUpgradeNoticeBody(&body.writer, upgrade);
+                    const owned_body = try body.toOwnedSlice();
+                    defer app.alloc.free(owned_body);
                     try sink.appendNotice(.{
                         .topic = "",
                         .tone = .success,
-                        .body = body,
+                        .body = owned_body,
                     });
                 },
             }
@@ -7032,6 +7071,48 @@ test "execution replay releases action-formatting scratch allocations" {
     );
 }
 
+test "upgrade notice body identifies stable notes and dev changes" {
+    const cases = [_]struct {
+        upgrade: UpgradeNotice,
+        expected: []const u8,
+    }{
+        .{
+            .upgrade = .{
+                .version = "9.9.9",
+                .channel = .stable,
+                .previous_revision = "",
+                .revision = "",
+            },
+            .expected = "fx has been updated to v9.9.9\nnotes: https://fx.sh/changelog#v9.9.9",
+        },
+        .{
+            .upgrade = .{
+                .version = "9.9.9",
+                .channel = .dev,
+                .previous_revision = "1111111111111111111111111111111111111111",
+                .revision = "abcdef0123456789abcdef0123456789abcdef01",
+            },
+            .expected = "fx has been updated to dev abcdef012345 (v9.9.9)\nchanges: https://github.com/vercel-labs/fx/compare/1111111111111111111111111111111111111111...abcdef0123456789abcdef0123456789abcdef01",
+        },
+        .{
+            .upgrade = .{
+                .version = "9.9.9",
+                .channel = .dev,
+                .previous_revision = "",
+                .revision = "abcdef0123456789abcdef0123456789abcdef01",
+            },
+            .expected = "fx has been updated to dev abcdef012345 (v9.9.9)\nchanges: https://github.com/vercel-labs/fx/commit/abcdef0123456789abcdef0123456789abcdef01",
+        },
+    };
+
+    for (cases) |case| {
+        var out: std.Io.Writer.Allocating = .init(std.testing.allocator);
+        defer out.deinit();
+        try writeUpgradeNoticeBody(&out.writer, case.upgrade);
+        try std.testing.expectEqualStrings(case.expected, out.writer.buffered());
+    }
+}
+
 test "execution replay projects answered questions as a semantic card and retains detail" {
     const alloc = std.testing.allocator;
     var app = try TestApp.init(alloc, "/workspace");
@@ -7524,7 +7605,13 @@ test "upgrade resume restores active session with the installed version notice" 
     app.requested_resume = .{ .id = try alloc.dupe(u8, "session-1") };
     app.total_web_search_requests = 99;
 
-    try Runtime(TestApp).resumeRequestedSessionAfterUpgrade(&app, "9.9.9");
+    try Runtime(TestApp).resumeRequestedSessionAfterUpgrade(
+        &app,
+        "9.9.9",
+        .stable,
+        "",
+        "",
+    );
 
     try std.testing.expect(app.requested_resume == null);
     try std.testing.expectEqual(@as(usize, 1), app.startup_resume_anchor_count);
@@ -7548,7 +7635,10 @@ test "upgrade resume restores active session with the installed version notice" 
     try std.testing.expectEqualStrings("inspect file", context[1].assistant.user.text);
     try std.testing.expectEqualStrings("run server", context[2].assistant.user.text);
     try std.testing.expectEqual(@as(usize, 2), app.notices.items.len);
-    try std.testing.expectEqualStrings("● fx has been updated to v9.9.9", app.notices.items[0]);
+    try std.testing.expectEqualStrings(
+        "● fx has been updated to v9.9.9\nnotes: https://fx.sh/changelog#v9.9.9",
+        app.notices.items[0],
+    );
     try std.testing.expect(std.mem.find(u8, app.notices.items[1], "older context") != null);
     try std.testing.expectEqual(@as(usize, 2), app.completed_tool_statuses.items.len);
     try std.testing.expectEqualStrings("● Completed read_file\n", app.completed_tool_statuses.items[0]);

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -269,10 +269,8 @@ fn writeUpgradeNoticeBody(writer: *std.Io.Writer, upgrade: UpgradeNotice) !void 
         upgrade.previous_revision,
         upgrade.revision,
     )) |notes| {
-        try writer.writeByte('\n');
-        try update_notes.writeLabel(notes.kind, writer);
-        try writer.writeAll(": ");
-        try notes.writeUrl(writer);
+        try writer.writeByte(' ');
+        try notes.writeHyperlinkLabel(writer);
     }
 }
 
@@ -7083,7 +7081,7 @@ test "upgrade notice body identifies stable notes and dev changes" {
                 .previous_revision = "",
                 .revision = "",
             },
-            .expected = "fx has been updated to v9.9.9\nnotes: https://fx.sh/changelog#v9.9.9",
+            .expected = "fx has been updated to v9.9.9 \x1b]8;;https://fx.sh/changelog#v9.9.9\x1b\\\x1b[4m(notes)\x1b[24m\x1b]8;;\x1b\\",
         },
         .{
             .upgrade = .{
@@ -7092,7 +7090,7 @@ test "upgrade notice body identifies stable notes and dev changes" {
                 .previous_revision = "1111111111111111111111111111111111111111",
                 .revision = "abcdef0123456789abcdef0123456789abcdef01",
             },
-            .expected = "fx has been updated to dev abcdef012345 (v9.9.9)\nchanges: https://github.com/vercel-labs/fx/compare/1111111111111111111111111111111111111111...abcdef0123456789abcdef0123456789abcdef01",
+            .expected = "fx has been updated to dev abcdef012345 (v9.9.9) \x1b]8;;https://github.com/vercel-labs/fx/compare/1111111111111111111111111111111111111111...abcdef0123456789abcdef0123456789abcdef01\x1b\\\x1b[4m(changes)\x1b[24m\x1b]8;;\x1b\\",
         },
         .{
             .upgrade = .{
@@ -7101,7 +7099,7 @@ test "upgrade notice body identifies stable notes and dev changes" {
                 .previous_revision = "",
                 .revision = "abcdef0123456789abcdef0123456789abcdef01",
             },
-            .expected = "fx has been updated to dev abcdef012345 (v9.9.9)\nchanges: https://github.com/vercel-labs/fx/commit/abcdef0123456789abcdef0123456789abcdef01",
+            .expected = "fx has been updated to dev abcdef012345 (v9.9.9) \x1b]8;;https://github.com/vercel-labs/fx/commit/abcdef0123456789abcdef0123456789abcdef01\x1b\\\x1b[4m(changes)\x1b[24m\x1b]8;;\x1b\\",
         },
     };
 
@@ -7636,7 +7634,7 @@ test "upgrade resume restores active session with the installed version notice" 
     try std.testing.expectEqualStrings("run server", context[2].assistant.user.text);
     try std.testing.expectEqual(@as(usize, 2), app.notices.items.len);
     try std.testing.expectEqualStrings(
-        "● fx has been updated to v9.9.9\nnotes: https://fx.sh/changelog#v9.9.9",
+        "● fx has been updated to v9.9.9 \x1b]8;;https://fx.sh/changelog#v9.9.9\x1b\\\x1b[4m(notes)\x1b[24m\x1b]8;;\x1b\\",
         app.notices.items[0],
     );
     try std.testing.expect(std.mem.find(u8, app.notices.items[1], "older context") != null);

--- a/src/core/cli/cli_surface.zig
+++ b/src/core/cli/cli_surface.zig
@@ -92,6 +92,15 @@ const ResumeInvocation = struct {
 const resume_id_alias_prefix = "--resume-";
 pub const upgrade_relaunch_arg = "--upgrade-relaunch";
 
+pub const UpgradeRelaunch = struct {
+    previous_revision: ?[]u8 = null,
+
+    pub fn deinit(self: *UpgradeRelaunch, alloc: Allocator) void {
+        if (self.previous_revision) |revision| alloc.free(revision);
+        self.* = undefined;
+    }
+};
+
 // The one resume alias that asks which session to open. Every other spelling
 // names its target, so it resumes without a prompt.
 const resume_picker_alias = "-r";
@@ -129,11 +138,12 @@ pub const LaunchModifiers = struct {
 
 pub const InteractiveLaunch = struct {
     requested_resume: ?ResumeTarget = null,
-    upgrade_relaunch: bool = false,
+    upgrade_relaunch: ?UpgradeRelaunch = null,
     modifiers: LaunchModifiers = .{},
 
     pub fn deinit(self: *InteractiveLaunch, alloc: Allocator) void {
         if (self.requested_resume) |*target| target.deinit(alloc);
+        if (self.upgrade_relaunch) |*relaunch| relaunch.deinit(alloc);
         self.modifiers.deinit(alloc);
         self.* = undefined;
     }
@@ -531,22 +541,31 @@ pub fn parseInteractiveLaunch(
         } },
         .resume_session => |invocation| {
             const resume_args = invocation.args;
-            const upgrade_relaunch = !invocation.top_level_alias and
-                resume_args.len == 2 and
+            const has_upgrade_relaunch = !invocation.top_level_alias and
+                resume_args.len >= 2 and
                 std.mem.eql(u8, resume_args[1], upgrade_relaunch_arg);
-            const target_args = if (upgrade_relaunch)
-                resume_args[0..1]
-            else
-                resume_args;
+            if (has_upgrade_relaunch and resume_args.len > 3) return error.InvalidResumeArgs;
+            var upgrade_relaunch: ?UpgradeRelaunch = null;
+            errdefer if (upgrade_relaunch) |*relaunch| relaunch.deinit(alloc);
+            if (has_upgrade_relaunch) {
+                const previous_revision = if (resume_args.len == 3) revision: {
+                    if (!update_target.isValidRevision(resume_args[2])) return error.InvalidResumeArgs;
+                    break :revision try alloc.dupe(u8, resume_args[2]);
+                } else null;
+                upgrade_relaunch = .{ .previous_revision = previous_revision };
+            }
+            const target_args = if (has_upgrade_relaunch) resume_args[0..1] else resume_args;
             const target = try parseResumeArgs(
                 alloc,
                 command_catalog,
                 target_args,
                 invocation.top_level_alias,
             );
+            const relaunch = upgrade_relaunch;
+            upgrade_relaunch = null;
             return .{ .interactive = .{
                 .requested_resume = target,
-                .upgrade_relaunch = upgrade_relaunch,
+                .upgrade_relaunch = relaunch,
                 .modifiers = global_args.takeModifiers(),
             } };
         },
@@ -4117,6 +4136,55 @@ test "parse resume args treats last after id flag as exact id" {
         .pick, .last => return error.TestExpectedExactResumeId,
         .id => |id| try std.testing.expectEqualStrings("last", id),
     }
+}
+
+test "parseInteractiveLaunch accepts legacy and revision-bearing upgrade relaunches" {
+    const alloc = std.testing.allocator;
+    const command_catalog = testCommandCatalog();
+    const revision = "abcdef0123456789abcdef0123456789abcdef01";
+
+    const cases = [_]struct {
+        args: []const [:0]const u8,
+        expected_revision: ?[]const u8,
+    }{
+        .{
+            .args = &.{ @constCast("resume"), @constCast("session-123"), @constCast("--upgrade-relaunch") },
+            .expected_revision = null,
+        },
+        .{
+            .args = &.{ @constCast("resume"), @constCast("session-123"), @constCast("--upgrade-relaunch"), @constCast(revision) },
+            .expected_revision = revision,
+        },
+    };
+
+    for (cases) |case| {
+        const parsed = try parseInteractiveLaunch(alloc, case.args, command_catalog);
+        switch (parsed) {
+            .interactive => |value| {
+                var launch = value;
+                defer launch.deinit(alloc);
+                const relaunch = launch.upgrade_relaunch orelse return error.TestExpectedUpgradeRelaunch;
+                if (case.expected_revision) |expected| {
+                    try std.testing.expectEqualStrings(expected, relaunch.previous_revision.?);
+                } else try std.testing.expect(relaunch.previous_revision == null);
+            },
+            .noninteractive => |value| {
+                var noninteractive = value;
+                defer noninteractive.deinit(alloc);
+                return error.TestExpectedInteractiveLaunch;
+            },
+        }
+    }
+
+    try std.testing.expectError(
+        error.InvalidResumeArgs,
+        parseInteractiveLaunch(alloc, &.{
+            @constCast("resume"),
+            @constCast("session-123"),
+            @constCast("--upgrade-relaunch"),
+            @constCast("not-a-revision"),
+        }, command_catalog),
+    );
 }
 
 test "parseInteractiveLaunch shares native resume grammar" {

--- a/src/core/output/output_contracts.zig
+++ b/src/core/output/output_contracts.zig
@@ -13,6 +13,8 @@ const session_store = @import("../session/session_store.zig");
 const usage_report = @import("../session/usage_report.zig");
 const text_utils = @import("../shared/text_utils.zig");
 const types = @import("../shared/types.zig");
+const update_notes = @import("../upgrade/update_notes.zig");
+const update_target = @import("../upgrade/update_target.zig");
 const workspace_access = @import("../workspace/workspace_access.zig");
 const workspace_commands = @import("../workspace/workspace_commands.zig");
 
@@ -1572,6 +1574,18 @@ pub const UpgradeSnapshot = struct {
                     try writeVersionWithPrefix(&out.writer, self.latest);
                 }
                 try out.writer.writeByte('\n');
+                const channel = update_target.Channel.parse(self.channel) orelse .stable;
+                if (update_notes.destination(
+                    channel,
+                    self.latest,
+                    self.current_revision,
+                    self.latest_revision,
+                )) |notes| {
+                    try update_notes.writeLabel(notes.kind, &out.writer);
+                    try out.writer.writeAll(": ");
+                    try notes.writeUrl(&out.writer);
+                    try out.writer.writeByte('\n');
+                }
             },
             .up_to_date => {
                 if (std.mem.eql(u8, self.channel, "dev") and self.latest_revision.len > 0) {
@@ -2837,7 +2851,11 @@ test "core upgrade snapshot renders errors and statuses" {
         .status = .upgraded,
     }).renderText(std.testing.allocator);
     defer std.testing.allocator.free(upgraded_text);
-    try std.testing.expectEqualStrings("upgraded to v0.2.10\n", upgraded_text);
+    try std.testing.expectEqualStrings(
+        "upgraded to v0.2.10\n" ++
+            "notes: https://fx.sh/changelog#v0.2.10\n",
+        upgraded_text,
+    );
 
     const upgraded_json = try (UpgradeSnapshot{
         .current = "0.2.9",
@@ -2857,7 +2875,11 @@ test "core upgrade snapshot renders errors and statuses" {
         .status = .upgraded,
     }).renderText(std.testing.allocator);
     defer std.testing.allocator.free(prefixed_text);
-    try std.testing.expectEqualStrings("upgraded to v0.2.10\n", prefixed_text);
+    try std.testing.expectEqualStrings(
+        "upgraded to v0.2.10\n" ++
+            "notes: https://fx.sh/changelog#v0.2.10\n",
+        prefixed_text,
+    );
 
     const up_to_date = UpgradeSnapshot{
         .current = "0.2.9",
@@ -2898,7 +2920,11 @@ test "core upgrade snapshot identifies dev revisions" {
 
     const text = try snapshot.renderText(std.testing.allocator);
     defer std.testing.allocator.free(text);
-    try std.testing.expectEqualStrings("upgraded to dev abcdef012345 (v0.3.66)\n", text);
+    try std.testing.expectEqualStrings(
+        "upgraded to dev abcdef012345 (v0.3.66)\n" ++
+            "changes: https://github.com/vercel-labs/fx/compare/111111111111...abcdef0123456789abcdef0123456789abcdef01\n",
+        text,
+    );
 
     const json = try snapshot.renderJson(std.testing.allocator);
     defer std.testing.allocator.free(json);

--- a/src/core/upgrade/auto_upgrade.zig
+++ b/src/core/upgrade/auto_upgrade.zig
@@ -21,9 +21,16 @@ pub const State = enum(u8) {
 pub const RelaunchRequest = struct {
     executable_path_buf: [std.fs.max_path_bytes]u8 = undefined,
     executable_path_len: usize = 0,
+    previous_revision_buf: [update_target.max_revision_bytes]u8 = undefined,
+    previous_revision_len: u8 = 0,
 
     pub fn executablePath(self: *const RelaunchRequest) []const u8 {
         return self.executable_path_buf[0..self.executable_path_len];
+    }
+
+    pub fn previousRevision(self: *const RelaunchRequest) ?[]const u8 {
+        if (self.previous_revision_len == 0) return null;
+        return self.previous_revision_buf[0..self.previous_revision_len];
     }
 };
 
@@ -47,6 +54,8 @@ pub const AutoUpgrade = struct {
     version_mutex: std.Io.Mutex = .init,
     latest_version_buf: [64]u8 = undefined,
     latest_version_len: u8 = 0,
+    previous_revision_buf: [update_target.max_revision_bytes]u8 = undefined,
+    previous_revision_len: u8 = 0,
 
     selected_channel: update_target.Channel = .stable,
 
@@ -65,6 +74,7 @@ pub const AutoUpgrade = struct {
         alloc: Allocator,
         current: update_target.CurrentBuild,
     ) void {
+        self.setPreviousRevision(current.revision);
         self.thread = std.Thread.spawn(.{}, runLoop, .{ self, alloc, current }) catch return;
     }
 
@@ -89,6 +99,15 @@ pub const AutoUpgrade = struct {
             request.executable_path_buf[0..executable_path.len],
             executable_path,
         );
+        self.version_mutex.lockUncancelable(io_mod.getIo());
+        defer self.version_mutex.unlock(io_mod.getIo());
+        if (self.selected_channel == .dev and self.previous_revision_len > 0) {
+            @memcpy(
+                request.previous_revision_buf[0..self.previous_revision_len],
+                self.previous_revision_buf[0..self.previous_revision_len],
+            );
+            request.previous_revision_len = self.previous_revision_len;
+        }
         self.relaunch_request = request;
     }
 
@@ -130,6 +149,15 @@ pub const AutoUpgrade = struct {
         const next = @intFromEnum(state);
         const previous = self.state.swap(next, .acq_rel);
         if (previous != next) self.markRenderDirty();
+    }
+
+    fn setPreviousRevision(self: *AutoUpgrade, revision: []const u8) void {
+        const valid = update_target.isValidRevision(revision);
+        const len: u8 = if (valid) @intCast(revision.len) else 0;
+        self.version_mutex.lockUncancelable(io_mod.getIo());
+        defer self.version_mutex.unlock(io_mod.getIo());
+        if (len > 0) @memcpy(self.previous_revision_buf[0..len], revision);
+        self.previous_revision_len = len;
     }
 
     fn setLatestVersion(self: *AutoUpgrade, version: []const u8) void {
@@ -304,15 +332,23 @@ test "setLatestVersion stores normalized version" {
     try std.testing.expect(au.takeRenderDirty());
 }
 
-test "relaunch request owns the executable path and is consumed once" {
+test "relaunch request owns its path and previous revision and is consumed once" {
     var au = AutoUpgrade{};
-    var source = [_]u8{ '/', 't', 'm', 'p', '/', 'f', 'x' };
-    try au.requestRelaunch(&source);
-    source[1] = 'x';
+    var path = [_]u8{ '/', 't', 'm', 'p', '/', 'f', 'x' };
+    var revision = [_]u8{'1'} ** 40;
+    au.configure_channel(.dev);
+    au.setPreviousRevision(&revision);
+    try au.requestRelaunch(&path);
+    path[1] = 'x';
+    revision[0] = '2';
 
     const request = au.takeRelaunchRequest() orelse
         return error.TestExpectedRelaunchRequest;
     try std.testing.expectEqualStrings("/tmp/fx", request.executablePath());
+    try std.testing.expectEqualStrings(
+        "1111111111111111111111111111111111111111",
+        request.previousRevision().?,
+    );
     try std.testing.expect(au.takeRelaunchRequest() == null);
 }
 

--- a/src/core/upgrade/update_notes.zig
+++ b/src/core/upgrade/update_notes.zig
@@ -1,0 +1,142 @@
+const std = @import("std");
+const update_target = @import("update_target.zig");
+
+pub const Kind = enum {
+    notes,
+    changes,
+};
+
+pub const Destination = struct {
+    kind: Kind,
+    channel: update_target.Channel,
+    version: []const u8,
+    previous_revision: ?[]const u8 = null,
+    revision: ?[]const u8 = null,
+
+    pub fn writeUrl(self: Destination, writer: *std.Io.Writer) !void {
+        switch (self.channel) {
+            .stable => try writer.print(
+                "https://fx.sh/changelog#v{s}",
+                .{update_target.normalizeVersion(self.version)},
+            ),
+            .dev => {
+                const revision = self.revision orelse return error.InvalidRevision;
+                if (!update_target.isValidRevision(revision)) return error.InvalidRevision;
+                if (self.previous_revision) |previous| {
+                    if (!update_target.isValidRevision(previous)) return error.InvalidRevision;
+                    if (!update_target.revisionsEqual(previous, revision)) {
+                        try writer.print(
+                            "https://github.com/vercel-labs/fx/compare/{s}...{s}",
+                            .{ previous, revision },
+                        );
+                        return;
+                    }
+                }
+                try writer.print(
+                    "https://github.com/vercel-labs/fx/commit/{s}",
+                    .{revision},
+                );
+            },
+        }
+    }
+};
+
+pub fn destination(
+    channel: update_target.Channel,
+    version: []const u8,
+    previous_revision: []const u8,
+    revision: []const u8,
+) ?Destination {
+    return switch (channel) {
+        .stable => if (update_target.isValidVersion(update_target.normalizeVersion(version))) .{
+            .kind = .notes,
+            .channel = .stable,
+            .version = version,
+        } else null,
+        .dev => if (update_target.isValidRevision(revision)) .{
+            .kind = .changes,
+            .channel = .dev,
+            .version = version,
+            .previous_revision = if (update_target.isValidRevision(previous_revision)) previous_revision else null,
+            .revision = revision,
+        } else null,
+    };
+}
+
+pub fn writeLabel(kind: Kind, writer: *std.Io.Writer) !void {
+    try writer.writeAll(switch (kind) {
+        .notes => "notes",
+        .changes => "changes",
+    });
+}
+
+test "stable destination uses normalized changelog anchor" {
+    var out: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer out.deinit();
+
+    const value = destination(.stable, "v0.0.8", "", "") orelse
+        return error.TestExpectedDestination;
+    try std.testing.expectEqual(Kind.notes, value.kind);
+    try value.writeUrl(&out.writer);
+    try std.testing.expectEqualStrings(
+        "https://fx.sh/changelog#v0.0.8",
+        out.writer.buffered(),
+    );
+}
+
+test "dev destination uses compare range when both revisions are valid" {
+    var out: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer out.deinit();
+
+    const value = destination(
+        .dev,
+        "0.0.8",
+        "1111111111111111111111111111111111111111",
+        "abcdef0123456789abcdef0123456789abcdef01",
+    ) orelse return error.TestExpectedDestination;
+    try std.testing.expectEqual(Kind.changes, value.kind);
+    try value.writeUrl(&out.writer);
+    try std.testing.expectEqualStrings(
+        "https://github.com/vercel-labs/fx/compare/1111111111111111111111111111111111111111...abcdef0123456789abcdef0123456789abcdef01",
+        out.writer.buffered(),
+    );
+}
+
+test "dev destination falls back to the installed commit" {
+    var out: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer out.deinit();
+
+    const value = destination(
+        .dev,
+        "0.0.8",
+        "unknown",
+        "abcdef0123456789abcdef0123456789abcdef01",
+    ) orelse return error.TestExpectedDestination;
+    try value.writeUrl(&out.writer);
+    try std.testing.expectEqualStrings(
+        "https://github.com/vercel-labs/fx/commit/abcdef0123456789abcdef0123456789abcdef01",
+        out.writer.buffered(),
+    );
+}
+
+test "dev destination treats a short previous revision as the same commit" {
+    var out: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer out.deinit();
+
+    const value = destination(
+        .dev,
+        "0.0.8",
+        "abcdef012345",
+        "abcdef0123456789abcdef0123456789abcdef01",
+    ) orelse return error.TestExpectedDestination;
+    try value.writeUrl(&out.writer);
+    try std.testing.expectEqualStrings(
+        "https://github.com/vercel-labs/fx/commit/abcdef0123456789abcdef0123456789abcdef01",
+        out.writer.buffered(),
+    );
+}
+
+test "invalid build identity has no destination" {
+    try std.testing.expect(destination(.stable, "dev", "", "") == null);
+    try std.testing.expect(destination(.dev, "0.0.8", "", "not-a-revision") == null);
+}

--- a/src/core/upgrade/update_notes.zig
+++ b/src/core/upgrade/update_notes.zig
@@ -39,6 +39,14 @@ pub const Destination = struct {
             },
         }
     }
+
+    pub fn writeHyperlinkLabel(self: Destination, writer: *std.Io.Writer) !void {
+        try writer.writeAll("\x1b]8;;");
+        try self.writeUrl(writer);
+        try writer.writeAll("\x1b\\\x1b[4m(");
+        try writeLabel(self.kind, writer);
+        try writer.writeAll(")\x1b[24m\x1b]8;;\x1b\\");
+    }
 };
 
 pub fn destination(
@@ -132,6 +140,20 @@ test "dev destination treats a short previous revision as the same commit" {
     try value.writeUrl(&out.writer);
     try std.testing.expectEqualStrings(
         "https://github.com/vercel-labs/fx/commit/abcdef0123456789abcdef0123456789abcdef01",
+        out.writer.buffered(),
+    );
+}
+
+test "destination writes a compact OSC 8 hyperlink label" {
+    var out: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer out.deinit();
+
+    const value = destination(.stable, "0.0.8", "", "") orelse
+        return error.TestExpectedDestination;
+    try value.writeHyperlinkLabel(&out.writer);
+    try std.testing.expectEqualStrings(
+        "\x1b]8;;https://fx.sh/changelog#v0.0.8\x1b\\" ++
+            "\x1b[4m(notes)\x1b[24m\x1b]8;;\x1b\\",
         out.writer.buffered(),
     );
 }

--- a/src/core/upgrade/update_target.zig
+++ b/src/core/upgrade/update_target.zig
@@ -46,7 +46,7 @@ pub const Target = union(Channel) {
     pub fn initStable(alloc: Allocator, raw_version: []const u8) !Target {
         const trimmed = std.mem.trim(u8, raw_version, " \t\r\n");
         const normalized_version = normalizeVersion(trimmed);
-        if (!validVersion(normalized_version)) return error.InvalidVersion;
+        if (!isValidVersion(normalized_version)) return error.InvalidVersion;
 
         const owned_version = try alloc.dupe(u8, normalized_version);
         errdefer alloc.free(owned_version);
@@ -75,7 +75,7 @@ pub const Target = union(Channel) {
 
         const normalized_version = normalizeVersion(version_value.string);
         const manifest_revision = revision_value.string;
-        if (!validVersion(normalized_version) or !validRevision(manifest_revision)) {
+        if (!isValidVersion(normalized_version) or !isValidRevision(manifest_revision)) {
             return error.InvalidManifest;
         }
 
@@ -160,7 +160,7 @@ pub fn compareVersions(a: []const u8, b: []const u8) std.math.Order {
     return std.math.order(av[2], bv[2]);
 }
 
-fn validVersion(raw: []const u8) bool {
+pub fn isValidVersion(raw: []const u8) bool {
     if (raw.len == 0 or raw.len > max_version_bytes) return false;
     var count: usize = 0;
     var parts = std.mem.splitScalar(u8, raw, '.');
@@ -173,7 +173,7 @@ fn validVersion(raw: []const u8) bool {
     return count == 3;
 }
 
-fn validRevision(raw: []const u8) bool {
+pub fn isValidRevision(raw: []const u8) bool {
     if (raw.len < min_revision_bytes or raw.len > max_revision_bytes) return false;
     for (raw) |byte| if (!std.ascii.isHex(byte)) return false;
     return true;
@@ -189,7 +189,7 @@ fn parseVersionParts(raw: []const u8) [3]u32 {
     return values;
 }
 
-fn revisionsEqual(full: []const u8, current: []const u8) bool {
+pub fn revisionsEqual(full: []const u8, current: []const u8) bool {
     if (std.mem.eql(u8, current, "unknown")) return false;
     const common_len = @min(full.len, current.len);
     if (common_len < min_revision_bytes) return false;

--- a/src/main.zig
+++ b/src/main.zig
@@ -670,10 +670,13 @@ const App = struct {
         app.context_limits.applyCommandLine(launch.modifiers.context_limit_overrides);
         if (comptime host_profile.durable_sessions or host_profile.js_host_sessions) {
             if (app.requested_resume != null) {
-                if (launch.upgrade_relaunch) {
+                if (launch.upgrade_relaunch != null) {
                     try SessionAppRuntime.resumeRequestedSessionAfterUpgrade(
                         &app,
                         app_version,
+                        build_update_channel,
+                        launch.upgrade_relaunch.?.previous_revision orelse "",
+                        build_revision,
                     );
                 } else {
                     try SessionAppRuntime.resumeRequestedSession(&app);

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -70,6 +70,9 @@ function shellQuote(value: string): string {
 function startUpgradeServer(
   root: string,
   argvLogPath: string,
+  options: {
+    revision?: string;
+  } = {},
 ): { baseUrl: string; stop: () => void } {
   const artifactDir = join(root, "release-artifact");
   const wrapperPath = join(artifactDir, "fx");
@@ -93,15 +96,24 @@ exec ${shellQuote(FX_BIN)} "$@"
   const archive = readFileSync(archivePath);
   const checksum = createHash("sha256").update(archive).digest("hex");
   const platform = `${process.platform === "darwin" ? "macos" : "linux"}-${process.arch === "arm64" ? "aarch64" : "x86_64"}`;
-  const archiveRoute = `/v9.9.9/fx-${platform}.tar.gz`;
+  const revision = options.revision ?? "abcdef0123456789abcdef0123456789abcdef01";
+  const stableArchiveRoute = `/v9.9.9/fx-${platform}.tar.gz`;
+  const devArchiveRoute = `/dev/${revision}/fx-${platform}.tar.gz`;
   const server = Bun.serve({
     hostname: "127.0.0.1",
     port: 0,
     fetch(request) {
       const path = new URL(request.url).pathname;
       if (path === "/latest.txt") return new Response("v9.9.9\n");
-      if (path === archiveRoute) return new Response(archive);
-      if (path === `${archiveRoute}.sha256`) return new Response(`${checksum}\n`);
+      if (path === "/dev.json") {
+        return Response.json({ version: "9.9.9", commit: revision });
+      }
+      if (path === stableArchiveRoute || path === devArchiveRoute) {
+        return new Response(archive);
+      }
+      if (path === `${stableArchiveRoute}.sha256` || path === `${devArchiveRoute}.sha256`) {
+        return new Response(`${checksum}\n`);
+      }
       return new Response("not found", { status: 404 });
     },
   });
@@ -5036,6 +5048,51 @@ test.skipIf(!tmuxAvailable())(
   TIMEOUT * 5,
 );
 
+test("manual upgrade output links stable notes and dev changes", async () => {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), "fx-upgrade-links-")));
+  const argvLogPath = join(root, "upgrade-argv.log");
+  const installedFx = join(root, "fx");
+  const home = join(root, "home");
+  mkdirSync(home);
+  const currentRevision = (await runFx(["status", "--json"], {
+    env: { AI_GATEWAY_API_KEY: undefined, VERCEL_OIDC_TOKEN: undefined },
+  })).stdout;
+  const revision = "abcdef0123456789abcdef0123456789abcdef01";
+  const release = startUpgradeServer(root, argvLogPath, { revision });
+  copyFileSync(FX_BIN, installedFx);
+  chmodSync(installedFx, 0o755);
+
+  try {
+    const stable = Bun.spawn([installedFx, "upgrade", "--channel", "stable"], {
+      env: { ...process.env, HOME: home, FX_E2E_UPGRADE_BASE_URL: release.baseUrl },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const stableExitCode = await stable.exited;
+    expect(stableExitCode).toBe(0);
+    expect(await new Response(stable.stdout).text()).toContain(
+      "notes: https://fx.sh/changelog#v9.9.9",
+    );
+
+    copyFileSync(FX_BIN, installedFx);
+    chmodSync(installedFx, 0o755);
+    const dev = Bun.spawn([installedFx, "upgrade", "--channel", "dev"], {
+      env: { ...process.env, HOME: home, FX_E2E_UPGRADE_BASE_URL: release.baseUrl },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const devExitCode = await dev.exited;
+    expect(devExitCode).toBe(0);
+    const buildRevision = JSON.parse(currentRevision).build_revision;
+    expect(await new Response(dev.stdout).text()).toContain(
+      `changes: https://github.com/vercel-labs/fx/compare/${buildRevision}...${revision}`,
+    );
+  } finally {
+    release.stop();
+    rmSync(root, { recursive: true, force: true });
+  }
+}, UPGRADE_TIMEOUT);
+
 test.skipIf(!tmuxAvailable())(
   "upgrade ctrl-g reloads the background-installed binary and resumes",
   async () => {
@@ -5112,7 +5169,7 @@ test.skipIf(!tmuxAvailable())(
       const version = (await runFx(["--version"])).stdout.trim();
       await active.sendHexBytes(["07"]);
 
-      const updatedNotice = `● fx has been updated to v${version}`;
+      const updatedNotice = `● fx has been updated to v${version}\n  notes: https://fx.sh/changelog#v${version}`;
       await active.waitForText(updatedNotice, TIMEOUT);
       const resumed = await waitForScrollback(active, "UPGRADE_CTRL_G_INITIAL_DONE");
       expect(resumed).toContain("UPGRADE_CTRL_G_INITIAL_DONE");
@@ -5210,7 +5267,10 @@ test.skipIf(!tmuxAvailable())(
       const version = (await runFx(["--version"])).stdout.trim();
       await active.sendHexBytes(["07"]);
 
-      await active.waitForText(`● fx has been updated to v${version}`, TIMEOUT);
+      await active.waitForText(
+        `● fx has been updated to v${version}\n  notes: https://fx.sh/changelog#v${version}`,
+        TIMEOUT,
+      );
       const resumed = await waitForScrollback(
         active,
         "UPGRADE_CORRUPT_INITIAL_DONE",

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -5169,11 +5169,14 @@ test.skipIf(!tmuxAvailable())(
       const version = (await runFx(["--version"])).stdout.trim();
       await active.sendHexBytes(["07"]);
 
-      const updatedNotice = `● fx has been updated to v${version}\n  notes: https://fx.sh/changelog#v${version}`;
+      const updatedNotice = `● fx has been updated to v${version} (notes)`;
       await active.waitForText(updatedNotice, TIMEOUT);
       const resumed = await waitForScrollback(active, "UPGRADE_CTRL_G_INITIAL_DONE");
       expect(resumed).toContain("UPGRADE_CTRL_G_INITIAL_DONE");
       expect(resumed).toContain(updatedNotice);
+      expect(await active.capturePaneEscapes()).toContain(
+        `\x1b[4m\x1b]8;;https://fx.sh/changelog#v${version}\x1b\\(notes)\x1b]8;;\x1b\\`,
+      );
       expect(resumed).not.toContain("● Session resumed:");
       expect(resumed).not.toContain("● Session: resumed:");
 
@@ -5268,7 +5271,7 @@ test.skipIf(!tmuxAvailable())(
       await active.sendHexBytes(["07"]);
 
       await active.waitForText(
-        `● fx has been updated to v${version}\n  notes: https://fx.sh/changelog#v${version}`,
+        `● fx has been updated to v${version} (notes)`,
         TIMEOUT,
       );
       const resumed = await waitForScrollback(


### PR DESCRIPTION
## Summary

- Link stable update messages to the matching fx changelog entry.
- Link dev update messages to the installed commit range.
- Preserve update links after automatic reload and session resume.