### PR TITLE
Prevent rapid empty shell polling

### DIFF
--- a/src/builtins/tools.zig
+++ b/src/builtins/tools.zig
@@ -85,7 +85,7 @@ const shell_interact_properties = [_]model_tool_schema.Property{
     .{ .name = "action", .json_type = .string, .shape = &.{ .enum_values = &.{"interact"} } },
     .{ .name = "session_id", .json_type = .string, .description = "Owned execution handle returned by shell.run." },
     .{ .name = "chars", .json_type = .string, .bounds = &.{ .max_length = terminal_contracts.max_write_bytes }, .description = "Exact characters to send to tty=true work before observing it. Omit or send an empty string to only observe. Observe application readiness before sending control characters. Use \\n for Enter and JSON escapes such as \\u0003 for control characters." },
-    .{ .name = "yield_time_ms", .json_type = .integer, .bounds = &.{ .minimum = 0, .maximum = managed_execution_contract.max_wait_ceiling_ms }, .description = "Observation window after optional input. Defaults to 5000; use 0 for an immediate snapshot. If the process remains running, interact with the same session_id again; never rerun it." },
+    .{ .name = "yield_time_ms", .json_type = .integer, .bounds = &.{ .minimum = 0, .maximum = managed_execution_contract.max_wait_ceiling_ms }, .description = "Wait before yielding output. Empty observations wait 5000-300000 ms; shorter values are raised to 5000. Non-empty input is capped at 30000 ms and keeps shorter requested waits. Defaults to 5000. If the process remains running, interact with the same session_id again; never rerun it." },
 };
 
 const shell_stop_properties = [_]model_tool_schema.Property{
@@ -938,7 +938,7 @@ test "built-in model-facing tool contract stays byte exact" {
 
     const actual_hex = std.fmt.bytesToHex(hasher.finalResult(), .lower);
     try std.testing.expectEqualStrings(
-        "7fed627d6a17a6c38bf2bd635c074121c2fb5eae8be33f124bb42abe47dfbe34",
+        "47e84930e1fdc99133e76843f795891b35592d32615cacb76a3dfc81e1b23b7a",
         &actual_hex,
     );
 }
@@ -1071,6 +1071,11 @@ test "shell advertises only run interact and stop" {
         u8,
         schema_json,
         "output_delta is always terminal-safe",
+    ) != null);
+    try std.testing.expect(std.mem.find(
+        u8,
+        schema_json,
+        "Empty observations wait 5000-300000 ms",
     ) != null);
     try std.testing.expect(registry.lookup("terminal") == null);
     try std.testing.expect(registry.lookup("shell") != null);

--- a/src/tools/shell/shell.zig
+++ b/src/tools/shell/shell.zig
@@ -159,6 +159,16 @@ fn defaultYieldTime(action: Action) u32 {
     };
 }
 
+fn effective_interact_yield_time(has_input: bool, requested_ms: u32) u32 {
+    if (!has_input) {
+        return @min(
+            @max(requested_ms, managed_contract.default_wait_ceiling_ms),
+            managed_contract.max_wait_ceiling_ms,
+        );
+    }
+    return @min(requested_ms, managed_contract.max_yield_time_ms);
+}
+
 fn decodeFailure(
     ctx: tool_dispatch.DispatchContext,
 ) tool_dispatch.DispatchError!tool_dispatch.DecodeResult {
@@ -423,6 +433,7 @@ fn callInteract(
     ensureOwnedTtyIndexed(ctx, runtime, session_id) catch |err|
         return runtimeFailure(ctx, err);
     const chars = input.chars orelse "";
+    const yield_time_ms = effective_interact_yield_time(chars.len != 0, input.yield_time_ms);
     if (runtime.isTombstone(session_id)) {
         if (chars.len != 0) return runtimeFailure(ctx, error.ExecutionTerminal);
         if (runtime.retainedTerminalSnapshot(ctx.allocator, session_id) catch |err|
@@ -434,13 +445,13 @@ fn callInteract(
         }
     }
     if (runtime.backendFor(session_id) == .tty) {
-        return callTtyInteract(ctx, input);
+        return callTtyInteract(ctx, input, yield_time_ms);
     }
     if (chars.len != 0) return runtimeFailure(ctx, error.InvalidBackend);
     var prepared = runtime.wait(
         ctx.allocator,
         session_id,
-        input.yield_time_ms,
+        yield_time_ms,
         ctx.cancel_flag,
     ) catch |err| return runtimeFailure(ctx, err);
     defer prepared.deinit(ctx.allocator);
@@ -603,6 +614,7 @@ fn callTtyRun(
 fn callTtyInteract(
     ctx: tool_dispatch.DispatchContext,
     input: Input,
+    yield_time_ms: u32,
 ) tool_dispatch.DispatchError!tool_dispatch.ToolResult {
     const runtime = ctx.managed_executions orelse return unavailable(ctx);
     const session_id = input.session_id orelse return unavailable(ctx);
@@ -684,11 +696,11 @@ fn callTtyInteract(
     const waiter_id = runtime.reserveExternalWait(session_id) catch |err|
         return runtimeFailure(ctx, err);
     defer runtime.releaseExternalWait(session_id, waiter_id);
-    if (state == .running and input.yield_time_ms != 0) {
+    if (state == .running and yield_time_ms != 0) {
         var waited = executeAuthorizedTerminal(ctx, session_id, .{ .wait = .{
             .session_id = session_id,
             .return_when = .exit,
-            .safety_ceiling_ms = input.yield_time_ms,
+            .safety_ceiling_ms = yield_time_ms,
             .authority = null,
         } }) catch |err| return runtimeFailure(ctx, err);
         defer waited.deinit(ctx.allocator);
@@ -701,7 +713,7 @@ fn callTtyInteract(
         };
         state = terminal_managed_observer.snapshotState(result.session, result.outcome);
     }
-    if (accepted_bytes != null and input.yield_time_ms == 0) {
+    if (accepted_bytes != null and yield_time_ms == 0) {
         io_mod.sleep(100 * std.time.ns_per_ms);
     }
     var observed = terminal_managed_observer.observe(
@@ -1740,6 +1752,53 @@ test "shell decoder applies action specific observation defaults" {
     }
 }
 
+test "shell interaction wait bounds empty observations without delaying writes" {
+    const cases = [_]struct {
+        has_input: bool,
+        requested_ms: u32,
+        expected_ms: u32,
+    }{
+        .{ .has_input = false, .requested_ms = 0, .expected_ms = 5_000 },
+        .{ .has_input = false, .requested_ms = 1_000, .expected_ms = 5_000 },
+        .{ .has_input = false, .requested_ms = 5_000, .expected_ms = 5_000 },
+        .{ .has_input = false, .requested_ms = 45_000, .expected_ms = 45_000 },
+        .{ .has_input = false, .requested_ms = 300_000, .expected_ms = 300_000 },
+        .{ .has_input = true, .requested_ms = 0, .expected_ms = 0 },
+        .{ .has_input = true, .requested_ms = 1_000, .expected_ms = 1_000 },
+        .{ .has_input = true, .requested_ms = 30_000, .expected_ms = 30_000 },
+        .{ .has_input = true, .requested_ms = 300_000, .expected_ms = 30_000 },
+    };
+    for (cases) |case| {
+        try std.testing.expectEqual(
+            case.expected_ms,
+            effective_interact_yield_time(case.has_input, case.requested_ms),
+        );
+    }
+
+    const failure = try validateInteract(
+        .{ .allocator = std.testing.allocator },
+        .{
+            .action = .interact,
+            .session_id = "shell-1",
+            .yield_time_ms = managed_contract.max_wait_ceiling_ms + 1,
+        },
+    ) orelse return error.TestUnexpectedResult;
+    defer std.testing.allocator.free(failure);
+    try std.testing.expect(std.mem.find(u8, failure, "between 0 and 300000") != null);
+
+    const overflow = try decode(
+        .{ .allocator = std.testing.allocator },
+        "{\"action\":\"interact\",\"session_id\":\"shell-1\",\"yield_time_ms\":4294967296}",
+    );
+    switch (overflow) {
+        .input => |input| {
+            defer input.deinit(std.testing.allocator);
+            return error.TestUnexpectedResult;
+        },
+        .failure => |message| std.testing.allocator.free(message),
+    }
+}
+
 test "shell decoder rejects removed handoff and legacy actions" {
     const alloc = std.testing.allocator;
     const ctx = tool_dispatch.DispatchContext{ .allocator = alloc };
@@ -1935,7 +1994,7 @@ test "running shell snapshot leaves continuation intent to the caller" {
     );
 }
 
-test "registered shell run yields and waits through one managed execution" {
+test "registered shell empty observation waits through one managed execution" {
     if (comptime @import("builtin").os.tag == .wasi) return;
     const alloc = std.testing.allocator;
     var runtime = managed_execution.Runtime.init(alloc);
@@ -1977,7 +2036,7 @@ test "registered shell run yields and waits through one managed execution" {
         .clean,
     );
     const command_ctx = command_admission.CommandContext{
-        .command = "printf ready; sleep 1; printf done",
+        .command = "sleep 2; printf done",
         .resolved_cwd = "/tmp",
         .target_os = @import("builtin").os.tag,
         .environment = environment,
@@ -2009,7 +2068,7 @@ test "registered shell run yields and waits through one managed execution" {
         .{
             .id = "shell-integration",
             .name = "shell",
-            .arguments_json = "{\"action\":\"run\",\"command\":\"printf ready; sleep 1; printf done\",\"cwd\":\"/tmp\",\"profile\":\"clean\",\"yield_time_ms\":0}",
+            .arguments_json = "{\"action\":\"run\",\"command\":\"sleep 2; printf done\",\"cwd\":\"/tmp\",\"profile\":\"clean\",\"yield_time_ms\":0}",
         },
         &start_status_detail,
     );
@@ -2022,7 +2081,7 @@ test "registered shell run yields and waits through one managed execution" {
         return error.TestExpectedEqual;
     const interact_arguments = try std.fmt.allocPrint(
         alloc,
-        "{{\"action\":\"interact\",\"session_id\":\"{s}\",\"yield_time_ms\":2000}}",
+        "{{\"action\":\"interact\",\"session_id\":\"{s}\",\"yield_time_ms\":1000}}",
         .{execution_id.string},
     );
     defer alloc.free(interact_arguments);
@@ -2059,9 +2118,8 @@ test "registered shell run yields and waits through one managed execution" {
     defer waited.deinit(alloc);
     try std.testing.expectEqual(tool_dispatch.DispatchResult.Status.success, waited.status);
     try std.testing.expect(std.mem.find(u8, waited.body, "\"state\":\"completed\"") != null);
-    try std.testing.expect(std.mem.find(u8, waited.body, "ready") != null);
     try std.testing.expect(std.mem.find(u8, waited.body, "done") != null);
-    try std.testing.expectEqual(@as(usize, "readydone".len), streamed_bytes.load(.seq_cst));
+    try std.testing.expectEqual(@as(usize, "done".len), streamed_bytes.load(.seq_cst));
     try std.testing.expect(std.mem.find(
         u8,
         command_result_json orelse return error.TestExpectedEqual,

--- a/tests/e2e/tui-terminal-tool.test.ts
+++ b/tests/e2e/tui-terminal-tool.test.ts
@@ -187,7 +187,7 @@ async function waitForFile(path: string): Promise<void> {
 }
 
 test.skipIf(!tmuxAvailable())(
-  "shell captured execution yields one handle and waits without respawn",
+  "shell captured empty observation floors short waits without respawn",
   async () => {
     const fixture = createFixture("fx-shell-captured-");
     let sessionId = "";
@@ -195,7 +195,7 @@ test.skipIf(!tmuxAvailable())(
       fakeGatewayToolCall("shell_run", "shell", {
         request: {
           action: "run",
-          command: "printf CAPTURED_READY; sleep 0.2; printf CAPTURED_DONE",
+          command: "sleep 2; printf CAPTURED_DONE",
           profile: "clean",
           yield_time_ms: 0,
         },
@@ -207,7 +207,7 @@ test.skipIf(!tmuxAvailable())(
           request: {
             action: "interact",
             session_id: sessionId,
-            yield_time_ms: 5_000,
+            yield_time_ms: 1_000,
           },
         });
       },
@@ -232,10 +232,16 @@ test.skipIf(!tmuxAvailable())(
       gateway.requests[1]!.body,
       "shell_run",
     );
+    const interactResult = toolResultEnvelope(
+      gateway.requests[2]!.body,
+      "shell_interact",
+    );
     expect(runResult).not.toContain('\\"next_action\\"');
     expect(runResult).toContain(`\\"session_id\\":\\"${sessionId}\\"`);
+    expect(interactResult).toContain('\\"state\\":\\"completed\\"');
+    expect(interactResult).toContain("CAPTURED_DONE");
     const scrollback = await active.captureFullScrollback();
-    expect(scrollback).toContain("Ran printf CAPTURED_READY");
+    expect(scrollback).toContain("Ran sleep 2; printf CAPTURED_DONE");
     expect(scrollback).toContain(`Observed session ${sessionId}`);
     expect(scrollback).not.toContain("Using terminal");
     expect(scrollback).not.toContain("Used terminal");


### PR DESCRIPTION
## Summary

- Enforce a five-second minimum wait for empty `shell.interact` observations.
- Cap observation after non-empty input at 30 seconds while preserving shorter waits.
- Describe the effective wait ranges in the model-facing shell schema.