### PR TITLE
Return monotonic debug-trace IDs on WASI

### DIFF
--- a/src/core/shared/debug_trace.zig
+++ b/src/core/shared/debug_trace.zig
@@ -32,6 +32,9 @@ var state: State = .{};
 var next_turn_id = std.atomic.Value(u64).init(1);
 var next_step_id = std.atomic.Value(u64).init(1);
 var next_subagent_id = std.atomic.Value(u64).init(1);
+var next_turn_id_wasi: u64 = 1;
+var next_step_id_wasi: u64 = 1;
+var next_subagent_id_wasi: u64 = 1;
 
 pub fn configureFromEnv(alloc: Allocator, workspace_root: []const u8) void {
     const options = loadOptionsFromEnv(alloc, workspace_root) catch return;
@@ -60,17 +63,29 @@ pub fn activeLogPath() ?[]const u8 {
 }
 
 pub fn nextTurnId() u64 {
-    if (comptime @import("builtin").os.tag == .wasi) return 1;
+    if (comptime @import("builtin").os.tag == .wasi) {
+        const id = next_turn_id_wasi;
+        next_turn_id_wasi += 1;
+        return id;
+    }
     return next_turn_id.fetchAdd(1, .seq_cst);
 }
 
 pub fn nextStepId() u64 {
-    if (comptime @import("builtin").os.tag == .wasi) return 1;
+    if (comptime @import("builtin").os.tag == .wasi) {
+        const id = next_step_id_wasi;
+        next_step_id_wasi += 1;
+        return id;
+    }
     return next_step_id.fetchAdd(1, .seq_cst);
 }
 
 pub fn nextSubagentId() u64 {
-    if (comptime @import("builtin").os.tag == .wasi) return 1;
+    if (comptime @import("builtin").os.tag == .wasi) {
+        const id = next_subagent_id_wasi;
+        next_subagent_id_wasi += 1;
+        return id;
+    }
     return next_subagent_id.fetchAdd(1, .seq_cst);
 }
 
@@ -317,6 +332,9 @@ pub fn resetForTest() void {
     next_turn_id.store(1, .seq_cst);
     next_step_id.store(1, .seq_cst);
     next_subagent_id.store(1, .seq_cst);
+    next_turn_id_wasi = 1;
+    next_step_id_wasi = 1;
+    next_subagent_id_wasi = 1;
 }
 
 pub fn configureForTest(alloc: Allocator, path: []const u8) !void {


### PR DESCRIPTION
## Summary

WASI builds currently return the constant `1` from `nextTurnId()`,
`nextStepId()`, and `nextSubagentId()`. These values are also used in
presentation identities, so the collision changes terminal behavior: tool
statuses from different steps resolve to one group and accumulate in the
first tool-call block.

This change gives the single-threaded WASI path ordinary per-type counters.
Native builds keep their atomic counters. `resetForTest()` also resets the
new counters on the WASI path so the test helper stays meaningful there.

## User-visible behavior

Before this change, a `fx-term.wasm` conversation with several sequential tool
calls rendered one merged tool block. In longer transcripts that block could
scroll out of view, making later tool calls appear to be missing. A native fx
run with the same model, prompt, and 106 by 27 terminal geometry rendered the
blocks separately.

The relevant presentation identity is `{ turn_id, anchor_step_id }`.
`tool_group_projection` groups entries by equality of that identity, so
constant WASI IDs collapse unrelated steps even though the transcript's
detach logic is otherwise correct.

## Verification

- Captured the raw ANSI output from the wasm terminal surface and replayed it
  through `@xterm/headless` at device geometry.
- Before: one merged block for later tool calls.
- After: one block per step, correctly interleaved with assistant text.
- Compared the result with the native CLI at the same geometry.
- Confirmed the issue on `v0.0.7` (`cef08aa0`) and `main` at `1561f494`:
  both refs rebuilt untouched with Zig 0.16.0, then replayed through a
  scripted two-tool-call session. The fixed build's ANSI output for that
  session is byte-identical across both bases. The branch has since been
  rebased onto `main` `19ae8f54` (one file, +21/−3; `debug_trace.zig` is
  unchanged upstream between those two commits) and rebuilt as
  `fx-term.wasm` there. `resetForTest()` additionally resets the
  new counters so the helper stays correct if a WASI test surface ever calls
  it.

Size/startup: +366 bytes on `-Doptimize=ReleaseFast` (5,255,934 → 5,256,300,
+0.007%); time-to-interactive unchanged versus clean `main` (within
run-to-run noise in the host harness).
