### PR TITLE
Prevent steering from cancelling pending tools

### DIFF
--- a/src/core/agent/worker_runtime.zig
+++ b/src/core/agent/worker_runtime.zig
@@ -636,6 +636,9 @@ pub const WorkerRuntime = struct {
     active_turn_id: u64 = 0,
     active_tool_calls: std.StringHashMapUnmanaged(void) = .empty,
     active_tool_allocator: ?std.mem.Allocator = null,
+    /// Retains the tool-producing step so later text from that same step cannot
+    /// reopen immediate steering before authoritative lifecycle IDs exist.
+    tool_phase_step_id: ?u64 = null,
     worker_stop_requested: bool = false,
     finalization_failure: ?FinalizationFailure = null,
     worker_cancel_requested: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
@@ -793,6 +796,7 @@ pub const WorkerRuntime = struct {
         errdefer tool_transition.deinit(alloc);
         self.worker_events.appendAssumeCapacity(event);
         self.applyActiveToolTransitionLocked(tool_transition);
+        self.applyToolBoundaryPhaseLocked(event);
         self.applyRecoveryStateEvent(event);
         self.worker_cond.broadcast(io_mod.getIo());
     }
@@ -1013,7 +1017,7 @@ pub const WorkerRuntime = struct {
         var interrupt_after_admission = false;
         if (steer_if_active and self.worker_processing and self.active_turn_id != 0) {
             queued.delivery = .{ .active_turn = self.active_turn_id };
-            interrupt_after_admission = self.active_tool_calls.count() == 0;
+            interrupt_after_admission = !self.hasActiveToolBoundaryLocked();
         }
         try self.enqueuePromptLocked(alloc, queued);
         if (interrupt_after_admission) {
@@ -1376,6 +1380,7 @@ pub const WorkerRuntime = struct {
         {
             self.worker_processing = false;
             self.active_turn_id = 0;
+            self.tool_phase_step_id = null;
             self.worker_cond.wait(io_mod.getIo(), &self.worker_mutex) catch break;
         }
         return self.takeNextPromptLocked(alloc);
@@ -1392,6 +1397,7 @@ pub const WorkerRuntime = struct {
         {
             self.worker_processing = false;
             self.active_turn_id = 0;
+            self.tool_phase_step_id = null;
             self.worker_cond.wait(io_mod.getIo(), &self.worker_mutex) catch break;
         }
         return self.takeNextWorkLocked(alloc);
@@ -1436,6 +1442,7 @@ pub const WorkerRuntime = struct {
             self.recovery_continuation_ready = false;
             self.worker_processing = true;
             self.active_turn_id = task.turn_id;
+            self.tool_phase_step_id = null;
             self.active_context_compaction = true;
             debug_trace.eventf(
                 "worker",
@@ -1489,6 +1496,7 @@ pub const WorkerRuntime = struct {
         self.recovery_continuation_ready = false;
         self.worker_processing = true;
         self.active_turn_id = job.turn_id;
+        self.tool_phase_step_id = null;
         if (job.delivery.isContinuation()) {
             for (self.queued_prompts.items) |*prompt| {
                 if (!prompt.delivery.isContinuation() or !sameTurnSteeringEligible(prompt.*)) continue;
@@ -1526,6 +1534,7 @@ pub const WorkerRuntime = struct {
         self.active_turn_id = 0;
         self.steering_cancel_turn_id = null;
         self.clearActiveToolCallsLocked();
+        self.tool_phase_step_id = null;
         self.active_context_compaction = false;
         self.worker_connectivity_wait_active.store(false, .seq_cst);
         self.worker_cond.broadcast(io_mod.getIo());
@@ -1544,6 +1553,7 @@ pub const WorkerRuntime = struct {
         self.worker_connectivity_wait_active.store(false, .seq_cst);
         self.worker_processing = true;
         self.active_turn_id = turn_id;
+        self.tool_phase_step_id = null;
         return true;
     }
 
@@ -1612,6 +1622,24 @@ pub const WorkerRuntime = struct {
             },
             .clear => self.clearActiveToolCallsLocked(),
         }
+    }
+
+    fn applyToolBoundaryPhaseLocked(self: *WorkerRuntime, event: WorkerEvent) void {
+        switch (event) {
+            .turn_phase_update => |update| if (update.turn_id == self.active_turn_id) {
+                switch (update.phase) {
+                    .running => self.tool_phase_step_id = update.step_id,
+                    .thinking, .generating => if (self.tool_phase_step_id != update.step_id) {
+                        self.tool_phase_step_id = null;
+                    },
+                }
+            },
+            else => {},
+        }
+    }
+
+    fn hasActiveToolBoundaryLocked(self: *const WorkerRuntime) bool {
+        return self.tool_phase_step_id != null or self.active_tool_calls.count() > 0;
     }
 
     fn clearActiveToolCallsLocked(self: *WorkerRuntime) void {
@@ -1708,7 +1736,7 @@ pub const WorkerRuntime = struct {
         }
         var snapshot: QueuePresentationSnapshot = .{
             .ordinary_count = queued_count -| steering_count,
-            .steering_waits_for_tool = steering_count > 0 and self.active_tool_calls.count() > 0,
+            .steering_waits_for_tool = steering_count > 0 and self.hasActiveToolBoundaryLocked(),
             .paused = self.queue_admission != null,
         };
         if (steering_count == 0) return snapshot;
@@ -3877,6 +3905,49 @@ test "tool lifecycle decides whether interactive steering interrupts immediately
         .outcome = .{ .kind = .completed, .summary = "completed" },
     } } });
     try runtime.admitInteractivePrompt(alloc, try makePrompt(alloc, "interrupt generation", "model"));
+    try std.testing.expect(runtime.isCancelRequested());
+}
+
+test "tool handoff phase holds steering only through its model step" {
+    const alloc = std.testing.allocator;
+    var runtime = WorkerRuntime{};
+    defer runtime.deinit(alloc);
+    runtime.worker_processing = true;
+    runtime.active_turn_id = 41;
+
+    try runtime.pushEvent(alloc, .{ .turn_phase_update = .{
+        .turn_id = 41,
+        .step_id = 7,
+        .phase = .running,
+    } });
+    try runtime.pushEvent(alloc, .{ .turn_phase_update = .{
+        .turn_id = 41,
+        .step_id = 7,
+        .phase = .generating,
+    } });
+    try runtime.admitInteractivePrompt(alloc, try makePrompt(alloc, "wait for pending tools", "model"));
+
+    try std.testing.expect(!runtime.isCancelRequested());
+    try std.testing.expectEqual(@as(usize, 1), runtime.queuedPromptCount());
+    var snapshot = try runtime.snapshotQueuePresentation(alloc);
+    defer snapshot.deinit(alloc);
+    try std.testing.expect(snapshot.steering_waits_for_tool);
+
+    const guidance = try expectContinuedSteering(
+        try runtime.takeSteeringBoundary(alloc, 41, .model),
+    );
+    defer {
+        for (guidance) |text| alloc.free(text);
+        alloc.free(guidance);
+    }
+    try std.testing.expectEqualStrings("wait for pending tools", guidance[0]);
+
+    try runtime.pushEvent(alloc, .{ .turn_phase_update = .{
+        .turn_id = 41,
+        .step_id = 8,
+        .phase = .thinking,
+    } });
+    try runtime.admitInteractivePrompt(alloc, try makePrompt(alloc, "interrupt next model step", "model"));
     try std.testing.expect(runtime.isCancelRequested());
 }
 

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -3018,6 +3018,132 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
   );
 
   test(
+    "steering waits across streamed tool handoff before authoritative start",
+    async () => {
+      root = realpathSync(mkdtempSync(join(tmpdir(), "fx-tui-steering-tool-handoff-")));
+      const home = join(root, "home");
+      const workspacePath = join(root, "workspace");
+      const stderrPath = join(root, "stderr.log");
+      const tracePath = join(root, "trace.log");
+      const tapePath = join(root, "session.fxtape");
+      const toolHandoff: HoldState = { started: false, cancelled: false };
+      const toolOutput = "TOOL_HANDOFF_EXECUTED";
+      const steering = "Respond exactly TOOL_HANDOFF_STEERING_COMPLETE.";
+      const finalText = "TOOL_HANDOFF_STEERING_COMPLETE";
+      mkdirSync(join(home, ".fx"), { recursive: true });
+      mkdirSync(workspacePath, { recursive: true });
+      writeFileSync(join(home, ".fx", "settings.json"), "{}");
+      const workspace = realpathSync(workspacePath);
+
+      const handoffGateway = startFakeGateway([
+        () => heldGatewayResponse(
+          toolHandoff,
+          [
+            { type: "tool-input-start", id: "handoff_tool", toolName: "shell" },
+            { type: "text-start", id: "handoff_text" },
+            {
+              type: "text-delta",
+              id: "handoff_text",
+              delta: "Preparing the tool handoff.",
+            },
+          ],
+          [
+            { type: "text-end", id: "handoff_text" },
+            { type: "tool-input-end", id: "handoff_tool" },
+            {
+              type: "tool-call",
+              toolCallId: "handoff_tool",
+              toolName: "shell",
+              input: {
+                request: {
+                  action: "run",
+                  yield_time_ms: 30_000,
+                  timeout_ms: 30_000,
+                  command: `printf ${toolOutput}`,
+                },
+              },
+            },
+            {
+              type: "finish",
+              finishReason: { unified: "tool-calls", raw: "tool-calls" },
+              usage: {
+                inputTokens: { total: 11 },
+                outputTokens: { total: 17 },
+              },
+            },
+          ],
+        ),
+        fakeGatewayFinalText(finalText),
+      ]);
+      gateway = handoffGateway;
+
+      session = await TmuxSession.create({
+        cwd: workspace,
+        width: 120,
+        height: 34,
+        minimumHistoryLines: 500,
+        stderrPath,
+        env: {
+          HOME: home,
+          AI_GATEWAY_API_KEY: "fake-steering-tool-handoff-key",
+          VERCEL_OIDC_TOKEN: undefined,
+          FX_AUTO_UPGRADE: "0",
+          FX_SOUND: "0",
+          FX_PERMISSION_MODE: "yolo",
+          FX_GATEWAY_BASE_URL: handoffGateway.baseUrl,
+          FX_GATEWAY_CHAT_URL: handoffGateway.chatUrl,
+          FX_E2E_GATEWAY_CHAT_URL: handoffGateway.chatUrl,
+          FX_MODEL: MODEL,
+          FX_TRACE_LOG: tracePath,
+          FX_TRACE_SCOPES: "agent,worker,input,tool,interrupt",
+          FX_RECORD: tapePath,
+          FX_RECORD_INPUT: "1",
+        },
+      });
+
+      await session.waitForComposer(TIMEOUT);
+      await session.sendText("Run the streamed tool handoff fixture.");
+      await waitForCondition(
+        () => handoffGateway.requests.length === 1 && toolHandoff.started,
+        "held tool handoff response",
+      );
+      await session.waitForText("Generating", TIMEOUT);
+
+      await session.sendText(steering);
+      await Bun.sleep(150);
+      const pendingPane = await session.capturePane();
+      expect(toolHandoff.cancelled).toBe(false);
+      expect(pendingPane).toContain(`${steering} · Esc to steer now`);
+      expect(handoffGateway.requests).toHaveLength(1);
+
+      toolHandoff.release?.();
+      await session.waitForText(finalText, TIMEOUT);
+      await waitForCondition(
+        () => handoffGateway.requests.length === 2,
+        "steering request after tool handoff",
+      );
+
+      const continuedBody = handoffGateway.requests[1]!.body;
+      expect(continuedBody.indexOf(toolOutput)).toBeGreaterThanOrEqual(0);
+      expect(continuedBody.indexOf(steering)).toBeGreaterThan(
+        continuedBody.indexOf(toolOutput),
+      );
+      expect(continuedBody).toContain("<user_steering>");
+      expect(await session.captureFullScrollback()).not.toContain("Cancelled");
+      expect(readFileSync(tracePath, "utf8")).toContain(
+        "event=prompt_steering_consumed",
+      );
+      const replay = execFileSync(FX_BIN, ["replay", tapePath, "--frames"], {
+        encoding: "utf8",
+      });
+      expect(replay).toContain(finalText);
+      expect(replay).not.toContain("Cancelled");
+      expect(readFileSync(stderrPath, "utf8")).toBe("");
+    },
+    TIMEOUT * 2,
+  );
+
+  test(
     "ordinary Enter keeps pending steering visible through narrow resize",
     async () => {
       root = realpathSync(mkdtempSync(join(tmpdir(), "fx-tui-cooperative-steering-")));


### PR DESCRIPTION
## Summary

- Wait for a tool-producing model step to reach its safe boundary before consuming Enter steering.
- Keep generated tool calls running instead of rendering the pending batch as cancelled.
- Preserve immediate steering for text generation and Escape interruption for active tool work.