### PR TITLE
Bound shell termination and expose diagnostics

### DIFF
--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -2647,11 +2647,12 @@ fn appendToolCallRecord(
     var scratch_state = std.heap.ArenaAllocator.init(ctx.alloc);
     defer scratch_state.deinit();
     const scratch = scratch_state.allocator();
-    const action = if (error_category != null)
+    const is_shell = std.mem.eql(u8, call.name, "shell");
+    const action = if (is_shell and error_category != null)
         shell_action_for_call(scratch, call)
     else
         null;
-    const error_code = if (action != null and error_category != null)
+    const error_code = if (is_shell and error_category != null)
         try ctx.alloc.dupe(
             u8,
             explicit_error_code orelse shell_failure_code(
@@ -2678,7 +2679,7 @@ fn appendToolCallRecord(
         .name = name,
         .status = owned_status,
         .action = action,
-        .error_category = if (action != null) error_category else null,
+        .error_category = if (is_shell) error_category else null,
         .error_code = error_code,
         .command_result_json = command_result_json,
         .ask_question_text = ask_question_text,
@@ -8282,6 +8283,14 @@ test "fx ask JSON preserves shell action and runtime error identity" {
         .max_tool_result_bytes = 4096,
     }, error.ExecutionNotFound);
 
+    var arena_state = std.heap.ArenaAllocator.init(alloc);
+    defer arena_state.deinit();
+    try recordToolCallRejected(@ptrCast(&ctx), arena_state.allocator(), .{
+        .id = "shell-invalid-action",
+        .name = "shell",
+        .arguments_json = "{\"action\":\"legacy\"}",
+    }, "Invalid shell action", null);
+
     const records = try takeToolCallRecords(&ctx, alloc);
     const result = PromptRunResult{
         .exit_code = 1,
@@ -8299,6 +8308,19 @@ test "fx ask JSON preserves shell action and runtime error identity" {
     const failure = (record.get("error") orelse return error.TestExpectedEqual).object;
     try std.testing.expectEqualStrings("runtime_failed", failure.get("category").?.string);
     try std.testing.expectEqualStrings("ExecutionNotFound", failure.get("code").?.string);
+
+    const rejected = parsed.value.object.get("tool_calls").?.array.items[1].object;
+    try std.testing.expect(rejected.get("action") == null);
+    const rejected_failure = (rejected.get("error") orelse
+        return error.TestExpectedEqual).object;
+    try std.testing.expectEqualStrings(
+        "rejected",
+        rejected_failure.get("category").?.string,
+    );
+    try std.testing.expectEqualStrings(
+        "rejected",
+        rejected_failure.get("code").?.string,
+    );
 }
 
 test "shell diagnostic action projection accepts only current actions" {

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -12,6 +12,7 @@ const oauth_transport = @import("../auth/oauth_transport.zig");
 const terminal_client_runtime = @import("../terminal/client.zig");
 const managed_execution = @import("../execution/managed_execution.zig");
 const context_contract = @import("../workspace/context_contract.zig");
+const workspace_diagnostics = @import("../workspace/diagnostics.zig");
 const gateway_provider = @import("../gateway/gateway_provider.zig");
 const model_catalog = @import("../gateway/model_catalog.zig");
 const provider_set = @import("../gateway/provider_set.zig");
@@ -97,6 +98,12 @@ const ToolPermissionDecision = types.ToolPermissionDecision;
 const WorkerEvent = worker_runtime.WorkerEvent;
 const WorkerRuntime = worker_runtime.WorkerRuntime;
 const McpHasToolFn = tool_mcp_runtime.HasToolFn;
+
+const ShellAction = enum {
+    run,
+    interact,
+    stop,
+};
 
 const supports_headless_interrupt = switch (std_builtin.os.tag) {
     .windows, .wasi, .freestanding => false,
@@ -348,6 +355,9 @@ const AskOptions = struct {
 const ToolCallRecord = struct {
     name: []u8,
     status: []u8,
+    action: ?ShellAction = null,
+    error_category: ?workspace_diagnostics.ToolCallOutcome = null,
+    error_code: ?[]u8 = null,
     command_result_json: ?[]u8 = null,
     ask_question_text: ?[]u8 = null,
     web_search_completion: ?types.WebSearchCompletion = null,
@@ -370,6 +380,7 @@ const PendingToolProgress = struct {
 fn freeToolCallRecord(alloc: Allocator, record: ToolCallRecord) void {
     alloc.free(record.name);
     alloc.free(record.status);
+    if (record.error_code) |code| alloc.free(code);
     if (record.command_result_json) |json| alloc.free(json);
     if (record.ask_question_text) |text| alloc.free(text);
 }
@@ -2526,10 +2537,17 @@ fn executeToolCallAuthorized(
 fn captureToolExecutionError(
     ctx: *AskContext,
     request: agent_runtime.ToolExecutionRequest,
-    _: anyerror,
+    err: anyerror,
 ) void {
     if (ctx.output_mode.capturesJson()) {
-        appendToolCallRecordBestEffort(ctx, request.call, "error", null);
+        appendToolCallRecordBestEffort(
+            ctx,
+            request.call,
+            "error",
+            null,
+            .runtime_failed,
+            @errorName(err),
+        );
     }
 }
 
@@ -2544,6 +2562,11 @@ fn captureToolExecutionResult(
             request.call,
             if (result.status == .failure) "error" else "success",
             result,
+            if (result.status == .failure)
+                if (result.command_result_json != null) .command_failed else .tool_failed
+            else
+                null,
+            null,
         );
     }
     if (result.status == .failure and result.finish_turn) {
@@ -2568,11 +2591,18 @@ fn recordToolCallRejected(
 ) !void {
     const ctx: *AskContext = @ptrCast(@alignCast(raw_ctx));
     if (!ctx.output_mode.capturesJson()) return;
-    appendToolCallRecordBestEffort(ctx, call, "error", .{
-        .status = .failure,
-        .model_output = model_output,
-        .command_result_json = command_result_json,
-    });
+    appendToolCallRecordBestEffort(
+        ctx,
+        call,
+        "error",
+        .{
+            .status = .failure,
+            .model_output = model_output,
+            .command_result_json = command_result_json,
+        },
+        .rejected,
+        "rejected",
+    );
 }
 
 fn appendToolCallRecordBestEffort(
@@ -2580,8 +2610,17 @@ fn appendToolCallRecordBestEffort(
     call: ToolCall,
     status: []const u8,
     result: ?ToolExecutionResult,
+    error_category: ?workspace_diagnostics.ToolCallOutcome,
+    error_code: ?[]const u8,
 ) void {
-    appendToolCallRecord(ctx, call, status, result) catch |err| {
+    appendToolCallRecord(
+        ctx,
+        call,
+        status,
+        result,
+        error_category,
+        error_code,
+    ) catch |err| {
         debug_trace.logf(
             "cli_ask",
             "tool-call capture dropped name={s} status={s} err={s}",
@@ -2595,6 +2634,8 @@ fn appendToolCallRecord(
     call: ToolCall,
     status: []const u8,
     result: ?ToolExecutionResult,
+    error_category: ?workspace_diagnostics.ToolCallOutcome,
+    explicit_error_code: ?[]const u8,
 ) !void {
     ctx.tool_call_records_mutex.lockUncancelable(io_mod.getIo());
     defer ctx.tool_call_records_mutex.unlock(io_mod.getIo());
@@ -2603,6 +2644,25 @@ fn appendToolCallRecord(
     errdefer ctx.alloc.free(name);
     const owned_status = try ctx.alloc.dupe(u8, status);
     errdefer ctx.alloc.free(owned_status);
+    var scratch_state = std.heap.ArenaAllocator.init(ctx.alloc);
+    defer scratch_state.deinit();
+    const scratch = scratch_state.allocator();
+    const action = if (error_category != null)
+        shell_action_for_call(scratch, call)
+    else
+        null;
+    const error_code = if (action != null and error_category != null)
+        try ctx.alloc.dupe(
+            u8,
+            explicit_error_code orelse shell_failure_code(
+                scratch,
+                error_category.?,
+                result,
+            ),
+        )
+    else
+        null;
+    errdefer if (error_code) |code| ctx.alloc.free(code);
     const command_result_json = if (result) |execution|
         if (execution.command_result_json) |json|
             try ctx.alloc.dupe(u8, json)
@@ -2617,11 +2677,128 @@ fn appendToolCallRecord(
     try ctx.tool_call_records.append(ctx.alloc, .{
         .name = name,
         .status = owned_status,
+        .action = action,
+        .error_category = if (action != null) error_category else null,
+        .error_code = error_code,
         .command_result_json = command_result_json,
         .ask_question_text = ask_question_text,
         .web_search_completion = if (result) |execution| execution.web_search_completion else null,
         .web_fetch_completion = if (result) |execution| execution.web_fetch_completion else null,
     });
+}
+
+fn shell_action_for_call(arena: Allocator, call: ToolCall) ?ShellAction {
+    if (!std.mem.eql(u8, call.name, "shell")) return null;
+    const parsed = std.json.parseFromSliceLeaky(
+        std.json.Value,
+        arena,
+        call.arguments_json,
+        .{},
+    ) catch return null;
+    const root = switch (parsed) {
+        .object => |object| object,
+        else => return null,
+    };
+    const request = if (root.get("request")) |value| switch (value) {
+        .object => |object| object,
+        else => return null,
+    } else root;
+    const action = switch (request.get("action") orelse return null) {
+        .string => |value| value,
+        else => return null,
+    };
+    return std.meta.stringToEnum(ShellAction, action);
+}
+
+fn shell_failure_code(
+    arena: Allocator,
+    category: workspace_diagnostics.ToolCallOutcome,
+    result: ?ToolExecutionResult,
+) []const u8 {
+    return switch (category) {
+        .succeeded => "tool_failed",
+        .rejected => "rejected",
+        .runtime_failed => "runtime_failed",
+        .command_failed => command_failure_code(arena, result),
+        .tool_failed => shell_tool_failure_code(arena, result),
+    };
+}
+
+fn command_failure_code(
+    arena: Allocator,
+    result: ?ToolExecutionResult,
+) []const u8 {
+    const json = (result orelse return "command_failed").command_result_json orelse
+        return "command_failed";
+    const parsed = std.json.parseFromSliceLeaky(std.json.Value, arena, json, .{}) catch
+        return "command_failed";
+    const object = switch (parsed) {
+        .object => |value| value,
+        else => return "command_failed",
+    };
+    if (json_bool(object, "termination_indeterminate")) return "termination_indeterminate";
+    if (json_bool(object, "output_incomplete")) return "output_incomplete";
+    if (json_bool(object, "timed_out")) return "timeout";
+    if (json_has_value(object, "signal")) return "signal";
+    if (json_nonzero_int(object, "exit_code")) return "nonzero_exit";
+    return "command_failed";
+}
+
+fn shell_tool_failure_code(
+    arena: Allocator,
+    result: ?ToolExecutionResult,
+) []const u8 {
+    const body = (result orelse return "tool_failed").model_output;
+    const parsed = std.json.parseFromSliceLeaky(std.json.Value, arena, body, .{}) catch
+        return "tool_failed";
+    const root = switch (parsed) {
+        .object => |value| value,
+        else => return "tool_failed",
+    };
+    const failure = switch (root.get("error") orelse return "tool_failed") {
+        .object => |value| value,
+        else => return "tool_failed",
+    };
+    const tool = switch (failure.get("tool") orelse return "tool_failed") {
+        .string => |value| value,
+        else => return "tool_failed",
+    };
+    if (!std.mem.eql(u8, tool, "shell")) return "tool_failed";
+    const code = switch (failure.get("code") orelse return "tool_failed") {
+        .string => |value| value,
+        else => return "tool_failed",
+    };
+    if (!safe_error_code(code)) return "tool_failed";
+    return code;
+}
+
+fn safe_error_code(code: []const u8) bool {
+    if (code.len == 0 or code.len > 64) return false;
+    for (code) |byte| {
+        if (!std.ascii.isAlphanumeric(byte) and byte != '_' and byte != '-') return false;
+    }
+    return true;
+}
+
+fn json_bool(object: std.json.ObjectMap, name: []const u8) bool {
+    return switch (object.get(name) orelse return false) {
+        .bool => |value| value,
+        else => false,
+    };
+}
+
+fn json_has_value(object: std.json.ObjectMap, name: []const u8) bool {
+    return switch (object.get(name) orelse return false) {
+        .null => false,
+        else => true,
+    };
+}
+
+fn json_nonzero_int(object: std.json.ObjectMap, name: []const u8) bool {
+    return switch (object.get(name) orelse return false) {
+        .integer => |value| value != 0,
+        else => false,
+    };
 }
 
 fn questionTextForAskCall(alloc: Allocator, call: ToolCall) !?[]u8 {
@@ -3611,6 +3788,21 @@ fn renderFinalJsonResult(alloc: Allocator, result: PromptRunResult) ![]u8 {
         try std.json.Stringify.value(tc.name, .{}, &out.writer);
         try out.writer.writeAll(",\"status\":");
         try std.json.Stringify.value(tc.status, .{}, &out.writer);
+        if (tc.action) |action| {
+            try out.writer.writeAll(",\"action\":");
+            try std.json.Stringify.value(@tagName(action), .{}, &out.writer);
+        }
+        if (tc.error_category) |category| {
+            try out.writer.writeAll(",\"error\":{\"category\":");
+            try std.json.Stringify.value(@tagName(category), .{}, &out.writer);
+            try out.writer.writeAll(",\"code\":");
+            try std.json.Stringify.value(
+                tc.error_code orelse "tool_failed",
+                .{},
+                &out.writer,
+            );
+            try out.writer.writeByte('}');
+        }
         if (tc.command_result_json) |json| {
             try out.writer.writeAll(",\"command_result\":");
             try out.writer.writeAll(json);
@@ -8060,6 +8252,129 @@ test "fx ask JSON records permission-denied tool calls as error status" {
     );
 }
 
+test "fx ask JSON preserves shell action and runtime error identity" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io_mod.getIo(), "workspace");
+    const root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "workspace");
+    defer alloc.free(root);
+
+    var ctx = AskContext.init(alloc, testConfig(), .{
+        .context_registry = test_no_context_registry,
+        .tool_set = builtin_tools.advertisement_set,
+        .load_mcp_runtime = testNoMcpRuntime,
+    }, root);
+    defer ctx.deinit();
+    ctx.output_mode = .json;
+
+    captureToolExecutionError(&ctx, .{
+        .call_allocator = alloc,
+        .result_allocator = alloc,
+        .call = .{
+            .id = "shell-runtime-error",
+            .name = "shell",
+            .arguments_json = "{\"action\":\"interact\",\"session_id\":\"shell-missing\"}",
+        },
+        .authority = .ordinary,
+        .session_grants = &.{},
+        .advertised_dynamic_tool_names = &.{},
+        .max_tool_result_bytes = 4096,
+    }, error.ExecutionNotFound);
+
+    const records = try takeToolCallRecords(&ctx, alloc);
+    const result = PromptRunResult{
+        .exit_code = 1,
+        .assistant_output = try alloc.dupe(u8, ""),
+        .tool_calls = records,
+    };
+    defer result.deinit(alloc);
+    const rendered = try renderFinalJsonResult(alloc, result);
+    defer alloc.free(rendered);
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, rendered, .{});
+    defer parsed.deinit();
+    const record = parsed.value.object.get("tool_calls").?.array.items[0].object;
+    const action = record.get("action") orelse return error.TestExpectedEqual;
+    try std.testing.expectEqualStrings("interact", action.string);
+    const failure = (record.get("error") orelse return error.TestExpectedEqual).object;
+    try std.testing.expectEqualStrings("runtime_failed", failure.get("category").?.string);
+    try std.testing.expectEqualStrings("ExecutionNotFound", failure.get("code").?.string);
+}
+
+test "shell diagnostic action projection accepts only current actions" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const cases = [_]struct {
+        arguments_json: []const u8,
+        expected: ShellAction,
+    }{
+        .{ .arguments_json = "{\"action\":\"run\"}", .expected = .run },
+        .{ .arguments_json = "{\"action\":\"interact\"}", .expected = .interact },
+        .{ .arguments_json = "{\"request\":{\"action\":\"stop\"}}", .expected = .stop },
+    };
+    for (cases) |case| {
+        try std.testing.expectEqual(
+            case.expected,
+            shell_action_for_call(arena, .{
+                .id = "shell-action",
+                .name = "shell",
+                .arguments_json = case.arguments_json,
+            }).?,
+        );
+    }
+    try std.testing.expect(shell_action_for_call(arena, .{
+        .id = "shell-action-invalid",
+        .name = "shell",
+        .arguments_json = "{\"action\":\"legacy\"}",
+    }) == null);
+}
+
+test "shell diagnostic codes remain bounded semantic identifiers" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    try std.testing.expectEqualStrings(
+        "termination_indeterminate",
+        shell_failure_code(arena, .command_failed, .{
+            .status = .failure,
+            .model_output = "failure",
+            .command_result_json = "{\"termination_indeterminate\":true}",
+        }),
+    );
+    try std.testing.expectEqualStrings(
+        "nonzero_exit",
+        shell_failure_code(arena, .command_failed, .{
+            .status = .failure,
+            .model_output = "failure",
+            .command_result_json = "{\"exit_code\":7}",
+        }),
+    );
+    try std.testing.expectEqualStrings(
+        "command_failed",
+        shell_failure_code(arena, .command_failed, .{
+            .status = .failure,
+            .model_output = "failure",
+            .command_result_json = "{\"exit_code\":0}",
+        }),
+    );
+    try std.testing.expectEqualStrings(
+        "ExecutionNotFound",
+        shell_failure_code(arena, .tool_failed, .{
+            .status = .failure,
+            .model_output = "{\"error\":{\"tool\":\"shell\",\"code\":\"ExecutionNotFound\"}}",
+        }),
+    );
+    try std.testing.expectEqualStrings(
+        "tool_failed",
+        shell_failure_code(arena, .tool_failed, .{
+            .status = .failure,
+            .model_output = "{\"error\":{\"tool\":\"shell\",\"code\":\"secret value\"}}",
+        }),
+    );
+}
+
 test "fx ask JSON permission-denied capture is best effort under allocation failure" {
     var failing = std.testing.FailingAllocator.init(
         std.testing.allocator,
@@ -8202,6 +8517,8 @@ fn checkAskJsonCaptureAllocationFailures(alloc: Allocator) !void {
             .model_output = "contents",
             .command_result_json = "{\"ok\":true}",
         },
+        null,
+        null,
     );
 
     const result = try takePromptRunResult(&ctx, alloc);
@@ -8283,6 +8600,8 @@ test "fx ask JSON clips ask_user_question text at a UTF-8 boundary" {
             .arguments_json = arguments_json,
         },
         "success",
+        null,
+        null,
         null,
     );
 

--- a/src/core/execution/command_runner.zig
+++ b/src/core/execution/command_runner.zig
@@ -344,20 +344,13 @@ const ChildWaiter = struct {
         future.await(self.io);
     }
 
-    fn cancel(self: *ChildWaiter) !std.process.Child.Term {
-        if (self.isReady()) return self.awaitReady();
-        var future = &self.future.?;
-        future.cancel(self.io);
-        return try self.result;
-    }
-
     fn abort(self: *ChildWaiter, pid: std.posix.pid_t) void {
         if (self.isReady()) {
             self.awaitDiscard();
             return;
         }
         signalProcess(pid, std.posix.SIG.KILL) catch {};
-        _ = self.cancel() catch {};
+        self.awaitDiscard();
     }
 };
 
@@ -2328,7 +2321,7 @@ const ProcessObserver = struct {
     ) command_contract.CommandStatus {
         debug_trace.logf(
             "core",
-            "command termination became indeterminate err={s}",
+            "command termination became indeterminate boundary=process_wait err={s}",
             .{@errorName(err)},
         );
         return .indeterminate;
@@ -2369,36 +2362,7 @@ const ProcessObserver = struct {
                 .{@errorName(err)},
             );
         };
-        _ = self.waiter.cancel() catch |err| {
-            debug_trace.logf(
-                "core",
-                "command observer cleanup wait cancelled err={s}",
-                .{@errorName(err)},
-            );
-        };
-    }
-
-    fn settle_after_deadline(
-        self: *ProcessObserver,
-        process_group_id: ?std.posix.pid_t,
-    ) command_contract.CommandStatus {
-        const pid = process_group_id orelse self.process_id;
-        signalProcessGroup(pid, std.posix.SIG.KILL) catch |err| {
-            debug_trace.logf(
-                "core",
-                "command termination deadline cleanup failed err={s}",
-                .{@errorName(err)},
-            );
-        };
-        const term = self.waiter.cancel() catch |err| {
-            debug_trace.logf(
-                "core",
-                "command termination became indeterminate boundary=post_force_wait err={s}",
-                .{@errorName(err)},
-            );
-            return .indeterminate;
-        };
-        return ProcessObserver.statusFromTerm(term);
+        self.waiter.awaitDiscard();
     }
 };
 
@@ -2489,8 +2453,6 @@ fn collectOutput(
                     if (observer.waiter.isReady()) "true" else "false",
                 },
             );
-            const settled_status = observer.settle_after_deadline(process_group_id);
-            if (leader_status.* == null) leader_status.* = settled_status;
             recordOutputDrainFailure(
                 &output_incomplete,
                 "termination_settle_deadline",

--- a/src/core/execution/command_runner.zig
+++ b/src/core/execution/command_runner.zig
@@ -49,6 +49,7 @@ const command_artifact_stdout_suffix = ".stdout.log";
 const command_artifact_stderr_suffix = ".stderr.log";
 const pending_output_flush_bytes: usize = 4096;
 const command_output_poll_ms: i64 = 100;
+pub const termination_settle_timeout_ms: i64 = 5_000;
 const supports_foreground_session = builtin.link_libc and
     std.process.can_spawn and
     std.process.can_replace and
@@ -343,13 +344,20 @@ const ChildWaiter = struct {
         future.await(self.io);
     }
 
+    fn cancel(self: *ChildWaiter) !std.process.Child.Term {
+        if (self.isReady()) return self.awaitReady();
+        var future = &self.future.?;
+        future.cancel(self.io);
+        return try self.result;
+    }
+
     fn abort(self: *ChildWaiter, pid: std.posix.pid_t) void {
         if (self.isReady()) {
             self.awaitDiscard();
             return;
         }
         signalProcess(pid, std.posix.SIG.KILL) catch {};
-        self.awaitDiscard();
+        _ = self.cancel() catch {};
     }
 };
 
@@ -1018,13 +1026,16 @@ fn finishCollectedProcess(
     output_incomplete: bool,
     duration_ms: u64,
     source: TerminationSource,
+    preserve_cancelled_status: bool,
 ) !CollectedProcess {
     switch (source) {
         .timed_out => return error.TimeoutExpired,
         .natural => {},
         .cancelled => {
-            if (output.totalBytes() == 0) return error.Cancelled;
-            if (output.artifact == null) {
+            if (!preserve_cancelled_status and output.totalBytes() == 0) {
+                return error.Cancelled;
+            }
+            if (output.totalBytes() != 0 and output.artifact == null) {
                 output.startArtifact() catch |err| {
                     debug_trace.logf("core", "cancelled command artifact promotion failed err={s}", .{@errorName(err)});
                     return error.Cancelled;
@@ -1116,6 +1127,7 @@ fn executeProcessWithInput(
         collected.output_incomplete,
         duration_ms,
         collected.source,
+        cfg.force_cancel_flag != null,
     );
 }
 
@@ -1248,6 +1260,7 @@ fn executeProcessWithDetachedSession(
         collected.output_incomplete,
         duration_ms,
         collected.source,
+        cfg.force_cancel_flag != null,
     );
 }
 
@@ -1396,6 +1409,7 @@ fn executeProcessWithScriptUnisolated(
         collected.output_incomplete,
         duration_ms,
         collected.source,
+        cfg.force_cancel_flag != null,
     );
 }
 
@@ -1820,7 +1834,7 @@ fn commandStatusFromTerm(term: std.process.Child.Term) command_contract.CommandS
     return switch (term) {
         .exited => |code| .{ .exit_code = @intCast(code) },
         .signal => |sig| .{ .signal = @intFromEnum(sig) },
-        else => .finished,
+        .stopped, .unknown => .indeterminate,
     };
 }
 
@@ -2297,7 +2311,16 @@ const ProcessObserver = struct {
             );
             return .indeterminate;
         }
-        return commandStatusFromTerm(term);
+        const status = commandStatusFromTerm(term);
+        switch (status) {
+            .indeterminate => debug_trace.logf(
+                "core",
+                "command termination became indeterminate boundary=child_term term={s}",
+                .{@tagName(std.meta.activeTag(term))},
+            ),
+            .exit_code, .signal, .finished => {},
+        }
+        return status;
     }
 
     fn indeterminateStatus(
@@ -2346,9 +2369,49 @@ const ProcessObserver = struct {
                 .{@errorName(err)},
             );
         };
-        self.waiter.awaitDiscard();
+        _ = self.waiter.cancel() catch |err| {
+            debug_trace.logf(
+                "core",
+                "command observer cleanup wait cancelled err={s}",
+                .{@errorName(err)},
+            );
+        };
+    }
+
+    fn settle_after_deadline(
+        self: *ProcessObserver,
+        process_group_id: ?std.posix.pid_t,
+    ) command_contract.CommandStatus {
+        const pid = process_group_id orelse self.process_id;
+        signalProcessGroup(pid, std.posix.SIG.KILL) catch |err| {
+            debug_trace.logf(
+                "core",
+                "command termination deadline cleanup failed err={s}",
+                .{@errorName(err)},
+            );
+        };
+        const term = self.waiter.cancel() catch |err| {
+            debug_trace.logf(
+                "core",
+                "command termination became indeterminate boundary=post_force_wait err={s}",
+                .{@errorName(err)},
+            );
+            return .indeterminate;
+        };
+        return ProcessObserver.statusFromTerm(term);
     }
 };
+
+fn termination_settle_expired(
+    signal_started_ms: ?i64,
+    force_kill_sent: bool,
+    now_ms: i64,
+) bool {
+    const started_ms = signal_started_ms orelse return false;
+    return force_kill_sent and
+        now_ms >= started_ms and
+        now_ms - started_ms >= termination_settle_timeout_ms;
+}
 
 fn collectOutput(
     arena: Allocator,
@@ -2410,6 +2473,30 @@ fn collectOutput(
                     }
                 }
             }
+        }
+
+        const now_ms = io_mod.milliTimestamp();
+        if (termination_settle_expired(
+            signal_started_ms,
+            force_kill_sent,
+            now_ms,
+        )) {
+            debug_trace.logf(
+                "core",
+                "command termination settlement expired boundary=post_force source={s} wait_ready={s}",
+                .{
+                    @tagName(source.*),
+                    if (observer.waiter.isReady()) "true" else "false",
+                },
+            );
+            const settled_status = observer.settle_after_deadline(process_group_id);
+            if (leader_status.* == null) leader_status.* = settled_status;
+            recordOutputDrainFailure(
+                &output_incomplete,
+                "termination_settle_deadline",
+                error.Timeout,
+            );
+            break;
         }
 
         if (streams_finished) {
@@ -2824,7 +2911,11 @@ test "format output covers stdout stderr empty signal and unknown statuses" {
 
     const none = try formatOutput(std.testing.allocator, "cmd", "/tmp", .{ .unknown = 9 }, "", "", null);
     defer std.testing.allocator.free(none.output);
-    try std.testing.expectEqualStrings("process finished\n(no output)\n", none.output);
+    try std.testing.expect(std.mem.find(
+        u8,
+        none.output,
+        "termination_indeterminate=true\n",
+    ) != null);
 
     const signaled = try formatOutput(std.testing.allocator, "cmd", "/tmp", .{ .signal = .TERM }, "", "", null);
     defer std.testing.allocator.free(signaled.output);
@@ -4297,6 +4388,24 @@ test "termination result follows the delivered signal source" {
     try std.testing.expectEqual(
         TerminationSource.cancelled,
         reconcileForegroundTerminationSource(.cancelled, 1700, 2000),
+    );
+}
+
+test "forced termination settlement expires only after its deadline" {
+    try std.testing.expect(!termination_settle_expired(null, true, 10_000));
+    try std.testing.expect(!termination_settle_expired(5_000, false, 10_000));
+    try std.testing.expect(!termination_settle_expired(5_000, true, 9_999));
+    try std.testing.expect(termination_settle_expired(5_000, true, 10_000));
+}
+
+test "nonterminal child terms remain indeterminate" {
+    try std.testing.expectEqual(
+        command_contract.CommandStatus.indeterminate,
+        commandStatusFromTerm(.{ .unknown = 0 }),
+    );
+    try std.testing.expectEqual(
+        command_contract.CommandStatus.indeterminate,
+        commandStatusFromTerm(.{ .stopped = std.posix.SIG.STOP }),
     );
 }
 

--- a/src/core/execution/managed_execution.zig
+++ b/src/core/execution/managed_execution.zig
@@ -450,10 +450,7 @@ const Entry = struct {
                 "managed execution became lost boundary=worker_route execution_id={s} err={s}",
                 .{ self.execution_id, @errorName(err) },
             );
-            self.state = if (err == error.Cancelled or err == error.TimeoutExpired)
-                .{ .stopped = null }
-            else
-                .lost;
+            self.state = state_for_worker_error(err);
             self.barrier.output_drained = true;
             self.mutex.unlock(zio);
             return;
@@ -1514,6 +1511,28 @@ fn statusFromResult(
     if (command.exit_code) |code| return .{ .exit_code = code };
     if (command.signal) |signal| return .{ .signal = signal };
     return .finished;
+}
+
+fn state_for_worker_error(err: anyerror) contract.State {
+    return if (err == error.TimeoutExpired)
+        .{ .stopped = null }
+    else
+        .lost;
+}
+
+test "worker errors do not turn ambiguous cancellation into success" {
+    try std.testing.expectEqual(
+        contract.State.lost,
+        state_for_worker_error(error.Cancelled),
+    );
+    try std.testing.expectEqual(
+        contract.State{ .stopped = null },
+        state_for_worker_error(error.TimeoutExpired),
+    );
+    try std.testing.expectEqual(
+        contract.State.lost,
+        state_for_worker_error(error.Unexpected),
+    );
 }
 
 fn stop_wait_expired(started_ms: i64, now_ms: i64, settle_timeout_ms: i64) bool {

--- a/src/core/execution/managed_execution.zig
+++ b/src/core/execution/managed_execution.zig
@@ -14,6 +14,10 @@ const session_child_store = @import("../session/session_child_store.zig");
 
 const Allocator = std.mem.Allocator;
 const max_entries = contract.max_live_entries + contract.max_tombstones;
+const captured_stop_settle_timeout_ms: i64 = if (builtin.is_test)
+    100
+else
+    command_runner.termination_settle_timeout_ms + 1_000;
 
 pub const StartCapturedInput = struct {
     execution_id: []const u8,
@@ -441,6 +445,11 @@ const Entry = struct {
             self.mutex.lockUncancelable(zio);
             self.finalizeReplayLocked();
             self.error_name = @errorName(err);
+            debug_trace.logf(
+                "core",
+                "managed execution became lost boundary=worker_route execution_id={s} err={s}",
+                .{ self.execution_id, @errorName(err) },
+            );
             self.state = if (err == error.Cancelled or err == error.TimeoutExpired)
                 .{ .stopped = null }
             else
@@ -450,7 +459,7 @@ const Entry = struct {
             return;
         };
 
-        const status = statusFromResult(routed.result);
+        const status = statusFromResult(self.execution_id, routed.result);
         const zio = io_mod.getIo();
         self.mutex.lockUncancelable(zio);
         self.finalizeReplayLocked();
@@ -880,6 +889,21 @@ pub const Runtime = struct {
         execution_id: []const u8,
         force: bool,
     ) !PreparedSnapshot {
+        return self.stop_with_ceiling(
+            alloc,
+            execution_id,
+            force,
+            captured_stop_settle_timeout_ms,
+        );
+    }
+
+    fn stop_with_ceiling(
+        self: *Runtime,
+        alloc: Allocator,
+        execution_id: []const u8,
+        force: bool,
+        settle_timeout_ms: i64,
+    ) !PreparedSnapshot {
         const entry = self.acquireEntry(execution_id) orelse return error.ExecutionNotFound;
         defer self.releaseEntry(entry);
         const zio = io_mod.getIo();
@@ -899,11 +923,31 @@ pub const Runtime = struct {
             }
         }
         entry.mutex.unlock(zio);
+        const started_ms = io_mod.milliTimestamp();
         while (true) {
             entry.mutex.lockUncancelable(zio);
             const terminal = entry.isTerminal();
             entry.mutex.unlock(zio);
             if (terminal) break;
+            const now_ms = io_mod.milliTimestamp();
+            if (stop_wait_expired(started_ms, now_ms, settle_timeout_ms)) {
+                debug_trace.logf(
+                    "core",
+                    "managed execution stop became lost boundary=settle_deadline execution_id={s} force={s}",
+                    .{ execution_id, if (force) "true" else "false" },
+                );
+                var prepared = try self.prepareSnapshotForEntry(alloc, entry);
+                if (prepared.snapshot.state == .running) {
+                    prepared.snapshot.state = .lost;
+                    prepared.snapshot.output_incomplete = true;
+                    if (prepared.snapshot.error_name) |name| alloc.free(name);
+                    prepared.snapshot.error_name = try alloc.dupe(
+                        u8,
+                        "StopSettlementTimedOut",
+                    );
+                }
+                return prepared;
+            }
             io_mod.sleep(10 * std.time.ns_per_ms);
         }
         return self.prepareSnapshotForEntry(alloc, entry);
@@ -1447,12 +1491,40 @@ fn rebindAuthority(
     };
 }
 
-fn statusFromResult(result: command_contract.RunCommandResult) command_contract.CommandStatus {
-    const command = result.command_result orelse return .finished;
-    if (command.termination_indeterminate) return .indeterminate;
+fn statusFromResult(
+    execution_id: []const u8,
+    result: command_contract.RunCommandResult,
+) command_contract.CommandStatus {
+    const command = result.command_result orelse {
+        debug_trace.logf(
+            "core",
+            "managed execution termination indeterminate boundary=missing_command_result execution_id={s}",
+            .{execution_id},
+        );
+        return .indeterminate;
+    };
+    if (command.termination_indeterminate) {
+        debug_trace.logf(
+            "core",
+            "managed execution termination indeterminate boundary=command_result execution_id={s}",
+            .{execution_id},
+        );
+        return .indeterminate;
+    }
     if (command.exit_code) |code| return .{ .exit_code = code };
     if (command.signal) |signal| return .{ .signal = signal };
     return .finished;
+}
+
+fn stop_wait_expired(started_ms: i64, now_ms: i64, settle_timeout_ms: i64) bool {
+    return now_ms >= started_ms and
+        now_ms - started_ms >= settle_timeout_ms;
+}
+
+test "stop wait expires only at its deterministic bound" {
+    try std.testing.expect(!stop_wait_expired(1_000, 999, 100));
+    try std.testing.expect(!stop_wait_expired(1_000, 1_099, 100));
+    try std.testing.expect(stop_wait_expired(1_000, 1_100, 100));
 }
 
 fn contractStateFromSnapshot(state: SnapshotState) contract.State {
@@ -1514,6 +1586,100 @@ test "captured managed execution yields one handle and delivers ordered output o
     defer repeated.deinit(alloc);
     try std.testing.expectEqual(@as(usize, 0), repeated.snapshot.output_delta.len);
     try runtime.commitDelivery(repeated.snapshot.execution_id, repeated.reservation_id);
+}
+
+test "captured stop returns lost when its worker cannot settle" {
+    if (comptime builtin.os.tag == .wasi) return;
+    const alloc = std.testing.allocator;
+    var runtime = Runtime.init(alloc);
+    defer runtime.deinit();
+
+    const BlockingOutput = struct {
+        fn append(
+            raw: *anyopaque,
+            _: ?types.ToolLifecycleId,
+            _: command_contract.CommandOutputStream,
+            _: []const u8,
+        ) !void {
+            const flags: *[2]std.atomic.Value(bool) = @ptrCast(@alignCast(raw));
+            flags[0].store(true, .seq_cst);
+            while (!flags[1].load(.seq_cst)) io_mod.sleep(std.time.ns_per_ms);
+        }
+    };
+    var callback_flags = [_]std.atomic.Value(bool){
+        .init(false),
+        .init(false),
+    };
+    var input = StartCapturedInput{
+        .execution_id = "managed-stop-stalled",
+        .command = "printf 'ready\\n'; sleep 30",
+        .cwd = "/tmp",
+        .environment = .legacy,
+        .authority = undefined,
+        .max_output_bytes = 4096,
+        .timeout_ms = null,
+        .command_artifact_dir = null,
+        .yield_time_ms = 0,
+        .output_chunk_ctx = &callback_flags,
+        .on_output_chunk = BlockingOutput.append,
+    };
+    input.authority = testAuthority(input);
+    var started = try runtime.startCaptured(alloc, input);
+    defer started.deinit(alloc);
+    try runtime.commitDelivery(started.snapshot.execution_id, started.reservation_id);
+
+    const callback_deadline_ms = io_mod.milliTimestamp() + 2_000;
+    while (!callback_flags[0].load(.seq_cst) and
+        io_mod.milliTimestamp() < callback_deadline_ms)
+    {
+        io_mod.sleep(std.time.ns_per_ms);
+    }
+    try std.testing.expect(callback_flags[0].load(.seq_cst));
+
+    var stop_finished = std.atomic.Value(bool).init(false);
+    var stop_lost = std.atomic.Value(bool).init(false);
+    var stop_failed = std.atomic.Value(bool).init(false);
+    const StopTask = struct {
+        fn run(
+            rt: *Runtime,
+            finished: *std.atomic.Value(bool),
+            lost: *std.atomic.Value(bool),
+            failed: *std.atomic.Value(bool),
+        ) void {
+            var stopped = rt.stop(std.testing.allocator, "managed-stop-stalled", true) catch {
+                failed.store(true, .seq_cst);
+                finished.store(true, .seq_cst);
+                return;
+            };
+            lost.store(
+                stopped.snapshot.state == .lost and
+                    stopped.snapshot.output_incomplete and
+                    if (stopped.snapshot.error_name) |name|
+                        std.mem.eql(u8, name, "StopSettlementTimedOut")
+                    else
+                        false,
+                .seq_cst,
+            );
+            rt.commitDelivery(stopped.snapshot.execution_id, stopped.reservation_id) catch {
+                failed.store(true, .seq_cst);
+            };
+            stopped.deinit(std.testing.allocator);
+            finished.store(true, .seq_cst);
+        }
+    };
+    const stop_thread = try std.Thread.spawn(
+        .{},
+        StopTask.run,
+        .{ &runtime, &stop_finished, &stop_lost, &stop_failed },
+    );
+    io_mod.sleep(250 * std.time.ns_per_ms);
+    const settled_before_release = stop_finished.load(.seq_cst);
+    callback_flags[1].store(true, .seq_cst);
+    stop_thread.join();
+
+    try std.testing.expect(settled_before_release);
+    try std.testing.expect(stop_lost.load(.seq_cst));
+    try std.testing.expect(!stop_failed.load(.seq_cst));
 }
 
 test "generated captured execution identities do not depend on provider call ids" {

--- a/src/tools/shell/shell.zig
+++ b/src/tools/shell/shell.zig
@@ -1163,7 +1163,11 @@ fn finishPrepared(
     handoffPreparedDelivery(ctx, runtime, prepared.reservation_id) catch {
         return .{ .failure = try ctx.allocator.dupe(u8, "shell result commit failed") };
     };
-    return if (action == .command and snapshotFailed(prepared.snapshot))
+    const failed = switch (action) {
+        .command => snapshotFailed(prepared.snapshot),
+        .stop => stop_result_failed(prepared.snapshot.state),
+    };
+    return if (failed)
         .{ .failure = body }
     else
         .{ .success = body };
@@ -1468,6 +1472,24 @@ fn snapshotFailed(snapshot: managed_execution.Snapshot) bool {
         },
         .stopped, .lost => true,
     };
+}
+
+fn stop_result_failed(state: managed_execution.SnapshotState) bool {
+    return switch (state) {
+        .lost => true,
+        .stopped => |status| if (status) |value| switch (value) {
+            .indeterminate => true,
+            .exit_code, .signal, .finished => false,
+        } else false,
+        .running, .completed => false,
+    };
+}
+
+test "shell stop fails closed only for lost or indeterminate outcomes" {
+    try std.testing.expect(stop_result_failed(.lost));
+    try std.testing.expect(stop_result_failed(.{ .stopped = .indeterminate }));
+    try std.testing.expect(!stop_result_failed(.{ .stopped = .{ .signal = 9 } }));
+    try std.testing.expect(!stop_result_failed(.{ .completed = .{ .exit_code = 0 } }));
 }
 
 fn runtimeFailure(

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -3080,6 +3080,8 @@ describe("gateway stream lifecycle", () => {
         tool_calls: Array<{
           name: string;
           status: string;
+          action?: string;
+          error?: { category?: string; code?: string };
           command_result?: { termination_indeterminate?: boolean };
         }>;
       };
@@ -3099,6 +3101,11 @@ describe("gateway stream lifecycle", () => {
       expect(json.tool_calls[0]).toMatchObject({
         name: "shell",
         status: "error",
+        action: "run",
+        error: {
+          category: "command_failed",
+          code: "termination_indeterminate",
+        },
         command_result: { termination_indeterminate: true },
       });
       expect(readFileSync(tracePath, "utf8")).toContain(
@@ -3185,6 +3192,60 @@ describe("gateway stream lifecycle", () => {
       expect(readFileSync(tracePath, "utf8")).toContain(
         "command output drain incomplete reason=injected_after_exit",
       );
+      expect(result.stderr).not.toContain("Unexpected");
+      expect(result.stderr).not.toContain("error.Unexpected");
+    } finally {
+      gateway.stop();
+      rmSync(root.root, { recursive: true, force: true });
+    }
+  });
+
+  test("shell runtime failure keeps action and typed JSON diagnostics", async () => {
+    const root = createFixtureRoot("shell-runtime-diagnostic");
+    const tracePath = join(root.root, "trace.log");
+    const callId = "shell_runtime_diagnostic_1";
+    let step = 0;
+    const gateway = startGateway(() => {
+      switch (step++) {
+        case 0:
+          return fakeGatewayToolCall(callId, "shell", {
+            request: {
+              action: "interact",
+              session_id: "shell-missing",
+            },
+          });
+        case 1:
+          return fakeGatewayFinalText("Shell failure recorded.");
+        default:
+          return new Response("unexpected request", { status: 500 });
+      }
+    });
+
+    try {
+      const result = await runFx(
+        ["ask", "--json", "--yolo", "--no-save", "Observe the missing shell handle."],
+        {
+          cwd: root.workspace,
+          env: fixtureEnv(root, gateway, tracePath),
+          timeoutMs: 15_000,
+        },
+      );
+      const json = JSON.parse(result.stdout) as {
+        tool_calls: Array<Record<string, unknown>>;
+      };
+
+      expect(result.code).toBe(0);
+      expect(gateway.requestCount()).toBe(2);
+      expect(json.tool_calls).toHaveLength(1);
+      expect(json.tool_calls[0]).toMatchObject({
+        name: "shell",
+        status: "error",
+        action: "interact",
+        error: {
+          category: "tool_failed",
+          code: "ExecutionNotFound",
+        },
+      });
       expect(result.stderr).not.toContain("Unexpected");
       expect(result.stderr).not.toContain("error.Unexpected");
     } finally {

--- a/tests/e2e/permission-errors.test.ts
+++ b/tests/e2e/permission-errors.test.ts
@@ -206,7 +206,15 @@ describe("generic permission typed errors", () => {
         });
         const json = parseFxJson(result);
         expect(result.stderr).toBe('Running touch "./denied-marker.txt"\n');
-        expect(json.tool_calls).toContainEqual({ name: "shell", status: "error" });
+        expect(json.tool_calls).toContainEqual({
+          name: "shell",
+          status: "error",
+          action: "run",
+          error: {
+            category: "rejected",
+            code: "rejected",
+          },
+        });
         expect(existsSync(marker)).toBe(false);
         expect(gateway.requests).toHaveLength(2);
 

--- a/tests/e2e/tui-terminal-tool.test.ts
+++ b/tests/e2e/tui-terminal-tool.test.ts
@@ -305,6 +305,76 @@ test.skipIf(!tmuxAvailable())(
 );
 
 test.skipIf(!tmuxAvailable())(
+  "force stop settles a stubborn captured command and permits later work",
+  async () => {
+    const fixture = createFixture("fx-shell-force-stop-");
+    const pidPath = join(fixture.workspace, "stubborn.pid");
+    let sessionId = "";
+    const gateway = startFakeGateway([
+      fakeGatewayToolCall("shell_stubborn_run", "shell", {
+        request: {
+          action: "run",
+          command: `printf '%s' "$$" > ${JSON.stringify(pidPath)}; trap '' TERM; while :; do sleep 1; done`,
+          profile: "clean",
+          yield_time_ms: 0,
+        },
+      }),
+      (body) => {
+        sessionId = findSessionId(JSON.parse(body)) ?? "";
+        if (!sessionId) return new Response("missing session id", { status: 500 });
+        return fakeGatewayToolCall("shell_stubborn_stop", "shell", {
+          request: {
+            action: "stop",
+            session_id: sessionId,
+            force: true,
+          },
+        });
+      },
+      fakeGatewayToolCall("shell_after_stop", "shell", {
+        request: {
+          action: "run",
+          command: "printf AFTER_STOP",
+          profile: "clean",
+        },
+      }),
+      fakeGatewayFinalText("SHELL_FORCE_STOP_OK"),
+    ]);
+    gateways.push(gateway);
+    const active = await launch(fixture, gateway);
+    await active.sendText("Force-stop the stubborn command, then run the follow-up command.");
+    await active.sendKeys("Enter");
+    await active.waitForText("SHELL_FORCE_STOP_OK", TIMEOUT);
+
+    expect(sessionId.length).toBeGreaterThan(0);
+    const stopResult = toolResultEnvelope(
+      gateway.requests[2]!.body,
+      "shell_stubborn_stop",
+    );
+    expect(stopResult).toContain('\\"state\\":\\"stopped\\"');
+    expect(stopResult).toContain('\\"termination_indeterminate\\":false');
+    expect(toolResultEnvelope(
+      gateway.requests[3]!.body,
+      "shell_after_stop",
+    )).toContain("AFTER_STOP");
+    await waitForFile(pidPath);
+    const pid = Number(readFileSync(pidPath, "utf8"));
+    expect(Number.isSafeInteger(pid) && pid > 0).toBe(true);
+    const deadline = Date.now() + 3_000;
+    while (Date.now() < deadline) {
+      try {
+        process.kill(pid, 0);
+      } catch {
+        break;
+      }
+      await Bun.sleep(25);
+    }
+    expect(() => process.kill(pid, 0)).toThrow();
+    expect(readFileSync(fixture.stderrPath, "utf8")).toBe("");
+  },
+  TIMEOUT,
+);
+
+test.skipIf(!tmuxAvailable())(
   "reused provider call ids start distinct captured commands",
   async () => {
     const fixture = createFixture("fx-shell-reused-call-id-");


### PR DESCRIPTION
## Summary

- Bound force-stopping captured shell commands and return an indeterminate result when termination cannot be confirmed.
- Preserve observed exit and signal status through managed cancellation.
- Trace each managed lost or indeterminate transition with its causal boundary.
- Include failed shell action, error category, and bounded error code in `fx ask --json`.
- Preserve command metadata and captured output when shell execution becomes indeterminate.