### PR TITLE
Preserve new sessions during cache contention

### DIFF
--- a/src/core/session/session_log.zig
+++ b/src/core/session/session_log.zig
@@ -458,6 +458,23 @@ pub const CommitLifecycle = struct {
         }
     }
 
+    fn prepareRequired(
+        self: *CommitLifecycle,
+        alloc: Allocator,
+        session_id: []const u8,
+        workspace_root: []const u8,
+        commit_lock_deadline_ms: u64,
+    ) !bool {
+        try self.prepare(
+            alloc,
+            session_id,
+            workspace_root,
+            workspace_root,
+            commit_lock_deadline_ms,
+        );
+        return false;
+    }
+
     fn prepareOpportunistic(
         self: *CommitLifecycle,
         alloc: Allocator,
@@ -1184,14 +1201,23 @@ pub const Root = struct {
         };
         var writable_owned = true;
         errdefer if (writable_owned) writable.deinit(alloc);
+        var cache_deferred = false;
         if (lifecycle_value) |*value| {
-            value.prepare(
-                alloc,
-                initial_state.id,
-                initial_state.workspace_root,
-                initial_state.workspace_root,
-                options.commit_lock_deadline_ms,
-            ) catch |err| {
+            const preparation = if (initial_state.history.len == 0)
+                value.prepareOpportunistic(
+                    alloc,
+                    initial_state.id,
+                    initial_state.workspace_root,
+                    options.commit_lock_deadline_ms,
+                )
+            else
+                value.prepareRequired(
+                    alloc,
+                    initial_state.id,
+                    initial_state.workspace_root,
+                    options.commit_lock_deadline_ms,
+                );
+            cache_deferred = preparation catch |err| {
                 writable.deinit(alloc);
                 writable_owned = false;
                 sessions.dir.deleteTree(io_mod.getIo(), initial_state.id) catch |cleanup_err| {
@@ -1220,11 +1246,38 @@ pub const Root = struct {
             options,
         );
         writable_owned = false;
-        errdefer created.deinit(alloc);
+        var created_owned = true;
+        errdefer if (created_owned) created.deinit(alloc);
         if (lifecycle_value) |value| {
             try created.installCommitLifecycle(value);
             lifecycle_value = null;
-            if (!created.publishCommitLifecycle(alloc)) {
+            if (cache_deferred) {
+                created.writeDeferredCommitLifecycle(
+                    alloc,
+                    created.position,
+                ) catch |err| {
+                    created.deinit(alloc);
+                    created_owned = false;
+                    sessions.dir.deleteTree(io_mod.getIo(), initial_state.id) catch |cleanup_err| {
+                        debug_trace.logf(
+                            "session",
+                            "event=deferred_session_cleanup_failed err={s}",
+                            .{@errorName(cleanup_err)},
+                        );
+                        return cleanup_err;
+                    };
+                    io_mod.syncVerifiedDir(sessions.dir) catch |cleanup_err| {
+                        debug_trace.logf(
+                            "session",
+                            "event=deferred_session_cleanup_sync_failed err={s}",
+                            .{@errorName(cleanup_err)},
+                        );
+                        return cleanup_err;
+                    };
+                    return err;
+                };
+                created.state_replacement_pending = true;
+            } else if (!created.publishCommitLifecycle(alloc)) {
                 created.state_replacement_pending = true;
             }
         }

--- a/src/core/session/session_store.zig
+++ b/src/core/session/session_store.zig
@@ -8106,13 +8106,13 @@ test "migration and recovery replacements keep latest cache contention strict" {
     }
 }
 
-test "session creation keeps latest cache contention strict" {
+test "empty session creation survives latest cache contention" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     var ctx = try initTempStore(alloc, &tmp);
     defer ctx.deinit(alloc);
-    var state = try testDurableState(alloc, "strict-creation-cache-lock", ctx.workspace);
+    var state = try testDurableState(alloc, "contended-empty-session", ctx.workspace);
     defer state.deinit(alloc);
 
     var sessions = ctx.store.canonical_root.sessions orelse return error.TestExpectedEqual;
@@ -8121,19 +8121,56 @@ test "session creation keeps latest cache contention strict" {
         latest_sessions_lock_file,
         2000,
     );
-    defer latest_lock.release();
+    var latest_lock_held = true;
+    defer if (latest_lock_held) latest_lock.release();
+
+    var loaded = try ctx.store.startWritableSessionWithOptions(
+        alloc,
+        state,
+        .{ .commit_lock_deadline_ms = 0 },
+    );
+    var loaded_open = true;
+    defer if (loaded_open) loaded.deinit(alloc);
+    if (!loaded.state_replacement_pending) return error.ExpectedDeferredCreation;
+    if (loaded.state.history.len != 0) return error.ExpectedEmptyCreatedSession;
+    var readable = try ctx.store.loadReadOnly(alloc, state.id);
+    defer readable.deinit(alloc);
+    if (readable.history.len != 0) return error.ExpectedReadableEmptySession;
     try std.testing.expectError(
-        error.SessionCommitBoundaryUnavailable,
-        ctx.store.startWritableSessionWithOptions(
-            alloc,
-            state,
-            .{ .commit_lock_deadline_ms = 0 },
-        ),
+        error.InvalidSessionIndex,
+        readLatestPointer(ctx.store, alloc, ctx.workspace),
     );
     try std.testing.expectError(
-        error.SessionNotFound,
-        ctx.store.openSessionDir(state.id),
+        error.InvalidSessionIndex,
+        readSessionIndex(alloc, &sessions),
     );
+    var initial_token = (try summary_codec.readDeferredCacheToken(
+        alloc,
+        &sessions,
+        state.id,
+    )) orelse return error.TestExpectedEqual;
+    if (!std.meta.eql(loaded.position, initial_token.position)) return error.ExpectedInitialDeferredPosition;
+    initial_token.deinit(alloc);
+
+    const committed = try loaded.appendEvent(
+        alloc,
+        .{ .preferences_changed = .{ .fast_mode = true } },
+        20,
+        .retry_expected_tail,
+        .{ .commit_lock_deadline_ms = 0 },
+    );
+    var token = (try summary_codec.readDeferredCacheToken(
+        alloc,
+        &sessions,
+        state.id,
+    )) orelse return error.TestExpectedEqual;
+    defer token.deinit(alloc);
+    if (!std.meta.eql(committed, token.position)) return error.ExpectedAdvancedDeferredPosition;
+
+    latest_lock.release();
+    latest_lock_held = false;
+    loaded.deinit(alloc);
+    loaded_open = false;
 }
 
 test "read-only session page replays canonical state for a deferred token" {

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -4211,9 +4211,11 @@ describe("cli: ask success", () => {
       const gateway = startFakeGateway([
         fakeGatewayFinalText(unrelatedReply),
         fakeGatewayFinalText("first saved turn"),
+        fakeGatewayFinalText("created during contention"),
         fakeGatewayFinalText("contended exact turn"),
         fakeGatewayFinalText("contended latest turn"),
         fakeGatewayFinalText("repairing turn"),
+        fakeGatewayFinalText("repaired created turn"),
       ]);
       let lockHolder: ReturnType<typeof Bun.spawn> | null = null;
       try {
@@ -4270,6 +4272,25 @@ describe("cli: ask success", () => {
         }
         expect(existsSync(lockReady)).toBe(true);
 
+        const createdDuringContention = await runFx(
+          ["ask", "--json", "--auto", "Create a saved turn while the cache is busy."],
+          { cwd: workspaceRoot, env, timeoutMs: 60_000 },
+        );
+        expect(createdDuringContention.code).toBe(0);
+        expect(createdDuringContention.stderr).toBe("");
+        const createdDuringContentionJson = JSON.parse(createdDuringContention.stdout);
+        const createdDuringContentionId = createdDuringContentionJson.session_id as string;
+        expect(createdDuringContentionJson.output.trim()).toBe("created during contention");
+        const createdDuringContentionTokenPath = join(
+          home,
+          ".fx",
+          "sessions",
+          "latest",
+          "deferred",
+          createdDuringContentionId,
+        );
+        expect(existsSync(createdDuringContentionTokenPath)).toBe(true);
+
         const exact = await runFx(
           [
             "ask",
@@ -4307,6 +4328,10 @@ describe("cli: ask success", () => {
           history_len: 2,
         });
         expect(listedSessions[1]).toMatchObject({
+          id: createdDuringContentionId,
+          history_len: 1,
+        });
+        expect(listedSessions[2]).toMatchObject({
           id: unrelatedSessionId,
           history_len: 1,
         });
@@ -4347,6 +4372,28 @@ describe("cli: ask success", () => {
         expect(repaired.stderr).toBe("");
         expect(JSON.parse(repaired.stdout).output.trim()).toBe("repairing turn");
         expect(existsSync(tokenPath)).toBe(false);
+        const createdDuringContentionDetail = await runFx(
+          ["session", "--id", createdDuringContentionId, "--json"],
+          { cwd: workspaceRoot, env: { HOME: home }, timeoutMs: 60_000 },
+        );
+        expect(createdDuringContentionDetail.code).toBe(0);
+        expect(createdDuringContentionDetail.stderr).toBe("");
+        expect(JSON.parse(createdDuringContentionDetail.stdout).history_len).toBe(1);
+        const repairedCreated = await runFx(
+          [
+            "ask",
+            "--json",
+            "--auto",
+            "--resume-id",
+            createdDuringContentionId,
+            "Repair the newly created session.",
+          ],
+          { cwd: workspaceRoot, env, timeoutMs: 60_000 },
+        );
+        expect(repairedCreated.code).toBe(0);
+        expect(repairedCreated.stderr).toBe("");
+        expect(JSON.parse(repairedCreated.stdout).output.trim()).toBe("repaired created turn");
+        expect(existsSync(createdDuringContentionTokenPath)).toBe(false);
         const targetDetail = await runFx(
           ["session", "--id", sessionId, "--json"],
           { cwd: workspaceRoot, env: { HOME: home }, timeoutMs: 60_000 },
@@ -4361,7 +4408,7 @@ describe("cli: ask success", () => {
         expect(unrelatedDetail.code).toBe(0);
         expect(unrelatedDetail.stderr).toBe("");
         expect(JSON.parse(unrelatedDetail.stdout).history_len).toBe(1);
-        expect(gateway.requests).toHaveLength(5);
+        expect(gateway.requests).toHaveLength(7);
       } finally {
         if (lockHolder) {
           lockHolder.kill();


### PR DESCRIPTION
## Summary

- Keep new conversations durable when another process is updating session discovery state.
- Repair deferred session discovery after cache contention clears.
