### PR TITLE
Reflow completed command summaries

### DIFF
--- a/src/core/app/app_callbacks.zig
+++ b/src/core/app/app_callbacks.zig
@@ -498,6 +498,33 @@ pub fn Bindings(comptime App: type) type {
                 try app.shell.applyToolLifecyclePreservingNormalBufferAnchor(alloc, event)
             else
                 try app.shell.applyToolLifecycle(alloc, event);
+            if (comptime @hasField(App, "workspace_root")) switch (event) {
+                .authoritative_started => |started| if (started.arguments_json) |arguments_json| {
+                    var parsed = std.json.parseFromSlice(std.json.Value, alloc, arguments_json, .{}) catch null;
+                    if (parsed) |*value| {
+                        defer value.deinit();
+                        if (value.value == .object) {
+                            if (value.value.object.get("command")) |command_value| {
+                                if (command_value == .string) {
+                                    const display = tool_presentation.formatRunCommandDetailBounded(
+                                        alloc,
+                                        command_value.string,
+                                        app.workspace_root,
+                                        tool_presentation.max_run_command_reflow_bytes,
+                                    ) catch null;
+                                    defer if (display) |bytes| alloc.free(bytes);
+                                    if (display) |bytes| app.shell.setToolCommandDisplay(
+                                        alloc,
+                                        started.id,
+                                        bytes,
+                                    ) catch {};
+                                }
+                            }
+                        }
+                    }
+                },
+                else => {},
+            };
             return .{
                 .previous_focused_entry_id = previous_focused_entry_id,
                 .snapshot = worker_tool_lifecycle_snapshot(raw_ctx),

--- a/src/core/app/app_callbacks.zig
+++ b/src/core/app/app_callbacks.zig
@@ -517,10 +517,14 @@ pub fn Bindings(comptime App: type) type {
                     if (parsed.value == .object) {
                         if (parsed.value.object.get("command")) |command_value| {
                             if (command_value == .string) {
+                                const workspace_root = if (comptime @hasDecl(App, "workspaceHostInfo"))
+                                    if (app.workspaceHostInfo()) |info| info.root() else app.workspace_root
+                                else
+                                    app.workspace_root;
                                 const display = tool_presentation.formatRunCommandDetailBounded(
                                     alloc,
                                     command_value.string,
-                                    app.workspace_root,
+                                    workspace_root,
                                     tool_presentation.max_run_command_reflow_bytes,
                                 ) catch |err| blk: {
                                     debug_trace.logf(
@@ -531,6 +535,11 @@ pub fn Bindings(comptime App: type) type {
                                     break :blk null;
                                 };
                                 defer if (display) |bytes| alloc.free(bytes);
+                                if (display == null) debug_trace.logf(
+                                    "ui_activity",
+                                    "command display withheld turn_id={d}",
+                                    .{started.id.turn_id},
+                                );
                                 const action_label = tool_presentation.runCommandCompletedActionLabel(
                                     alloc,
                                     app.toolRegistry(),
@@ -547,6 +556,11 @@ pub fn Bindings(comptime App: type) type {
                                     );
                                     break :blk null;
                                 };
+                                if (action_label == null) debug_trace.logf(
+                                    "ui_activity",
+                                    "command action label withheld turn_id={d}",
+                                    .{started.id.turn_id},
+                                );
                                 if (display != null and action_label != null) {
                                     app.shell.setToolCommandMetadata(
                                         alloc,

--- a/src/core/app/app_callbacks.zig
+++ b/src/core/app/app_callbacks.zig
@@ -500,24 +500,64 @@ pub fn Bindings(comptime App: type) type {
                 try app.shell.applyToolLifecycle(alloc, event);
             if (comptime @hasField(App, "workspace_root")) switch (event) {
                 .authoritative_started => |started| if (started.arguments_json) |arguments_json| {
-                    var parsed = std.json.parseFromSlice(std.json.Value, alloc, arguments_json, .{}) catch null;
-                    if (parsed) |*value| {
-                        defer value.deinit();
-                        if (value.value == .object) {
-                            if (value.value.object.get("command")) |command_value| {
-                                if (command_value == .string) {
-                                    const display = tool_presentation.formatRunCommandDetailBounded(
-                                        alloc,
-                                        command_value.string,
-                                        app.workspace_root,
-                                        tool_presentation.max_run_command_reflow_bytes,
-                                    ) catch null;
-                                    defer if (display) |bytes| alloc.free(bytes);
-                                    if (display) |bytes| app.shell.setToolCommandDisplay(
+                    var parsed = std.json.parseFromSlice(std.json.Value, alloc, arguments_json, .{}) catch |err| {
+                        debug_trace.logf(
+                            "ui_activity",
+                            "command metadata parse failed turn_id={d} err={s}",
+                            .{ started.id.turn_id, @errorName(err) },
+                        );
+                        return .{
+                            .previous_focused_entry_id = previous_focused_entry_id,
+                            .snapshot = worker_tool_lifecycle_snapshot(raw_ctx),
+                            .applied_activity_kind = applied_activity_kind,
+                            .terminal_record = null,
+                        };
+                    };
+                    defer parsed.deinit();
+                    if (parsed.value == .object) {
+                        if (parsed.value.object.get("command")) |command_value| {
+                            if (command_value == .string) {
+                                const display = tool_presentation.formatRunCommandDetailBounded(
+                                    alloc,
+                                    command_value.string,
+                                    app.workspace_root,
+                                    tool_presentation.max_run_command_reflow_bytes,
+                                ) catch |err| blk: {
+                                    debug_trace.logf(
+                                        "ui_activity",
+                                        "command display unavailable turn_id={d} err={s}",
+                                        .{ started.id.turn_id, @errorName(err) },
+                                    );
+                                    break :blk null;
+                                };
+                                defer if (display) |bytes| alloc.free(bytes);
+                                const action_label = tool_presentation.runCommandCompletedActionLabel(
+                                    alloc,
+                                    app.toolRegistry(),
+                                    .{
+                                        .id = started.id.call_id,
+                                        .name = started.tool_name,
+                                        .arguments_json = arguments_json,
+                                    },
+                                ) catch |err| blk: {
+                                    debug_trace.logf(
+                                        "ui_activity",
+                                        "command action label unavailable turn_id={d} err={s}",
+                                        .{ started.id.turn_id, @errorName(err) },
+                                    );
+                                    break :blk null;
+                                };
+                                if (display != null and action_label != null) {
+                                    app.shell.setToolCommandMetadata(
                                         alloc,
                                         started.id,
-                                        bytes,
-                                    ) catch {};
+                                        display.?,
+                                        action_label.?,
+                                    ) catch |err| debug_trace.logf(
+                                        "ui_activity",
+                                        "command metadata unavailable turn_id={d} err={s}",
+                                        .{ started.id.turn_id, @errorName(err) },
+                                    );
                                 }
                             }
                         }

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -2000,6 +2000,7 @@ pub fn Runtime(comptime App: type) type {
                 var sink = DetachedHistorySink(@TypeOf(projection)){
                     .app = app,
                     .projection = &projection,
+                    .workspace_root = state.workspace_root,
                 };
                 try writeResumeNotice(app, &sink, display_title, notice);
                 try replayHistoryToSink(app, &sink, state.history);
@@ -3414,6 +3415,7 @@ pub fn Runtime(comptime App: type) type {
             return struct {
                 app: *App,
                 projection: *Projection,
+                workspace_root: []const u8,
 
                 const Self = @This();
 
@@ -3422,7 +3424,14 @@ pub fn Runtime(comptime App: type) type {
                 }
 
                 fn attachCommandDisplay(self: *Self, entry_id: u32, call: types.ToolCall) !void {
-                    var parsed = std.json.parseFromSlice(std.json.Value, self.projection.alloc, call.arguments_json, .{}) catch return;
+                    var parsed = std.json.parseFromSlice(std.json.Value, self.projection.alloc, call.arguments_json, .{}) catch |err| {
+                        debug_trace.logf(
+                            "session",
+                            "historical command metadata parse failed entry_id={d} err={s}",
+                            .{ entry_id, @errorName(err) },
+                        );
+                        return;
+                    };
                     defer parsed.deinit();
                     if (parsed.value != .object) return;
                     const command_value = parsed.value.object.get("command") orelse return;
@@ -3430,11 +3439,38 @@ pub fn Runtime(comptime App: type) type {
                     const display = (tooling_presentation.formatRunCommandDetailBounded(
                         self.projection.alloc,
                         command_value.string,
-                        self.app.workspace_root,
+                        self.workspace_root,
                         tooling_presentation.max_run_command_reflow_bytes,
-                    ) catch null) orelse return;
+                    ) catch |err| blk: {
+                        debug_trace.logf(
+                            "session",
+                            "historical command display unavailable entry_id={d} err={s}",
+                            .{ entry_id, @errorName(err) },
+                        );
+                        break :blk null;
+                    }) orelse return;
                     defer self.projection.alloc.free(display);
-                    self.projection.setHistoricalToolCommandDisplay(entry_id, display) catch {};
+                    const label = tooling_presentation.runCommandCompletedActionLabel(
+                        self.projection.alloc,
+                        self.app.toolRegistry(),
+                        call,
+                    ) catch |err| blk: {
+                        debug_trace.logf(
+                            "session",
+                            "historical command action label unavailable entry_id={d} err={s}",
+                            .{ entry_id, @errorName(err) },
+                        );
+                        break :blk null;
+                    };
+                    if (label) |value| self.projection.setHistoricalToolCommandMetadata(
+                        entry_id,
+                        display,
+                        value,
+                    ) catch |err| debug_trace.logf(
+                        "session",
+                        "historical command metadata unavailable entry_id={d} err={s}",
+                        .{ entry_id, @errorName(err) },
+                    );
                 }
 
                 fn appendNotice(self: *Self, notice: types.SemanticNotice) !void {
@@ -3775,6 +3811,7 @@ pub fn Runtime(comptime App: type) type {
             var sink = DetachedHistorySink(@TypeOf(projection.*)){
                 .app = app,
                 .projection = projection,
+                .workspace_root = app.workspace_root,
             };
             return replayHistoryToSinkIncremental(
                 app,

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -1997,10 +1997,18 @@ pub fn Runtime(comptime App: type) type {
                 const projection_started_ns = io_mod.nanoTimestamp();
                 var projection = try app.beginResumeProjection();
                 defer projection.deinit();
+                const projection_workspace_root = if (std.mem.eql(
+                    u8,
+                    state.origin_workspace_root,
+                    state.workspace_root,
+                ))
+                    state.workspace_root
+                else
+                    "";
                 var sink = DetachedHistorySink(@TypeOf(projection)){
                     .app = app,
                     .projection = &projection,
-                    .workspace_root = state.workspace_root,
+                    .workspace_root = projection_workspace_root,
                 };
                 try writeResumeNotice(app, &sink, display_title, notice);
                 try replayHistoryToSink(app, &sink, state.history);
@@ -3448,7 +3456,14 @@ pub fn Runtime(comptime App: type) type {
                             .{ entry_id, @errorName(err) },
                         );
                         break :blk null;
-                    }) orelse return;
+                    }) orelse {
+                        debug_trace.logf(
+                            "session",
+                            "historical command display withheld entry_id={d}",
+                            .{entry_id},
+                        );
+                        return;
+                    };
                     defer self.projection.alloc.free(display);
                     const label = tooling_presentation.runCommandCompletedActionLabel(
                         self.projection.alloc,
@@ -3462,6 +3477,11 @@ pub fn Runtime(comptime App: type) type {
                         );
                         break :blk null;
                     };
+                    if (label == null) debug_trace.logf(
+                        "session",
+                        "historical command action label withheld entry_id={d}",
+                        .{entry_id},
+                    );
                     if (label) |value| self.projection.setHistoricalToolCommandMetadata(
                         entry_id,
                         display,

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -33,6 +33,7 @@ const legacy_background_migration = @import("../session/legacy_background_migrat
 const result_store = @import("../session/result_store.zig");
 const command_replay_store = @import("../session/command_replay_store.zig");
 const command_output_content = @import("../tooling/command_output_content.zig");
+const tooling_presentation = @import("../tooling/tool_presentation.zig");
 const captured_command = @import("../tooling/captured_command.zig");
 const tool_result_errors = @import("../tooling/tool_result_errors.zig");
 const session_display_metadata = @import("../session/session_display_metadata.zig");
@@ -3420,6 +3421,22 @@ pub fn Runtime(comptime App: type) type {
                     return self.app.historicalToolActivityKind(call);
                 }
 
+                fn attachCommandDisplay(self: *Self, entry_id: u32, call: types.ToolCall) !void {
+                    var parsed = std.json.parseFromSlice(std.json.Value, self.projection.alloc, call.arguments_json, .{}) catch return;
+                    defer parsed.deinit();
+                    if (parsed.value != .object) return;
+                    const command_value = parsed.value.object.get("command") orelse return;
+                    if (command_value != .string) return;
+                    const display = (tooling_presentation.formatRunCommandDetailBounded(
+                        self.projection.alloc,
+                        command_value.string,
+                        self.app.workspace_root,
+                        tooling_presentation.max_run_command_reflow_bytes,
+                    ) catch null) orelse return;
+                    defer self.projection.alloc.free(display);
+                    self.projection.setHistoricalToolCommandDisplay(entry_id, display) catch {};
+                }
+
                 fn appendNotice(self: *Self, notice: types.SemanticNotice) !void {
                     _ = try self.projection.appendNotice(notice);
                 }
@@ -3476,6 +3493,7 @@ pub fn Runtime(comptime App: type) type {
                         self.activityKind(call),
                         result,
                     );
+                    try self.attachCommandDisplay(entry_id, call);
                 }
 
                 fn attachHistoricalToolDetailWithLifecycle(
@@ -3492,6 +3510,7 @@ pub fn Runtime(comptime App: type) type {
                         result,
                         lifecycle_id,
                     );
+                    try self.attachCommandDisplay(entry_id, call);
                 }
 
                 fn attachHistoricalToolDetailAfterCommandOutput(
@@ -3506,6 +3525,7 @@ pub fn Runtime(comptime App: type) type {
                         self.activityKind(call),
                         result,
                     );
+                    try self.attachCommandDisplay(entry_id, call);
                 }
 
                 fn attachHistoricalToolCallWithoutResult(

--- a/src/core/tooling/tool_presentation.zig
+++ b/src/core/tooling/tool_presentation.zig
@@ -18,6 +18,7 @@ const Allocator = std.mem.Allocator;
 const ToolCall = types.ToolCall;
 const max_run_command_activity_bytes = 120;
 const max_run_command_activity_source_bytes = max_run_command_activity_bytes * max_run_command_activity_bytes;
+pub const max_run_command_reflow_bytes = max_run_command_activity_source_bytes;
 pub const max_auto_permission_reason_presentation_bytes: usize = 160;
 
 pub const ToolActionInput = struct {
@@ -186,7 +187,7 @@ pub fn formatRunCommandActivity(
     };
 }
 
-fn formatRunCommandDetailBounded(
+pub fn formatRunCommandDetailBounded(
     alloc: Allocator,
     command: []const u8,
     workspace_root: []const u8,

--- a/src/core/tooling/tool_presentation.zig
+++ b/src/core/tooling/tool_presentation.zig
@@ -42,7 +42,7 @@ pub fn isProviderSearchAlias(name: []const u8) bool {
 fn projectRunCommandActivitySource(
     command: []const u8,
     workspace_root_input: []const u8,
-    storage: *[max_run_command_activity_bytes + 1]u8,
+    storage: []u8,
 ) []const u8 {
     const display_command = stripNoopCurrentDirectoryPrefix(command);
     var workspace_root_end = workspace_root_input.len;
@@ -114,6 +114,20 @@ fn workspaceRootMatchesAt(command: []const u8, workspace_root: []const u8, index
     return command[next_index] == '/' or !isPathTokenByte(command[next_index]);
 }
 
+fn containsUnresolvedAbsolutePath(command: []const u8) bool {
+    for (command, 0..) |byte, index| {
+        if (byte != '/' or (index > 0 and isPathTokenByte(command[index - 1]))) continue;
+        const suffix = command[index..];
+        if (std.mem.startsWith(u8, suffix, "/dev/null") and
+            (suffix.len == "/dev/null".len or !isPathTokenByte(suffix["/dev/null".len])))
+        {
+            continue;
+        }
+        return true;
+    }
+    return false;
+}
+
 fn isPathTokenByte(byte: u8) bool {
     return std.ascii.isAlphanumeric(byte) or switch (byte) {
         '/', '-', '.', '_', '~' => true,
@@ -160,13 +174,55 @@ pub fn formatRunCommandActivity(
     const args = tool_args.parseToolArgsObject(scratch, call.arguments_json) catch return null;
     if (!isCapturedCommandCall(registry, call, args)) return null;
     const command = tool_args.optionalStringArg(args, "command") orelse return null;
-    var projected_storage: [max_run_command_activity_bytes + 1]u8 = undefined;
-    const projected = projectRunCommandActivitySource(command, workspace_root, &projected_storage);
-    const encoded = try text_utils.encodeTerminalSafe(scratch, projected, max_run_command_activity_bytes);
+    const detail = (try formatRunCommandDetailBounded(
+        alloc,
+        call.arguments_json,
+        workspace_root,
+        max_run_command_activity_bytes,
+    )) orelse return null;
     return .{
-        .detail = try alloc.dupe(u8, encoded.bytes),
+        .detail = detail,
         .compatibility_tool = if (try tool_dispatch.matchRunCommandCompatibility(registry, command)) |matched| matched.tool else null,
     };
+}
+
+fn formatRunCommandDetailBounded(
+    alloc: Allocator,
+    arguments_json: []const u8,
+    workspace_root: []const u8,
+    max_encoded_bytes: usize,
+) !?[]u8 {
+    if (max_encoded_bytes == 0) return try alloc.dupe(u8, "");
+
+    var scratch_state = std.heap.ArenaAllocator.init(alloc);
+    defer scratch_state.deinit();
+    const scratch = scratch_state.allocator();
+    const args = tool_args.parseToolArgsObject(scratch, arguments_json) catch return null;
+    const command = tool_args.optionalStringArg(args, "command") orelse return null;
+    if (workspace_root.len == 0 and containsUnresolvedAbsolutePath(command)) return null;
+    const effective_max = @min(max_encoded_bytes, max_run_command_activity_source_bytes - 1);
+    const projected_storage = try scratch.alloc(u8, effective_max + 1);
+    const projected = projectRunCommandActivitySource(command, workspace_root, projected_storage);
+    const encoded = try text_utils.encodeTerminalSafe(alloc, projected, effective_max);
+    return encoded.bytes;
+}
+
+/// Returns an owned terminal-safe command detail for one visible transcript row.
+/// The caller owns the returned allocation and must free it with `alloc`.
+pub fn formatRunCommandDetailForWidth(
+    alloc: Allocator,
+    arguments_json: []const u8,
+    workspace_root: []const u8,
+    max_visible_width: usize,
+) !?[]u8 {
+    const max_encoded_bytes = std.math.mul(usize, max_visible_width, 4) catch
+        max_run_command_activity_source_bytes;
+    return formatRunCommandDetailBounded(
+        alloc,
+        arguments_json,
+        workspace_root,
+        @min(max_encoded_bytes, max_run_command_activity_source_bytes),
+    );
 }
 
 /// The caller owns the returned allocation and must free it with `alloc`.
@@ -664,6 +720,58 @@ test "run command activity projects line boundaries without changing other bytes
 
         try std.testing.expectEqualStrings(case.expected, activity.detail);
     }
+}
+
+test "run command detail uses the caller bound without changing activity labels" {
+    const alloc = std.testing.allocator;
+    const command = "printf " ++ ("alpha-beta-gamma-delta-" ** 8);
+    const arguments_json = try std.fmt.allocPrint(
+        alloc,
+        "{{\"command\":{f}}}",
+        .{std.json.fmt(command, .{})},
+    );
+    defer alloc.free(arguments_json);
+
+    const detail = (try formatRunCommandDetailForWidth(alloc, arguments_json, "", 240)) orelse
+        return error.TestExpectedEqual;
+    defer alloc.free(detail);
+    try std.testing.expectEqualStrings(command, detail);
+
+    const bounded = (try formatRunCommandDetailBounded(alloc, arguments_json, "", 80)) orelse
+        return error.TestExpectedEqual;
+    defer alloc.free(bounded);
+    try std.testing.expect(bounded.len <= 80);
+    try std.testing.expect(std.mem.endsWith(u8, bounded, "..."));
+
+    const activity = (try formatRunCommandActivity(alloc, test_tool_registry, "", .{
+        .id = "bounded_activity",
+        .name = "run_command",
+        .arguments_json = arguments_json,
+    })) orelse return error.TestExpectedEqual;
+    defer alloc.free(activity.detail);
+    try std.testing.expect(activity.detail.len <= max_run_command_activity_bytes);
+    try std.testing.expect(std.mem.endsWith(u8, activity.detail, "..."));
+
+    try std.testing.expectEqual(
+        @as(?[]u8, null),
+        try formatRunCommandDetailForWidth(alloc, "{}", "", 80),
+    );
+    try std.testing.expectEqual(
+        @as(?[]u8, null),
+        try formatRunCommandDetailForWidth(alloc, "{", "", 80),
+    );
+
+    const hidden_workspace_path = "printf " ++ ("prefix-" ** 20) ++ " /Users/example/workspace/file";
+    const hidden_workspace_json = try std.fmt.allocPrint(
+        alloc,
+        "{{\"command\":{f}}}",
+        .{std.json.fmt(hidden_workspace_path, .{})},
+    );
+    defer alloc.free(hidden_workspace_json);
+    try std.testing.expectEqual(
+        @as(?[]u8, null),
+        try formatRunCommandDetailForWidth(alloc, hidden_workspace_json, "", 240),
+    );
 }
 
 test "run command activity abbreviates only active workspace paths" {

--- a/src/core/tooling/tool_presentation.zig
+++ b/src/core/tooling/tool_presentation.zig
@@ -219,28 +219,6 @@ pub fn formatRunCommandDetailBounded(
     return encoded.bytes;
 }
 
-/// Returns an owned terminal-safe command detail for one visible transcript row.
-/// The caller owns the returned allocation and must free it with `alloc`.
-pub fn formatRunCommandDetailForWidth(
-    alloc: Allocator,
-    arguments_json: []const u8,
-    workspace_root: []const u8,
-    max_visible_width: usize,
-) !?[]u8 {
-    var parsed = std.json.parseFromSlice(std.json.Value, alloc, arguments_json, .{}) catch return null;
-    defer parsed.deinit();
-    if (parsed.value != .object) return null;
-    const command = tool_args.optionalStringArg(parsed.value.object, "command") orelse return null;
-    const max_encoded_bytes = std.math.mul(usize, max_visible_width, 4) catch
-        max_run_command_activity_source_bytes;
-    return formatRunCommandDetailBounded(
-        alloc,
-        command,
-        workspace_root,
-        @min(max_encoded_bytes, max_run_command_activity_source_bytes),
-    );
-}
-
 /// The caller owns the returned allocation and must free it with `alloc`.
 fn resolveTerminalDisplayTargetFromRows(
     alloc: Allocator,
@@ -748,8 +726,12 @@ test "run command detail uses the caller bound without changing activity labels"
     );
     defer alloc.free(arguments_json);
 
-    const detail = (try formatRunCommandDetailForWidth(alloc, arguments_json, "", 240)) orelse
-        return error.TestExpectedEqual;
+    const detail = (try formatRunCommandDetailBounded(
+        alloc,
+        command,
+        "",
+        max_run_command_reflow_bytes,
+    )) orelse return error.TestExpectedEqual;
     defer alloc.free(detail);
     try std.testing.expectEqualStrings(command, detail);
 
@@ -768,25 +750,15 @@ test "run command detail uses the caller bound without changing activity labels"
     try std.testing.expect(activity.detail.len <= max_run_command_activity_bytes);
     try std.testing.expect(std.mem.endsWith(u8, activity.detail, "..."));
 
-    try std.testing.expectEqual(
-        @as(?[]u8, null),
-        try formatRunCommandDetailForWidth(alloc, "{}", "", 80),
-    );
-    try std.testing.expectEqual(
-        @as(?[]u8, null),
-        try formatRunCommandDetailForWidth(alloc, "{", "", 80),
-    );
-
     const hidden_workspace_path = "printf " ++ ("prefix-" ** 20) ++ " /Users/example/workspace/file";
-    const hidden_workspace_json = try std.fmt.allocPrint(
-        alloc,
-        "{{\"command\":{f}}}",
-        .{std.json.fmt(hidden_workspace_path, .{})},
-    );
-    defer alloc.free(hidden_workspace_json);
     try std.testing.expectEqual(
         @as(?[]u8, null),
-        try formatRunCommandDetailForWidth(alloc, hidden_workspace_json, "", 240),
+        try formatRunCommandDetailBounded(
+            alloc,
+            hidden_workspace_path,
+            "",
+            max_run_command_reflow_bytes,
+        ),
     );
 }
 

--- a/src/core/tooling/tool_presentation.zig
+++ b/src/core/tooling/tool_presentation.zig
@@ -176,7 +176,7 @@ pub fn formatRunCommandActivity(
     const command = tool_args.optionalStringArg(args, "command") orelse return null;
     const detail = (try formatRunCommandDetailBounded(
         alloc,
-        call.arguments_json,
+        command,
         workspace_root,
         max_run_command_activity_bytes,
     )) orelse return null;
@@ -188,20 +188,16 @@ pub fn formatRunCommandActivity(
 
 fn formatRunCommandDetailBounded(
     alloc: Allocator,
-    arguments_json: []const u8,
+    command: []const u8,
     workspace_root: []const u8,
     max_encoded_bytes: usize,
 ) !?[]u8 {
     if (max_encoded_bytes == 0) return try alloc.dupe(u8, "");
-
-    var scratch_state = std.heap.ArenaAllocator.init(alloc);
-    defer scratch_state.deinit();
-    const scratch = scratch_state.allocator();
-    const args = tool_args.parseToolArgsObject(scratch, arguments_json) catch return null;
-    const command = tool_args.optionalStringArg(args, "command") orelse return null;
     if (workspace_root.len == 0 and containsUnresolvedAbsolutePath(command)) return null;
+
     const effective_max = @min(max_encoded_bytes, max_run_command_activity_source_bytes - 1);
-    const projected_storage = try scratch.alloc(u8, effective_max + 1);
+    const projected_storage = try alloc.alloc(u8, effective_max + 1);
+    defer alloc.free(projected_storage);
     const projected = projectRunCommandActivitySource(command, workspace_root, projected_storage);
     const encoded = try text_utils.encodeTerminalSafe(alloc, projected, effective_max);
     return encoded.bytes;
@@ -215,11 +211,15 @@ pub fn formatRunCommandDetailForWidth(
     workspace_root: []const u8,
     max_visible_width: usize,
 ) !?[]u8 {
+    var parsed = std.json.parseFromSlice(std.json.Value, alloc, arguments_json, .{}) catch return null;
+    defer parsed.deinit();
+    if (parsed.value != .object) return null;
+    const command = tool_args.optionalStringArg(parsed.value.object, "command") orelse return null;
     const max_encoded_bytes = std.math.mul(usize, max_visible_width, 4) catch
         max_run_command_activity_source_bytes;
     return formatRunCommandDetailBounded(
         alloc,
-        arguments_json,
+        command,
         workspace_root,
         @min(max_encoded_bytes, max_run_command_activity_source_bytes),
     );
@@ -737,7 +737,7 @@ test "run command detail uses the caller bound without changing activity labels"
     defer alloc.free(detail);
     try std.testing.expectEqualStrings(command, detail);
 
-    const bounded = (try formatRunCommandDetailBounded(alloc, arguments_json, "", 80)) orelse
+    const bounded = (try formatRunCommandDetailBounded(alloc, command, "", 80)) orelse
         return error.TestExpectedEqual;
     defer alloc.free(bounded);
     try std.testing.expect(bounded.len <= 80);

--- a/src/core/tooling/tool_presentation.zig
+++ b/src/core/tooling/tool_presentation.zig
@@ -162,6 +162,21 @@ pub fn isAdvertisedDynamicMcpName(registry: tool_dispatch.Registry, name: []cons
 }
 
 /// The caller owns `detail` and must free it with `alloc`.
+pub fn runCommandCompletedActionLabel(
+    alloc: Allocator,
+    registry: tool_dispatch.Registry,
+    call: ToolCall,
+) !?[]const u8 {
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, call.arguments_json, .{});
+    defer parsed.deinit();
+    if (parsed.value != .object or !isCapturedCommandCall(registry, call, parsed.value.object)) return null;
+    const command = tool_args.optionalStringArg(parsed.value.object, "command") orelse return null;
+    return if (try tool_dispatch.matchRunCommandCompatibility(registry, command)) |matched|
+        matched.tool.completed_action_label
+    else
+        "Ran";
+}
+
 pub fn formatRunCommandActivity(
     alloc: Allocator,
     registry: tool_dispatch.Registry,

--- a/src/core/tooling/tool_presentation.zig
+++ b/src/core/tooling/tool_presentation.zig
@@ -161,7 +161,7 @@ pub fn isAdvertisedDynamicMcpName(registry: tool_dispatch.Registry, name: []cons
     return false;
 }
 
-/// The caller owns `detail` and must free it with `alloc`.
+/// Returns a borrowed static label when the call is a captured command.
 pub fn runCommandCompletedActionLabel(
     alloc: Allocator,
     registry: tool_dispatch.Registry,

--- a/src/ui/render_engine/transcript_blocks.zig
+++ b/src/ui/render_engine/transcript_blocks.zig
@@ -56,6 +56,7 @@ pub const ToolDetailRecord = struct {
     activity_kind: ?types.ToolActivityKind = null,
     arguments_json: ?[]u8 = null,
     command_display: ?[]u8 = null,
+    command_action_label: ?[]u8 = null,
     result: ?[]u8 = null,
     result_handle: ?[]u8 = null,
     command_artifact_handle: ?[]u8 = null,
@@ -77,6 +78,7 @@ pub const ToolDetailRecord = struct {
         alloc.free(self.tool_name);
         if (self.arguments_json) |value| alloc.free(value);
         if (self.command_display) |value| alloc.free(value);
+        if (self.command_action_label) |value| alloc.free(value);
         if (self.result) |value| alloc.free(value);
         if (self.result_handle) |value| alloc.free(value);
         if (self.command_artifact_handle) |value| alloc.free(value);

--- a/src/ui/render_engine/transcript_blocks.zig
+++ b/src/ui/render_engine/transcript_blocks.zig
@@ -55,6 +55,7 @@ pub const ToolDetailRecord = struct {
     captured_command: bool = false,
     activity_kind: ?types.ToolActivityKind = null,
     arguments_json: ?[]u8 = null,
+    command_display: ?[]u8 = null,
     result: ?[]u8 = null,
     result_handle: ?[]u8 = null,
     command_artifact_handle: ?[]u8 = null,
@@ -75,6 +76,7 @@ pub const ToolDetailRecord = struct {
     pub fn deinit(self: *ToolDetailRecord, alloc: std.mem.Allocator) void {
         alloc.free(self.tool_name);
         if (self.arguments_json) |value| alloc.free(value);
+        if (self.command_display) |value| alloc.free(value);
         if (self.result) |value| alloc.free(value);
         if (self.result_handle) |value| alloc.free(value);
         if (self.command_artifact_handle) |value| alloc.free(value);

--- a/src/ui/transcript/resume_projection.zig
+++ b/src/ui/transcript/resume_projection.zig
@@ -244,6 +244,18 @@ pub const ResumeProjection = struct {
         );
     }
 
+    pub fn setHistoricalToolCommandDisplay(
+        self: *ResumeProjection,
+        entry_id: u32,
+        display: []const u8,
+    ) !void {
+        try self.runtime.setToolCommandDisplayForEntry(
+            self.alloc,
+            entry_id,
+            display,
+        );
+    }
+
     pub fn attachHistoricalToolDetailWithLifecycle(
         self: *ResumeProjection,
         entry_id: u32,

--- a/src/ui/transcript/resume_projection.zig
+++ b/src/ui/transcript/resume_projection.zig
@@ -244,15 +244,17 @@ pub const ResumeProjection = struct {
         );
     }
 
-    pub fn setHistoricalToolCommandDisplay(
+    pub fn setHistoricalToolCommandMetadata(
         self: *ResumeProjection,
         entry_id: u32,
         display: []const u8,
+        action_label: []const u8,
     ) !void {
-        try self.runtime.setToolCommandDisplayForEntry(
+        try self.runtime.setToolCommandMetadataForEntry(
             self.alloc,
             entry_id,
             display,
+            action_label,
         );
     }
 

--- a/src/ui/transcript/runtime.zig
+++ b/src/ui/transcript/runtime.zig
@@ -5213,6 +5213,29 @@ pub const TranscriptRuntime = struct {
         return &self.tool_details.items[search.index];
     }
 
+    pub fn setToolCommandDisplay(
+        self: *TranscriptRuntime,
+        alloc: Allocator,
+        id: types.ToolLifecycleId,
+        display: []const u8,
+    ) !void {
+        const record = self.lifecycle_state.record(id) orelse return;
+        try self.setToolCommandDisplayForEntry(alloc, record.entry_id, display);
+    }
+
+    pub fn setToolCommandDisplayForEntry(
+        self: *TranscriptRuntime,
+        alloc: Allocator,
+        entry_id: u32,
+        display: []const u8,
+    ) !void {
+        const detail = self.toolDetailPtr(entry_id) orelse return;
+        const owned = try alloc.dupe(u8, display);
+        if (detail.command_display) |previous| alloc.free(previous);
+        detail.command_display = owned;
+        self.markTranscriptContentDirtyFrom(entry_id);
+    }
+
     fn toolDetailPtr(self: *TranscriptRuntime, entry_id: u32) ?*ToolDetailRecord {
         const search = self.toolDetailSearch(entry_id);
         if (!search.found) return null;

--- a/src/ui/transcript/runtime.zig
+++ b/src/ui/transcript/runtime.zig
@@ -5220,7 +5220,7 @@ pub const TranscriptRuntime = struct {
         display: []const u8,
         action_label: []const u8,
     ) !void {
-        const record = self.lifecycle_state.record(id) orelse return;
+        const record = self.lifecycle_state.record(id) orelse return error.UnknownToolLifecycleIdentity;
         try self.setToolCommandMetadataForEntry(
             alloc,
             record.entry_id,
@@ -5236,7 +5236,7 @@ pub const TranscriptRuntime = struct {
         display: []const u8,
         action_label: []const u8,
     ) !void {
-        const detail = self.toolDetailPtr(entry_id) orelse return;
+        const detail = self.toolDetailPtr(entry_id) orelse return error.MissingToolDetail;
         const owned_display = try alloc.dupe(u8, display);
         errdefer alloc.free(owned_display);
         const owned_label = try alloc.dupe(u8, action_label);

--- a/src/ui/transcript/runtime.zig
+++ b/src/ui/transcript/runtime.zig
@@ -5213,26 +5213,37 @@ pub const TranscriptRuntime = struct {
         return &self.tool_details.items[search.index];
     }
 
-    pub fn setToolCommandDisplay(
+    pub fn setToolCommandMetadata(
         self: *TranscriptRuntime,
         alloc: Allocator,
         id: types.ToolLifecycleId,
         display: []const u8,
+        action_label: []const u8,
     ) !void {
         const record = self.lifecycle_state.record(id) orelse return;
-        try self.setToolCommandDisplayForEntry(alloc, record.entry_id, display);
+        try self.setToolCommandMetadataForEntry(
+            alloc,
+            record.entry_id,
+            display,
+            action_label,
+        );
     }
 
-    pub fn setToolCommandDisplayForEntry(
+    pub fn setToolCommandMetadataForEntry(
         self: *TranscriptRuntime,
         alloc: Allocator,
         entry_id: u32,
         display: []const u8,
+        action_label: []const u8,
     ) !void {
         const detail = self.toolDetailPtr(entry_id) orelse return;
-        const owned = try alloc.dupe(u8, display);
+        const owned_display = try alloc.dupe(u8, display);
+        errdefer alloc.free(owned_display);
+        const owned_label = try alloc.dupe(u8, action_label);
         if (detail.command_display) |previous| alloc.free(previous);
-        detail.command_display = owned;
+        if (detail.command_action_label) |previous| alloc.free(previous);
+        detail.command_display = owned_display;
+        detail.command_action_label = owned_label;
         self.markTranscriptContentDirtyFrom(entry_id);
     }
 

--- a/src/ui/transcript/store.zig
+++ b/src/ui/transcript/store.zig
@@ -2069,6 +2069,11 @@ pub fn cloneToolDetailForSnapshot(alloc: Allocator, source: ToolDetailRecord) !T
     else
         null;
     errdefer if (arguments_json) |value| alloc.free(value);
+    const command_display = if (source.command_display) |value|
+        try alloc.dupe(u8, value)
+    else
+        null;
+    errdefer if (command_display) |value| alloc.free(value);
     const result = if (source.result) |value|
         try alloc.dupe(u8, value)
     else
@@ -2104,6 +2109,7 @@ pub fn cloneToolDetailForSnapshot(alloc: Allocator, source: ToolDetailRecord) !T
         .captured_command = source.captured_command,
         .activity_kind = source.activity_kind,
         .arguments_json = arguments_json,
+        .command_display = command_display,
         .result = result,
         .result_handle = result_handle,
         .command_artifact_handle = command_artifact_handle,

--- a/src/ui/transcript/store.zig
+++ b/src/ui/transcript/store.zig
@@ -2074,6 +2074,11 @@ pub fn cloneToolDetailForSnapshot(alloc: Allocator, source: ToolDetailRecord) !T
     else
         null;
     errdefer if (command_display) |value| alloc.free(value);
+    const command_action_label = if (source.command_action_label) |value|
+        try alloc.dupe(u8, value)
+    else
+        null;
+    errdefer if (command_action_label) |value| alloc.free(value);
     const result = if (source.result) |value|
         try alloc.dupe(u8, value)
     else
@@ -2110,6 +2115,7 @@ pub fn cloneToolDetailForSnapshot(alloc: Allocator, source: ToolDetailRecord) !T
         .activity_kind = source.activity_kind,
         .arguments_json = arguments_json,
         .command_display = command_display,
+        .command_action_label = command_action_label,
         .result = result,
         .result_handle = result_handle,
         .command_artifact_handle = command_artifact_handle,

--- a/src/ui/transcript/tool_group_projection.zig
+++ b/src/ui/transcript/tool_group_projection.zig
@@ -4,7 +4,6 @@ const transcript_blocks = @import("../render_engine/transcript_blocks.zig");
 const types = @import("../../core/shared/types.zig");
 const display_width = @import("../../core/shared/display_width.zig");
 const sort_utils = @import("../../core/shared/sort_utils.zig");
-const tool_presentation = @import("../../core/tooling/tool_presentation.zig");
 
 const TranscriptEntry = transcript_blocks.TranscriptEntry;
 const ToolDetailRecord = transcript_blocks.ToolDetailRecord;
@@ -489,7 +488,6 @@ fn formatGroupBlock(
             scratch,
             raw_phrase,
             detail,
-            cols,
         ) orelse raw_phrase;
         static_index += 1;
         const connector = if (!focused_in_group and static_index == static_count) "└" else "├";
@@ -537,17 +535,10 @@ fn reprojectTruncatedCommandPhrase(
     scratch: std.mem.Allocator,
     phrase: []const u8,
     detail: ?*const ToolDetailRecord,
-    cols: u16,
 ) !?[]const u8 {
     const record = detail orelse return null;
     if (!record.isCapturedCommand() or record.outcome != .completed) return null;
-    const arguments_json = record.arguments_json orelse return null;
-    const command = (try tool_presentation.formatRunCommandDetailForWidth(
-        scratch,
-        arguments_json,
-        "",
-        cols,
-    )) orelse return null;
+    const command = record.command_display orelse return null;
     const action = actionForTruncatedCommandPhrase(phrase, command) orelse return null;
     return try std.fmt.allocPrint(scratch, "{s} {s}", .{ action, command });
 }
@@ -1315,6 +1306,7 @@ test "minimal completed command rows reproject stored arguments at the current w
             .captured_command = true,
             .activity_kind = .command,
             .arguments_json = arguments_json,
+            .command_display = @constCast(command),
             .outcome = .completed,
             .command_process_presentation = .{ .exit_code = 0 },
         },
@@ -1366,6 +1358,7 @@ test "minimal completed command rows reproject stored arguments at the current w
             .captured_command = true,
             .activity_kind = .command,
             .arguments_json = relative_arguments_json,
+            .command_display = @constCast(relative_command),
             .outcome = .completed,
             .command_process_presentation = .{ .exit_code = 0 },
         },

--- a/src/ui/transcript/tool_group_projection.zig
+++ b/src/ui/transcript/tool_group_projection.zig
@@ -4,6 +4,7 @@ const transcript_blocks = @import("../render_engine/transcript_blocks.zig");
 const types = @import("../../core/shared/types.zig");
 const display_width = @import("../../core/shared/display_width.zig");
 const sort_utils = @import("../../core/shared/sort_utils.zig");
+const tool_presentation = @import("../../core/tooling/tool_presentation.zig");
 
 const TranscriptEntry = transcript_blocks.TranscriptEntry;
 const ToolDetailRecord = transcript_blocks.ToolDetailRecord;
@@ -480,10 +481,16 @@ fn formatGroupBlock(
         const detail = detailForEntry(details, detail_indices, entry_id, null);
         if (statusNamesAsk(entry, detail) or focused_entry_id == entry_id) continue;
 
-        const phrase = switch (entry) {
+        const raw_phrase = switch (entry) {
             .raw_bytes => |raw| try normalizeCanonicalStatus(scratch, raw.bytes),
             else => null,
         } orelse if (detail) |record| record.tool_name else "tool activity";
+        const phrase = try reprojectTruncatedCommandPhrase(
+            scratch,
+            raw_phrase,
+            detail,
+            cols,
+        ) orelse raw_phrase;
         static_index += 1;
         const connector = if (!focused_in_group and static_index == static_count) "└" else "├";
         const child = try std.fmt.allocPrint(scratch, "{s} {s}", .{ connector, phrase });
@@ -508,6 +515,33 @@ fn formatGroupBlock(
         terminal.deinit(scratch);
     }
     return out.toOwnedSlice();
+}
+
+fn reprojectTruncatedCommandPhrase(
+    scratch: std.mem.Allocator,
+    phrase: []const u8,
+    detail: ?*const ToolDetailRecord,
+    cols: u16,
+) !?[]const u8 {
+    const record = detail orelse return null;
+    if (!record.isCapturedCommand() or record.outcome != .completed) return null;
+    const arguments_json = record.arguments_json orelse return null;
+    const action = "Ran";
+    const prefix = action ++ " ";
+    if (!std.mem.startsWith(u8, phrase, prefix) or
+        !std.mem.endsWith(u8, phrase, "...") or
+        std.mem.find(u8, phrase, "./") != null)
+    {
+        return null;
+    }
+    const detail_width = @as(usize, cols) -| action.len -| 2;
+    const command = (try tool_presentation.formatRunCommandDetailForWidth(
+        scratch,
+        arguments_json,
+        "",
+        detail_width,
+    )) orelse return null;
+    return try std.fmt.allocPrint(scratch, "{s} {s}", .{ action, command });
 }
 
 fn formatExpandedChild(
@@ -1248,6 +1282,80 @@ test "minimal command details expose running completed and failed process states
             "└ Ran zig build test",
         projection.entry_actions.items[0].override.bytes,
     );
+}
+
+test "minimal completed command rows reproject stored arguments at the current width" {
+    const alloc = std.testing.allocator;
+    const command = "printf " ++ ("alpha-beta-gamma-delta-" ** 8);
+    const arguments_json = try std.fmt.allocPrint(
+        alloc,
+        "{{\"command\":{f}}}",
+        .{std.json.fmt(command, .{})},
+    );
+    defer alloc.free(arguments_json);
+    const entries = [_]TranscriptEntry{
+        .{ .raw_bytes = .{
+            .id = 1,
+            .bytes = "● Ran\x1b[0m \x1b[38;5;245mprintf alpha-beta-gamma-delta-alpha-beta-gamma-delta-alpha-beta-gamma-delta-alpha-beta-gamma-delta-alpha-beta-gamma-...\x1b[0m\n",
+            .class = .tool_status,
+        } },
+    };
+    const details = [_]ToolDetailRecord{
+        .{
+            .entry_id = 1,
+            .tool_name = @constCast("shell"),
+            .captured_command = true,
+            .activity_kind = .command,
+            .arguments_json = arguments_json,
+            .outcome = .completed,
+            .command_process_presentation = .{ .exit_code = 0 },
+        },
+    };
+
+    var narrow = try build(alloc, &entries, &details, 80);
+    defer narrow.deinit(alloc);
+    const narrow_row = narrow.entry_actions.items[0].override.bytes;
+    try std.testing.expect(std.mem.endsWith(u8, narrow_row, "…"));
+    try std.testing.expect(std.mem.find(u8, narrow_row, "alpha-beta-gamma") != null);
+
+    var wide = try build(alloc, &entries, &details, 240);
+    defer wide.deinit(alloc);
+    try std.testing.expectEqualStrings(
+        "● 1 tool call · 1 command\n└ Ran " ++ command,
+        wide.entry_actions.items[0].override.bytes,
+    );
+
+    const legacy_details = [_]ToolDetailRecord{
+        .{
+            .entry_id = 1,
+            .tool_name = @constCast("run_command"),
+            .activity_kind = .command,
+            .outcome = .completed,
+        },
+    };
+    var legacy = try build(alloc, &entries, &legacy_details, 240);
+    defer legacy.deinit(alloc);
+    try std.testing.expect(std.mem.endsWith(u8, legacy.entry_actions.items[0].override.bytes, "..."));
+
+    const workspace_entries = [_]TranscriptEntry{
+        .{ .raw_bytes = .{
+            .id = 1,
+            .bytes = "● Ran cd ./packages/cli && printf alpha-beta-gamma-delta-alpha-beta-gamma-delta-alpha-beta-gamma-delta-alpha-beta-gamma-delta-...\n",
+            .class = .tool_status,
+        } },
+    };
+    var workspace = try build(alloc, &workspace_entries, &details, 240);
+    defer workspace.deinit(alloc);
+    try std.testing.expect(std.mem.find(
+        u8,
+        workspace.entry_actions.items[0].override.bytes,
+        "cd ./packages/cli",
+    ) != null);
+    try std.testing.expect(std.mem.endsWith(
+        u8,
+        workspace.entry_actions.items[0].override.bytes,
+        "...",
+    ));
 }
 
 test "minimal command timeout uses its typed cause in the row and group" {

--- a/src/ui/transcript/tool_group_projection.zig
+++ b/src/ui/transcript/tool_group_projection.zig
@@ -517,6 +517,22 @@ fn formatGroupBlock(
     return out.toOwnedSlice();
 }
 
+fn actionForTruncatedCommandPhrase(
+    phrase: []const u8,
+    command: []const u8,
+) ?[]const u8 {
+    const marker = "...";
+    if (!std.mem.endsWith(u8, phrase, marker)) return null;
+    const truncated = phrase[0 .. phrase.len - marker.len];
+    for (truncated, 0..) |byte, index| {
+        if (byte != ' ' or index == 0 or index + 1 == truncated.len) continue;
+        if (std.mem.startsWith(u8, command, truncated[index + 1 ..])) {
+            return truncated[0..index];
+        }
+    }
+    return null;
+}
+
 fn reprojectTruncatedCommandPhrase(
     scratch: std.mem.Allocator,
     phrase: []const u8,
@@ -526,20 +542,13 @@ fn reprojectTruncatedCommandPhrase(
     const record = detail orelse return null;
     if (!record.isCapturedCommand() or record.outcome != .completed) return null;
     const arguments_json = record.arguments_json orelse return null;
-    const action = "Ran";
-    const prefix = action ++ " ";
-    if (!std.mem.startsWith(u8, phrase, prefix) or
-        !std.mem.endsWith(u8, phrase, "..."))
-    {
-        return null;
-    }
-    const detail_width = @as(usize, cols) -| action.len -| 2;
     const command = (try tool_presentation.formatRunCommandDetailForWidth(
         scratch,
         arguments_json,
         "",
-        detail_width,
+        cols,
     )) orelse return null;
+    const action = actionForTruncatedCommandPhrase(phrase, command) orelse return null;
     return try std.fmt.allocPrint(scratch, "{s} {s}", .{ action, command });
 }
 
@@ -1366,6 +1375,20 @@ test "minimal completed command rows reproject stored arguments at the current w
     try std.testing.expectEqualStrings(
         "● 1 tool call · 1 command\n└ Ran " ++ relative_command,
         relative.entry_actions.items[0].override.bytes,
+    );
+
+    const compatibility_entries = [_]TranscriptEntry{
+        .{ .raw_bytes = .{
+            .id = 1,
+            .bytes = "● Installed skill printf alpha-beta-gamma-delta-alpha-beta-gamma-delta-alpha-beta-gamma-delta-alpha-beta-gamma-delta-alpha-beta-gamma-...\n",
+            .class = .tool_status,
+        } },
+    };
+    var compatibility = try build(alloc, &compatibility_entries, &details, 240);
+    defer compatibility.deinit(alloc);
+    try std.testing.expectEqualStrings(
+        "● 1 tool call · 1 command\n└ Installed skill " ++ command,
+        compatibility.entry_actions.items[0].override.bytes,
     );
 }
 

--- a/src/ui/transcript/tool_group_projection.zig
+++ b/src/ui/transcript/tool_group_projection.zig
@@ -529,8 +529,7 @@ fn reprojectTruncatedCommandPhrase(
     const action = "Ran";
     const prefix = action ++ " ";
     if (!std.mem.startsWith(u8, phrase, prefix) or
-        !std.mem.endsWith(u8, phrase, "...") or
-        std.mem.find(u8, phrase, "./") != null)
+        !std.mem.endsWith(u8, phrase, "..."))
     {
         return null;
     }
@@ -1337,25 +1336,37 @@ test "minimal completed command rows reproject stored arguments at the current w
     defer legacy.deinit(alloc);
     try std.testing.expect(std.mem.endsWith(u8, legacy.entry_actions.items[0].override.bytes, "..."));
 
-    const workspace_entries = [_]TranscriptEntry{
+    const relative_command = "cd ./packages/cli && " ++ ("printf relative-path " ** 6);
+    const relative_arguments_json = try std.fmt.allocPrint(
+        alloc,
+        "{{\"command\":{f}}}",
+        .{std.json.fmt(relative_command, .{})},
+    );
+    defer alloc.free(relative_arguments_json);
+    const relative_entries = [_]TranscriptEntry{
         .{ .raw_bytes = .{
             .id = 1,
-            .bytes = "● Ran cd ./packages/cli && printf alpha-beta-gamma-delta-alpha-beta-gamma-delta-alpha-beta-gamma-delta-alpha-beta-gamma-delta-...\n",
+            .bytes = "● Ran cd ./packages/cli && printf relative-path printf relative-path printf relative-path printf relative-path printf relative-path pri...\n",
             .class = .tool_status,
         } },
     };
-    var workspace = try build(alloc, &workspace_entries, &details, 240);
-    defer workspace.deinit(alloc);
-    try std.testing.expect(std.mem.find(
-        u8,
-        workspace.entry_actions.items[0].override.bytes,
-        "cd ./packages/cli",
-    ) != null);
-    try std.testing.expect(std.mem.endsWith(
-        u8,
-        workspace.entry_actions.items[0].override.bytes,
-        "...",
-    ));
+    const relative_details = [_]ToolDetailRecord{
+        .{
+            .entry_id = 1,
+            .tool_name = @constCast("shell"),
+            .captured_command = true,
+            .activity_kind = .command,
+            .arguments_json = relative_arguments_json,
+            .outcome = .completed,
+            .command_process_presentation = .{ .exit_code = 0 },
+        },
+    };
+    var relative = try build(alloc, &relative_entries, &relative_details, 240);
+    defer relative.deinit(alloc);
+    try std.testing.expectEqualStrings(
+        "● 1 tool call · 1 command\n└ Ran " ++ relative_command,
+        relative.entry_actions.items[0].override.bytes,
+    );
 }
 
 test "minimal command timeout uses its typed cause in the row and group" {

--- a/src/ui/transcript/tool_group_projection.zig
+++ b/src/ui/transcript/tool_group_projection.zig
@@ -515,22 +515,6 @@ fn formatGroupBlock(
     return out.toOwnedSlice();
 }
 
-fn actionForTruncatedCommandPhrase(
-    phrase: []const u8,
-    command: []const u8,
-) ?[]const u8 {
-    const marker = "...";
-    if (!std.mem.endsWith(u8, phrase, marker)) return null;
-    const truncated = phrase[0 .. phrase.len - marker.len];
-    for (truncated, 0..) |byte, index| {
-        if (byte != ' ' or index == 0 or index + 1 == truncated.len) continue;
-        if (std.mem.startsWith(u8, command, truncated[index + 1 ..])) {
-            return truncated[0..index];
-        }
-    }
-    return null;
-}
-
 fn reprojectTruncatedCommandPhrase(
     scratch: std.mem.Allocator,
     phrase: []const u8,
@@ -538,8 +522,9 @@ fn reprojectTruncatedCommandPhrase(
 ) !?[]const u8 {
     const record = detail orelse return null;
     if (!record.isCapturedCommand() or record.outcome != .completed) return null;
+    if (!std.mem.endsWith(u8, phrase, "...")) return null;
     const command = record.command_display orelse return null;
-    const action = actionForTruncatedCommandPhrase(phrase, command) orelse return null;
+    const action = record.command_action_label orelse return null;
     return try std.fmt.allocPrint(scratch, "{s} {s}", .{ action, command });
 }
 
@@ -1307,6 +1292,7 @@ test "minimal completed command rows reproject stored arguments at the current w
             .activity_kind = .command,
             .arguments_json = arguments_json,
             .command_display = @constCast(command),
+            .command_action_label = @constCast("Ran"),
             .outcome = .completed,
             .command_process_presentation = .{ .exit_code = 0 },
         },
@@ -1359,6 +1345,7 @@ test "minimal completed command rows reproject stored arguments at the current w
             .activity_kind = .command,
             .arguments_json = relative_arguments_json,
             .command_display = @constCast(relative_command),
+            .command_action_label = @constCast("Ran"),
             .outcome = .completed,
             .command_process_presentation = .{ .exit_code = 0 },
         },
@@ -1377,7 +1364,18 @@ test "minimal completed command rows reproject stored arguments at the current w
             .class = .tool_status,
         } },
     };
-    var compatibility = try build(alloc, &compatibility_entries, &details, 240);
+    const compatibility_details = [_]ToolDetailRecord{.{
+        .entry_id = 1,
+        .tool_name = @constCast("shell"),
+        .captured_command = true,
+        .activity_kind = .command,
+        .arguments_json = arguments_json,
+        .command_display = @constCast(command),
+        .command_action_label = @constCast("Installed skill"),
+        .outcome = .completed,
+        .command_process_presentation = .{ .exit_code = 0 },
+    }};
+    var compatibility = try build(alloc, &compatibility_entries, &compatibility_details, 240);
     defer compatibility.deinit(alloc);
     try std.testing.expectEqualStrings(
         "● 1 tool call · 1 command\n└ Installed skill " ++ command,

--- a/tests/e2e/tui-command-permissions.test.ts
+++ b/tests/e2e/tui-command-permissions.test.ts
@@ -1283,6 +1283,47 @@ describe("effect-aware command permissions", () => {
   );
 
   test.skipIf(!tmuxAvailable())(
+    "TUI reprojects completed command summaries after widening",
+    async () => {
+      const root = createIsolatedRoot();
+      const stderrPath = join(root.root, "command-summary-width-stderr.log");
+      const command =
+        "printf ok && printf '%s' alpha-beta-gamma-delta-epsilon-zeta-eta-theta-iota-kappa-lambda-mu-nu-xi-omicron-pi-rho-sigma-tau-upsilon-phi-chi-psi-omega >/dev/null";
+      const gateway = startFakeGateway([
+        toolCall(command, {}, "command_summary_width"),
+        finalText("COMMAND_SUMMARY_WIDTH_COMPLETE"),
+      ]);
+
+      activeSession = await TmuxSession.create({
+        cmd: FX_BIN,
+        cwd: root.workspace,
+        env: gatewayEnv(root, gateway, {
+          FX_PERMISSION_MODE: "yolo",
+        }),
+        stderrPath,
+        width: 100,
+        height: 32,
+      });
+      await activeSession.waitForComposer(TIMEOUT);
+      await activeSession.sendText("Run the prepared command.");
+      await activeSession.waitForText("COMMAND_SUMMARY_WIDTH_COMPLETE", TIMEOUT);
+
+      const narrow = await activeSession.captureFullScrollback();
+      const narrowRow = narrow.split("\n").find((line) => line.includes("└ Ran printf ok"));
+      expect(narrowRow).toBeDefined();
+      expect(narrowRow).toEndWith("…");
+      expect(narrowRow).not.toContain("omega >/dev/null");
+
+      await activeSession.resizeWindow(240, 32);
+      const wide = await activeSession.captureFullScrollback();
+      const wideRow = wide.split("\n").find((line) => line.includes("└ Ran printf ok"));
+      expect(wideRow).toBe(`└ Ran ${command}`);
+      expect(readFileSync(stderrPath, "utf8")).toBe("");
+    },
+    TIMEOUT,
+  );
+
+  test.skipIf(!tmuxAvailable())(
     "TUI user-profile printf keeps compact output hidden and Ctrl-O complete",
     async () => {
       const root = createIsolatedRoot();

--- a/tests/e2e/tui-command-permissions.test.ts
+++ b/tests/e2e/tui-command-permissions.test.ts
@@ -1289,9 +1289,13 @@ describe("effect-aware command permissions", () => {
       const stderrPath = join(root.root, "command-summary-width-stderr.log");
       const command =
         "printf ok && printf '%s' alpha-beta-gamma-delta-epsilon-zeta-eta-theta-iota-kappa-lambda-mu-nu-xi-omicron-pi-rho-sigma-tau-upsilon-phi-chi-psi-omega >/dev/null";
+      const workspaceCommand =
+        `printf '%s' ${"absolute-path-prefix-".repeat(7)} ${root.workspace}/file >/dev/null`;
       const gateway = startFakeGateway([
         toolCall(command, {}, "command_summary_width"),
         finalText("COMMAND_SUMMARY_WIDTH_COMPLETE"),
+        toolCall(workspaceCommand, {}, "workspace_command_summary_width"),
+        finalText("WORKSPACE_COMMAND_SUMMARY_WIDTH_COMPLETE"),
       ]);
 
       activeSession = await TmuxSession.create({
@@ -1318,6 +1322,15 @@ describe("effect-aware command permissions", () => {
       const wide = await activeSession.captureFullScrollback();
       const wideRow = wide.split("\n").find((line) => line.includes("└ Ran printf ok"));
       expect(wideRow).toBe(`└ Ran ${command}`);
+
+      await activeSession.sendText("Run the next prepared command.");
+      await activeSession.waitForText("WORKSPACE_COMMAND_SUMMARY_WIDTH_COMPLETE", TIMEOUT);
+      const workspaceWide = await activeSession.captureFullScrollback();
+      const workspaceRow = workspaceWide.split("\n").find((line) =>
+        line.includes("└ Ran printf '%s' absolute-path-prefix-"),
+      );
+      expect(workspaceRow).toContain(" ./file >/dev/null");
+      expect(workspaceRow).not.toContain(root.workspace);
       expect(readFileSync(stderrPath, "utf8")).toBe("");
     },
     TIMEOUT,


### PR DESCRIPTION
## Summary

- Expand completed command summaries when the terminal grows.
- Keep narrow command summaries clipped to the available width.
