### PR TITLE
Restore compaction for resumed sessions

### DIFF
--- a/src/core/agent/runtime/context_compaction.zig
+++ b/src/core/agent/runtime/context_compaction.zig
@@ -63,7 +63,9 @@ pub fn validateUnversionedHistoryResults(
         };
         for (execution.tool_steps) |step| {
             for (step.tool_results) |result| {
-                if (result.output_handle == null) return error.AmbiguousCompactionResult;
+                if (result.output_handle == null and result.truncated) {
+                    return error.AmbiguousCompactionResult;
+                }
             }
         }
     }
@@ -631,21 +633,33 @@ fn countOccurrences(haystack: []const u8, needle: []const u8) usize {
     return count;
 }
 
-test "compaction result retention promotes only corrected history" {
+test "compaction result retention promotes complete unversioned history" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     const result_dir = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
     defer alloc.free(result_dir);
 
-    var results = [_]types.PersistedToolResult{.{
-        .tool_call_id = @constCast("call-promote"),
-        .tool_name = @constCast("read_file"),
-        .status = .success,
-        .output = @constCast("complete redacted output"),
-        .output_bytes = 24,
-        .stored_output_bytes = 24,
-    }};
+    var results = [_]types.PersistedToolResult{
+        .{
+            .tool_call_id = @constCast("call-promote"),
+            .tool_name = @constCast("read_file"),
+            .status = .success,
+            .output = @constCast("complete redacted output"),
+            .output_bytes = 24,
+            .stored_output_bytes = 24,
+        },
+        .{
+            .tool_call_id = @constCast("call-handled"),
+            .tool_name = @constCast("grep_files"),
+            .status = .success,
+            .output = @constCast("truncated preview"),
+            .output_handle = @constCast("result-call-handled-grep_files.txt"),
+            .output_bytes = 128,
+            .stored_output_bytes = 128,
+            .truncated = true,
+        },
+    };
     var steps = [_]types.ToolExecutionStep{.{ .tool_results = &results }};
     var history = [_]types.HistoryTurn{.{ .assistant = .{
         .user = .{ .text = @constCast("read it") },
@@ -653,7 +667,7 @@ test "compaction result retention promotes only corrected history" {
         .execution = .{ .tool_steps = &steps },
     } }};
 
-    try validateUnversionedHistoryResults(&history, 0);
+    try validateUnversionedHistoryResults(&history, 1);
     var messages = [_]types.ChatMessage{.{
         .role = .tool,
         .content = results[0].output,
@@ -671,6 +685,7 @@ test "compaction result retention promotes only corrected history" {
     defer alloc.free(stored);
     try std.testing.expect(std.mem.find(u8, stored, "complete redacted output") != null);
 
+    results[0].truncated = true;
     try std.testing.expectError(
         error.AmbiguousCompactionResult,
         validateUnversionedHistoryResults(&history, 1),

--- a/src/core/agent/runtime/tests/gateway_flow.zig
+++ b/src/core/agent/runtime/tests/gateway_flow.zig
@@ -2997,10 +2997,28 @@ test "processQueuedPrompt semantically compacts history at eighty percent and co
     config.tool_result_dir = result_dir;
     var job = fixture.job();
     job.model = @constCast(model);
+    var restored_calls = [_]ToolCall{toolCall(
+        "auto_restored_1",
+        "read_file",
+        "{\"path\":\"restored.txt\"}",
+    )};
+    var restored_results = [_]types.PersistedToolResult{.{
+        .tool_call_id = @constCast("auto_restored_1"),
+        .tool_name = @constCast("read_file"),
+        .status = .success,
+        .output = @constCast("AUTO_RESTORED_RESULT_SENTINEL"),
+        .output_bytes = 29,
+        .stored_output_bytes = 29,
+    }};
+    var restored_steps = [_]types.ToolExecutionStep{.{
+        .tool_calls = &restored_calls,
+        .tool_results = &restored_results,
+    }};
     var history = [_]HistoryTurn{
         .{ .assistant = .{
             .user = .{ .text = @constCast("AUTO_HISTORY_USER_SENTINEL") },
             .assistant = @constCast("AUTO_HISTORY_ASSISTANT_SENTINEL\n" ++ ("h" ** 200_000)),
+            .execution = .{ .tool_steps = &restored_steps },
         } },
         .{ .assistant = .{
             .user = .{ .text = @constCast("AUTO_RECENT_USER") },
@@ -3008,6 +3026,7 @@ test "processQueuedPrompt semantically compacts history at eighty percent and co
         } },
     };
     job.history = &history;
+    job.unversioned_history_count = history.len;
 
     try runFakePrompt(&gateway, &hooks, config, job);
 


### PR DESCRIPTION
## Summary

- let resumed sessions compact complete inline tool results that do not already have durable handles
- keep rejecting truncated handle-free results because their missing output cannot be recovered
- cover the restored-history path in the automatic compaction integration test

## Verification

- `zig fmt --check src/`
- `zig build test`
- `zig build`
- live copied-session resume with `./zig-out/bin/fx ask --json --yolo --resume-id n5eSQHuWtTJM ...`
- second prompt against the same copied resumed session
