### PR TITLE
Honor explicitly selected skills

### DIFF
--- a/src/builtins/context.zig
+++ b/src/builtins/context.zig
@@ -3088,7 +3088,10 @@ test "gateway_system_prompt: local workspace authority" {
 test "gateway_system_prompt: evidence-led scoped execution" {
     try expectDefaultPromptContains("gather local evidence before answering");
     try expectDefaultPromptContains("make at least one safe local inspection before the final answer");
-    try expectDefaultPromptContains("Before generic inspection, load any available skill whose name and description clearly match the user's task.");
+    try expectDefaultPromptContains("If the user names available skills, use every named skill for that query.");
+    try expectDefaultPromptContains("load each selected skill that is not already supplied as explicit skill content");
+    try expectDefaultPromptContains("read its complete instructions and required resources, and follow its workflow");
+    try expectDefaultPromptContains("If a selected skill cannot be followed, state the blocker before using a fallback.");
     try expectDefaultPromptContains("When no skill clearly matches, start with direct file, search, or local git inspection.");
     try expectDefaultPromptContains("Do not ask for discoverable workspace facts. Inspect first");
     try expectDefaultPromptContains("When users ask to build or edit something, use tools to make the change.");

--- a/src/builtins/system_prompt.md
+++ b/src/builtins/system_prompt.md
@@ -9,7 +9,9 @@
 # Workspace behavior
 
 - For requests about the workspace, repository, code, configuration, CI, git history, commands, errors, or project structure, gather local evidence before answering and make at least one safe local inspection before the final answer. Do not rely on memory or general knowledge when inspection can make progress.
-- Before generic inspection, load any available skill whose name and description clearly match the user's task. When no skill clearly matches, start with direct file, search, or local git inspection.
+- If the user names available skills, use every named skill for that query.
+- Before substantive work, load each selected skill that is not already supplied as explicit skill content, read its complete instructions and required resources, and follow its workflow. If a selected skill cannot be followed, state the blocker before using a fallback.
+- When no skill clearly matches, start with direct file, search, or local git inspection.
 - Do not ask for discoverable workspace facts. Inspect first, then ask only for preferences, tradeoffs, credentials, or irreversible decisions that still block progress.
 - When users ask to build or edit something, use tools to make the change. Read the relevant files and local conventions, stay inside the requested scope, and align UI or web work with the existing stack and visual language.
 - If a tool or command fails, diagnose the latest result before retrying and do not repeat the same action without new evidence.

--- a/src/core/skills/skill_invocation.zig
+++ b/src/core/skills/skill_invocation.zig
@@ -123,7 +123,12 @@ pub fn buildExplicitPromptSection(
     var diagnostic_notices: std.Io.Writer.Allocating = .init(alloc);
     defer diagnostic_notices.deinit();
 
-    try out.writer.writeAll("Explicitly invoked skill content for this query:\n");
+    try out.writer.writeAll(
+        "Explicitly invoked skill content for this query:\n" ++
+            "Every skill below is already loaded and must be used for this query.\n" ++
+            "Follow each skill's complete instructions and required resources before substantive work.\n" ++
+            "If a skill cannot be followed, state the blocker instead of silently substituting another workflow.\n",
+    );
     for (binding_plan) |binding| {
         try appendExplicitSkill(
             alloc,
@@ -1437,7 +1442,9 @@ test "explicit invocation supplies the bounded first skill chunk before the resp
     );
     defer explicit.deinit(alloc);
 
-    try expectContains(explicit.text, "Explicitly invoked skill content for this query");
+    try expectContains(explicit.text, "Every skill below is already loaded and must be used for this query.");
+    try expectContains(explicit.text, "Follow each skill's complete instructions and required resources before substantive work.");
+    try expectContains(explicit.text, "If a skill cannot be followed, state the blocker instead of silently substituting another workflow.");
     try expectContains(explicit.text, "<skill_content name=\"workflow\" resource=\"SKILL.md\" offset=\"0\"");
     try expectContains(explicit.text, "name=\"skill_chunk_bytes\" action=\"truncated\"");
     try expectNotContains(explicit.text, "TAIL MUST WAIT");

--- a/tests/e2e/tui-slash-menu.test.ts
+++ b/tests/e2e/tui-slash-menu.test.ts
@@ -3464,7 +3464,12 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
 
       expect(gateway.requests).toHaveLength(1);
       const firstPrompt = gatewayPromptText(gateway.requests[0]!.body);
-      expect(firstPrompt).toContain("Explicitly invoked skill content for this query");
+      expect(firstPrompt).toContain(
+        "Every skill below is already loaded and must be used for this query.",
+      );
+      expect(firstPrompt).toContain(
+        "If a skill cannot be followed, state the blocker instead of silently substituting another workflow.",
+      );
       expect(firstPrompt).toContain('<skill_content name="exact-picker"');
       expect(firstPrompt).toContain(fixture.workspaceDescription);
       expect(firstPrompt).toContain(fixture.bodyB);


### PR DESCRIPTION
## Summary

- Require every explicitly selected skill to govern the current request.
- Load complete skill instructions and required resources before substantive work.
- Report blocked skill workflows before using a fallback.