### PR TITLE
Stabilize prompt submission layout

### DIFF
--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -1307,6 +1307,14 @@ pub fn Runtime(comptime App: type) type {
                     measurement.activity_projection
                 else
                     .{ .turn_thinking = .{ .label = footer_frame.label() } };
+                const minimum_content_rows = turnTransitionMinimumContentRows(
+                    app,
+                    presentation_shell,
+                    canonical_transcript_preview,
+                    pending_card,
+                    if (footer_measurement) |*measurement| measurement else null,
+                    frame_activity,
+                );
                 var fixed_point_ctx = FixedPointTranscriptContext(App){
                     .app = app,
                     .presentation_shell = presentation_shell,
@@ -1339,6 +1347,7 @@ pub fn Runtime(comptime App: type) type {
                         .footer = neutral_footer,
                         .transcript = transcript_preview,
                         .activity = frame_activity,
+                        .minimum_content_rows = minimum_content_rows,
                         .body_mode = .transcript,
                         .prior = active_committed_layout,
                     },
@@ -2225,6 +2234,46 @@ fn validatePreparedTranscriptFitsPlan(
         );
         return error.InvalidPaintPlan;
     }
+}
+
+fn turnTransitionMinimumContentRows(
+    app: anytype,
+    shell: *const transcript_runtime.TranscriptRuntime,
+    canonical_preview: render_engine.frame_layout.TranscriptFlowPreview,
+    pending_card: ?PendingCardProjection,
+    footer_measurement: ?*const surface_frame.SurfaceFooterMeasurement,
+    frame_activity: render_engine.frame_layout.ActivityState,
+) u16 {
+    if (frame_activity != .none) return 0;
+    const measurement = footer_measurement orelse return 0;
+    if (!measurement.input_visible or
+        measurement.show_picker or
+        measurement.picker_rows > 0 or
+        measurement.banner_active or
+        measurement.footer_gap_active or
+        app.stream.active or
+        shell.fullTranscriptActive()) return 0;
+    if (comptime @hasField(@TypeOf(app.*), "skills")) {
+        if (comptime @hasDecl(@TypeOf(app.skills), "menuVisible")) {
+            if (app.skills.menuVisible()) return 0;
+        }
+    }
+
+    const future_activity_rows = render_engine.transcript_blocks.blockGapRowsBetween(.user_turn, .assistant_turn) +| 1 +|
+        render_engine.transcript_blocks.footerBoundaryGapRowsForTail(.turn_summary);
+    const footer_rows = measurement.frameLayoutMeasurement().natural_rows;
+    const pending_submission_active = if (comptime @hasField(@TypeOf(app.*), "submission"))
+        app.submission.pending != null
+    else
+        false;
+    if (pending_card != null or pending_submission_active) {
+        const canonical_rows = if (pending_card) |card|
+            canonical_preview.natural_visual_rows +| (card.row_count -| 1)
+        else
+            canonical_preview.natural_visual_rows;
+        return canonical_rows +| future_activity_rows +| footer_rows;
+    }
+    return 0;
 }
 
 fn footerMeasurementFromRows(rows: render_engine.footer_layout.FooterRows) render_engine.frame_layout.FooterMeasurement {

--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -1307,7 +1307,7 @@ pub fn Runtime(comptime App: type) type {
                     measurement.activity_projection
                 else
                     .{ .turn_thinking = .{ .label = footer_frame.label() } };
-                const minimum_content_rows = turnTransitionMinimumContentRows(
+                const transition_reservation = turnTransitionReservation(
                     app,
                     presentation_shell,
                     canonical_transcript_preview,
@@ -1347,7 +1347,7 @@ pub fn Runtime(comptime App: type) type {
                         .footer = neutral_footer,
                         .transcript = transcript_preview,
                         .activity = frame_activity,
-                        .minimum_content_rows = minimum_content_rows,
+                        .transition = transition_reservation,
                         .body_mode = .transcript,
                         .prior = active_committed_layout,
                     },
@@ -2236,32 +2236,33 @@ fn validatePreparedTranscriptFitsPlan(
     }
 }
 
-fn turnTransitionMinimumContentRows(
+fn turnTransitionReservation(
     app: anytype,
     shell: *const transcript_runtime.TranscriptRuntime,
     canonical_preview: render_engine.frame_layout.TranscriptFlowPreview,
     pending_card: ?PendingCardProjection,
     footer_measurement: ?*const surface_frame.SurfaceFooterMeasurement,
     frame_activity: render_engine.frame_layout.ActivityState,
-) u16 {
-    if (frame_activity != .none) return 0;
-    const measurement = footer_measurement orelse return 0;
+) render_engine.frame_layout.TransitionReservation {
+    if (frame_activity != .none) return .{};
+    const measurement = footer_measurement orelse return .{};
     if (!measurement.input_visible or
         measurement.show_picker or
         measurement.picker_rows > 0 or
         measurement.banner_active or
         measurement.footer_gap_active or
         app.stream.active or
-        shell.fullTranscriptActive()) return 0;
+        shell.fullTranscriptActive()) return .{};
     if (comptime @hasField(@TypeOf(app.*), "skills")) {
         if (comptime @hasDecl(@TypeOf(app.skills), "menuVisible")) {
-            if (app.skills.menuVisible()) return 0;
+            if (app.skills.menuVisible()) return .{};
         }
     }
 
-    const future_activity_rows = render_engine.transcript_blocks.blockGapRowsBetween(.user_turn, .assistant_turn) +| 1 +|
-        render_engine.transcript_blocks.footerBoundaryGapRowsForTail(.turn_summary);
-    const footer_rows = measurement.frameLayoutMeasurement().natural_rows;
+    const future_activity = render_engine.frame_layout.ActivityState{ .thinking = .{
+        .gap_above_activity = render_engine.transcript_blocks.blockGapRowsBetween(.user_turn, .assistant_turn),
+        .footer_gap_after_activity = render_engine.transcript_blocks.footerBoundaryGapRowsForTail(.turn_summary),
+    } };
     const pending_submission_active = if (comptime @hasField(@TypeOf(app.*), "submission"))
         app.submission.pending != null
     else
@@ -2271,9 +2272,9 @@ fn turnTransitionMinimumContentRows(
             canonical_preview.natural_visual_rows +| (card.row_count -| 1)
         else
             canonical_preview.natural_visual_rows;
-        return canonical_rows +| future_activity_rows +| footer_rows;
+        return .{ .transcript_rows = canonical_rows, .activity = future_activity };
     }
-    return 0;
+    return .{};
 }
 
 fn footerMeasurementFromRows(rows: render_engine.footer_layout.FooterRows) render_engine.frame_layout.FooterMeasurement {

--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -1307,7 +1307,7 @@ pub fn Runtime(comptime App: type) type {
                     measurement.activity_projection
                 else
                     .{ .turn_thinking = .{ .label = footer_frame.label() } };
-                const transition_reservation = turnTransitionReservation(
+                const prompt_turn_reservation = promptTurnReservation(
                     app,
                     presentation_shell,
                     canonical_transcript_preview,
@@ -1347,7 +1347,7 @@ pub fn Runtime(comptime App: type) type {
                         .footer = neutral_footer,
                         .transcript = transcript_preview,
                         .activity = frame_activity,
-                        .transition = transition_reservation,
+                        .prompt_turn = prompt_turn_reservation,
                         .body_mode = .transcript,
                         .prior = active_committed_layout,
                     },
@@ -1359,7 +1359,7 @@ pub fn Runtime(comptime App: type) type {
                 scroll_plan = fixed_point.scroll_plan;
                 debug_trace.logf(
                     "frame_layout",
-                    "layout_id={x} solved_frame_height={d} footer_height={d} footer_top={d} owned_top={d} owned_bottom={d} scroll_rows={d}",
+                    "layout_id={x} solved_frame_height={d} footer_height={d} footer_top={d} owned_top={d} owned_bottom={d} prompt_turn_transcript_rows={d} prompt_turn_active={s} scroll_rows={d}",
                     .{
                         solved.layout_id,
                         solved.solved_frame_height,
@@ -1367,6 +1367,8 @@ pub fn Runtime(comptime App: type) type {
                         solved.footer_area.top,
                         solved.owned_top,
                         solved.owned_band.bottom,
+                        prompt_turn_reservation.transcript_rows,
+                        if (prompt_turn_reservation.active()) "true" else "false",
                         scroll_plan.terminal_scroll_rows,
                     },
                 );
@@ -2236,14 +2238,14 @@ fn validatePreparedTranscriptFitsPlan(
     }
 }
 
-fn turnTransitionReservation(
+fn promptTurnReservation(
     app: anytype,
     shell: *const transcript_runtime.TranscriptRuntime,
     canonical_preview: render_engine.frame_layout.TranscriptFlowPreview,
     pending_card: ?PendingCardProjection,
     footer_measurement: ?*const surface_frame.SurfaceFooterMeasurement,
     frame_activity: render_engine.frame_layout.ActivityState,
-) render_engine.frame_layout.TransitionReservation {
+) render_engine.frame_layout.PromptTurnReservation {
     if (frame_activity != .none) return .{};
     const measurement = footer_measurement orelse return .{};
     if (!measurement.input_visible or
@@ -2259,10 +2261,7 @@ fn turnTransitionReservation(
         }
     }
 
-    const future_activity = render_engine.frame_layout.ActivityState{ .thinking = .{
-        .gap_above_activity = render_engine.transcript_blocks.blockGapRowsBetween(.user_turn, .assistant_turn),
-        .footer_gap_after_activity = render_engine.transcript_blocks.footerBoundaryGapRowsForTail(.turn_summary),
-    } };
+    const future_activity = render_engine.frame_layout.ActivityState.thinkingAfterUserTurn();
     const pending_submission_active = if (comptime @hasField(@TypeOf(app.*), "submission"))
         app.submission.pending != null
     else

--- a/src/ui/render_engine/frame_layout.zig
+++ b/src/ui/render_engine/frame_layout.zig
@@ -159,6 +159,7 @@ pub const SolveInput = struct {
     footer: FooterMeasurement,
     transcript: TranscriptFlowPreview,
     activity: ActivityState = .none,
+    minimum_content_rows: u16 = 0,
     body_mode: BodyMode = .transcript,
     prior: CommittedLayoutSnapshot = .{},
     placement_policy: FramePlacementPolicy = .compact_until_full,
@@ -249,11 +250,14 @@ pub fn solve(input: SolveInput) FrameLayout {
         .transcript, .subagent_panel => input.transcript.natural_visual_rows,
     };
     const transcript_height = @min(natural_body_rows, body_capacity);
-    const solved_frame_height = @min(available_rows, transcript_height +| reserved_activity_rows +| footer_height);
+    const natural_content_rows = transcript_height +| reserved_activity_rows +| footer_height;
+    const minimum_content_rows = if (reservation.activity_rows == 0) input.minimum_content_rows else 0;
+    const solved_frame_height = @min(available_rows, @max(natural_content_rows, minimum_content_rows));
+    const neutral_rows = solved_frame_height -| natural_content_rows;
     const owned_band = rectFromTopHeight(owned_top, solved_frame_height);
     const transcript_area = rectFromTopHeight(owned_top, transcript_height);
     const blank_top = if (transcript_area.isEmpty()) owned_top else transcript_area.bottom + 1;
-    const blank_area = rectFromTopHeight(blank_top, reservation.boundary_gap);
+    const blank_area = rectFromTopHeight(blank_top, reservation.boundary_gap +| neutral_rows);
     const activity_row: ?u16 = if (reservation.activity_rows > 0)
         if (reservation.tool_before_activity)
             blank_top + reservation.boundary_gap + 2
@@ -306,6 +310,7 @@ pub fn solveWithPreservedRowRelease(input: SolveInput, release_floor_rows: u16) 
 
     var maximum_input = input;
     maximum_input.owned_top = 1;
+    maximum_input.minimum_content_rows = 0;
     const maximum = solve(maximum_input);
     const geometry_top = if (maximum.solved_frame_height == 0)
         initial.owned_top
@@ -699,6 +704,93 @@ test "layout id ignores non layout-affecting cursor column changes" {
 
     try std.testing.expect(base.layout_id != 0);
     try std.testing.expectEqual(base.layout_id, repaint.layout_id);
+}
+
+test "minimum content rows keep a neutral transition aligned with thinking" {
+    const idle = solve(.{
+        .terminal = testLayout(24, 80),
+        .owned_top = 1,
+        .footer = testFooter(3),
+        .transcript = .{ .natural_visual_rows = 5 },
+        .minimum_content_rows = 13,
+    });
+    const pending = solve(.{
+        .terminal = testLayout(24, 80),
+        .owned_top = 1,
+        .footer = testFooter(3),
+        .transcript = .{ .natural_visual_rows = 8 },
+        .minimum_content_rows = 13,
+    });
+    const adopted = solve(.{
+        .terminal = testLayout(24, 80),
+        .owned_top = 1,
+        .footer = testFooter(3),
+        .transcript = .{ .natural_visual_rows = 7 },
+        .minimum_content_rows = 13,
+    });
+    const thinking = solve(.{
+        .terminal = testLayout(24, 80),
+        .owned_top = 1,
+        .footer = testFooter(3),
+        .transcript = .{ .natural_visual_rows = 7 },
+        .activity = .{ .thinking = .{ .gap_above_activity = 1, .footer_gap_after_activity = 1 } },
+    });
+
+    inline for (.{ idle, pending, adopted, thinking }) |layout| {
+        try std.testing.expectEqual(FrameRect{ .top = 11, .bottom = 13 }, layout.footer_area);
+        try std.testing.expectEqual(@as(u16, 13), layout.solved_frame_height);
+    }
+    try std.testing.expectEqual(@as(?u16, null), idle.activity_row);
+    try std.testing.expectEqual(@as(u16, 5), idle.blank_area.height());
+    try std.testing.expectEqual(@as(?u16, null), pending.activity_row);
+    try std.testing.expectEqual(@as(u16, 2), pending.blank_area.height());
+    try std.testing.expectEqual(@as(?u16, null), adopted.activity_row);
+    try std.testing.expectEqual(@as(u16, 3), adopted.blank_area.height());
+    try std.testing.expectEqual(@as(?u16, 9), thinking.activity_row);
+}
+
+test "real activity supersedes neutral minimum content rows" {
+    const layout = solve(.{
+        .terminal = testLayout(24, 80),
+        .owned_top = 1,
+        .footer = testFooter(3),
+        .transcript = .{ .natural_visual_rows = 7 },
+        .activity = .{ .thinking = .{ .gap_above_activity = 1, .footer_gap_after_activity = 1 } },
+        .minimum_content_rows = 20,
+    });
+
+    try std.testing.expectEqual(@as(?u16, 9), layout.activity_row);
+    try std.testing.expectEqual(FrameRect{ .top = 11, .bottom = 13 }, layout.footer_area);
+    try std.testing.expectEqual(@as(u16, 13), layout.solved_frame_height);
+}
+
+test "minimum content rows do not release preserved shell rows" {
+    const input = SolveInput{
+        .terminal = testLayout(24, 80),
+        .owned_top = 6,
+        .footer = testFooter(3),
+        .transcript = .{ .natural_visual_rows = 2 },
+        .minimum_content_rows = 13,
+    };
+    const plan = solveWithPreservedRowRelease(input, 0);
+
+    try std.testing.expectEqual(@as(u16, 6), plan.layout.owned_top);
+    try std.testing.expectEqual(@as(u16, 0), plan.released_rows);
+}
+
+test "minimum content rows clamp without displacing visible content" {
+    const layout = solve(.{
+        .terminal = testLayout(8, 80),
+        .owned_top = 1,
+        .footer = testFooter(3),
+        .transcript = .{ .natural_visual_rows = 6 },
+        .minimum_content_rows = 13,
+    });
+
+    try std.testing.expectEqual(@as(u16, 8), layout.solved_frame_height);
+    try std.testing.expectEqual(@as(u16, 5), layout.transcript_area.height());
+    try std.testing.expectEqual(@as(u16, 0), layout.blank_area.height());
+    try std.testing.expectEqual(FrameRect{ .top = 6, .bottom = 8 }, layout.footer_area);
 }
 
 test "thinking activity owns a deterministic leading blank gap without moving footer separately" {

--- a/src/ui/render_engine/frame_layout.zig
+++ b/src/ui/render_engine/frame_layout.zig
@@ -68,6 +68,13 @@ pub const ActivityState = union(enum) {
     thinking: Thinking,
     overlay_entry: u16,
 
+    pub fn thinkingAfterUserTurn() ActivityState {
+        return .{ .thinking = .{
+            .gap_above_activity = transcript_blocks.blockGapRowsBetween(.user_turn, .assistant_turn),
+            .footer_gap_after_activity = transcript_blocks.footerBoundaryGapRowsForTail(.turn_summary),
+        } };
+    }
+
     pub const Thinking = struct {
         gap_above_activity: u16,
         activity_rows: u16 = 1,
@@ -153,11 +160,11 @@ pub const CommittedLayoutSnapshot = struct {
     }
 };
 
-pub const TransitionReservation = struct {
+pub const PromptTurnReservation = struct {
     transcript_rows: u16 = 0,
     activity: ActivityState = .none,
 
-    pub fn active(self: TransitionReservation) bool {
+    pub fn active(self: PromptTurnReservation) bool {
         return self.transcript_rows > 0 and self.activity != .none;
     }
 };
@@ -168,7 +175,7 @@ pub const SolveInput = struct {
     footer: FooterMeasurement,
     transcript: TranscriptFlowPreview,
     activity: ActivityState = .none,
-    transition: TransitionReservation = .{},
+    prompt_turn: PromptTurnReservation = .{},
     body_mode: BodyMode = .transcript,
     prior: CommittedLayoutSnapshot = .{},
     placement_policy: FramePlacementPolicy = .compact_until_full,
@@ -260,7 +267,7 @@ pub fn solve(input: SolveInput) FrameLayout {
     };
     const transcript_height = @min(natural_body_rows, body_capacity);
     const natural_content_rows = transcript_height +| reserved_activity_rows +| footer_height;
-    const transition_rows = solveTransitionReservation(input, footer_height, available_rows);
+    const transition_rows = solvePromptTurnReservation(input, footer_height, available_rows);
     const solved_frame_height = @min(available_rows, @max(natural_content_rows, transition_rows));
     const neutral_rows = solved_frame_height -| natural_content_rows;
     const owned_band = rectFromTopHeight(owned_top, solved_frame_height);
@@ -319,7 +326,7 @@ pub fn solveWithPreservedRowRelease(input: SolveInput, release_floor_rows: u16) 
 
     var maximum_input = input;
     maximum_input.owned_top = 1;
-    maximum_input.transition = .{};
+    if (input.owned_top == 1) maximum_input.prompt_turn = .{};
     const maximum = solve(maximum_input);
     const geometry_top = if (maximum.solved_frame_height == 0)
         initial.owned_top
@@ -336,14 +343,14 @@ pub fn solveWithPreservedRowRelease(input: SolveInput, release_floor_rows: u16) 
     };
 }
 
-fn solveTransitionReservation(input: SolveInput, footer_height: u16, available_rows: u16) u16 {
-    if (input.activity != .none or !input.transition.active()) return 0;
-    var transition_input = input;
-    transition_input.transcript.natural_visual_rows = input.transition.transcript_rows;
-    transition_input.activity = input.transition.activity;
-    transition_input.transition = .{};
-    const reservation = solveActivityReservation(transition_input, footer_height, available_rows);
-    return input.transition.transcript_rows +|
+fn solvePromptTurnReservation(input: SolveInput, footer_height: u16, available_rows: u16) u16 {
+    if (input.activity != .none or !input.prompt_turn.active()) return 0;
+    var prompt_turn_input = input;
+    prompt_turn_input.transcript.natural_visual_rows = input.prompt_turn.transcript_rows;
+    prompt_turn_input.activity = input.prompt_turn.activity;
+    prompt_turn_input.prompt_turn = .{};
+    const reservation = solveActivityReservation(prompt_turn_input, footer_height, available_rows);
+    return input.prompt_turn.transcript_rows +|
         reservation.boundary_gap +|
         reservation.activity_rows +|
         reservation.footer_gap +|
@@ -729,27 +736,27 @@ test "layout id ignores non layout-affecting cursor column changes" {
     try std.testing.expectEqual(base.layout_id, repaint.layout_id);
 }
 
-test "minimum content rows keep a neutral transition aligned with thinking" {
+test "prompt turn reservation aligns pending frames with thinking" {
     const idle = solve(.{
         .terminal = testLayout(24, 80),
         .owned_top = 1,
         .footer = testFooter(3),
         .transcript = .{ .natural_visual_rows = 5 },
-        .transition = .{ .transcript_rows = 7, .activity = .{ .thinking = .{ .gap_above_activity = 1, .footer_gap_after_activity = 1 } } },
+        .prompt_turn = .{ .transcript_rows = 7, .activity = .{ .thinking = .{ .gap_above_activity = 1, .footer_gap_after_activity = 1 } } },
     });
     const pending = solve(.{
         .terminal = testLayout(24, 80),
         .owned_top = 1,
         .footer = testFooter(3),
         .transcript = .{ .natural_visual_rows = 8 },
-        .transition = .{ .transcript_rows = 7, .activity = .{ .thinking = .{ .gap_above_activity = 1, .footer_gap_after_activity = 1 } } },
+        .prompt_turn = .{ .transcript_rows = 7, .activity = .{ .thinking = .{ .gap_above_activity = 1, .footer_gap_after_activity = 1 } } },
     });
     const adopted = solve(.{
         .terminal = testLayout(24, 80),
         .owned_top = 1,
         .footer = testFooter(3),
         .transcript = .{ .natural_visual_rows = 7 },
-        .transition = .{ .transcript_rows = 7, .activity = .{ .thinking = .{ .gap_above_activity = 1, .footer_gap_after_activity = 1 } } },
+        .prompt_turn = .{ .transcript_rows = 7, .activity = .{ .thinking = .{ .gap_above_activity = 1, .footer_gap_after_activity = 1 } } },
     });
     const thinking = solve(.{
         .terminal = testLayout(24, 80),
@@ -772,14 +779,14 @@ test "minimum content rows keep a neutral transition aligned with thinking" {
     try std.testing.expectEqual(@as(?u16, 9), thinking.activity_row);
 }
 
-test "real activity supersedes neutral minimum content rows" {
+test "real activity supersedes prompt turn reservation" {
     const layout = solve(.{
         .terminal = testLayout(24, 80),
         .owned_top = 1,
         .footer = testFooter(3),
         .transcript = .{ .natural_visual_rows = 7 },
         .activity = .{ .thinking = .{ .gap_above_activity = 1, .footer_gap_after_activity = 1 } },
-        .transition = .{ .transcript_rows = 20, .activity = .{ .thinking = .{ .gap_above_activity = 1, .footer_gap_after_activity = 1 } } },
+        .prompt_turn = .{ .transcript_rows = 20, .activity = .{ .thinking = .{ .gap_above_activity = 1, .footer_gap_after_activity = 1 } } },
     });
 
     try std.testing.expectEqual(@as(?u16, 9), layout.activity_row);
@@ -787,27 +794,28 @@ test "real activity supersedes neutral minimum content rows" {
     try std.testing.expectEqual(@as(u16, 13), layout.solved_frame_height);
 }
 
-test "minimum content rows do not release preserved shell rows" {
+test "prompt turn reservation participates in preserved row release" {
     const input = SolveInput{
-        .terminal = testLayout(24, 80),
-        .owned_top = 6,
+        .terminal = testLayout(10, 80),
+        .owned_top = 5,
         .footer = testFooter(3),
         .transcript = .{ .natural_visual_rows = 2 },
-        .transition = .{ .transcript_rows = 7, .activity = .{ .thinking = .{ .gap_above_activity = 1, .footer_gap_after_activity = 1 } } },
+        .prompt_turn = .{ .transcript_rows = 7, .activity = .{ .thinking = .{ .gap_above_activity = 1, .footer_gap_after_activity = 1 } } },
     };
     const plan = solveWithPreservedRowRelease(input, 0);
 
-    try std.testing.expectEqual(@as(u16, 6), plan.layout.owned_top);
-    try std.testing.expectEqual(@as(u16, 0), plan.released_rows);
+    try std.testing.expectEqual(@as(u16, 1), plan.layout.owned_top);
+    try std.testing.expectEqual(@as(u16, 4), plan.released_rows);
+    try std.testing.expectEqual(FrameRect{ .top = 8, .bottom = 10 }, plan.layout.footer_area);
 }
 
-test "minimum content rows clamp without displacing visible content" {
+test "prompt turn reservation clamps to terminal height" {
     const layout = solve(.{
         .terminal = testLayout(8, 80),
         .owned_top = 1,
         .footer = testFooter(3),
         .transcript = .{ .natural_visual_rows = 6 },
-        .transition = .{ .transcript_rows = 7, .activity = .{ .thinking = .{ .gap_above_activity = 1, .footer_gap_after_activity = 1 } } },
+        .prompt_turn = .{ .transcript_rows = 7, .activity = .{ .thinking = .{ .gap_above_activity = 1, .footer_gap_after_activity = 1 } } },
     });
 
     try std.testing.expectEqual(@as(u16, 8), layout.solved_frame_height);

--- a/src/ui/render_engine/frame_layout.zig
+++ b/src/ui/render_engine/frame_layout.zig
@@ -153,13 +153,22 @@ pub const CommittedLayoutSnapshot = struct {
     }
 };
 
+pub const TransitionReservation = struct {
+    transcript_rows: u16 = 0,
+    activity: ActivityState = .none,
+
+    pub fn active(self: TransitionReservation) bool {
+        return self.transcript_rows > 0 and self.activity != .none;
+    }
+};
+
 pub const SolveInput = struct {
     terminal: Layout,
     owned_top: u16,
     footer: FooterMeasurement,
     transcript: TranscriptFlowPreview,
     activity: ActivityState = .none,
-    minimum_content_rows: u16 = 0,
+    transition: TransitionReservation = .{},
     body_mode: BodyMode = .transcript,
     prior: CommittedLayoutSnapshot = .{},
     placement_policy: FramePlacementPolicy = .compact_until_full,
@@ -251,8 +260,8 @@ pub fn solve(input: SolveInput) FrameLayout {
     };
     const transcript_height = @min(natural_body_rows, body_capacity);
     const natural_content_rows = transcript_height +| reserved_activity_rows +| footer_height;
-    const minimum_content_rows = if (reservation.activity_rows == 0) input.minimum_content_rows else 0;
-    const solved_frame_height = @min(available_rows, @max(natural_content_rows, minimum_content_rows));
+    const transition_rows = solveTransitionReservation(input, footer_height, available_rows);
+    const solved_frame_height = @min(available_rows, @max(natural_content_rows, transition_rows));
     const neutral_rows = solved_frame_height -| natural_content_rows;
     const owned_band = rectFromTopHeight(owned_top, solved_frame_height);
     const transcript_area = rectFromTopHeight(owned_top, transcript_height);
@@ -310,7 +319,7 @@ pub fn solveWithPreservedRowRelease(input: SolveInput, release_floor_rows: u16) 
 
     var maximum_input = input;
     maximum_input.owned_top = 1;
-    maximum_input.minimum_content_rows = 0;
+    maximum_input.transition = .{};
     const maximum = solve(maximum_input);
     const geometry_top = if (maximum.solved_frame_height == 0)
         initial.owned_top
@@ -325,6 +334,20 @@ pub fn solveWithPreservedRowRelease(input: SolveInput, release_floor_rows: u16) 
         .layout = final,
         .released_rows = initial.owned_top -| final.owned_top,
     };
+}
+
+fn solveTransitionReservation(input: SolveInput, footer_height: u16, available_rows: u16) u16 {
+    if (input.activity != .none or !input.transition.active()) return 0;
+    var transition_input = input;
+    transition_input.transcript.natural_visual_rows = input.transition.transcript_rows;
+    transition_input.activity = input.transition.activity;
+    transition_input.transition = .{};
+    const reservation = solveActivityReservation(transition_input, footer_height, available_rows);
+    return input.transition.transcript_rows +|
+        reservation.boundary_gap +|
+        reservation.activity_rows +|
+        reservation.footer_gap +|
+        footer_height;
 }
 
 const ActivityReservation = struct {
@@ -712,21 +735,21 @@ test "minimum content rows keep a neutral transition aligned with thinking" {
         .owned_top = 1,
         .footer = testFooter(3),
         .transcript = .{ .natural_visual_rows = 5 },
-        .minimum_content_rows = 13,
+        .transition = .{ .transcript_rows = 7, .activity = .{ .thinking = .{ .gap_above_activity = 1, .footer_gap_after_activity = 1 } } },
     });
     const pending = solve(.{
         .terminal = testLayout(24, 80),
         .owned_top = 1,
         .footer = testFooter(3),
         .transcript = .{ .natural_visual_rows = 8 },
-        .minimum_content_rows = 13,
+        .transition = .{ .transcript_rows = 7, .activity = .{ .thinking = .{ .gap_above_activity = 1, .footer_gap_after_activity = 1 } } },
     });
     const adopted = solve(.{
         .terminal = testLayout(24, 80),
         .owned_top = 1,
         .footer = testFooter(3),
         .transcript = .{ .natural_visual_rows = 7 },
-        .minimum_content_rows = 13,
+        .transition = .{ .transcript_rows = 7, .activity = .{ .thinking = .{ .gap_above_activity = 1, .footer_gap_after_activity = 1 } } },
     });
     const thinking = solve(.{
         .terminal = testLayout(24, 80),
@@ -756,7 +779,7 @@ test "real activity supersedes neutral minimum content rows" {
         .footer = testFooter(3),
         .transcript = .{ .natural_visual_rows = 7 },
         .activity = .{ .thinking = .{ .gap_above_activity = 1, .footer_gap_after_activity = 1 } },
-        .minimum_content_rows = 20,
+        .transition = .{ .transcript_rows = 20, .activity = .{ .thinking = .{ .gap_above_activity = 1, .footer_gap_after_activity = 1 } } },
     });
 
     try std.testing.expectEqual(@as(?u16, 9), layout.activity_row);
@@ -770,7 +793,7 @@ test "minimum content rows do not release preserved shell rows" {
         .owned_top = 6,
         .footer = testFooter(3),
         .transcript = .{ .natural_visual_rows = 2 },
-        .minimum_content_rows = 13,
+        .transition = .{ .transcript_rows = 7, .activity = .{ .thinking = .{ .gap_above_activity = 1, .footer_gap_after_activity = 1 } } },
     };
     const plan = solveWithPreservedRowRelease(input, 0);
 
@@ -784,7 +807,7 @@ test "minimum content rows clamp without displacing visible content" {
         .owned_top = 1,
         .footer = testFooter(3),
         .transcript = .{ .natural_visual_rows = 6 },
-        .minimum_content_rows = 13,
+        .transition = .{ .transcript_rows = 7, .activity = .{ .thinking = .{ .gap_above_activity = 1, .footer_gap_after_activity = 1 } } },
     });
 
     try std.testing.expectEqual(@as(u16, 8), layout.solved_frame_height);

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -2729,8 +2729,11 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       await session.waitForText("Thinking", TIMEOUT);
       await Bun.sleep(250);
       const thinkingGrid = await session.capturePaneGrid();
-      const rowContaining = (grid: string[], needle: string) =>
-        grid.findIndex((row) => row.includes(needle));
+      const rowContaining = (grid: string[], needle: string) => {
+        const row = grid.findIndex((line) => line.includes(needle));
+        expect(row).toBeGreaterThanOrEqual(0);
+        return row;
+      };
       expect(rowContaining(thinkingGrid, submittedPrompt)).toBe(
         rowContaining(preEnterGrid, submittedPrompt),
       );

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -2719,6 +2719,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
 
       await session.waitForComposer(TIMEOUT);
       await session.sendLiteral(submittedPrompt);
+      const preEnterGrid = await session.capturePaneGrid();
       session.sendKeysImmediate(["Enter"]);
       session.sendLiteralImmediate(newerDraft);
       await waitForCondition(
@@ -2727,6 +2728,12 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       );
       await session.waitForText("Thinking", TIMEOUT);
       await Bun.sleep(250);
+      const thinkingGrid = await session.capturePaneGrid();
+      const rowContaining = (grid: string[], needle: string) =>
+        grid.findIndex((row) => row.includes(needle));
+      expect(rowContaining(thinkingGrid, submittedPrompt)).toBe(
+        rowContaining(preEnterGrid, submittedPrompt),
+      );
       await session.sendKeys("C-c");
       const cancelledPane = await session.waitForText("cancelled", TIMEOUT);
 


### PR DESCRIPTION
## Summary

- Keep the composer and status rows fixed while a submitted prompt transitions into Thinking.