### PR TITLE
Use named options for libfx agents

### DIFF
--- a/benchmarks/libfx/bench-bridge.mjs
+++ b/benchmarks/libfx/bench-bridge.mjs
@@ -60,11 +60,9 @@ const agent = await createFxAgent({
       return `bridge:${input.value}`;
     },
   }],
-  env: {
-    AI_GATEWAY_API_KEY: "bridge-key",
-    FX_GATEWAY_CHAT_URL: `http://127.0.0.1:${server.address().port}/chat`,
-    FX_MODEL: "bridge/model",
-  },
+  apiKey: "bridge-key",
+  gatewayChatUrl: `http://127.0.0.1:${server.address().port}/chat`,
+  model: "bridge/model",
 });
 
 try {

--- a/benchmarks/libfx/bench-fx.mjs
+++ b/benchmarks/libfx/bench-fx.mjs
@@ -72,11 +72,9 @@ async function runChild() {
     fetch: tracedFetch,
     home: repoRoot,
     workspaceRoot: repoRoot,
-    env: {
-      AI_GATEWAY_API_KEY: "libfx-benchmark-key",
-      FX_GATEWAY_CHAT_URL: gatewayUrl,
-      FX_MODEL: "benchmark/model",
-    },
+    apiKey: "libfx-benchmark-key",
+    gatewayChatUrl: gatewayUrl,
+    model: "benchmark/model",
   });
   const agentReadyAt = performance.now();
   const promptAt = performance.now();

--- a/sdk/NAPI.md
+++ b/sdk/NAPI.md
@@ -133,7 +133,7 @@ This restriction is a security boundary. New tools or host effects must not be e
 
 ## Gateway endpoint policy
 
-The Gateway URL is validated independently in JavaScript and Zig. This duplication is intentional defense in depth because callers can load and call `libfx.node` directly, bypassing `sdk/node.js`.
+The Gateway URL is validated independently in JavaScript and Zig. This duplication is intentional defense in depth because callers can load and call `libfx.node` directly, bypassing `sdk/fx-sdk.js`.
 
 Accepted endpoints are:
 
@@ -142,7 +142,7 @@ Accepted endpoints are:
 
 URLs with embedded credentials or fragments are rejected. Arbitrary HTTPS hosts, non-loopback HTTP hosts, and other schemes are rejected. Loopback HTTP exists only for local development and deterministic tests.
 
-Keep the validation in `sdk/node.js`, `src/napi_core_main.zig`, and `streamable_http.validateEndpoint()` aligned. Loosening only one layer creates inconsistent behavior and may create a server-side request forgery path for callers using the low-level addon directly.
+Keep the validation in `sdk/fx-sdk.js`, `src/napi_core_main.zig`, and `streamable_http.validateEndpoint()` aligned. Loosening only one layer creates inconsistent behavior and may create a server-side request forgery path for callers using the low-level addon directly.
 
 ## Resource limits and backpressure
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -19,7 +19,8 @@ filesystem read when imported.
 import { createFxAgent } from "libfx";
 
 const agent = await createFxAgent({
-  env: { AI_GATEWAY_API_KEY: process.env.AI_GATEWAY_API_KEY },
+  apiKey: process.env.AI_GATEWAY_API_KEY,
+  model: "google/gemini-2.5-flash-lite",
 });
 
 const turn = agent.prompt("Explain this project.");
@@ -32,6 +33,10 @@ console.log(await turn.result); // { stopReason, usage }
 const checkpoint = await agent.checkpoint();
 await agent.close();
 ```
+
+`apiKey` is required. `model` is optional and defaults to fx's built-in model.
+Agent configuration uses named options; `env` is reserved for
+`createFxTerminal()`.
 
 `prompt(input, { signal? })` accepts a string or text/resource blocks. It
 returns an async iterable of normalized events:
@@ -46,7 +51,7 @@ opaque, bounded, versioned bytes. Restore them only when creating a fresh
 agent:
 
 ```js
-const restored = await createFxAgent({ checkpoint, env });
+const restored = await createFxAgent({ apiKey, model, checkpoint });
 ```
 
 The checkpoint contains conversation history and usage only. The host owns
@@ -57,6 +62,8 @@ MCP clients, and skill records.
 
 ```js
 const agent = await createFxAgent({
+  apiKey,
+  model,
   instructions: "Keep answers concise.",
   tools: [{
     name: "lookup",
@@ -70,7 +77,6 @@ const agent = await createFxAgent({
       return database.get(input.key, { signal });
     },
   }],
-  env,
 });
 ```
 
@@ -94,9 +100,10 @@ const mcp = await createMcpAdapter(client, {
 });
 
 const agent = await createFxAgent({
+  apiKey,
+  model,
   tools: mcp.tools,
   instructions: mcp.instructions,
-  env,
 });
 
 // ...
@@ -115,15 +122,15 @@ import { createSkillsAdapter } from "libfx/skills";
 
 const record = await loadSkillFile("./skills/review/SKILL.md");
 const skills = createSkillsAdapter([record]);
-const agent = await createFxAgent({ ...skills, env });
+const agent = await createFxAgent({ apiKey, model, ...skills });
 ```
 
 ## Backends
 
 ```js
-await createFxAgent({ backend: "auto" });   // native, then Wasm fallback
-await createFxAgent({ backend: "native" }); // require N-API
-await createFxAgent({ backend: "wasm" });   // require Wasm + JSPI
+await createFxAgent({ apiKey, backend: "auto" });   // native, then Wasm fallback
+await createFxAgent({ apiKey, backend: "native" }); // require N-API
+await createFxAgent({ apiKey, backend: "wasm" });   // require Wasm + JSPI
 ```
 
 Within one JavaScript realm, libfx compiles each stable Wasm source once and
@@ -156,7 +163,7 @@ stores remain terminal-only host integrations.
 
 ## Security
 
-Treat `nativeAddon` and `env.FX_GATEWAY_CHAT_URL` as trusted host
+Treat `nativeAddon` and `gatewayChatUrl` as trusted host
 configuration. Do not embed long-lived credentials in public browser code.
 Host tool functions, MCP clients, and skill loaders retain their own authority;
 libfx validates and sequences them but does not grant operating-system access.

--- a/sdk/fx-sdk.js
+++ b/sdk/fx-sdk.js
@@ -5,7 +5,58 @@ const workspaceInfoLimit = 4 * 1024;
 const workspaceCommandLimit = 64 * 1024;
 const workspaceOutputLimit = 64 * 1024;
 const maxInstructionsBytes = 64 * 1024;
+const maxApiKeyBytes = 64 * 1024;
+const maxModelBytes = 1024;
+const maxUrlBytes = 16 * 1024;
 const streamReadsPerTaskYield = 32;
+
+function boundedString(value, name, maxBytes, required) {
+  if (value === undefined && !required) return undefined;
+  if (typeof value !== "string" || value.length === 0) {
+    throw new TypeError(`${name} ${required ? "is required and " : ""}must be a non-empty string`);
+  }
+  if (encoder.encode(value).length > maxBytes) {
+    throw new RangeError(`${name} exceeds the ${maxBytes} byte libfx limit`);
+  }
+  return value;
+}
+
+function validateGatewayChatUrl(value) {
+  if (value === undefined) return;
+  boundedString(value, "gatewayChatUrl", maxUrlBytes, false);
+  let url;
+  try { url = new URL(value); } catch { throw new TypeError("gatewayChatUrl must be a valid URL"); }
+  if (url.username || url.password || url.hash) {
+    throw new TypeError("gatewayChatUrl must not contain credentials or a fragment");
+  }
+  if (url.href === "https://ai-gateway.vercel.sh/v3/ai/language-model") return;
+  const loopback = url.hostname === "127.0.0.1" || url.hostname === "[::1]" || url.hostname === "localhost";
+  if (url.protocol !== "http:" || !loopback || !url.port) {
+    throw new TypeError("gatewayChatUrl must use the canonical Gateway or explicit loopback HTTP");
+  }
+}
+
+function normalizeAgentOptions(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError("createFxAgent() options must be an object");
+  }
+  const options = { ...value };
+  if (Object.hasOwn(options, "env")) {
+    throw new TypeError("createFxAgent() does not accept env; pass apiKey and model directly");
+  }
+  options.apiKey = boundedString(options.apiKey, "apiKey", maxApiKeyBytes, true);
+  options.model = boundedString(options.model, "model", maxModelBytes, false);
+  validateGatewayChatUrl(options.gatewayChatUrl);
+  return options;
+}
+
+function agentEnvironment(options) {
+  return {
+    AI_GATEWAY_API_KEY: options.apiKey,
+    ...(options.model === undefined ? {} : { FX_MODEL: options.model }),
+    ...(options.gatewayChatUrl === undefined ? {} : { FX_GATEWAY_CHAT_URL: options.gatewayChatUrl }),
+  };
+}
 
 function validWorkspacePath(path) {
   if (typeof path !== "string" || !path.startsWith("/") || path.includes("\0")) return false;
@@ -1014,7 +1065,7 @@ function base64ToBytes(value) {
 }
 
 export async function createFxAgent(options = {}) {
-  options = { ...options };
+  options = normalizeAgentOptions(options);
   const hostTools = normalizeHostTools(options.tools);
   const instructions = normalizeInstructions(options.instructions);
   const initialCheckpoint = checkpointBytes(options.checkpoint);
@@ -1047,7 +1098,12 @@ export async function createFxAgent(options = {}) {
     return { content, isError, cancelled: controller.signal.aborted };
   };
   emit("runtime.start");
-  const runtimeOptions = { ...options, args: ["acp"], hostToolExecutor: executeHostTool };
+  const runtimeOptions = {
+    ...options,
+    args: ["acp"],
+    env: agentEnvironment(options),
+    hostToolExecutor: executeHostTool,
+  };
   const runtime = options.runtimeFactory
     ? await options.runtimeFactory(runtimeOptions)
     : await instantiate(runtimeOptions);

--- a/sdk/index.html
+++ b/sdk/index.html
@@ -310,10 +310,8 @@
           wasm: location.hostname === "localhost" || location.hostname === "127.0.0.1"
             ? "../zig-out/bin/fx-core.wasm"
             : "./fx-core.wasm",
-          env: {
-            AI_GATEWAY_API_KEY: localStorage.getItem("FX_API_KEY") || "sdk-test-key",
-            ...(initialModel ? { FX_MODEL: initialModel } : {}),
-          },
+          apiKey: localStorage.getItem("FX_API_KEY") || "sdk-test-key",
+          ...(initialModel ? { model: initialModel } : {}),
           fetch: dispatchFetch,
           onEvent: observe,
           onPermission: resolvePermission,

--- a/sdk/node.js
+++ b/sdk/node.js
@@ -120,26 +120,8 @@ function wasmBytes(input) {
   return pending;
 }
 
-function validateGatewayChatUrl(value) {
-  if (value === undefined) return;
-  if (typeof value !== "string") throw new TypeError("FX_GATEWAY_CHAT_URL must be a string");
-  let url;
-  try { url = new URL(value); } catch { throw new TypeError("FX_GATEWAY_CHAT_URL must be a valid URL"); }
-  if (url.username || url.password || url.hash) {
-    throw new TypeError("FX_GATEWAY_CHAT_URL must not contain credentials or a fragment");
-  }
-  if (url.href === "https://ai-gateway.vercel.sh/v3/ai/language-model") return;
-  const loopback = url.hostname === "127.0.0.1" || url.hostname === "[::1]" || url.hostname === "localhost";
-  if (url.protocol !== "http:" || !loopback || !url.port) {
-    throw new TypeError("FX_GATEWAY_CHAT_URL must use the canonical Gateway or explicit loopback HTTP");
-  }
-}
-
 function createNativeCoreRuntime(addon, options) {
-  const apiKey = options.env?.AI_GATEWAY_API_KEY;
-  const model = options.env?.FX_MODEL;
-  const gatewayChatUrl = options.env?.FX_GATEWAY_CHAT_URL;
-  validateGatewayChatUrl(gatewayChatUrl);
+  const { apiKey, model, gatewayChatUrl } = options;
   const core = addon.createCore({
     apiKey,
     home: options.home ?? homedir(),
@@ -258,7 +240,6 @@ function createNativeAgent(addon, options) {
 
 async function createWithFallback(surface, nativeMethod, wasmFactory, defaultWasm, options) {
   const { nativeAddon, backend = "auto", ...runtimeOptions } = options ?? {};
-  validateGatewayChatUrl(runtimeOptions.env?.FX_GATEWAY_CHAT_URL);
   if (!new Set(["auto", "native", "wasm"]).has(backend)) {
     throw new TypeError('backend must be "auto", "native", or "wasm"');
   }
@@ -298,8 +279,17 @@ async function createWithFallback(surface, nativeMethod, wasmFactory, defaultWas
   });
 }
 
-export function createFxAgent(options = {}) {
-  return createWithFallback("agent", "createFxAgent", createWasmAgent, defaultCoreWasm, options);
+export async function createFxAgent(options = {}) {
+  if (options != null && Object.hasOwn(Object(options), "env")) {
+    throw new TypeError("createFxAgent() does not accept env; pass apiKey and model directly");
+  }
+  return createWithFallback(
+    "agent",
+    "createFxAgent",
+    createWasmAgent,
+    defaultCoreWasm,
+    options,
+  );
 }
 
 export function createFxTerminal(options = {}) {

--- a/sdk/node.js
+++ b/sdk/node.js
@@ -67,9 +67,8 @@ function validateNativeBackend(backend) {
     const actualVersion = backend.libfxApiVersion ?? "missing";
     throw new Error(`native addon API version ${actualVersion} is incompatible with libfx API version ${libfxApiVersion}`);
   }
-  if (typeof backend.createFxAgent !== "function" && typeof backend.createCore !== "function" &&
-    typeof backend.createFxTerminal !== "function") {
-    throw new Error("native addon must export createFxAgent(), createCore(), or createFxTerminal()");
+  if (typeof backend.createCore !== "function" && typeof backend.createFxTerminal !== "function") {
+    throw new Error("native addon must export createCore() or createFxTerminal()");
   }
   return backend;
 }
@@ -249,14 +248,11 @@ async function createWithFallback(surface, nativeMethod, wasmFactory, defaultWas
   if (backend !== "wasm") {
     const native = await resolveNativeBackend(nativeAddon);
     nativeError = native.error;
-    if (typeof native.backend?.[nativeMethod] === "function" ||
-      (surface === "agent" && typeof native.backend?.createCore === "function")) {
+    if (typeof native.backend?.[nativeMethod] === "function") {
       nativeAttempted = true;
       try {
-        if (typeof native.backend?.[nativeMethod] === "function") {
-          return await native.backend[nativeMethod](runtimeOptions);
-        }
-        return await createNativeAgent(native.backend, runtimeOptions);
+        if (surface === "agent") return await createNativeAgent(native.backend, runtimeOptions);
+        return await native.backend[nativeMethod](runtimeOptions);
       } catch (error) {
         nativeError = error;
         if (backend === "native") throw error;
@@ -285,7 +281,7 @@ export async function createFxAgent(options = {}) {
   }
   return createWithFallback(
     "agent",
-    "createFxAgent",
+    "createCore",
     createWasmAgent,
     defaultCoreWasm,
     options,

--- a/sdk/tests/test-agent-bootstrap.mjs
+++ b/sdk/tests/test-agent-bootstrap.mjs
@@ -35,7 +35,7 @@ if (!child) {
     backend,
     nativeAddon,
     ...(wasm ? { wasm } : {}),
-    env: { AI_GATEWAY_API_KEY: "bootstrap-test-key" },
+    apiKey: "bootstrap-test-key",
   };
   const attempts = backend === "native" ? 65 : 1;
 

--- a/sdk/tests/test-checkpoint.mjs
+++ b/sdk/tests/test-checkpoint.mjs
@@ -53,11 +53,9 @@ const options = (backend, checkpoint) => ({
   ...(backend === "wasm" ? { wasm } : {}),
   ...(checkpoint ? { checkpoint } : {}),
   fetch,
-  env: {
-    AI_GATEWAY_API_KEY: "checkpoint-key",
-    FX_GATEWAY_CHAT_URL: `http://127.0.0.1:${port}/chat`,
-    FX_MODEL: "checkpoint/model",
-  },
+  apiKey: "checkpoint-key",
+  gatewayChatUrl: `http://127.0.0.1:${port}/chat`,
+  model: "checkpoint/model",
 });
 
 let source;

--- a/sdk/tests/test-core-cancel.mjs
+++ b/sdk/tests/test-core-cancel.mjs
@@ -39,7 +39,7 @@ const agent = await Promise.race([
   backend: "wasm",
     wasm: await readFile(wasmPath),
     fetch: stalledFetch,
-    env: { AI_GATEWAY_API_KEY: "sdk-test-key" },
+    apiKey: "sdk-test-key",
   }),
   timeout("fx-core initialize"),
 ]);

--- a/sdk/tests/test-core-home-unavailable.mjs
+++ b/sdk/tests/test-core-home-unavailable.mjs
@@ -54,10 +54,7 @@ const agent = await Promise.race([
     backend: "wasm",
     wasm: await readFile(wasmPath),
     fetch: mockFetch,
-    env: {
-      AI_GATEWAY_API_KEY: "sdk-test-key",
-      HOME: "/repo",
-    },
+    apiKey: "sdk-test-key",
     workspace: {
       info: {
         version: 1,

--- a/sdk/tests/test-core-live.mjs
+++ b/sdk/tests/test-core-live.mjs
@@ -11,6 +11,7 @@ const wasmPath = resolve(process.argv[2] || defaultWasm);
 const backend = process.env.LIBFX_LIVE_BACKEND || "wasm";
 const nativeAddon = resolve(scriptDir, "../../zig-out/lib/libfx.node");
 const apiKey = process.env.AI_GATEWAY_API_KEY || process.env.FX_API_KEY;
+const model = process.env.FX_MODEL || "google/gemini-2.5-flash-lite";
 
 if (!supportsJspi()) {
   console.error("Node JSPI is disabled. Run with: node --experimental-wasm-jspi sdk/scripts/test-core-live.mjs");
@@ -71,7 +72,7 @@ const tracedFetch = async (url, init) => {
 };
 
 const agent = await Promise.race([
-  createFxAgent({ backend, nativeAddon, wasm: await readFile(wasmPath), fetch: tracedFetch, env: { AI_GATEWAY_API_KEY: apiKey } }),
+  createFxAgent({ backend, nativeAddon, wasm: await readFile(wasmPath), fetch: tracedFetch, apiKey, model }),
   new Promise((_, reject) => setTimeout(() => reject(new Error("timed out waiting for fx-core initialize")), 5000)),
 ]);
 

--- a/sdk/tests/test-core.mjs
+++ b/sdk/tests/test-core.mjs
@@ -15,12 +15,17 @@ if (!supportsJspi()) {
 const encoded = new TextEncoder();
 let fetchCalls = 0;
 let requestedSessionId;
+let requestedAuthorization;
+let requestedModel;
 const mockFetch = async (url, init) => {
   if (init.method === "GET") {
     return Response.json({ object: "list", data: [{ id: "sdk/core-model", type: "language" }] });
   }
   fetchCalls += 1;
-  requestedSessionId = new Headers(init.headers).get("x-session-id");
+  const headers = new Headers(init.headers);
+  requestedSessionId = headers.get("x-session-id");
+  requestedAuthorization = headers.get("authorization");
+  requestedModel = headers.get("ai-language-model-id");
   const payload = JSON.parse(new TextDecoder().decode(init.body));
   assert.ok(Array.isArray(payload.prompt) || Array.isArray(payload.messages));
   return new Response(new ReadableStream({
@@ -38,10 +43,8 @@ const agent = await createFxAgent({
   backend: "wasm",
   wasm: await readFile(wasmPath),
   fetch: mockFetch,
-  env: {
-    AI_GATEWAY_API_KEY: "sdk-test-key",
-    FX_MODEL: "sdk/core-model",
-  },
+  apiKey: "sdk-test-key",
+  model: "sdk/core-model",
 });
 assert.deepEqual(Object.keys(agent).sort(), ["checkpoint", "close", "prompt"]);
 
@@ -60,6 +63,8 @@ assert.deepEqual(await turn.result, {
 });
 assert.equal(fetchCalls, 1);
 assert.ok(requestedSessionId);
+assert.equal(requestedAuthorization, "Bearer sdk-test-key");
+assert.equal(requestedModel, "sdk/core-model");
 assert.ok((await agent.checkpoint()).length > 48);
 assert.equal(await agent.close(), undefined);
 console.log("core SDK passed: minimal prompt, stream, usage, checkpoint, and close");

--- a/sdk/tests/test-host-tool-cancel.mjs
+++ b/sdk/tests/test-host-tool-cancel.mjs
@@ -47,7 +47,9 @@ const agent = await createFxAgent({
       }, { once: true }));
     },
   }],
-  env: { AI_GATEWAY_API_KEY: "cancel-key", FX_GATEWAY_CHAT_URL: `http://127.0.0.1:${server.address().port}/chat`, FX_MODEL: "cancel/model" },
+  apiKey: "cancel-key",
+  gatewayChatUrl: `http://127.0.0.1:${server.address().port}/chat`,
+  model: "cancel/model",
 });
 
 try {

--- a/sdk/tests/test-host-tools.mjs
+++ b/sdk/tests/test-host-tools.mjs
@@ -61,11 +61,9 @@ try {
     ...(backend === "wasm" ? { wasm: await readFile(wasmPath) } : {}),
     fetch,
     onEvent(event) { sdkEvents.push(event); },
-    env: {
-      AI_GATEWAY_API_KEY: "host-tool-key",
-      FX_GATEWAY_CHAT_URL: `http://127.0.0.1:${port}/chat`,
-      FX_MODEL: "host/tool-model",
-    },
+    apiKey: "host-tool-key",
+    gatewayChatUrl: `http://127.0.0.1:${port}/chat`,
+    model: "host/tool-model",
     tools: [{
       name: "lookup",
       description: "Look up a value by key.",

--- a/sdk/tests/test-instruction-limits.mjs
+++ b/sdk/tests/test-instruction-limits.mjs
@@ -24,7 +24,7 @@ const options = {
   ...(backend === "wasm"
     ? { wasm: await readFile(resolve(scriptDir, "../../zig-out/bin/fx-core.wasm")) }
     : {}),
-  env: { AI_GATEWAY_API_KEY: "instruction-limit-test-key" },
+  apiKey: "instruction-limit-test-key",
 };
 
 const agent = await createFxAgent({ ...options, instructions: exactInstructions });
@@ -33,6 +33,7 @@ await agent.close();
 let runtimeCreations = 0;
 await assert.rejects(
   createSharedAgent({
+    apiKey: "instruction-limit-test-key",
     instructions: `${exactInstructions}x`,
     runtimeFactory() {
       runtimeCreations += 1;

--- a/sdk/tests/test-libfx-loader.mjs
+++ b/sdk/tests/test-libfx-loader.mjs
@@ -35,20 +35,60 @@ for (const gatewayChatUrl of [
   "file:///tmp/socket",
 ]) {
   await assert.rejects(
-    createFxAgent({ nativeAddon: nativeUrl, env: { FX_GATEWAY_CHAT_URL: gatewayChatUrl } }),
+    createFxAgent({ backend: "native", nativeAddon: realNativeAddon, apiKey: "loader-key", gatewayChatUrl }),
     TypeError,
   );
 }
 
-const agent = await createFxAgent({ nativeAddon: nativeUrl, marker: 1 });
+await assert.rejects(
+  createFxAgent({
+    nativeAddon: nativeUrl,
+    apiKey: "loader-key",
+    env: { FX_MODEL: "legacy/model" },
+  }),
+  (error) => error instanceof TypeError && error.message.includes("apiKey") && error.message.includes("model"),
+);
+await assert.rejects(
+  browser.createFxAgent({ apiKey: "loader-key", env: { FX_MODEL: "legacy/model" } }),
+  (error) => error instanceof TypeError && error.message.includes("apiKey") && error.message.includes("model"),
+);
+await assert.rejects(
+  createFxAgent({ nativeAddon: nativeUrl, apiKey: "loader-key", env: undefined }),
+  (error) => error instanceof TypeError && error.message.includes("apiKey") && error.message.includes("model"),
+);
+
+for (const [options, errorType, message] of [
+  [{}, TypeError, "apiKey"],
+  [{ apiKey: "" }, TypeError, "apiKey"],
+  [{ apiKey: 1 }, TypeError, "apiKey"],
+  [{ apiKey: "loader-key", model: "" }, TypeError, "model"],
+  [{ apiKey: "loader-key", model: 1 }, TypeError, "model"],
+  [{ apiKey: "x".repeat(65_537) }, RangeError, "65536"],
+  [{ apiKey: "loader-key", model: "x".repeat(1_025) }, RangeError, "1024"],
+]) {
+  await assert.rejects(
+    createFxAgent({ backend: "native", nativeAddon: realNativeAddon, ...options }),
+    (error) => error instanceof errorType && error.message.includes(message),
+  );
+}
+
+const agent = await createFxAgent({
+  nativeAddon: nativeUrl,
+  apiKey: "loader-key",
+  model: "loader/model",
+  marker: 1,
+});
 assert.equal(agent.backend, "native-agent");
+assert.equal(agent.options.apiKey, "loader-key");
+assert.equal(agent.options.model, "loader/model");
 assert.equal(agent.options.marker, 1);
 assert.equal("nativeAddon" in agent.options, false);
 assert.equal("backend" in agent.options, false);
 
-const terminal = await createFxTerminal({ nativeAddon: nativeUrl, marker: 2 });
+const terminal = await createFxTerminal({ nativeAddon: nativeUrl, env: { FX_THEME: "dark" }, marker: 2 });
 assert.equal(terminal.backend, "native-terminal");
 assert.equal(terminal.options.marker, 2);
+assert.deepEqual(terminal.options.env, { FX_THEME: "dark" });
 
 const savedSuspending = WebAssembly.Suspending;
 const savedPromising = WebAssembly.promising;
@@ -56,19 +96,19 @@ try {
   Object.defineProperty(WebAssembly, "Suspending", { configurable: true, value: undefined });
   Object.defineProperty(WebAssembly, "promising", { configurable: true, value: undefined });
   await assert.rejects(
-    createFxAgent({ nativeAddon: nativeUrl, backend: "wasm" }),
+    createFxAgent({ nativeAddon: nativeUrl, backend: "wasm", apiKey: "loader-key" }),
     (error) => error?.code === "LIBFX_JSPI_REQUIRED" &&
       error.message.includes("--experimental-wasm-jspi"),
   );
   await assert.rejects(
-    createFxAgent({ nativeAddon: realNativeAddon, instructions: "x".repeat(65_537) }),
+    createFxAgent({ nativeAddon: realNativeAddon, apiKey: "loader-key", instructions: "x".repeat(65_537) }),
     (error) => error instanceof RangeError && error.message.includes("65536"),
   );
   await assert.rejects(
     createFxAgent({
       nativeAddon: realNativeAddon,
       checkpoint: new Uint8Array([1, 2, 3]),
-      env: { AI_GATEWAY_API_KEY: "loader-checkpoint-key" },
+      apiKey: "loader-checkpoint-key",
     }),
     (error) => error.message.includes("Invalid or non-fresh libfx checkpoint"),
   );
@@ -94,7 +134,7 @@ await writeFile(incompatiblePath, `
   export async function createFxAgent() {}
 `);
 await assert.rejects(
-  createFxAgent({ nativeAddon: pathToFileURL(incompatiblePath), backend: "native" }),
+  createFxAgent({ nativeAddon: pathToFileURL(incompatiblePath), backend: "native", apiKey: "loader-key" }),
   (error) => error?.code === "LIBFX_NATIVE_UNAVAILABLE" &&
     error.message.includes("incompatible"),
 );
@@ -111,7 +151,7 @@ for (const [name, source] of [
   const modulePath = resolve(dir, `${name}.mjs`);
   await writeFile(modulePath, source);
   await assert.rejects(
-    createFxAgent({ nativeAddon: pathToFileURL(modulePath), backend: "native" }),
+    createFxAgent({ nativeAddon: pathToFileURL(modulePath), backend: "native", apiKey: "loader-key" }),
     (error) => error?.code === "LIBFX_NATIVE_UNAVAILABLE" &&
       error.message.includes("incompatible") &&
       !String(error.cause).includes("createCore invoked"),
@@ -129,7 +169,7 @@ await writeFile(matchingVersionPath, `
   }
 `);
 await assert.rejects(
-  createFxAgent({ nativeAddon: pathToFileURL(matchingVersionPath), backend: "native" }),
+  createFxAgent({ nativeAddon: pathToFileURL(matchingVersionPath), backend: "native", apiKey: "loader-key" }),
   (error) => error?.code === "MATCHING_VERSION_INVOKED",
   "matching v2 low-level addon must reach createCore",
 );

--- a/sdk/tests/test-libfx-loader.mjs
+++ b/sdk/tests/test-libfx-loader.mjs
@@ -23,10 +23,25 @@ const realNativeAddon = resolve(scriptDir, "../../zig-out/lib/libfx.node");
 const dir = await mkdtemp(resolve(tmpdir(), "libfx-loader-"));
 const nativePath = resolve(dir, "native.mjs");
 await writeFile(nativePath, `
-  export async function createFxAgent(options) { return { backend: "native-agent", options }; }
   export async function createFxTerminal(options) { return { backend: "native-terminal", options }; }
 `);
 const nativeUrl = pathToFileURL(nativePath);
+
+const highLevelAgentPath = resolve(dir, "high-level-agent.mjs");
+await writeFile(highLevelAgentPath, `
+  export const libfxApiVersion = 2;
+  export function createFxAgent() { throw new Error("high-level createFxAgent invoked"); }
+`);
+await assert.rejects(
+  createFxAgent({
+    backend: "native",
+    nativeAddon: pathToFileURL(highLevelAgentPath),
+    apiKey: "loader-key",
+  }),
+  (error) => error?.code === "LIBFX_NATIVE_UNAVAILABLE" &&
+    error.message.includes("createCore") &&
+    !String(error.cause).includes("high-level createFxAgent invoked"),
+);
 
 for (const gatewayChatUrl of [
   "http://attacker.example/chat",
@@ -72,19 +87,6 @@ for (const [options, errorType, message] of [
   );
 }
 
-const agent = await createFxAgent({
-  nativeAddon: nativeUrl,
-  apiKey: "loader-key",
-  model: "loader/model",
-  marker: 1,
-});
-assert.equal(agent.backend, "native-agent");
-assert.equal(agent.options.apiKey, "loader-key");
-assert.equal(agent.options.model, "loader/model");
-assert.equal(agent.options.marker, 1);
-assert.equal("nativeAddon" in agent.options, false);
-assert.equal("backend" in agent.options, false);
-
 const terminal = await createFxTerminal({ nativeAddon: nativeUrl, env: { FX_THEME: "dark" }, marker: 2 });
 assert.equal(terminal.backend, "native-terminal");
 assert.equal(terminal.options.marker, 2);
@@ -120,7 +122,7 @@ try {
 const coreOnlyPath = resolve(dir, "core-only.mjs");
 await writeFile(coreOnlyPath, `
   export const libfxApiVersion = 2;
-  export async function createFxAgent() { return { backend: "core-only" }; }
+  export function createCore() { throw new Error("unused createCore"); }
 `);
 await assert.rejects(
   createFxTerminal({ nativeAddon: pathToFileURL(coreOnlyPath), backend: "native" }),

--- a/sdk/tests/test-mcp-adapter.mjs
+++ b/sdk/tests/test-mcp-adapter.mjs
@@ -123,7 +123,9 @@ try {
     tools: adapter.tools,
     instructions: adapter.instructions,
     fetch,
-    env: { AI_GATEWAY_API_KEY: "mcp-key", FX_GATEWAY_CHAT_URL: `http://127.0.0.1:${gateway.address().port}/chat`, FX_MODEL: "mcp/model" },
+    apiKey: "mcp-key",
+    gatewayChatUrl: `http://127.0.0.1:${gateway.address().port}/chat`,
+    model: "mcp/model",
   });
   const turn = agent.prompt("use MCP");
   let text = "";

--- a/sdk/tests/test-minimal-api.mjs
+++ b/sdk/tests/test-minimal-api.mjs
@@ -6,6 +6,8 @@ import { fileURLToPath } from "node:url";
 import { createFxAgent } from "../node.js";
 
 const scriptDir = fileURLToPath(new URL(".", import.meta.url));
+let requestedAuthorization;
+let requestedModel;
 const server = createServer((request, response) => {
   request.resume();
   request.on("end", () => {
@@ -14,6 +16,8 @@ const server = createServer((request, response) => {
       response.end(JSON.stringify({ object: "list", data: [{ id: "minimal/model", type: "language" }] }));
       return;
     }
+    requestedAuthorization = request.headers.authorization;
+    requestedModel = request.headers["ai-language-model-id"];
     response.writeHead(200, { "content-type": "text/event-stream" });
     response.end([
       'data: {"type":"reasoning-delta","delta":"think"}',
@@ -33,11 +37,9 @@ try {
     backend: "native",
     nativeAddon: resolve(scriptDir, "../../zig-out/lib/libfx.node"),
     fetch,
-    env: {
-      AI_GATEWAY_API_KEY: "minimal-key",
-      FX_GATEWAY_CHAT_URL: `http://127.0.0.1:${port}/chat`,
-      FX_MODEL: "minimal/model",
-    },
+    apiKey: "minimal-key",
+    gatewayChatUrl: `http://127.0.0.1:${port}/chat`,
+    model: "minimal/model",
   });
   assert.deepEqual(Object.keys(agent).sort(), ["checkpoint", "close", "prompt"]);
   const turn = agent.prompt("hello");
@@ -53,6 +55,8 @@ try {
     stopReason: "end_turn",
     usage: { inputTokens: 1, outputTokens: 1 },
   });
+  assert.equal(requestedAuthorization, "Bearer minimal-key");
+  assert.equal(requestedModel, "minimal/model");
   const checkpoint = await agent.checkpoint();
   assert.ok(checkpoint instanceof Uint8Array);
   assert.equal(await agent.close(), undefined);

--- a/sdk/tests/test-native-core-cancel.mjs
+++ b/sdk/tests/test-native-core-cancel.mjs
@@ -27,11 +27,9 @@ try {
       fetchStartedResolve();
       return fetch(input, init);
     },
-    env: {
-      AI_GATEWAY_API_KEY: "native-core-cancel-key",
-      FX_GATEWAY_CHAT_URL: `http://127.0.0.1:${port}/stall`,
-      FX_MODEL: "native/test-model",
-    },
+    apiKey: "native-core-cancel-key",
+    gatewayChatUrl: `http://127.0.0.1:${port}/stall`,
+    model: "native/test-model",
   });
   const turn = agent.prompt("stall");
   await Promise.race([fetchStarted, timeout("stalled gateway fetch")]);

--- a/sdk/tests/test-native-core-config-isolation.mjs
+++ b/sdk/tests/test-native-core-config-isolation.mjs
@@ -50,11 +50,9 @@ try {
     home: runtimeHome,
     workspaceRoot: runtimeWorkspace,
     instructions: marker,
-    env: {
-      AI_GATEWAY_API_KEY: "native-core-config-key",
-      FX_GATEWAY_CHAT_URL: `http://127.0.0.1:${port}/chat`,
-      FX_MODEL: "native/test-model",
-    },
+    apiKey: "native-core-config-key",
+    gatewayChatUrl: `http://127.0.0.1:${port}/chat`,
+    model: "native/test-model",
   });
   await assert.rejects(
     access(projectMcpMarker),

--- a/sdk/tests/test-native-core-fetch-failure.mjs
+++ b/sdk/tests/test-native-core-fetch-failure.mjs
@@ -15,10 +15,8 @@ const agent = await createFxAgent({
     error.name = "AbortError";
     throw error;
   },
-  env: {
-    AI_GATEWAY_API_KEY: "native-core-fetch-failure-key",
-    FX_MODEL: "native/test-model",
-  },
+  apiKey: "native-core-fetch-failure-key",
+  model: "native/test-model",
 });
 
 let closed = false;

--- a/sdk/tests/test-native-core-stream.mjs
+++ b/sdk/tests/test-native-core-stream.mjs
@@ -70,11 +70,9 @@ try {
       }
       return fetch(input, init);
     },
-    env: {
-      AI_GATEWAY_API_KEY: "native-core-stream-key",
-      FX_GATEWAY_CHAT_URL: `http://127.0.0.1:${port}/chat`,
-      FX_MODEL: "native/test-model",
-    },
+    apiKey: "native-core-stream-key",
+    gatewayChatUrl: `http://127.0.0.1:${port}/chat`,
+    model: "native/test-model",
   });
   const firstTurn = agent.prompt("first native prompt");
   let firstText = "";

--- a/sdk/tests/test-native-core-worker-termination.mjs
+++ b/sdk/tests/test-native-core-worker-termination.mjs
@@ -20,11 +20,9 @@ try {
       const agent = await createFxAgent({
         nativeAddon: workerData.addonPath,
         backend: "native",
-        env: {
-          AI_GATEWAY_API_KEY: "worker-termination-key",
-          FX_GATEWAY_CHAT_URL: workerData.gatewayUrl,
-          FX_MODEL: "native/test-model",
-        },
+        apiKey: "worker-termination-key",
+        gatewayChatUrl: workerData.gatewayUrl,
+        model: "native/test-model",
       });
       agent.prompt("stall during worker termination");
       parentPort.postMessage("started");

--- a/sdk/tests/test-native-core.mjs
+++ b/sdk/tests/test-native-core.mjs
@@ -11,7 +11,7 @@ const events = [];
 const agent = await createFxAgent({
   nativeAddon: addon,
   backend: "native",
-  env: { AI_GATEWAY_API_KEY: "native-core-test-key" },
+  apiKey: "native-core-test-key",
   onEvent(event) { events.push(event); },
 });
 assert.deepEqual(Object.keys(agent).sort(), ["checkpoint", "close", "prompt"]);

--- a/sdk/tests/test-native-host-tool-late-settle.mjs
+++ b/sdk/tests/test-native-host-tool-late-settle.mjs
@@ -69,11 +69,9 @@ async function exerciseLateSettlement(closeBeforeSettle) {
           return new Promise((resolveTool) => { toolResolve = resolveTool; });
         },
       }],
-      env: {
-        AI_GATEWAY_API_KEY: "late-tool-key",
-        FX_GATEWAY_CHAT_URL: `http://127.0.0.1:${server.address().port}/chat`,
-        FX_MODEL: "late-tool/model",
-      },
+      apiKey: "late-tool-key",
+      gatewayChatUrl: `http://127.0.0.1:${server.address().port}/chat`,
+      model: "late-tool/model",
     });
 
     const controller = new AbortController();

--- a/sdk/tests/test-packed-example.mjs
+++ b/sdk/tests/test-packed-example.mjs
@@ -13,6 +13,8 @@ const { createSkillsAdapter } = await import(pathToFileURL(resolve(packageRoot, 
 assert.equal(typeof createMcpAdapter, "function");
 assert.equal(typeof createSkillsAdapter, "function");
 
+let requestedAuthorization;
+let requestedModel;
 const server = createServer((request, response) => {
   request.resume();
   request.on("end", () => {
@@ -21,6 +23,8 @@ const server = createServer((request, response) => {
       response.end('{"object":"list","data":[]}');
       return;
     }
+    requestedAuthorization = request.headers.authorization;
+    requestedModel = request.headers["ai-language-model-id"];
     response.writeHead(200, { "content-type": "text/event-stream" });
     response.end('data: {"type":"text-delta","delta":"packed"}\n\ndata: {"type":"finish","finishReason":{"unified":"stop","raw":"stop"},"usage":{"inputTokens":{"total":1},"outputTokens":{"total":1}}}\n\ndata: [DONE]\n\n');
   });
@@ -32,7 +36,9 @@ const agent = await createFxAgent({
   nativeAddon: resolve(packageRoot, `libfx.${platform}.node`),
   wasm: resolve(packageRoot, "fx-core.wasm"),
   fetch,
-  env: { AI_GATEWAY_API_KEY: "packed-key", FX_GATEWAY_CHAT_URL: `http://127.0.0.1:${server.address().port}/chat`, FX_MODEL: "packed/model" },
+  apiKey: "packed-key",
+  gatewayChatUrl: `http://127.0.0.1:${server.address().port}/chat`,
+  model: "packed/model",
 });
 try {
   assert.deepEqual(Object.keys(agent).sort(), ["checkpoint", "close", "prompt"]);
@@ -41,6 +47,8 @@ try {
   for await (const event of turn) if (event.type === "text_delta") text += event.delta;
   assert.equal(text, "packed");
   assert.deepEqual(await turn.result, { stopReason: "end_turn", usage: { inputTokens: 1, outputTokens: 1 } });
+  assert.equal(requestedAuthorization, "Bearer packed-key");
+  assert.equal(requestedModel, "packed/model");
   assert.ok((await agent.checkpoint()).length > 48);
   await agent.close();
   console.log(`${backend} packed libfx example passed`);

--- a/sdk/tests/test-skills-adapter.mjs
+++ b/sdk/tests/test-skills-adapter.mjs
@@ -58,7 +58,9 @@ try {
     ...(backend === "wasm" ? { wasm: await readFile(resolve(scriptDir, "../../zig-out/bin/fx-core.wasm")) } : {}),
     ...adapter,
     fetch,
-    env: { AI_GATEWAY_API_KEY: "skills-key", FX_GATEWAY_CHAT_URL: `http://127.0.0.1:${gateway.address().port}/chat`, FX_MODEL: "skills/model" },
+    apiKey: "skills-key",
+    gatewayChatUrl: `http://127.0.0.1:${gateway.address().port}/chat`,
+    model: "skills/model",
   });
   const turn = agent.prompt("apply the skill");
   let text = "";

--- a/sdk/tests/test-wasm-module-cache.mjs
+++ b/sdk/tests/test-wasm-module-cache.mjs
@@ -62,11 +62,9 @@ const options = (wasm = wasmPath) => ({
   backend: "wasm",
   wasm,
   fetch,
-  env: {
-    AI_GATEWAY_API_KEY: "wasm-cache-key",
-    FX_GATEWAY_CHAT_URL: `http://127.0.0.1:${server.address().port}/chat`,
-    FX_MODEL: "cache/model",
-  },
+  apiKey: "wasm-cache-key",
+  gatewayChatUrl: `http://127.0.0.1:${server.address().port}/chat`,
+  model: "cache/model",
 });
 
 async function create(wasm = wasmPath) {


### PR DESCRIPTION
## Summary

- Configure libfx agents with top-level `apiKey`, optional `model`, and trusted `gatewayChatUrl` options across native and WebAssembly backends.
- Reject `createFxAgent({ env })` with a migration error while preserving `createFxTerminal({ env })`.
- Validate credentials, model names, and Gateway URLs before starting the Agent runtime.
- Require custom native Agent addons to implement the versioned `createCore` ABI.