### PR TITLE
Migrate legacy results during compaction

### DIFF
--- a/src/core/agent/runtime/context_compaction.zig
+++ b/src/core/agent/runtime/context_compaction.zig
@@ -51,38 +51,28 @@ pub const ResultStorage = union(enum) {
     managed: *session_child_store.SessionChildCapability,
 };
 
-pub fn validateUnversionedHistoryResults(
-    history: []const types.HistoryTurn,
-    unversioned_history_count: usize,
-) !void {
-    for (history[0..@min(unversioned_history_count, history.len)]) |turn| {
-        const execution = switch (turn) {
-            .assistant => |entry| entry.execution,
-            .interrupted => |entry| entry.execution,
-            .compacted_summary => continue,
-        };
-        for (execution.tool_steps) |step| {
-            for (step.tool_results) |result| {
-                if (result.output_handle == null and result.truncated) {
-                    return error.AmbiguousCompactionResult;
-                }
-            }
-        }
-    }
-}
+pub const resultHandleForContinuation = compaction_state.resultHandleForContinuation;
 
 pub fn promoteMessageResults(
     alloc: Allocator,
     messages: []types.ChatMessage,
     storage: ResultStorage,
+    uncertain_prefix_message_count: usize,
 ) !void {
-    for (messages) |*message| {
+    for (messages, 0..) |*message, message_index| {
         if (message.role != .tool) continue;
         const content = message.content orelse continue;
-        var memory = message.tool_result_memory orelse
+        const uncertain = message_index < uncertain_prefix_message_count;
+        var memory = message.tool_result_memory orelse if (uncertain)
+            types.ToolResultMemory{
+                .output_bytes = content.len,
+                .stored_output_bytes = content.len,
+                .truncated = true,
+            }
+        else
             return error.IncompleteCompactionResult;
-        if (memory.output_handle != null) continue;
-        if (memory.truncated) return error.IncompleteCompactionResult;
+        if (resultHandleForContinuation(memory) != null) continue;
+        if (memory.truncated and !uncertain) return error.IncompleteCompactionResult;
         const call_id = message.tool_call_id orelse return error.IncompleteCompactionResult;
         const tool_name = message.tool_name orelse return error.IncompleteCompactionResult;
         const handle = switch (storage) {
@@ -104,6 +94,7 @@ pub fn promoteMessageResults(
         };
         memory.output_handle = handle;
         memory.stored_output_bytes = content.len;
+        memory.truncated = memory.truncated or uncertain;
         message.tool_result_memory = memory;
         message.content = try std.fmt.allocPrint(
             alloc,
@@ -633,14 +624,14 @@ fn countOccurrences(haystack: []const u8, needle: []const u8) usize {
     return count;
 }
 
-test "compaction result retention promotes complete unversioned history" {
+test "compaction result retention snapshots uncertain history without changing canonical results" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     const result_dir = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
     defer alloc.free(result_dir);
 
-    var results = [_]types.PersistedToolResult{
+    const results = [_]types.PersistedToolResult{
         .{
             .tool_call_id = @constCast("call-promote"),
             .tool_name = @constCast("read_file"),
@@ -650,44 +641,124 @@ test "compaction result retention promotes complete unversioned history" {
             .stored_output_bytes = 24,
         },
         .{
-            .tool_call_id = @constCast("call-handled"),
+            .tool_call_id = @constCast("call-uncertain-truncated"),
             .tool_name = @constCast("grep_files"),
             .status = .success,
-            .output = @constCast("truncated preview"),
-            .output_handle = @constCast("result-call-handled-grep_files.txt"),
+            .output = @constCast("available legacy bytes"),
             .output_bytes = 128,
-            .stored_output_bytes = 128,
+            .stored_output_bytes = 22,
             .truncated = true,
         },
+        .{
+            .tool_call_id = @constCast("call-current-complete"),
+            .tool_name = @constCast("read_file"),
+            .status = .success,
+            .output = @constCast("current complete output"),
+            .output_bytes = 23,
+            .stored_output_bytes = 23,
+        },
     };
-    var steps = [_]types.ToolExecutionStep{.{ .tool_results = &results }};
-    var history = [_]types.HistoryTurn{.{ .assistant = .{
-        .user = .{ .text = @constCast("read it") },
-        .assistant = @constCast("read"),
-        .execution = .{ .tool_steps = &steps },
-    } }};
-
-    try validateUnversionedHistoryResults(&history, 1);
-    var messages = [_]types.ChatMessage{.{
-        .role = .tool,
-        .content = results[0].output,
-        .tool_call_id = results[0].tool_call_id,
-        .tool_name = results[0].tool_name,
-        .tool_result_memory = .{ .truncated = false },
-    }};
-    try promoteMessageResults(alloc, &messages, .{ .legacy_dir = result_dir });
-    const handle = messages[0].tool_result_memory.?.output_handle orelse
-        return error.TestExpectedEqual;
-    defer alloc.free(handle);
-    try std.testing.expectEqualStrings("complete redacted output", results[0].output);
-    defer alloc.free(@constCast(messages[0].content.?));
-    const stored = try result_store.readByRange(alloc, result_dir, handle, 1, 100);
-    defer alloc.free(stored);
-    try std.testing.expect(std.mem.find(u8, stored, "complete redacted output") != null);
-
-    results[0].truncated = true;
-    try std.testing.expectError(
-        error.AmbiguousCompactionResult,
-        validateUnversionedHistoryResults(&history, 1),
+    var messages = [_]types.ChatMessage{
+        .{
+            .role = .tool,
+            .content = results[0].output,
+            .tool_call_id = results[0].tool_call_id,
+            .tool_name = results[0].tool_name,
+            .tool_result_memory = .{ .truncated = false },
+        },
+        .{
+            .role = .tool,
+            .content = results[1].output,
+            .tool_call_id = results[1].tool_call_id,
+            .tool_name = results[1].tool_name,
+            .tool_result_memory = .{
+                .output_bytes = results[1].output_bytes,
+                .stored_output_bytes = results[1].stored_output_bytes,
+                .truncated = true,
+            },
+        },
+        .{
+            .role = .tool,
+            .content = "interrupted legacy bytes",
+            .tool_call_id = "call-uncertain-missing-memory",
+            .tool_name = "subagent",
+        },
+        .{
+            .role = .tool,
+            .content = results[2].output,
+            .tool_call_id = results[2].tool_call_id,
+            .tool_name = results[2].tool_name,
+            .tool_result_memory = .{
+                .output_bytes = results[2].output_bytes,
+                .stored_output_bytes = results[2].stored_output_bytes,
+                .truncated = false,
+            },
+        },
+    };
+    try promoteMessageResults(
+        alloc,
+        &messages,
+        .{ .legacy_dir = result_dir },
+        3,
     );
+    defer for (&messages) |*message| {
+        if (message.tool_result_memory.?.output_handle) |handle| alloc.free(handle);
+        alloc.free(@constCast(message.content.?));
+    };
+    try std.testing.expectEqualStrings("complete redacted output", results[0].output);
+    try std.testing.expect(results[0].output_handle == null);
+    try std.testing.expect(!results[0].truncated);
+    try std.testing.expect(messages[0].tool_result_memory.?.truncated);
+    try std.testing.expect(messages[1].tool_result_memory.?.truncated);
+    try std.testing.expect(messages[2].tool_result_memory.?.truncated);
+    try std.testing.expectEqual(
+        @as(usize, "interrupted legacy bytes".len),
+        messages[2].tool_result_memory.?.stored_output_bytes,
+    );
+    try std.testing.expect(!messages[3].tool_result_memory.?.truncated);
+    const stored = try result_store.readByRange(
+        alloc,
+        result_dir,
+        messages[1].tool_result_memory.?.output_handle.?,
+        1,
+        100,
+    );
+    defer alloc.free(stored);
+    try std.testing.expect(std.mem.find(u8, stored, "available legacy bytes") != null);
+
+    var current_incomplete = [_]types.ChatMessage{.{
+        .role = .tool,
+        .content = "current truncated bytes",
+        .tool_call_id = "call-current-truncated",
+        .tool_name = "read_file",
+        .tool_result_memory = .{ .truncated = true },
+    }};
+    try std.testing.expectError(
+        error.IncompleteCompactionResult,
+        promoteMessageResults(
+            alloc,
+            &current_incomplete,
+            .{ .legacy_dir = result_dir },
+            0,
+        ),
+    );
+
+    var replay_backed = [_]types.ChatMessage{.{
+        .role = .tool,
+        .content = "bounded shell projection",
+        .tool_call_id = "call-command-replay",
+        .tool_name = "shell",
+        .tool_result_memory = .{
+            .truncated = true,
+            .command_output_replay = .{ .available = .{
+                .handle = "fx-command-replay-complete.bin",
+                .framed_bytes = 128,
+            } },
+        },
+    }};
+    const original_content = replay_backed[0].content.?;
+    try promoteMessageResults(alloc, &replay_backed, .unavailable, 0);
+    try std.testing.expectEqual(original_content.ptr, replay_backed[0].content.?.ptr);
+    try std.testing.expect(replay_backed[0].tool_result_memory.?.output_handle == null);
+    try std.testing.expect(replay_backed[0].tool_result_memory.?.truncated);
 }

--- a/src/core/agent/runtime/context_compaction_state.zig
+++ b/src/core/agent/runtime/context_compaction_state.zig
@@ -233,7 +233,7 @@ fn statusFromResult(status: ?types.PersistedToolStatus) OperationStatus {
     };
 }
 
-fn resultHandleForContinuation(memory: types.ToolResultMemory) ?[]const u8 {
+pub fn resultHandleForContinuation(memory: types.ToolResultMemory) ?[]const u8 {
     const replay = memory.command_output_replay orelse return memory.output_handle;
     return switch (replay) {
         .available => |descriptor| descriptor.handle,

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -4393,13 +4393,22 @@ fn buildCanonicalCompactionWindow(
     alloc: Allocator,
     history: []const HistoryTurn,
     within_turn_suffix: []const ChatMessage,
+    uncertain_history_count: usize,
+    uncertain_message_count: *usize,
 ) !std.ArrayList(ChatMessage) {
     var messages: std.ArrayList(ChatMessage) = .empty;
     errdefer messages.deinit(alloc);
+    const boundary = @min(uncertain_history_count, history.len);
     try session_runtime.appendCompactionHistoryChatMessages(
         alloc,
         &messages,
-        history,
+        history[0..boundary],
+    );
+    uncertain_message_count.* = messages.items.len;
+    try session_runtime.appendCompactionHistoryChatMessages(
+        alloc,
+        &messages,
+        history[boundary..],
     );
     try messages.appendSlice(alloc, within_turn_suffix);
     return messages;
@@ -4423,14 +4432,18 @@ test "repeated compaction source keeps canonical history and the complete active
         .{ .role = .assistant, .content = "new assistant" },
         .{ .role = .tool, .content = "new result" },
     };
+    var uncertain_message_count: usize = 0;
     var messages = try buildCanonicalCompactionWindow(
         std.testing.allocator,
         &history,
         &suffix,
+        0,
+        &uncertain_message_count,
     );
     defer messages.deinit(std.testing.allocator);
 
     try std.testing.expectEqual(@as(usize, 6), messages.items.len);
+    try std.testing.expectEqual(@as(usize, 0), uncertain_message_count);
     try std.testing.expectEqualStrings("canonical user", messages.items[0].content.?);
     try std.testing.expectEqualStrings("canonical assistant", messages.items[1].content.?);
     try std.testing.expectEqualStrings("old assistant", messages.items[2].content.?);
@@ -4492,6 +4505,7 @@ pub const ContextCompactionTransactionRequest = struct {
     source_tokens: usize,
     protected_tokens: usize,
     source_messages: []ChatMessage,
+    uncertain_source_message_count: usize = 0,
     result_storage: runtime_context_compaction.ResultStorage,
     api_key: []const u8,
     credential_source: ?types.CredentialSource = null,
@@ -4553,6 +4567,7 @@ pub fn compactContextTransaction(
         alloc,
         request.source_messages,
         request.result_storage,
+        request.uncertain_source_message_count,
     );
     if (request.cancel_flag.load(.seq_cst)) return error.Cancelled;
     if (deps.push_interactive_notice) |push_notice| {
@@ -5266,20 +5281,26 @@ fn processQueuedPromptLoop(
                         }
                     },
                     .compact => {
-                        try runtime_context_compaction.validateUnversionedHistoryResults(
-                            job.history,
-                            job.unversioned_history_count,
-                        );
                         try promoteRequestLocalResultsForCompaction(
                             arena,
                             config,
                             within_turn_suffix.items,
                             @constCast(request_messages),
                         );
+                        const uncertain_history_count = @min(
+                            @max(
+                                job.unversioned_history_count,
+                                job.context_history_start,
+                            ),
+                            job.history.len,
+                        );
+                        var uncertain_message_count: usize = 0;
                         var compaction_messages = try buildCanonicalCompactionWindow(
                             arena,
                             job.history,
                             within_turn_suffix.items,
+                            uncertain_history_count,
+                            &uncertain_message_count,
                         );
                         defer compaction_messages.deinit(arena);
                         const result_storage: runtime_context_compaction.ResultStorage =
@@ -5289,11 +5310,6 @@ fn processQueuedPromptLoop(
                                 .{ .legacy_dir = dir }
                             else
                                 .unavailable;
-                        try runtime_context_compaction.promoteMessageResults(
-                            arena,
-                            @constCast(request_messages),
-                            result_storage,
-                        );
                         const retained_tail_limit = retainedHistoryTailLimit(
                             job.history,
                             within_turn_suffix.items.len > 0,
@@ -5307,6 +5323,8 @@ fn processQueuedPromptLoop(
                                 retained_tail_limit,
                             );
                         const retained_message_count = retained_history_tail.message_count;
+                        const compaction_source_message_count =
+                            compaction_messages.items.len - retained_message_count;
                         const retained_tokens = runtime_prompt_context.estimateCompactionSourceTokens(
                             compaction_messages.items[compaction_messages.items.len - retained_message_count ..],
                         );
@@ -5355,7 +5373,11 @@ fn processQueuedPromptLoop(
                             .request_tokens = request_cost.estimated_input_tokens,
                             .source_tokens = request_cost.estimated_input_tokens,
                             .protected_tokens = prompt_tokens +| retained_tokens,
-                            .source_messages = compaction_messages.items[0 .. compaction_messages.items.len - retained_message_count],
+                            .source_messages = compaction_messages.items[0..compaction_source_message_count],
+                            .uncertain_source_message_count = @min(
+                                uncertain_message_count,
+                                compaction_source_message_count,
+                            ),
                             .result_storage = result_storage,
                             .api_key = active_api_key,
                             .credential_source = job.credential_source,
@@ -9776,7 +9798,7 @@ fn promoteRequestLocalResultsForCompaction(
         const content = message.content orelse continue;
         var memory = message.tool_result_memory orelse
             return error.ContextCapacityExceeded;
-        if (memory.output_handle != null) continue;
+        if (runtime_context_compaction.resultHandleForContinuation(memory) != null) continue;
         if (memory.truncated) return error.ContextCapacityExceeded;
         const call_id = message.tool_call_id orelse return error.ContextCapacityExceeded;
         const tool_name = message.tool_name orelse return error.ContextCapacityExceeded;

--- a/src/core/agent/runtime/tests/gateway_flow.zig
+++ b/src/core/agent/runtime/tests/gateway_flow.zig
@@ -3006,9 +3006,10 @@ test "processQueuedPrompt semantically compacts history at eighty percent and co
         .tool_call_id = @constCast("auto_restored_1"),
         .tool_name = @constCast("read_file"),
         .status = .success,
-        .output = @constCast("AUTO_RESTORED_RESULT_SENTINEL"),
-        .output_bytes = 29,
+        .output = @constCast("AUTO_RESTORED_AVAILABLE_BYTES"),
+        .output_bytes = 100,
         .stored_output_bytes = 29,
+        .truncated = true,
     }};
     var restored_steps = [_]types.ToolExecutionStep{.{
         .tool_calls = &restored_calls,
@@ -3033,6 +3034,16 @@ test "processQueuedPrompt semantically compacts history at eighty percent and co
     try std.testing.expectEqual(@as(usize, 2), hooks.history_turns.items.len);
     try std.testing.expect(hooks.history_turns.items[0] == .compacted_summary);
     try std.testing.expect(hooks.history_turns.items[1] == .assistant);
+    try std.testing.expect(std.mem.find(
+        u8,
+        hooks.history_turns.items[0].compacted_summary.summary,
+        "result_handle=",
+    ) != null);
+    try std.testing.expect(std.mem.find(
+        u8,
+        hooks.history_turns.items[0].compacted_summary.summary,
+        "truncated=true",
+    ) != null);
     try std.testing.expectEqual(@as(usize, 3), gateway.request_bodies.items.len);
     try expectBodyContains(&gateway, 0, "AUTO_HISTORY_ASSISTANT_SENTINEL");
     try expectBodyContains(&gateway, 0, "\"toolChoice\":{\"type\":\"none\"}");
@@ -3156,6 +3167,13 @@ test "processQueuedPrompt compacts mid-turn after tool output crosses eighty per
     hooks.permission_decisions = &.{.once};
     hooks.exec_plans = &.{.{ .result = .{
         .model_output = "MIDTURN_RESULT_SENTINEL\n" ++ ("m" ** (10 * 1024)),
+        .tool_result_memory = .{
+            .truncated = true,
+            .command_output_replay = .{ .available = .{
+                .handle = "fx-command-replay-midturn-complete.bin",
+                .framed_bytes = 12 * 1024,
+            } },
+        },
     } }};
     var fixture = PromptFixture{};
     var config = fixture.config();
@@ -3176,7 +3194,16 @@ test "processQueuedPrompt compacts mid-turn after tool output crosses eighty per
     try std.testing.expect(hooks.history_turns.items[0] == .compacted_summary);
     try std.testing.expect(hooks.history_turns.items[1] == .assistant);
     const persisted_result = hooks.history_turns.items[1].assistant.execution.tool_steps[0].tool_results[0];
-    try std.testing.expect(persisted_result.output_handle != null);
+    try std.testing.expect(persisted_result.output_handle == null);
+    const replay = persisted_result.command_output_replay orelse
+        return error.TestExpectedEqual;
+    switch (replay) {
+        .available => |descriptor| try std.testing.expectEqualStrings(
+            "fx-command-replay-midturn-complete.bin",
+            descriptor.handle,
+        ),
+        .unavailable => return error.TestExpectedEqual,
+    }
     try std.testing.expect(std.mem.find(u8, persisted_result.output, "MIDTURN_RESULT_SENTINEL") != null);
     try std.testing.expect(persisted_result.output.len > 10 * 1024);
     try std.testing.expectEqualStrings("Mid-turn compaction complete.", hooks.finish_assistant_text.?);

--- a/src/core/agent/worker_runtime.zig
+++ b/src/core/agent/worker_runtime.zig
@@ -144,6 +144,7 @@ pub const ContextCompactionTask = struct {
     credential_source: ?types.CredentialSource = null,
     account_id: ?[]u8 = null,
     history: []types.HistoryTurn,
+    context_history_start: usize = 0,
     unversioned_history_count: usize = std.math.maxInt(usize),
 };
 

--- a/src/core/app/app_agent_runtime.zig
+++ b/src/core/app/app_agent_runtime.zig
@@ -1070,16 +1070,25 @@ pub fn Runtime(comptime App: type) type {
                     .{ .managed = capability }
                 else
                     .unavailable;
-            try runtime_context_compaction.validateUnversionedHistoryResults(
-                job.history,
-                job.unversioned_history_count,
-            );
             var messages: std.ArrayList(ChatMessage) = .empty;
             defer messages.deinit(arena);
+            const uncertain_history_count = @min(
+                @max(
+                    job.unversioned_history_count,
+                    job.context_history_start,
+                ),
+                job.history.len,
+            );
             try session_runtime.appendCompactionHistoryChatMessages(
                 arena,
                 &messages,
-                job.history,
+                job.history[0..uncertain_history_count],
+            );
+            const uncertain_message_count = messages.items.len;
+            try session_runtime.appendCompactionHistoryChatMessages(
+                arena,
+                &messages,
+                job.history[uncertain_history_count..],
             );
             const source_tokens = runtime_prompt_context.estimateCompactionSourceTokens(
                 messages.items,
@@ -1118,6 +1127,10 @@ pub fn Runtime(comptime App: type) type {
                 .source_tokens = source_tokens,
                 .protected_tokens = retained_tokens,
                 .source_messages = messages.items[0 .. messages.items.len - retained_message_count],
+                .uncertain_source_message_count = @min(
+                    uncertain_message_count,
+                    messages.items.len - retained_message_count,
+                ),
                 .result_storage = result_storage,
                 .api_key = job.api_key,
                 .credential_source = job.credential_source,

--- a/src/core/app/app_process_runtime.zig
+++ b/src/core/app/app_process_runtime.zig
@@ -91,6 +91,10 @@ pub fn Runtime(comptime App: type) type {
                 error.ConnectionSetupTimedOut => return alloc.dupe(u8, "Connection setup timed out after 30 seconds."),
                 error.TlsInitializationFailed => return alloc.dupe(u8, "Connection setup failed: TLS could not be initialized."),
                 error.ModelImageCapabilityUnavailable => return alloc.dupe(u8, image_attachments.model_image_capability_unavailable_notice),
+                error.CompactionResultStorageUnavailable => return alloc.dupe(
+                    u8,
+                    "Context could not be compacted because older tool results could not be preserved. Save the session or restore writable session storage, then try again.",
+                ),
                 else => {},
             }
             if (detailedErrorSummary(err)) |detail| {
@@ -210,6 +214,22 @@ test "formatErrorBody describes terminal connection setup failures plainly" {
     const unrelated_timeout = try Rt.formatErrorBody(alloc, "request failed", error.ConnectionTimedOut);
     defer alloc.free(unrelated_timeout);
     try std.testing.expectEqualStrings("request failed: ConnectionTimedOut", unrelated_timeout);
+}
+
+test "formatErrorBody explains compaction result storage failure" {
+    const alloc = std.testing.allocator;
+    const Rt = Runtime(DummyApp);
+    const body = try Rt.formatErrorBody(
+        alloc,
+        "request failed",
+        error.CompactionResultStorageUnavailable,
+    );
+    defer alloc.free(body);
+
+    try std.testing.expectEqualStrings(
+        "Context could not be compacted because older tool results could not be preserved. Save the session or restore writable session storage, then try again.",
+        body,
+    );
 }
 
 test "formatToolExecutionError includes detail for MissingField" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -1540,6 +1540,7 @@ const App = struct {
             .credential_source = credential.source,
             .account_id = account_id,
             .history = history,
+            .context_history_start = self.session.contextHistoryStart(),
             .unversioned_history_count = self.session.unversionedHistoryEnd(),
         });
         HerdrAppRuntime.reportWorking(self);

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -4461,8 +4461,6 @@ printf '%s' ${JSON.stringify(trailingMarker)} > ${JSON.stringify(effectPath)}
             hasEmptyComposer(pane),
           15_000,
         );
-        await tui.sendText("/compact");
-        await tui.waitForText("Context compacted.", 15_000);
         await tui.sendText("/quit");
         await tui.waitForSessionEnd(15_000);
         tui = null;
@@ -4473,6 +4471,21 @@ printf '%s' ${JSON.stringify(trailingMarker)} > ${JSON.stringify(effectPath)}
         });
         expect(latest.code).toBe(0);
         const sessionId = JSON.parse(latest.stdout).id as string;
+
+        const compactionStderrPath = join(root.root, "compaction-stderr.log");
+        tui = await TmuxSession.create({
+          cmd: `${FX_BIN} --resume ${sessionId}`,
+          cwd: root.workspace,
+          env: fixtureEnv(root, gateway, tracePath),
+          stderrPath: compactionStderrPath,
+        });
+        await tui.waitForComposer(15_000);
+        await tui.sendText("/compact");
+        await tui.waitForText("Context compacted.", 15_000);
+        await tui.sendText("/quit");
+        await tui.waitForSessionEnd(15_000);
+        tui = null;
+        expect(readFileSync(compactionStderrPath, "utf8")).toBe("");
 
         const beforeResume = await runFx(
           ["session", "--id", sessionId, "--json"],
@@ -4503,6 +4516,11 @@ printf '%s' ${JSON.stringify(trailingMarker)} > ${JSON.stringify(effectPath)}
         expect(canonical.history.at(-1)?.summary).toContain(
           "Continue the compacted session.",
         );
+        const inlineSummary = canonical.history.at(-1)?.summary
+          ?.split("\n")
+          .find((line) => line.includes(`call_id="${inlineCallId}"`));
+        expect(inlineSummary).toContain("result_handle=");
+        expect(inlineSummary).toContain("truncated=true");
 
         expect(gateway.requests).toHaveLength(5);
         const compactRequest = JSON.parse(gateway.requests[4].body) as {
@@ -4607,6 +4625,11 @@ printf '%s' ${JSON.stringify(trailingMarker)} > ${JSON.stringify(effectPath)}
         const secondSummary = secondCanonical.history.at(-1)?.summary ?? "";
         expect(secondSummary).toContain(callId);
         expect(secondSummary).toContain(inlineCallId);
+        const secondInlineSummary = secondSummary
+          .split("\n")
+          .find((line) => line.includes(`call_id="${inlineCallId}"`));
+        expect(secondInlineSummary).toContain("result_handle=");
+        expect(secondInlineSummary).toContain("truncated=true");
       } finally {
         if (tui) await tui.kill();
         gateway.stop();


### PR DESCRIPTION
## Summary

- Resume and compact sessions containing handle-free historical tool results.
- Preserve available legacy bytes behind durable handles and mark them as uncertain.
- Reuse complete command replay handles instead of returning capacity or incomplete-result failures.
- Keep canonical history unchanged when result preservation cannot complete.