### PR TITLE
Make expired sign-in recovery resumable

### DIFF
--- a/src/core/app/app_auth_runtime.zig
+++ b/src/core/app/app_auth_runtime.zig
@@ -429,14 +429,14 @@ pub fn Runtime(comptime App: type) type {
                     _ = app.auth.toggleSignInCodeEntry();
                 } else if (app.auth.signInCodeEntryActive()) {
                     switch (byte) {
-                        3, 4 => _ = app.auth.popPickerStage(app.alloc),
+                        3, 4 => cancelAndPopPickerStage(app),
                         '\r', '\n' => _ = try app.auth.submitSignInCode(app.alloc),
                         8, 127 => _ = app.auth.deleteSignInCodeByte(),
                         else => _ = try app.auth.appendSignInCodeByte(app.alloc, byte),
                     }
                 } else {
                     switch (byte) {
-                        3, 4 => _ = app.auth.popPickerStage(app.alloc),
+                        3, 4 => cancelAndPopPickerStage(app),
                         '\r', '\n' => try openSignInBrowser(app),
                         else => {},
                     }
@@ -456,7 +456,7 @@ pub fn Runtime(comptime App: type) type {
             }
             if (!app.auth.apiKeyEntryActive()) return false;
             switch (byte) {
-                3, 4 => _ = app.auth.popPickerStage(app.alloc),
+                3, 4 => cancelAndPopPickerStage(app),
                 '\r', '\n' => try submitApiKeyEntry(app),
                 8, 127 => _ = app.auth.deleteApiKeyByte(),
                 else => _ = try app.auth.appendApiKeyByte(app.alloc, byte),
@@ -480,6 +480,11 @@ pub fn Runtime(comptime App: type) type {
             };
         }
 
+        fn cancelAndPopPickerStage(app: *App) void {
+            cancelPromptRetryAfterAuth(app);
+            _ = app.auth.popPickerStage(app.alloc);
+        }
+
         pub fn collectSignInFacts(app: *App) !void {
             if (comptime !oauthAuthEnabled(App)) return;
             const sign_in_source: credentials.Source = if (comptime @hasDecl(@TypeOf(app.auth), "pickerView"))
@@ -489,8 +494,12 @@ pub fn Runtime(comptime App: type) type {
             app.auth.pulseSignIn(app.alloc);
             switch (app.auth.pollSignInTransition(app.alloc)) {
                 .none => {},
-                .cancelled => app.shell.render_requests.request(.footer),
+                .cancelled => {
+                    cancelPromptRetryAfterAuth(app);
+                    app.shell.render_requests.request(.footer);
+                },
                 .failed => |err| {
+                    cancelPromptRetryAfterAuth(app);
                     debug_trace.logf("auth", "login failed source={t} err={s}", .{ sign_in_source, @errorName(err) });
                     _ = app.auth.popPickerStage(app.alloc);
                     try writeLoginError(app, sign_in_source, err);
@@ -507,6 +516,7 @@ pub fn Runtime(comptime App: type) type {
                                     .tone = .@"error",
                                     .body = "Signed in to Vercel, but no Vercel teams could be loaded. The current credential is unchanged.",
                                 });
+                                cancelPromptRetryAfterAuth(app);
                                 return;
                             }
                             try app.auth.refreshSourceInventory(app.alloc);
@@ -546,6 +556,7 @@ pub fn Runtime(comptime App: type) type {
                 },
                 .activate_source => |source| {
                     if (!try selectCredentialSource(app, source)) {
+                        cancelPromptRetryAfterAuth(app);
                         _ = app.auth.popPickerStage(app.alloc);
                         try writeAuthNotice(app, .{
                             .topic = "auth",
@@ -566,6 +577,7 @@ pub fn Runtime(comptime App: type) type {
                         else
                             "Signed in with Grok.",
                     });
+                    try resumePromptAfterAuth(app);
                 },
             }
         }
@@ -774,6 +786,7 @@ pub fn Runtime(comptime App: type) type {
             try app.flushBeforeBlockingExternalWork();
             const started = app.auth.openChatGptSignInPickerFromRoot(app.alloc);
             if (started catch |err| {
+                cancelPromptRetryAfterAuth(app);
                 debug_trace.logf("auth", "ChatGPT login failed err={s}", .{@errorName(err)});
                 try writeLoginError(app, .chatgpt_subscription, err);
                 return;
@@ -805,6 +818,7 @@ pub fn Runtime(comptime App: type) type {
             try app.flushBeforeBlockingExternalWork();
             const started = app.auth.openGrokSignInPickerFromRoot(app.alloc);
             if (started catch |err| {
+                cancelPromptRetryAfterAuth(app);
                 debug_trace.logf("auth", "Grok login failed err={s}", .{@errorName(err)});
                 try writeLoginError(app, .grok_subscription, err);
                 return;
@@ -1191,6 +1205,7 @@ pub fn Runtime(comptime App: type) type {
             defer app.alloc.free(body);
 
             var candidate = selection.validationCredential(app.alloc, index) catch |err| {
+                cancelPromptRetryAfterAuth(app);
                 if (err == error.OutOfMemory) return err;
                 debug_trace.logf("auth", "team validation credential failed err={s}", .{@errorName(err)});
                 app.auth.closePicker(app.alloc);
@@ -1205,6 +1220,7 @@ pub fn Runtime(comptime App: type) type {
             var validation = try validateTeamCredential(app, candidate);
             defer validation.deinit(app.alloc);
             if (validation == .rejected) {
+                cancelPromptRetryAfterAuth(app);
                 app.auth.closePicker(app.alloc);
                 try app.writeDomainNotice(.{
                     .topic = "auth",
@@ -1215,6 +1231,7 @@ pub fn Runtime(comptime App: type) type {
             }
 
             var selected_team = selection.select(app.alloc, index) catch |err| {
+                cancelPromptRetryAfterAuth(app);
                 debug_trace.logf("auth", "team change failed err={s}", .{@errorName(err)});
                 app.auth.closePicker(app.alloc);
                 try app.writeDomainNotice(.{
@@ -1254,9 +1271,8 @@ pub fn Runtime(comptime App: type) type {
                 }
             }
 
-            if (app.auth.credentialSource() == .fx_login) {
-                applyCredentialChange(app, app.auth.adoptSelectedTeam(app.alloc, &selected_team));
-            } else if (!try selectCredentialSource(app, .fx_login)) {
+            if (!try selectCredentialSource(app, .fx_login)) {
+                cancelPromptRetryAfterAuth(app);
                 app.auth.closePicker(app.alloc);
                 try app.writeDomainNotice(.{
                     .topic = "auth",
@@ -1276,6 +1292,7 @@ pub fn Runtime(comptime App: type) type {
                 .tone = .neutral,
                 .body = body,
             }, true);
+            try resumePromptAfterAuth(app);
             return true;
         }
 
@@ -1333,6 +1350,7 @@ pub fn Runtime(comptime App: type) type {
             else
                 app.auth.openSignInPicker(app.alloc);
             if (started catch |err| {
+                cancelPromptRetryAfterAuth(app);
                 debug_trace.logf("auth", "login failed err={s}", .{@errorName(err)});
                 try writeLoginError(app, .fx_login, err);
                 return;
@@ -1385,6 +1403,14 @@ pub fn Runtime(comptime App: type) type {
         }
 
         fn preparePromptCredential(app: *App) !bool {
+            if (comptime @hasDecl(@TypeOf(app.auth), "credentialFailure")) {
+                if (app.auth.credentialFailure()) |failure| {
+                    if (!failure.retryable()) {
+                        try beginCredentialRepair(app, failure);
+                        return false;
+                    }
+                }
+            }
             for (0..2) |_| {
                 refreshFxLoginCredentialIfNeeded(app) catch |err| switch (err) {
                     error.OutOfMemory => return err,
@@ -1393,6 +1419,41 @@ pub fn Runtime(comptime App: type) type {
                 if (app.auth.gatewayCredential() != null) return true;
             }
             return recoverPromptCredentialRefreshFailure(app, error.CredentialRefreshUnavailable);
+        }
+
+        fn beginCredentialRepair(
+            app: *App,
+            failure: auth_runtime.CredentialFailure,
+        ) !void {
+            requestPromptRetryAfterAuth(app);
+            switch (failure.source) {
+                .fx_login => try beginSignIn(app, false),
+                .chatgpt_subscription => try beginChatGptSignIn(app),
+                .grok_subscription => try beginGrokSignIn(app),
+                .vercel_oidc_token,
+                .ai_gateway_api_key,
+                .stored_key,
+                .host_managed,
+                => {},
+            }
+        }
+
+        fn requestPromptRetryAfterAuth(app: *App) void {
+            if (comptime @hasDecl(App, "requestPromptRetryAfterAuth")) {
+                app.requestPromptRetryAfterAuth();
+            }
+        }
+
+        fn cancelPromptRetryAfterAuth(app: *App) void {
+            if (comptime @hasDecl(App, "cancelPromptRetryAfterAuth")) {
+                app.cancelPromptRetryAfterAuth();
+            }
+        }
+
+        fn resumePromptAfterAuth(app: *App) !void {
+            if (comptime @hasDecl(App, "resumePromptAfterAuth")) {
+                try app.resumePromptAfterAuth();
+            }
         }
 
         fn recoverPromptCredentialRefreshFailure(app: *App, err: anyerror) !bool {
@@ -1406,27 +1467,20 @@ pub fn Runtime(comptime App: type) type {
 
         fn recoverCredentialFailure(app: *App, source: credentials.Source, err: anyerror) !bool {
             debug_trace.logf("auth", "prompt credential refresh failed source={t} err={s}", .{ source, @errorName(err) });
-            if (app.auth.credentialSource() == source) app.auth.recordCredentialRefreshFailure(source);
-            const failure = auth_runtime.FailureSnapshot{
-                .source = source,
-                .reason = .credential_refresh_failed,
-            };
-            const failure_text = try failure.renderText(app.alloc);
-            defer app.alloc.free(failure_text);
-            const recovery = try std.fmt.allocPrint(
-                app.alloc,
-                "{s}.\n{s}",
-                .{
-                    failure_text,
-                    switch (source) {
-                        .fx_login => "Run /login to repair this source.",
-                        .chatgpt_subscription => "Run /login and reconnect Codex to repair this source.",
-                        .grok_subscription => "Run /login and reconnect Grok to repair this source.",
-                        .vercel_oidc_token, .ai_gateway_api_key, .stored_key => "Run /setup to repair this source.",
-                        .host_managed => credentials.host_managed_auth_message,
-                    },
-                },
+            const failure = auth_runtime.classifyCredentialFailure(source, err);
+            debug_trace.logf(
+                "auth",
+                "credential failure source={t} reason={t} retryable={s}",
+                .{ failure.source, failure.reason, if (failure.retryable()) "true" else "false" },
             );
+            const first_observation = if (app.auth.credentialSource() == source and
+                comptime @hasDecl(@TypeOf(app.auth), "recordCredentialFailure"))
+                app.auth.recordCredentialFailure(failure)
+            else
+                true;
+            if (!first_observation) return false;
+
+            const recovery = try credentialRecoveryText(app.alloc, failure);
             defer app.alloc.free(recovery);
             try app.writeDomainNotice(.{
                 .topic = "auth",
@@ -1435,6 +1489,40 @@ pub fn Runtime(comptime App: type) type {
             }, true);
             app.shell.render_requests.request(.footer);
             return false;
+        }
+
+        fn credentialRecoveryText(
+            alloc: std.mem.Allocator,
+            failure: auth_runtime.CredentialFailure,
+        ) ![]u8 {
+            const source_label = credentials.sourceLabel(failure.source);
+            return switch (failure.reason) {
+                .invalid_credential => std.fmt.allocPrint(
+                    alloc,
+                    "{s} sign-in expired.\nPress Enter to sign in again. Your prompt is saved.",
+                    .{source_label},
+                ),
+                .invalid_storage => std.fmt.allocPrint(
+                    alloc,
+                    "{s} saved sign-in is unreadable.\nPress Enter to sign in again. Your prompt is saved.",
+                    .{source_label},
+                ),
+                .persistence_uncertain => std.fmt.allocPrint(
+                    alloc,
+                    "{s} refresh could not be saved.\nPress Enter to sign in again. Your prompt is saved.",
+                    .{source_label},
+                ),
+                .authority_changed => std.fmt.allocPrint(
+                    alloc,
+                    "{s} account or team changed during refresh.\nReview authentication before retrying. Your prompt is saved.",
+                    .{source_label},
+                ),
+                .temporary_unavailable => std.fmt.allocPrint(
+                    alloc,
+                    "{s} credential refresh failed.\nCheck your connection and press Enter to retry. Your prompt is saved.",
+                    .{source_label},
+                ),
+            };
         }
 
         fn applyCredentialChange(app: *App, changed: bool) void {
@@ -1765,7 +1853,7 @@ const TestAuth = struct {
     refresh_count: usize = 0,
     logout_reconcile_count: usize = 0,
     source_inventory_refresh_count: usize = 0,
-    refresh_failure_source: ?credentials.Source = null,
+    credential_failure: ?auth_runtime.CredentialFailure = null,
     picker_opened: bool = false,
     picker_provider: model_provider.ProviderId = .gateway,
     picker_closed: bool = false,
@@ -1773,10 +1861,10 @@ const TestAuth = struct {
     catalog_ready: bool = true,
     gateway_ready_after_refresh_count: ?usize = null,
     team_selection: TestTeamSelection = .{},
-    selected_team_adopted: bool = false,
     sign_in_url: ?[]const u8 = null,
     picker_pop_count: usize = 0,
     sign_in_entry_active: bool = false,
+    sign_in_start_count: usize = 0,
     sign_in_code_entry_active: bool = false,
     sign_in_code_toggle_count: usize = 0,
     sign_in_code_toggle_succeeds: bool = true,
@@ -1810,6 +1898,25 @@ const TestAuth = struct {
 
     fn signInEntryActive(self: *const TestAuth) bool {
         return self.sign_in_entry_active;
+    }
+
+    fn openSignInPicker(self: *TestAuth, _: std.mem.Allocator) !bool {
+        if (self.sign_in_entry_active) return false;
+        self.sign_in_entry_active = true;
+        self.sign_in_start_count += 1;
+        return true;
+    }
+
+    fn openSignInPickerFromRoot(self: *TestAuth, alloc: std.mem.Allocator) !bool {
+        return self.openSignInPicker(alloc);
+    }
+
+    fn openChatGptSignInPickerFromRoot(self: *TestAuth, alloc: std.mem.Allocator) !bool {
+        return self.openSignInPicker(alloc);
+    }
+
+    fn openGrokSignInPickerFromRoot(self: *TestAuth, alloc: std.mem.Allocator) !bool {
+        return self.openSignInPicker(alloc);
     }
 
     fn signInCodeEntryActive(self: *const TestAuth) bool {
@@ -1932,8 +2039,23 @@ const TestAuth = struct {
             .{ .ready = action };
     }
 
-    fn recordCredentialRefreshFailure(self: *TestAuth, source: credentials.Source) void {
-        self.refresh_failure_source = source;
+    fn recordCredentialFailure(
+        self: *TestAuth,
+        failure: auth_runtime.CredentialFailure,
+    ) bool {
+        if (self.credential_failure) |current| {
+            if (current.source == failure.source and
+                current.reason == failure.reason)
+            {
+                return false;
+            }
+        }
+        self.credential_failure = failure;
+        return true;
+    }
+
+    fn credentialFailure(self: *const TestAuth) ?auth_runtime.CredentialFailure {
+        return self.credential_failure;
     }
 
     fn openPickerForProvider(
@@ -1947,11 +2069,6 @@ const TestAuth = struct {
 
     fn loadedTeamSelection(self: *TestAuth) ?*TestTeamSelection {
         return &self.team_selection;
-    }
-
-    fn adoptSelectedTeam(self: *TestAuth, _: std.mem.Allocator, _: *TestSelectedTeam) bool {
-        self.selected_team_adopted = true;
-        return true;
     }
 
     fn closePicker(self: *TestAuth, _: std.mem.Allocator) void {
@@ -2324,7 +2441,6 @@ test "team change from an environment source activates and remembers fx login" {
     try std.testing.expect(try Runtime(TestApp).applyTeamChoice(&app, 0));
 
     try std.testing.expectEqual(@as(usize, 1), app.auth.team_selection.select_count);
-    try std.testing.expect(!app.auth.selected_team_adopted);
     try std.testing.expectEqual(credentials.Source.fx_login, app.auth.active_source.?);
     try std.testing.expectEqual(credentials.Source.fx_login, app.auth.selected_source.?);
     try std.testing.expectEqual(@as(usize, 1), app.preference_write_count);
@@ -2339,14 +2455,14 @@ test "team change from an environment source activates and remembers fx login" {
     );
 }
 
-test "team change on an active fx login updates and remembers the selected team" {
+test "team change on an active fx login reloads and remembers the selected credential" {
     var app: TestApp = .{};
     defer app.deinit();
     app.auth.active_source = .fx_login;
 
     try std.testing.expect(try Runtime(TestApp).applyTeamChoice(&app, 0));
 
-    try std.testing.expect(app.auth.selected_team_adopted);
+    try std.testing.expectEqual(credentials.Source.fx_login, app.auth.selected_source.?);
     try std.testing.expectEqual(@as(usize, 1), app.preference_write_count);
     try std.testing.expectEqual(credentials.Source.fx_login, app.last_preference_source.?);
 }
@@ -2521,14 +2637,38 @@ test "prompt credential refresh failure is recoverable and detail-free" {
 
     try std.testing.expect(!try Runtime(TestApp).preparePromptCredential(&app));
     try std.testing.expect(std.mem.find(u8, app.transcript.items, "fx login credential refresh failed.") != null);
-    try std.testing.expect(std.mem.find(u8, app.transcript.items, "Run /login to repair this source.") != null);
+    try std.testing.expect(std.mem.find(u8, app.transcript.items, "Check your connection and press Enter to retry.") != null);
+    try std.testing.expect(std.mem.find(u8, app.transcript.items, "Your prompt is saved.") != null);
     try std.testing.expect(std.mem.find(u8, app.transcript.items, "Choose another source") == null);
     try std.testing.expect(std.mem.find(u8, app.transcript.items, "OAuthRequestFailed") == null);
     try std.testing.expect(app.shell.render_requests.footer_requested);
     try std.testing.expectEqual(@as(usize, 0), app.auth.source_inventory_refresh_count);
-    try std.testing.expect(app.auth.refresh_failure_source == null);
+    try std.testing.expect(app.auth.credential_failure == null);
     try std.testing.expect(!app.auth.picker_opened);
     try std.testing.expectEqual(@as(usize, 0), app.model_cache.reset_count);
+}
+
+test "permanent prompt credential failure is one repair episode" {
+    var app: TestApp = .{};
+    defer app.deinit();
+    app.auth.active_source = .fx_login;
+    app.auth.refresh_error = error.InvalidGrant;
+
+    try std.testing.expect(!try Runtime(TestApp).preparePromptCredential(&app));
+    try std.testing.expect(!try Runtime(TestApp).preparePromptCredential(&app));
+
+    try std.testing.expectEqual(@as(usize, 1), app.auth.refresh_count);
+    try std.testing.expectEqual(@as(usize, 1), app.auth.sign_in_start_count);
+    try std.testing.expect(app.auth.sign_in_entry_active);
+    try std.testing.expectEqual(
+        auth_runtime.CredentialFailureReason.invalid_credential,
+        app.auth.credential_failure.?.reason,
+    );
+    try std.testing.expectEqual(
+        @as(usize, 1),
+        std.mem.count(u8, app.transcript.items, "fx login sign-in expired."),
+    );
+    try std.testing.expect(std.mem.find(u8, app.transcript.items, "Your prompt is saved.") != null);
 }
 
 test "prompt credential admission retries a crossed readiness deadline" {
@@ -2550,8 +2690,9 @@ test "prompt credential admission rejects a credential that remains unavailable"
 
     try std.testing.expect(!try Runtime(TestApp).preparePromptCredential(&app));
     try std.testing.expectEqual(@as(usize, 2), app.auth.refresh_count);
-    try std.testing.expect(std.mem.find(u8, app.transcript.items, "fx login credential refresh failed.") != null);
-    try std.testing.expect(std.mem.find(u8, app.transcript.items, "Run /login to repair this source.") != null);
+    try std.testing.expect(std.mem.find(u8, app.transcript.items, "fx login sign-in expired.") != null);
+    try std.testing.expect(std.mem.find(u8, app.transcript.items, "Press Enter to sign in again.") != null);
+    try std.testing.expect(std.mem.find(u8, app.transcript.items, "Your prompt is saved.") != null);
     try std.testing.expect(!app.auth.picker_opened);
 }
 

--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -1764,6 +1764,7 @@ pub fn Runtime(comptime App: type) type {
         fn dismissAuthPickerForComposerEdit(app: *App) bool {
             if (comptime !@hasField(App, "auth")) return false;
             if (!app.auth.pickerView().active) return false;
+            cancelPromptRetryAfterAuth(app);
             app.auth.closePicker(app.alloc);
             return true;
         }
@@ -1772,8 +1773,15 @@ pub fn Runtime(comptime App: type) type {
             if (comptime !@hasField(App, "auth")) return false;
             const picker = app.auth.pickerView();
             if (!picker.active) return false;
+            cancelPromptRetryAfterAuth(app);
             if (picker.stage == .root and picker.include_skip) app.auth.skipOnboarding();
             return app.auth.popPickerStage(app.alloc);
+        }
+
+        fn cancelPromptRetryAfterAuth(app: *App) void {
+            if (comptime @hasDecl(App, "cancelPromptRetryAfterAuth")) {
+                app.cancelPromptRetryAfterAuth();
+            }
         }
 
         fn commandSkillsMenuActive(app: *App) bool {
@@ -3673,6 +3681,7 @@ const RoutingFakeApp = struct {
     selected_credential_source: ?types.CredentialSource = null,
     selected_auth_action: ?auth_runtime.AcquisitionAction = null,
     selected_auth_team: ?usize = null,
+    prompt_retry_after_auth: bool = false,
     upgrade_apply_count: usize = 0,
     upgrade_denied_count: usize = 0,
     suspend_count: usize = 0,
@@ -3734,6 +3743,10 @@ const RoutingFakeApp = struct {
     }
 
     pub fn flushBeforeBlockingExternalWork(_: *RoutingFakeApp) !void {}
+
+    pub fn cancelPromptRetryAfterAuth(self: *RoutingFakeApp) void {
+        self.prompt_retry_after_auth = false;
+    }
 
     pub fn suspendToJobControl(self: *RoutingFakeApp) !void {
         self.suspend_count += 1;
@@ -4451,10 +4464,12 @@ test "app_input_runtime Escape closes auth picker without arming composer clear"
     defer app.deinit();
     app.auth.source_inventory = auth_runtime.SourceSet.initOne(.ai_gateway_api_key);
     app.auth.openPicker(alloc);
+    app.prompt_retry_after_auth = true;
 
     try Runtime(RoutingFakeApp).resolveEscape(&app, false, 1);
 
     try std.testing.expect(!app.auth.pickerView().active);
+    try std.testing.expect(!app.prompt_retry_after_auth);
     try std.testing.expect(!app.input_runtime.gestures.escapeClearArmed());
 }
 
@@ -4671,10 +4686,12 @@ test "app_input_runtime composer editing dismisses auth picker before inserting"
     defer app.deinit();
     app.auth.source_inventory = auth_runtime.SourceSet.initOne(.ai_gateway_api_key);
     app.auth.openPicker(alloc);
+    app.prompt_retry_after_auth = true;
 
     try Runtime(RoutingFakeApp).handleByte(&app, 'x', 4096, 100);
 
     try std.testing.expect(!app.auth.pickerView().active);
+    try std.testing.expect(!app.prompt_retry_after_auth);
     try std.testing.expectEqualStrings("x", app.input_runtime.edit_state.input.items);
 }
 

--- a/src/core/app/input_submit_runtime.zig
+++ b/src/core/app/input_submit_runtime.zig
@@ -65,6 +65,7 @@ pub const PendingSkillRefresh = enum {
 
 pub const State = struct {
     pending: ?PendingSubmission = null,
+    retry_after_auth: bool = false,
 };
 
 fn buildQueuedPromptDraft(
@@ -118,6 +119,25 @@ fn buildQueuedPromptDraft(
 pub fn SubmitRuntime(comptime App: type) type {
     return struct {
         const queue_rt = input_queue_runtime.Runtime(App);
+
+        pub fn requestPromptRetryAfterAuth(app: *App) void {
+            app.submission.retry_after_auth = true;
+        }
+
+        pub fn cancelPromptRetryAfterAuth(app: *App) void {
+            app.submission.retry_after_auth = false;
+        }
+
+        fn takePromptRetryAfterAuth(app: *App) bool {
+            const pending = app.submission.retry_after_auth;
+            app.submission.retry_after_auth = false;
+            return pending;
+        }
+
+        pub fn resumePromptAfterAuth(app: *App, max_prompt_history: usize) !void {
+            if (!takePromptRetryAfterAuth(app)) return;
+            try submit(app, max_prompt_history);
+        }
         const completion_rt = input_completion_runtime.CompletionRuntime(App);
 
         const PromptAdmission = enum {

--- a/src/core/auth/auth_runtime.zig
+++ b/src/core/auth/auth_runtime.zig
@@ -54,6 +54,54 @@ fn sourceLabelOrMissing(source: ?credentials.Source) []const u8 {
     return credentials.sourceLabel(source orelse return "missing");
 }
 
+pub const CredentialFailureReason = enum {
+    temporary_unavailable,
+    invalid_credential,
+    invalid_storage,
+    persistence_uncertain,
+    authority_changed,
+};
+
+pub const CredentialFailure = struct {
+    source: credentials.Source,
+    reason: CredentialFailureReason,
+
+    pub fn retryable(self: CredentialFailure) bool {
+        return self.reason == .temporary_unavailable;
+    }
+};
+
+pub fn classifyCredentialFailure(
+    source: credentials.Source,
+    err: anyerror,
+) CredentialFailure {
+    return .{
+        .source = source,
+        .reason = switch (err) {
+            error.InvalidGrant,
+            error.AccessDenied,
+            error.ExpiredToken,
+            error.InvalidClient,
+            error.CredentialRefreshUnavailable,
+            => .invalid_credential,
+            error.InvalidAuthSession,
+            error.InvalidOAuthKeychainSession,
+            error.InvalidOAuthStorageState,
+            error.KeychainItemNotFound,
+            => .invalid_storage,
+            error.KeychainWriteFailed,
+            error.OAuthSessionKeychainWriteMismatch,
+            error.OAuthSessionCleanupUncertain,
+            => .persistence_uncertain,
+            error.CredentialAuthorityChanged,
+            error.ChatGptAccountChanged,
+            error.GrokAccountChanged,
+            => .authority_changed,
+            else => .temporary_unavailable,
+        },
+    };
+}
+
 pub const FailureReason = enum {
     credential_refresh_failed,
     http_unauthorized,
@@ -1027,7 +1075,7 @@ pub const Runtime = struct {
     secret_store: host.SecretStore = host.unavailable_secret_store,
     auth_mode: credentials.AuthMode = .local,
     selected_credential: ?credentials.Credential = null,
-    credential_refresh_failure_source: ?credentials.Source = null,
+    credential_failure: ?CredentialFailure = null,
     source_inventory: SourceSet = .empty,
     stored_key_status: credentials.StoredKeyReadStatus = .not_attempted,
     fx_login_status: credentials.FxLoginReadStatus = .not_attempted,
@@ -1104,7 +1152,7 @@ pub const Runtime = struct {
         storage.secret_store = secret_store;
         storage.auth_mode = auth_mode;
         storage.selected_credential = null;
-        storage.credential_refresh_failure_source = null;
+        storage.credential_failure = null;
         storage.source_inventory = .empty;
         storage.stored_key_status = .not_attempted;
         storage.fx_login_status = .not_attempted;
@@ -1189,15 +1237,28 @@ pub const Runtime = struct {
 
     pub fn modelCatalogAccess(self: *const Self) credentials.CatalogAccess {
         if (self.auth_mode == .host_managed) return .host_managed;
-        if (self.credential_refresh_failure_source) |source| {
-            return credentials.catalogAccessAfterRefreshFailure(source);
+        if (self.credential_failure) |failure| {
+            return credentials.catalogAccessAfterRefreshFailure(failure.source);
         }
         return credentials.catalogAccessAt(self.selected_credential, io_mod.milliTimestamp());
     }
 
-    pub fn recordCredentialRefreshFailure(self: *Self, source: credentials.Source) void {
-        std.debug.assert(self.credentialSource() == source);
-        self.credential_refresh_failure_source = source;
+    /// Returns true only for the first observation of this failure episode.
+    pub fn recordCredentialFailure(self: *Self, failure: CredentialFailure) bool {
+        std.debug.assert(self.credentialSource() == failure.source);
+        if (self.credential_failure) |current| {
+            if (current.source == failure.source and
+                current.reason == failure.reason)
+            {
+                return false;
+            }
+        }
+        self.credential_failure = failure;
+        return true;
+    }
+
+    pub fn credentialFailure(self: *const Self) ?CredentialFailure {
+        return self.credential_failure;
     }
 
     pub fn credentialSource(self: *const Self) ?credentials.Source {
@@ -1994,7 +2055,7 @@ pub const Runtime = struct {
         if (self.selected_credential) |*selected| selected.deinit(alloc);
 
         self.selected_credential = credential.*;
-        self.credential_refresh_failure_source = null;
+        self.credential_failure = null;
         credential.token = &.{};
         credential.account_id = null;
         credential.team_id = null;
@@ -2018,21 +2079,6 @@ pub const Runtime = struct {
             )
         else
             .authority;
-    }
-
-    pub fn adoptSelectedTeam(self: *Self, alloc: Allocator, selected_team: *login_flow.SelectedTeam) bool {
-        const credential = if (self.selected_credential) |*selected| selected else return false;
-        if (credential.source != .fx_login) return false;
-
-        const changed = !optionalBytesEqual(credential.team_id, selected_team.id) or
-            !optionalBytesEqual(credential.team_slug, selected_team.slug);
-        if (credential.team_id) |team| alloc.free(team);
-        if (credential.team_slug) |team| alloc.free(team);
-        credential.team_id = selected_team.id;
-        credential.team_slug = selected_team.slug;
-        selected_team.id = &.{};
-        selected_team.slug = &.{};
-        return changed;
     }
 
     fn selectSourceWithLoader(
@@ -2121,7 +2167,7 @@ pub const Runtime = struct {
         const previous = self.credentialSource();
         if (self.selected_credential) |*credential| credential.deinit(alloc);
         self.selected_credential = null;
-        self.credential_refresh_failure_source = null;
+        self.credential_failure = null;
 
         try self.refreshSourceInventoryWithProbe(alloc, ctx, probe);
         for (credential_source_order) |source| {
@@ -2142,7 +2188,7 @@ pub const Runtime = struct {
         if (was_active) {
             if (self.selected_credential) |*credential| credential.deinit(alloc);
             self.selected_credential = null;
-            self.credential_refresh_failure_source = null;
+            self.credential_failure = null;
         }
         try self.refreshSourceInventory(alloc);
         return was_active or was_available;
@@ -2154,7 +2200,7 @@ pub const Runtime = struct {
         if (was_active) {
             if (self.selected_credential) |*credential| credential.deinit(alloc);
             self.selected_credential = null;
-            self.credential_refresh_failure_source = null;
+            self.credential_failure = null;
         }
         try self.refreshSourceInventory(alloc);
         return was_active or was_available;
@@ -2180,7 +2226,7 @@ pub const Runtime = struct {
         if (login_was_active) {
             if (self.selected_credential) |*credential| credential.deinit(alloc);
             self.selected_credential = null;
-            self.credential_refresh_failure_source = null;
+            self.credential_failure = null;
         }
 
         try self.refreshSourceInventoryWithProbe(alloc, ctx, probe);
@@ -2248,7 +2294,7 @@ test "auth in-place initialization preserves empty runtime state" {
     defer runtime.deinit(std.testing.allocator);
 
     try std.testing.expect(runtime.selected_credential == null);
-    try std.testing.expect(runtime.credential_refresh_failure_source == null);
+    try std.testing.expect(runtime.credential_failure == null);
     try std.testing.expect(runtime.source_inventory.count() == 0);
     try std.testing.expect(runtime.stored_key_status == .not_attempted);
     try std.testing.expect(!runtime.picker_active);
@@ -2603,6 +2649,27 @@ test "auth failure snapshot keeps refresh failures distinct from HTTP rejection"
     try std.testing.expect(FailureSnapshot.fromHttp(.unauthorized, null) == null);
 }
 
+test "credential refresh failures preserve repair and retry semantics" {
+    const cases = [_]struct {
+        err: anyerror,
+        expected_reason: CredentialFailureReason,
+        expected_retryable: bool,
+    }{
+        .{ .err = error.InvalidGrant, .expected_reason = .invalid_credential, .expected_retryable = false },
+        .{ .err = error.InvalidAuthSession, .expected_reason = .invalid_storage, .expected_retryable = false },
+        .{ .err = error.OAuthSessionKeychainWriteMismatch, .expected_reason = .persistence_uncertain, .expected_retryable = false },
+        .{ .err = error.CredentialAuthorityChanged, .expected_reason = .authority_changed, .expected_retryable = false },
+        .{ .err = error.ConnectionResetByPeer, .expected_reason = .temporary_unavailable, .expected_retryable = true },
+    };
+
+    for (cases) |case| {
+        const failure = classifyCredentialFailure(.fx_login, case.err);
+        try std.testing.expectEqual(credentials.Source.fx_login, failure.source);
+        try std.testing.expectEqual(case.expected_reason, failure.reason);
+        try std.testing.expectEqual(case.expected_retryable, failure.retryable());
+    }
+}
+
 test "catalog access records a refresh failure until another credential is adopted" {
     const alloc = std.testing.allocator;
     var runtime: Runtime = .{};
@@ -2611,7 +2678,10 @@ test "catalog access records a refresh failure until another credential is adopt
     var login = try makeTestCredential(alloc, "login-token", .fx_login, null, null);
     defer login.deinit(alloc);
     _ = runtime.adoptCredential(alloc, &login);
-    runtime.recordCredentialRefreshFailure(.fx_login);
+    _ = runtime.recordCredentialFailure(classifyCredentialFailure(
+        .fx_login,
+        error.OAuthRequestFailed,
+    ));
 
     const failed = runtime.modelCatalogAccess();
     try std.testing.expectEqual(credentials.CatalogPublicOnlyReason.credential_refresh_failed, failed.publicOnlyReason().?);
@@ -2622,6 +2692,28 @@ test "catalog access records a refresh failure until another credential is adopt
 
     const authenticated = runtime.modelCatalogAccess();
     try std.testing.expectEqualStrings("api-key", authenticated.authorizationCredential().?);
+}
+
+test "credential failure episodes deduplicate and clear on adoption" {
+    const alloc = std.testing.allocator;
+    var runtime: Runtime = .{};
+    defer runtime.deinit(alloc);
+
+    var login = try makeTestCredential(alloc, "login-token", .fx_login, null, null);
+    _ = runtime.adoptCredential(alloc, &login);
+
+    const failure = classifyCredentialFailure(.fx_login, error.InvalidGrant);
+    try std.testing.expect(runtime.recordCredentialFailure(failure));
+    try std.testing.expect(!runtime.recordCredentialFailure(failure));
+    try std.testing.expectEqual(failure, runtime.credentialFailure().?);
+    try std.testing.expectEqual(
+        credentials.CatalogPublicOnlyReason.credential_refresh_failed,
+        runtime.modelCatalogAccess().publicOnlyReason().?,
+    );
+
+    var refreshed = try makeTestCredential(alloc, "fresh-login-token", .fx_login, null, null);
+    _ = runtime.adoptCredential(alloc, &refreshed);
+    try std.testing.expect(runtime.credentialFailure() == null);
 }
 
 test "auth runtime adopts credential ownership and prefers team id" {

--- a/src/core/auth/login_flow.zig
+++ b/src/core/auth/login_flow.zig
@@ -765,9 +765,12 @@ pub fn logout(
             return LogoutError.SessionDeleteFailed;
         }) orelse return .{};
         defer mutation.deinit();
-        session = mutation.load(alloc) catch load: {
-            session_load_failed = true;
-            break :load null;
+        session = mutation.load(alloc) catch |err| switch (err) {
+            error.InvalidAuthSession => null,
+            else => load: {
+                session_load_failed = true;
+                break :load null;
+            },
         };
         break :blk mutation.delete(alloc) catch oauth_session.DeleteResult{
             .local_cleanup_failed = true,

--- a/src/core/auth/oauth.zig
+++ b/src/core/auth/oauth.zig
@@ -31,6 +31,7 @@ pub const OAuthError = error{
     AccessDenied,
     ExpiredToken,
     InvalidClient,
+    InvalidGrant,
     OAuthRequestFailed,
 };
 
@@ -331,6 +332,7 @@ fn mapOAuthHttpError(alloc: Allocator, body: []const u8) !void {
     if (std.mem.eql(u8, value.string, "access_denied")) return OAuthError.AccessDenied;
     if (std.mem.eql(u8, value.string, "expired_token")) return OAuthError.ExpiredToken;
     if (std.mem.eql(u8, value.string, "invalid_client")) return OAuthError.InvalidClient;
+    if (std.mem.eql(u8, value.string, "invalid_grant")) return OAuthError.InvalidGrant;
     return OAuthError.OAuthRequestFailed;
 }
 
@@ -551,6 +553,7 @@ test "oauth maps provider errors" {
     try std.testing.expectError(OAuthError.OAuthRequestFailed, mapOAuthHttpError(std.testing.allocator, "{\"error\":\"invalid_request\"}"));
     try std.testing.expectError(OAuthError.OAuthRequestFailed, mapOAuthHttpError(std.testing.allocator, "{\"error\":42}"));
     try std.testing.expectError(OAuthError.InvalidClient, mapOAuthHttpError(std.testing.allocator, "{\"error\":\"invalid_client\"}"));
+    try std.testing.expectError(OAuthError.InvalidGrant, mapOAuthHttpError(std.testing.allocator, "{\"error\":\"invalid_grant\"}"));
 }
 
 test "oauth parses token set" {

--- a/src/core/auth/oauth_session.zig
+++ b/src/core/auth/oauth_session.zig
@@ -662,7 +662,7 @@ fn loadFromDir(alloc: Allocator, fx_dir: *std.Io.Dir, mode: LoadMode) !?Session 
         error.OutOfMemory => return err,
         else => {
             debug_trace.logf("auth", "session load failed step=parse err={s}", .{@errorName(err)});
-            return null;
+            if (mode == .tolerate_open_failure) return null else return err;
         },
     };
 }
@@ -1326,6 +1326,26 @@ test "OAuth mutation loads report auth file open failures" {
     try std.testing.expect((try loadFromDir(std.testing.allocator, &tmp.dir, .tolerate_open_failure)) == null);
     try std.testing.expectError(
         error.SymLinkLoop,
+        loadFromDir(std.testing.allocator, &tmp.dir, .report_open_failure),
+    );
+}
+
+test "OAuth mutation distinguishes an invalid session from an absent session" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var file = try tmp.dir.createFile(std.testing.io, auth_file_name, .{
+        .permissions = std.Io.File.Permissions.fromMode(0o600),
+    });
+    try file.writeStreamingAll(std.testing.io, "{\"version\":2}\n");
+    file.close(std.testing.io);
+
+    try std.testing.expect((try loadFromDir(
+        std.testing.allocator,
+        &tmp.dir,
+        .tolerate_open_failure,
+    )) == null);
+    try std.testing.expectError(
+        error.InvalidAuthSession,
         loadFromDir(std.testing.allocator, &tmp.dir, .report_open_failure),
     );
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -964,6 +964,18 @@ const App = struct {
         try AuthAppRuntime.runProviderCommand(self);
     }
 
+    pub fn requestPromptRetryAfterAuth(self: *App) void {
+        InputSubmitRuntime.requestPromptRetryAfterAuth(self);
+    }
+
+    pub fn cancelPromptRetryAfterAuth(self: *App) void {
+        InputSubmitRuntime.cancelPromptRetryAfterAuth(self);
+    }
+
+    pub fn resumePromptAfterAuth(self: *App) !void {
+        try InputSubmitRuntime.resumePromptAfterAuth(self, max_prompt_history);
+    }
+
     pub fn runLoginCommand(self: *App) !void {
         try AuthAppRuntime.runLoginCommand(self);
     }

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -397,6 +397,7 @@ function startFakeOAuth(
     deviceError?: string;
     rejectAllDeviceClients?: boolean;
     tokenDelayMs?: number;
+    rejectRefreshGrant?: boolean;
     teams?: Array<{ id: string; slug: string; name: string }>;
   } = {},
 ) {
@@ -406,6 +407,7 @@ function startFakeOAuth(
     path: string;
     authorization: string | null;
     clientId?: string;
+    grantType?: string;
     revocation?: { tokenTypeHint: string; validForm: boolean };
   }> = [];
   let tokenResponseCount = 0;
@@ -457,8 +459,11 @@ function startFakeOAuth(
           const form = await request.formData();
           const clientId = form.get("client_id");
           recordedRequest.clientId = typeof clientId === "string" ? clientId : undefined;
+          const grantType = form.get("grant_type");
+          recordedRequest.grantType = typeof grantType === "string" ? grantType : undefined;
           tokenResponseCount += 1;
           if (
+            (options.rejectRefreshGrant && grantType === "refresh_token") ||
             accessToken === null ||
             tokenResponseCount > successfulTokenResponses
           ) {
@@ -4164,8 +4169,8 @@ tmuxTest(
     await session.sendKeys("Enter");
     const failed = await session.waitForPane(
       (pane) =>
-        pane.includes("fx login credential refresh failed.") &&
-        pane.includes("Run /login to repair this source.") &&
+        pane.includes("fx login sign-in expired.") &&
+        pane.includes("Press Enter to sign in again.") &&
         !pane.includes("Setup"),
       TIMEOUT,
     );
@@ -4193,6 +4198,45 @@ tmuxTest(
     for (const secret of [LOGIN_TOKEN, ENV_TOKEN, "seeded-refresh-token", "invalid_grant", "rejected"]) {
       expect(trace).not.toContain(secret);
     }
+    expect(readFileSync(stderrPath, "utf8")).toBe("");
+  },
+  60_000,
+);
+
+tmuxTest(
+  "permanent fx login failure enters repair without retrying or losing the prompt",
+  async () => {
+    home = mkdtempSync(join(tmpdir(), "fx-tui-auth-repair-"));
+    stderrPath = join(home, "stderr.log");
+    writeFileSync(stderrPath, "");
+    gateway = startFakeGateway([fakeGatewayFinalText(REFRESH_RECOVERY_RESPONSE)]);
+    oauth = startFakeOAuth(ACQUIRED_LOGIN_TOKEN, undefined, 3600, Number.POSITIVE_INFINITY, {
+      rejectRefreshGrant: true,
+      tokenDelayMs: 5_000,
+      teams: [{ id: "team_123", slug: "team-harness", name: "Team Harness" }],
+    });
+    writeSeededFxLogin(home, Date.now() - 60_000, oauth.issuerUrl);
+
+    session = await startFx(home, stderrPath, gateway, oauth.issuerUrl, undefined, {
+      AI_GATEWAY_API_KEY: undefined,
+    });
+    await session.waitForComposer(TIMEOUT);
+    const prompt = "PRESERVE_DURING_LOGIN_REPAIR";
+    await session.sendText(prompt);
+    await session.waitForText("fx login sign-in expired.", TIMEOUT);
+    expect(oauth.requests.filter((request) => request.grantType === "refresh_token")).toHaveLength(1);
+
+    await session.sendKeys("Enter");
+    await session.waitForText("Waiting for authorization", TIMEOUT);
+    expect(oauth.requests.filter((request) => request.grantType === "refresh_token")).toHaveLength(1);
+
+    await session.waitForText("Team Harness", TIMEOUT);
+    await session.sendKeys("Enter");
+    await session.waitForText(REFRESH_RECOVERY_RESPONSE, TIMEOUT);
+    const full = await session.captureFullScrollback();
+    expect(full.match(/fx login sign-in expired\./g)).toHaveLength(1);
+    expect(gateway.requests).toHaveLength(1);
+    expect(gateway.requests[0]!.body).toContain(prompt);
     expect(readFileSync(stderrPath, "utf8")).toBe("");
   },
   60_000,
@@ -4393,8 +4437,8 @@ tmuxTest(
     await session.waitForPane(
       (pane) =>
         pane.includes(blockedPrompt) &&
-        pane.includes("fx login credential refresh failed.") &&
-        pane.includes("Run /login to repair this source.") &&
+        pane.includes("fx login sign-in expired.") &&
+        pane.includes("Press Enter to sign in again.") &&
         !pane.includes("Model provider"),
       TIMEOUT,
     );
@@ -4462,7 +4506,7 @@ tmuxTest(
       (pane) =>
         pane.includes(firstPrompt) &&
         pane.includes("fx login credential refresh failed.") &&
-        pane.includes("Run /login to repair this source.") &&
+        pane.includes("Check your connection and press Enter to retry.") &&
         !pane.includes("Model provider"),
       TIMEOUT,
     );
@@ -4493,7 +4537,7 @@ tmuxTest(
       (pane) =>
         pane.includes(secondPrompt) &&
         pane.includes("fx login credential refresh failed.") &&
-        pane.includes("Run /login to repair this source.") &&
+        pane.includes("Check your connection and press Enter to retry.") &&
         !pane.includes("Model provider"),
       TIMEOUT,
     );
@@ -4617,8 +4661,8 @@ tmuxTest(
     await session.sendText("/credits");
     const failed = await session.waitForPane(
       (pane) =>
-        pane.includes("fx login credential refresh failed.") &&
-        pane.includes("Run /login to repair this source.") &&
+        pane.includes("fx login sign-in expired.") &&
+        pane.includes("Press Enter to sign in again.") &&
         pane.includes("/credits"),
       TIMEOUT,
     );


### PR DESCRIPTION
## Summary

- Distinguish expired sign-ins from temporary credential refresh failures.
- Stop retrying a permanently rejected credential on every prompt submission.
- Preserve and automatically resume the submitted prompt after successful Vercel sign-in and team selection.
- Reload the durable fx login after team selection so repaired tokens replace stale in-memory credentials.
