### PR TITLE
fix(mcp): prefer structured tool results

### DIFF
--- a/src/core/mcp/mcp_runtime.zig
+++ b/src/core/mcp/mcp_runtime.zig
@@ -16836,7 +16836,8 @@ test "modern MCP calls delegate unsupported schema assertions to the server" {
         tool_result_limits.default_max_tool_result_bytes,
     )).?;
     defer alloc.free(result.model_output);
-    try std.testing.expect(std.mem.find(u8, result.model_output, "accepted") != null);
+    try std.testing.expect(std.mem.find(u8, result.model_output, "person@example.com") != null);
+    try std.testing.expect(std.mem.find(u8, result.model_output, "accepted") == null);
 
     server.disconnect();
 }

--- a/src/core/mcp/tool_result.zig
+++ b/src/core/mcp/tool_result.zig
@@ -364,9 +364,18 @@ fn serialize_capped(
     return try alloc.dupe(u8, best);
 }
 
-/// Prefer the machine-readable MCP result when the server supplies one. The
-/// human-readable content is the compatibility fallback, so sending both to
-/// the model would duplicate context for conforming servers.
+/// Modern MCP servers can return the required `content` and the newer but optional
+/// `structuredContent`.
+///
+/// Its biggest advantage is that if the tool declares an `outputSchema`,
+/// `structuredContent` has to conform to it.
+///
+/// This function prefers keeping `structuredContent` if present, falling back to `content`.
+/// This avoids sending equivalent structured and unstructured results to the model and
+/// needlessly using additional input tokens.
+///
+/// Reference:
+/// https://modelcontextprotocol.io/specification/2026-07-28/server/tools#structured-content
 fn select_model_result(result: std.json.Value) std.json.Value {
     if (result != .object) return result;
     if (result.object.get("structuredContent")) |structured_content| {

--- a/src/core/mcp/tool_result.zig
+++ b/src/core/mcp/tool_result.zig
@@ -303,14 +303,15 @@ fn serialize_capped(
     defer arena_impl.deinit();
     const arena = arena_impl.allocator();
 
+    const model_result = select_model_result(result);
     var full = std.Io.Writer.Allocating.init(arena);
-    try write_envelope(arena, &full.writer, server_name, tool_name, result);
+    try write_envelope(arena, &full.writer, server_name, tool_name, model_result);
     const full_output = full.writer.buffered();
     if (full_output.len <= max_tool_result_bytes) {
         return try alloc.dupe(u8, full_output);
     }
 
-    const combined = try collect_result_text(arena, result);
+    const combined = try collect_result_text(arena, model_result);
     const marker = try std.fmt.allocPrint(
         arena,
         "\n... [mcp tool result truncated for {s}/{s}: original {d} bytes; cap is {d} bytes]\n",
@@ -361,6 +362,17 @@ fn serialize_capped(
         );
     }
     return try alloc.dupe(u8, best);
+}
+
+/// Prefer the machine-readable MCP result when the server supplies one. The
+/// human-readable content is the compatibility fallback, so sending both to
+/// the model would duplicate context for conforming servers.
+fn select_model_result(result: std.json.Value) std.json.Value {
+    if (result != .object) return result;
+    if (result.object.get("structuredContent")) |structured_content| {
+        if (structured_content != .null) return structured_content;
+    }
+    return result.object.get("content") orelse result;
 }
 
 fn write_envelope(
@@ -514,10 +526,59 @@ test "tool result extracts all content" {
         "server",
         parsed.value.object.get("server").?.string,
     );
-    const content = parsed.value.object.get("result").?.object.get("content").?.array.items;
+    const content = parsed.value.object.get("result").?.array.items;
     try std.testing.expectEqualStrings("hello ", content[0].object.get("text").?.string);
     try std.testing.expectEqualStrings("AA==", content[1].object.get("data").?.string);
     try std.testing.expectEqualStrings("world", content[2].object.get("text").?.string);
+}
+
+test "tool result prefers non-null structured content over compatibility content" {
+    const alloc = std.testing.allocator;
+    const response =
+        \\{"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"duplicate compatibility text"}],"structuredContent":{"answer":42,"source":"structured"},"isError":false}}
+    ;
+    var result = try extract(alloc, .{
+        .server_name = "server",
+        .tool_name = "mcp__server__tool",
+        .response = response,
+        .max_tool_result_bytes = tool_result_limits.default_max_tool_result_bytes,
+        .protocol = .modern,
+    });
+    defer result.deinit(alloc);
+
+    try std.testing.expectEqualStrings(
+        "{\"server\":\"server\",\"tool\":\"mcp__server__tool\",\"result\":{\"answer\":42,\"source\":\"structured\"}}",
+        result.model_output,
+    );
+    try std.testing.expect(std.mem.find(u8, result.model_output, "duplicate compatibility text") == null);
+}
+
+test "tool result falls back to content when structured content is null or absent" {
+    const alloc = std.testing.allocator;
+    const cases = [_][]const u8{
+        \\{"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"null fallback"}],"structuredContent":null}}
+        ,
+        \\{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"absent fallback"}]}}
+        ,
+    };
+    const expected = [_][]const u8{ "null fallback", "absent fallback" };
+
+    for (cases, expected) |response, expected_text| {
+        var result = try extract(alloc, .{
+            .server_name = "server",
+            .tool_name = "mcp__server__tool",
+            .response = response,
+            .max_tool_result_bytes = tool_result_limits.default_max_tool_result_bytes,
+            .protocol = .modern,
+        });
+        defer result.deinit(alloc);
+
+        var parsed = try std.json.parseFromSlice(std.json.Value, alloc, result.model_output, .{});
+        defer parsed.deinit();
+        const content = parsed.value.object.get("result").?.array.items;
+        try std.testing.expectEqual(@as(usize, 1), content.len);
+        try std.testing.expectEqualStrings(expected_text, content[0].object.get("text").?.string);
+    }
 }
 
 test "tool result retains protocol error diagnostics" {

--- a/tests/e2e/fixtures/mcp-modern-http.ts
+++ b/tests/e2e/fixtures/mcp-modern-http.ts
@@ -641,6 +641,8 @@ export function startModernMcpHttpFixture(
             type: "text",
             text: mode === "mrtr_form"
               ? "HTTP continued after elicitation"
+              : mode === "server_authoritative_schema"
+              ? `compatibility:${message.params?.arguments?.text ?? ""}`
               : `${MODERN_HTTP_TOOL_RESULT}:${message.params?.arguments?.text ?? ""}`,
           }],
           ...(mode === "server_authoritative_schema"

--- a/tests/e2e/mcp-http.test.ts
+++ b/tests/e2e/mcp-http.test.ts
@@ -1352,6 +1352,10 @@ describe("modern MCP Streamable HTTP", () => {
     expect(gateway.requests[2]?.body).toContain(
       `${MODERN_HTTP_TOOL_RESULT}:hello`,
     );
+    expect(toolResultText(gateway.requests[2]!.body, "call_mcp")).toBe(
+      `{"server":"fixture","tool":"${TOOL_NAME}","result":{"echo":"${MODERN_HTTP_TOOL_RESULT}:hello"}}`,
+    );
+    expect(gateway.requests[2]?.body).not.toContain("compatibility:hello");
     expect(gateway.requests.some((request) =>
       request.body.includes('"pattern":"^(?!blocked$).+$"')
     )).toBe(true);


### PR DESCRIPTION
Modern MCP servers can return the required `content`, and the newer but optional [`structuredContent`](https://modelcontextprotocol.io/specification/2026-07-28/server/tools#structured-content).

The big reason that `structuredContent` was added to the spec is that, if the tool declares an `outputSchema`,
`structuredContent` has to conform to it. For backward compatibility, the MCP spec recommends also returning the structured result serialized in a `TextContent` block, and many MCP servers indeed do that.

Before this PR, `fx` sent both representations to the model. For MCPs that contain both forms, this duplicates the tool response, using more input tokens than it needed.

This PR makes it so that if the MCP server returned both forms, it'll prefer keeping only `structuredContent`. Truncation is then applied only to the selected representation.

For reference, that's also what Codex does ([source](https://github.com/openai/codex/blob/8b8ee28a9b0df8188fec8d4e3855a7b3af3ed8a2/codex-rs/protocol/src/models.rs#L2270-L2291)), and OpenCode's upcoming code-mode does that too ([source](https://github.com/anomalyco/opencode/blob/b578b7261fc9ec4917fe272df5cc4bd8a056cd5d/packages/opencode/src/tool/code-mode.ts#L109-L109)).

## Verification

- Unit and runtime tests cover:
  - preferring non-null `structuredContent`
  - falling back when it is absent or null
  - excluding the duplicate `content` representation
  - Updates `mcp-http.test.ts` to assert the `structuredContent` preference  