### PR TITLE
Route Codex requests through macOS HTTPS proxies

### DIFF
--- a/src/builtins/gateway.zig
+++ b/src/builtins/gateway.zig
@@ -12,6 +12,7 @@ const collections = @import("../core/shared/collections.zig");
 const debug_trace = @import("../core/shared/debug_trace.zig");
 const gateway_error_format = @import("../core/shared/gateway_error_format.zig");
 const gateway_client = @import("../gateway/client.zig");
+const curl_proxy_transport = @import("../gateway/curl_proxy_transport.zig");
 const vercel_failure_diagnostics = @import("../gateway/vercel_failure_diagnostics.zig");
 const vercel_protocol = @import("../gateway/vercel_protocol.zig");
 const io_mod = @import("../core/shared/io.zig");
@@ -799,6 +800,8 @@ const OAuthHttpOperation = struct {
     request: oauth_transport.Request,
 
     pub fn run(self: *@This()) !oauth_transport.Response {
+        if (curl_proxy_transport.shouldUse(self.request.url)) return self.runWithCurl();
+
         var client: std.http.Client = .{
             .allocator = self.alloc,
             .io = io_mod.getIo(),
@@ -841,6 +844,41 @@ const OAuthHttpOperation = struct {
         return .{
             .disposition = if (result.status == .ok) .accepted else .rejected,
             .body = try self.alloc.dupe(u8, body),
+        };
+    }
+
+    fn runWithCurl(self: *@This()) !oauth_transport.Response {
+        var headers: [3]curl_proxy_transport.Header = undefined;
+        var header_count: usize = 0;
+        headers[header_count] = .{ .name = "User-Agent", .value = gateway_client.user_agent };
+        header_count += 1;
+        if (self.request.method != .get) {
+            headers[header_count] = .{
+                .name = "Content-Type",
+                .value = switch (self.request.method) {
+                    .get => unreachable,
+                    .post_form => "application/x-www-form-urlencoded",
+                    .post_json => "application/json",
+                },
+            };
+            header_count += 1;
+        }
+        if (self.request.authorization) |authorization| {
+            headers[header_count] = .{ .name = "Authorization", .value = authorization };
+            header_count += 1;
+        }
+        const response = try curl_proxy_transport.execute(self.alloc, .{
+            .url = self.request.url,
+            .method = if (self.request.method == .get) .get else .post,
+            .headers = headers[0..header_count],
+            .payload = self.request.payload,
+            .max_response_bytes = oauth_response_max_bytes,
+            .timeout_seconds = 15,
+            .cancel_flag = self.request.cancel_flag,
+        });
+        return .{
+            .disposition = if (response.status == .ok) .accepted else .rejected,
+            .body = response.body,
         };
     }
 };

--- a/src/gateway/curl_proxy_transport.zig
+++ b/src/gateway/curl_proxy_transport.zig
@@ -1,0 +1,167 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const io_mod = @import("../core/shared/io.zig");
+const secret = @import("../core/auth/secret.zig");
+
+const Allocator = std.mem.Allocator;
+
+pub const Header = struct {
+    name: []const u8,
+    value: []const u8,
+};
+
+pub const Request = struct {
+    url: []const u8,
+    method: enum { get, post } = .get,
+    headers: []const Header = &.{},
+    payload: ?[]const u8 = null,
+    max_response_bytes: usize,
+    timeout_seconds: u32,
+    cancel_flag: ?*std.atomic.Value(bool) = null,
+};
+
+pub const Response = struct {
+    status: std.http.Status,
+    body: []u8,
+
+    pub fn deinit(self: *Response, alloc: Allocator) void {
+        secret.zeroAndFree(alloc, self.body);
+        self.* = undefined;
+    }
+};
+
+/// Zig 0.16 sends plaintext HTTP after an HTTPS proxy CONNECT. macOS ships
+/// curl, so use it only for affected HTTPS requests when a proxy is configured.
+pub fn shouldUse(url: []const u8) bool {
+    if (comptime builtin.os.tag != .macos) return false;
+    if (!std.mem.startsWith(u8, url, "https://")) return false;
+    for ([_][]const u8{ "HTTPS_PROXY", "https_proxy", "ALL_PROXY", "all_proxy" }) |name| {
+        if (io_mod.getenv(name)) |value| {
+            if (std.mem.trim(u8, value, " \t\r\n").len > 0) return true;
+        }
+    }
+    return false;
+}
+
+pub fn execute(alloc: Allocator, request: Request) !Response {
+    var config_writer: std.Io.Writer.Allocating = .init(alloc);
+    defer config_writer.deinit();
+    const writer = &config_writer.writer;
+    try writeOption(writer, "url", request.url);
+    try writer.print("request = \"{s}\"\n", .{switch (request.method) {
+        .get => "GET",
+        .post => "POST",
+    }});
+    try writer.print("max-time = {d}\n", .{request.timeout_seconds});
+    for (request.headers) |header| try writeHeader(writer, header);
+    if (request.payload) |payload| try writeOption(writer, "data-binary", payload);
+    try writer.writeAll("write-out = \"\\n%{http_code}\"\n");
+    const config = try config_writer.toOwnedSlice();
+    defer secret.zeroAndFree(alloc, config);
+
+    const io = io_mod.getIo();
+    var child = try std.process.spawn(io, .{
+        .argv = &.{
+            "/usr/bin/curl",
+            "--silent",
+            "--show-error",
+            "--no-buffer",
+            "--config",
+            "-",
+        },
+        .stdin = .pipe,
+        .stdout = .pipe,
+        .stderr = .pipe,
+    });
+    defer if (child.id != null) child.kill(io);
+
+    var stdin = child.stdin orelse return error.CurlProxyStdinUnavailable;
+    child.stdin = null;
+    try stdin.writeStreamingAll(io, config);
+    stdin.close(io);
+
+    var multi_reader_buffer: std.Io.File.MultiReader.Buffer(2) = undefined;
+    var multi_reader: std.Io.File.MultiReader = undefined;
+    multi_reader.init(alloc, io, multi_reader_buffer.toStreams(), &.{ child.stdout.?, child.stderr.? });
+    defer multi_reader.deinit();
+    const stdout_reader = multi_reader.reader(0);
+    const stderr_reader = multi_reader.reader(1);
+    while (multi_reader.fill(64, .none)) |_| {
+        if (request.cancel_flag) |flag| if (flag.load(.seq_cst)) return error.Cancelled;
+        if (stdout_reader.buffered().len > request.max_response_bytes + 16 or
+            stderr_reader.buffered().len > 16 * 1024)
+        {
+            return error.CurlProxyResponseTooLarge;
+        }
+    } else |err| switch (err) {
+        error.EndOfStream => {},
+        else => |fill_err| return fill_err,
+    }
+    try multi_reader.checkAnyError();
+
+    const term = try child.wait(io);
+    if (term != .exited or term.exited != 0) return error.CurlProxyRequestFailed;
+    const stdout = try multi_reader.toOwnedSlice(0);
+    defer secret.zeroAndFree(alloc, stdout);
+    return parseResponse(alloc, stdout, request.max_response_bytes);
+}
+
+fn parseResponse(alloc: Allocator, stdout: []const u8, max_response_bytes: usize) !Response {
+    const separator = std.mem.findScalarLast(u8, stdout, '\n') orelse
+        return error.InvalidCurlProxyResponse;
+    const status_bytes = std.mem.trim(u8, stdout[separator + 1 ..], " \t\r\n");
+    const status_code = std.fmt.parseUnsigned(u10, status_bytes, 10) catch
+        return error.InvalidCurlProxyResponse;
+    if (status_code < 100 or status_code > 599) return error.InvalidCurlProxyResponse;
+    const body = stdout[0..separator];
+    if (body.len > max_response_bytes) return error.CurlProxyResponseTooLarge;
+    return .{
+        .status = @enumFromInt(status_code),
+        .body = try alloc.dupe(u8, body),
+    };
+}
+
+fn writeHeader(writer: *std.Io.Writer, header: Header) !void {
+    try writer.writeAll("header = \"");
+    try writeEscaped(writer, header.name);
+    try writer.writeAll(": ");
+    try writeEscaped(writer, header.value);
+    try writer.writeAll("\"\n");
+}
+
+fn writeOption(writer: *std.Io.Writer, name: []const u8, value: []const u8) !void {
+    try writer.print("{s} = \"", .{name});
+    try writeEscaped(writer, value);
+    try writer.writeAll("\"\n");
+}
+
+fn writeEscaped(writer: *std.Io.Writer, value: []const u8) !void {
+    for (value) |byte| switch (byte) {
+        '\\' => try writer.writeAll("\\\\"),
+        '"' => try writer.writeAll("\\\""),
+        '\r' => try writer.writeAll("\\r"),
+        '\n' => try writer.writeAll("\\n"),
+        '\t' => try writer.writeAll("\\t"),
+        0...8, 11...12, 14...0x1f, 0x7f => return error.InvalidCurlProxyConfigValue,
+        else => try writer.writeByte(byte),
+    };
+}
+
+test "curl proxy config escapes secrets and JSON without changing bytes" {
+    var out: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer out.deinit();
+    try writeHeader(&out.writer, .{ .name = "Authorization", .value = "Bearer a\\b\"c" });
+    try writeOption(&out.writer, "data-binary", "{\"line\":\"one\\ntwo\"}");
+    try std.testing.expectEqualStrings(
+        "header = \"Authorization: Bearer a\\\\b\\\"c\"\n" ++
+            "data-binary = \"{\\\"line\\\":\\\"one\\\\ntwo\\\"}\"\n",
+        out.written(),
+    );
+}
+
+test "curl proxy response separates body from status trailer" {
+    var response = try parseResponse(std.testing.allocator, "data: value\n\n200", 64);
+    defer response.deinit(std.testing.allocator);
+    try std.testing.expectEqual(std.http.Status.ok, response.status);
+    try std.testing.expectEqualStrings("data: value\n", response.body);
+}

--- a/src/gateway/curl_proxy_transport.zig
+++ b/src/gateway/curl_proxy_transport.zig
@@ -30,6 +30,13 @@ pub const Response = struct {
     }
 };
 
+pub fn StreamingResponse(comptime Result: type) type {
+    return union(enum) {
+        completed: Result,
+        failed: Response,
+    };
+}
+
 /// Zig 0.16 sends plaintext HTTP after an HTTPS proxy CONNECT. macOS ships
 /// curl, so use it only for affected HTTPS requests when a proxy is configured.
 pub fn shouldUse(url: []const u8) bool {
@@ -44,19 +51,7 @@ pub fn shouldUse(url: []const u8) bool {
 }
 
 pub fn execute(alloc: Allocator, request: Request) !Response {
-    var config_writer: std.Io.Writer.Allocating = .init(alloc);
-    defer config_writer.deinit();
-    const writer = &config_writer.writer;
-    try writeOption(writer, "url", request.url);
-    try writer.print("request = \"{s}\"\n", .{switch (request.method) {
-        .get => "GET",
-        .post => "POST",
-    }});
-    try writer.print("max-time = {d}\n", .{request.timeout_seconds});
-    for (request.headers) |header| try writeHeader(writer, header);
-    if (request.payload) |payload| try writeOption(writer, "data-binary", payload);
-    try writer.writeAll("write-out = \"\\n%{http_code}\"\n");
-    const config = try config_writer.toOwnedSlice();
+    const config = try buildConfig(alloc, request, false, true);
     defer secret.zeroAndFree(alloc, config);
 
     const io = io_mod.getIo();
@@ -104,6 +99,108 @@ pub fn execute(alloc: Allocator, request: Request) !Response {
     const stdout = try multi_reader.toOwnedSlice(0);
     defer secret.zeroAndFree(alloc, stdout);
     return parseResponse(alloc, stdout, request.max_response_bytes);
+}
+
+pub fn executeStreaming(
+    comptime Result: type,
+    alloc: Allocator,
+    request: Request,
+    operation: anytype,
+) !StreamingResponse(Result) {
+    const config = try buildConfig(alloc, request, true, false);
+    defer secret.zeroAndFree(alloc, config);
+
+    const io = io_mod.getIo();
+    var child = try spawnCurl(io);
+    defer if (child.id != null) child.kill(io);
+    try sendConfig(io, &child, config);
+
+    var multi_reader_buffer: std.Io.File.MultiReader.Buffer(2) = undefined;
+    var multi_reader: std.Io.File.MultiReader = undefined;
+    multi_reader.init(alloc, io, multi_reader_buffer.toStreams(), &.{ child.stdout.?, child.stderr.? });
+    defer multi_reader.deinit();
+    const stdout_reader = multi_reader.reader(0);
+    const status = try readFinalStatus(stdout_reader);
+    if (status != .ok) {
+        const body = stdout_reader.allocRemaining(alloc, .limited(request.max_response_bytes)) catch |err| switch (err) {
+            error.StreamTooLong => return error.CurlProxyResponseTooLarge,
+            else => return err,
+        };
+        errdefer secret.zeroAndFree(alloc, body);
+        const term = try child.wait(io);
+        if (term != .exited or term.exited != 0) return error.CurlProxyRequestFailed;
+        return .{ .failed = .{ .status = status, .body = body } };
+    }
+
+    const result = try operation.run(stdout_reader);
+    if (multi_reader.reader(1).buffered().len > 16 * 1024) return error.CurlProxyResponseTooLarge;
+    if (request.cancel_flag) |flag| if (flag.load(.seq_cst)) return error.Cancelled;
+    return .{ .completed = result };
+}
+
+fn buildConfig(alloc: Allocator, request: Request, include_headers: bool, write_status: bool) ![]u8 {
+    var config_writer: std.Io.Writer.Allocating = .init(alloc);
+    defer config_writer.deinit();
+    const writer = &config_writer.writer;
+    try writeOption(writer, "url", request.url);
+    try writer.print("request = \"{s}\"\n", .{switch (request.method) {
+        .get => "GET",
+        .post => "POST",
+    }});
+    try writer.print("max-time = {d}\n", .{request.timeout_seconds});
+    if (include_headers) try writer.writeAll("include\n");
+    for (request.headers) |header| try writeHeader(writer, header);
+    if (request.payload) |payload| try writeOption(writer, "data-binary", payload);
+    if (write_status) try writer.writeAll("write-out = \"\\n%{http_code}\"\n");
+    return config_writer.toOwnedSlice();
+}
+
+fn spawnCurl(io: std.Io) !std.process.Child {
+    return std.process.spawn(io, .{
+        .argv = &.{
+            "/usr/bin/curl",
+            "--silent",
+            "--show-error",
+            "--no-buffer",
+            "--config",
+            "-",
+        },
+        .stdin = .pipe,
+        .stdout = .pipe,
+        .stderr = .pipe,
+    });
+}
+
+fn sendConfig(io: std.Io, child: *std.process.Child, config: []const u8) !void {
+    var stdin = child.stdin orelse return error.CurlProxyStdinUnavailable;
+    child.stdin = null;
+    try stdin.writeStreamingAll(io, config);
+    stdin.close(io);
+}
+
+fn readFinalStatus(reader: *std.Io.Reader) !std.http.Status {
+    while (true) {
+        const status_line = try readHeaderLine(reader) orelse return error.InvalidCurlProxyResponse;
+        if (!std.mem.startsWith(u8, status_line, "HTTP/")) return error.InvalidCurlProxyResponse;
+        var parts = std.mem.tokenizeScalar(u8, status_line, ' ');
+        _ = parts.next() orelse return error.InvalidCurlProxyResponse;
+        const status_bytes = parts.next() orelse return error.InvalidCurlProxyResponse;
+        const status_code = std.fmt.parseUnsigned(u10, status_bytes, 10) catch
+            return error.InvalidCurlProxyResponse;
+        if (status_code < 100 or status_code > 599) return error.InvalidCurlProxyResponse;
+        const connection_established = std.mem.endsWith(u8, status_line, "Connection established");
+        while (try readHeaderLine(reader)) |line| {
+            if (line.len == 0) break;
+        }
+        if (!connection_established) {
+            return @enumFromInt(status_code);
+        }
+    }
+}
+
+fn readHeaderLine(reader: *std.Io.Reader) !?[]const u8 {
+    const line = try reader.takeDelimiter('\n') orelse return null;
+    return std.mem.trimEnd(u8, line, "\r");
 }
 
 fn parseResponse(alloc: Allocator, stdout: []const u8, max_response_bytes: usize) !Response {
@@ -164,4 +261,14 @@ test "curl proxy response separates body from status trailer" {
     defer response.deinit(std.testing.allocator);
     try std.testing.expectEqual(std.http.Status.ok, response.status);
     try std.testing.expectEqualStrings("data: value\n", response.body);
+}
+
+test "curl proxy streaming status skips CONNECT response" {
+    var reader = std.Io.Reader.fixed(
+        "HTTP/1.1 200 Connection established\r\n\r\n" ++
+            "HTTP/2 200\r\ncontent-type: text/event-stream\r\n\r\n" ++
+            "data: value\n",
+    );
+    try std.testing.expectEqual(std.http.Status.ok, try readFinalStatus(&reader));
+    try std.testing.expectEqualStrings("data: value", (try readHeaderLine(&reader)).?);
 }

--- a/src/gateway/openai_codex.zig
+++ b/src/gateway/openai_codex.zig
@@ -438,26 +438,34 @@ fn streamPreparedWithCurl(
 
     try request.admission.admit();
     request.delivery.markPossiblySent();
-    var response = try curl_proxy_transport.execute(alloc, .{
+    var operation = CurlSseOperation{ .alloc = alloc, .request = request };
+    const outcome = try curl_proxy_transport.executeStreaming(stream_provider.Result, alloc, .{
         .url = request_endpoint,
         .method = .post,
         .headers = headers[0..header_count],
         .payload = payload,
-        .max_response_bytes = max_sse_aggregate_bytes,
+        .max_response_bytes = max_error_body_bytes,
         .timeout_seconds = 300,
         .cancel_flag = request.cancel_flag,
-    });
-    defer response.deinit(alloc);
-    if (response.status != .ok) {
-        return .{ .failed = .{
+    }, &operation);
+    return switch (outcome) {
+        .completed => |result| result,
+        .failed => |response| .{ .failed = .{
             .kind = failureKind(response.status),
-            .detail = try alloc.dupe(u8, response.body[0..@min(response.body.len, max_error_body_bytes)]),
+            .detail = response.body,
             .ownership = .owned,
-        } };
-    }
-    var response_reader = std.Io.Reader.fixed(response.body);
-    return consumeSuccessfulResponse(alloc, request, &response_reader);
+        } },
+    };
 }
+
+const CurlSseOperation = struct {
+    alloc: Allocator,
+    request: stream_provider.ModelRequest,
+
+    pub fn run(self: *@This(), reader: *std.Io.Reader) !stream_provider.Result {
+        return consumeSuccessfulResponse(self.alloc, self.request, reader);
+    }
+};
 
 const EventBridge = struct {
     fn sink(raw: *anyopaque) *stream_provider.EventSink {

--- a/src/gateway/openai_codex.zig
+++ b/src/gateway/openai_codex.zig
@@ -6,6 +6,7 @@ const stream_provider = @import("../core/agent/stream_provider.zig");
 const io_mod = @import("../core/shared/io.zig");
 const types = @import("../core/shared/types.zig");
 const gateway_client = @import("client.zig");
+const curl_proxy_transport = @import("curl_proxy_transport.zig");
 const responses_protocol = @import("responses_protocol.zig");
 const model_tool_schema = @import("../core/tooling/model_tool_schema.zig");
 
@@ -290,6 +291,17 @@ pub fn streamPrepared(
         extra_count += 1;
     };
 
+    if (curl_proxy_transport.shouldUse(request_endpoint)) {
+        return streamPreparedWithCurl(
+            alloc,
+            request,
+            request_endpoint,
+            auth_headers.authorization,
+            extra_headers_buf[0..extra_count],
+            payload,
+        );
+    }
+
     var client: std.http.Client = .{ .allocator = alloc, .io = io_mod.getIo() };
     defer client.deinit();
     var open_operation = OpenRequestOperation{
@@ -353,6 +365,14 @@ pub fn streamPrepared(
 
     var transfer_buffer: [transfer_buffer_bytes]u8 = undefined;
     const reader = response.reader(&transfer_buffer);
+    return consumeSuccessfulResponse(alloc, request, reader);
+}
+
+fn consumeSuccessfulResponse(
+    alloc: Allocator,
+    request: stream_provider.ModelRequest,
+    reader: anytype,
+) !stream_provider.Result {
     var events = request.events;
     var completion = try consumeSse(
         alloc,
@@ -391,6 +411,52 @@ pub fn streamPrepared(
         .usage = usage_outcome,
         .ownership = .owned,
     } };
+}
+
+fn streamPreparedWithCurl(
+    alloc: Allocator,
+    request: stream_provider.ModelRequest,
+    request_endpoint: []const u8,
+    authorization: ?[]const u8,
+    extra_headers: []const std.http.Header,
+    payload: []const u8,
+) !stream_provider.Result {
+    var headers: [10]curl_proxy_transport.Header = undefined;
+    var header_count: usize = 0;
+    headers[header_count] = .{ .name = "Content-Type", .value = "application/json" };
+    header_count += 1;
+    headers[header_count] = .{ .name = "User-Agent", .value = gateway_client.user_agent };
+    header_count += 1;
+    if (authorization) |value| {
+        headers[header_count] = .{ .name = "Authorization", .value = value };
+        header_count += 1;
+    }
+    for (extra_headers) |header| {
+        headers[header_count] = .{ .name = header.name, .value = header.value };
+        header_count += 1;
+    }
+
+    try request.admission.admit();
+    request.delivery.markPossiblySent();
+    var response = try curl_proxy_transport.execute(alloc, .{
+        .url = request_endpoint,
+        .method = .post,
+        .headers = headers[0..header_count],
+        .payload = payload,
+        .max_response_bytes = max_sse_aggregate_bytes,
+        .timeout_seconds = 300,
+        .cancel_flag = request.cancel_flag,
+    });
+    defer response.deinit(alloc);
+    if (response.status != .ok) {
+        return .{ .failed = .{
+            .kind = failureKind(response.status),
+            .detail = try alloc.dupe(u8, response.body[0..@min(response.body.len, max_error_body_bytes)]),
+            .ownership = .owned,
+        } };
+    }
+    var response_reader = std.Io.Reader.fixed(response.body);
+    return consumeSuccessfulResponse(alloc, request, &response_reader);
 }
 
 const EventBridge = struct {

--- a/src/gateway/openai_codex_models.zig
+++ b/src/gateway/openai_codex_models.zig
@@ -7,6 +7,7 @@ const io_mod = @import("../core/shared/io.zig");
 const secret = @import("../core/auth/secret.zig");
 const types = @import("../core/shared/types.zig");
 const gateway_client = @import("client.zig");
+const curl_proxy_transport = @import("curl_proxy_transport.zig");
 
 const max_catalog_models: usize = 128;
 const max_model_id_bytes: usize = 1024;
@@ -158,6 +159,8 @@ const FetchOperation = struct {
     account_id: ?[]const u8,
 
     pub fn run(self: *@This()) !FetchResponse {
+        if (curl_proxy_transport.shouldUse(self.url)) return self.runWithCurl();
+
         var client: std.http.Client = .{ .allocator = self.alloc, .io = io_mod.getIo() };
         defer client.deinit();
         var auth_header: ?[]u8 = null;
@@ -200,6 +203,35 @@ const FetchOperation = struct {
             .status = result.status,
             .body = try self.alloc.dupe(u8, body),
         };
+    }
+
+    fn runWithCurl(self: *@This()) !FetchResponse {
+        var auth_header: ?[]u8 = null;
+        defer if (auth_header) |value| secret.zeroAndFree(self.alloc, value);
+        var headers: [5]curl_proxy_transport.Header = undefined;
+        var header_count: usize = 0;
+        headers[header_count] = .{ .name = "User-Agent", .value = gateway_client.user_agent };
+        header_count += 1;
+        headers[header_count] = .{ .name = "originator", .value = "fx" };
+        header_count += 1;
+        headers[header_count] = .{ .name = "accept", .value = "application/json" };
+        header_count += 1;
+        if (self.credential) |credential| {
+            auth_header = try std.fmt.allocPrint(self.alloc, "Bearer {s}", .{credential});
+            headers[header_count] = .{ .name = "Authorization", .value = auth_header.? };
+            header_count += 1;
+        }
+        if (self.account_id) |account_id| {
+            headers[header_count] = .{ .name = "chatgpt-account-id", .value = account_id };
+            header_count += 1;
+        }
+        const response = try curl_proxy_transport.execute(self.alloc, .{
+            .url = self.url,
+            .headers = headers[0..header_count],
+            .max_response_bytes = max_catalog_bytes,
+            .timeout_seconds = 30,
+        });
+        return .{ .status = response.status, .body = response.body };
     }
 };
 


### PR DESCRIPTION
## Summary

- route affected Codex HTTPS requests through the system `curl` on macOS when `HTTPS_PROXY` or `ALL_PROXY` is configured
- cover the OAuth token exchange, Codex model catalog, and Codex Responses request paths
- stream Codex SSE events incrementally through the existing reducer
- keep credentials and request payloads out of process arguments by passing a bounded curl config through stdin
- preserve the existing `std.http` transport on other platforms and when no HTTPS proxy is configured

Fixes #611.

## Root cause

With Zig 0.16, `std.http.Client` establishes an HTTP CONNECT tunnel through the configured proxy but the resulting proxied connection is not wrapped in TLS for the HTTPS target. The proxy therefore receives a plaintext HTTP request on the target's port 443 and returns HTTP 400 (`The plain HTTP request was sent to HTTPS port`).

The browser authorization succeeds because it uses a working proxy stack, but fx then fails during the token exchange. The same transport issue also affects the authenticated model catalog and Responses requests after login.

## Implementation notes

The fallback is intentionally limited to macOS HTTPS requests with an active HTTPS or ALL proxy. macOS provides `/usr/bin/curl`, while unaffected requests continue to use the native Zig transport. Response sizes, stderr, timeouts, and cancellation remain bounded. The curl config is escaped and sent over stdin so bearer tokens and JSON bodies do not appear in `argv`.

Streaming responses include curl's HTTP headers so the transport can skip the proxy CONNECT response, preserve final HTTP status mapping, and pass the SSE body to the existing reducer as bytes arrive. The request stops at the protocol's completion event instead of waiting for the proxy connection to close.

## Verification

- `zig build -Doptimize=ReleaseSafe`
- focused transport tests: 11 passed
- fresh repository binary: `./zig-out/bin/fx status --json` loaded the Codex subscription and model catalog through the configured proxy
- fresh repository binary: a two-turn request ran `pwd` through the terminal tool and returned `STREAM_FIX_OK` with exit code 0 using `gpt-5.6-sol`
- initial full `zig build test -Doptimize=ReleaseSafe` run: 8312 passed, 2 skipped, 1 failed

The one full-suite failure is `core.agent.runtime.assistant_stream.test.streamed presentation preserves ANSI OSC 8 code fence and table spans`. It is unrelated to the gateway changes and was also reproduced before this PR's changes on the released source revision. After the streaming follow-up, the ReleaseSafe build, focused tests, and live multi-turn verification all passed again.
