### PR TITLE
Keep large session loading and exit responsive

### DIFF
--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -6478,6 +6478,76 @@ test "requested resume handoff accepts deferred index publication at a durable b
     try std.testing.expectEqual(@as(usize, 1), reopened.state.history.len);
 }
 
+const HandoffLatestCacheFailure = struct {
+    armed: bool = false,
+
+    fn hit(context: ?*anyopaque, point: session_log.Boundary) !void {
+        const self: *HandoffLatestCacheFailure = @ptrCast(@alignCast(context.?));
+        if (self.armed and point == .before_latest_cache_ready) {
+            return error.TestLatestCacheFailure;
+        }
+    }
+
+    fn controls(self: *HandoffLatestCacheFailure) session_log.TestControls {
+        return .{ .context = self, .boundary_fn = hit };
+    }
+};
+
+test "requested resume handoff accepts post-commit latest cache publication failure" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const paths = try testPaths(alloc, &tmp);
+    defer {
+        alloc.free(paths.home);
+        alloc.free(paths.workspace);
+    }
+    const home = try TestHome.install(alloc, paths.home);
+    defer home.deinit();
+    var app = try TestApp.init(alloc, paths.workspace);
+    defer app.deinit();
+    try configureTestPreferences(&app);
+    try Runtime(TestApp).initializePersistence(&app, true);
+    var failure = HandoffLatestCacheFailure{};
+    var state = try Runtime(TestApp).freshState(
+        &app,
+        app.session_persistence.workspace_preferences.?,
+    );
+    defer state.deinit(alloc);
+    app.session_persistence.writable = try app.session_persistence.store.?.startWritableSessionWithOptions(
+        alloc,
+        state,
+        .{ .test_controls = failure.controls() },
+    );
+    failure.armed = true;
+    const loaded = &app.session_persistence.writable.?;
+    const expected_id = try alloc.dupe(u8, loaded.active_id);
+    defer alloc.free(expected_id);
+    _ = try loaded.appendEvent(
+        alloc,
+        .{ .preferences_changed = .{ .fast_mode = true } },
+        io_mod.milliTimestamp(),
+        .retry_expected_tail,
+        .{},
+    );
+    const expected_position = loaded.position;
+    try std.testing.expect(!loaded.state_replacement_pending);
+    try std.testing.expect(loaded.commit_lifecycle_pending);
+    Runtime(TestApp).requestResumeHandoff(&app);
+
+    var handoff = Runtime(TestApp).finalizePersistenceWithResumeHandoff(&app) orelse
+        return error.TestExpectedResumeHandoff;
+    defer handoff.deinit(alloc);
+    try std.testing.expectEqualStrings(expected_id, handoff.session_id);
+
+    var reopened = try app.session_persistence.store.?.resumeForWrite(
+        alloc,
+        expected_id,
+    );
+    defer reopened.deinit(alloc);
+    try std.testing.expectEqualDeep(expected_position, reopened.position);
+}
+
 test "resume handoff preparation repairs an exactly recoverable live commit watermark" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -647,6 +647,11 @@ fn selectionAfterLoadedPage(
 }
 
 const SessionPickerLoad = struct {
+    const Intent = enum {
+        interactive,
+        prewarm,
+    };
+
     const Continuation = struct {
         updated_at_ms: i64,
         id: []u8,
@@ -660,6 +665,7 @@ const SessionPickerLoad = struct {
     const PageRequest = struct {
         generation: u64,
         scope: SessionPickerScope,
+        intent: Intent = .interactive,
         active_id: ?[]u8 = null,
         continuation: ?Continuation = null,
         limit: usize = session_store.default_resume_page_limit,
@@ -702,6 +708,7 @@ const SessionPickerLoad = struct {
     const Task = struct {
         thread: ?std.Thread = null,
         done: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+        cancel_requested: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
         home_dir: []u8,
         workspace_root: []u8,
         request: PageRequest,
@@ -709,7 +716,18 @@ const SessionPickerLoad = struct {
         failure: ?anyerror = null,
 
         fn deinit(self: *Task) void {
-            if (self.thread) |thread| thread.join();
+            if (self.thread) |thread| {
+                if (!self.done.load(.acquire) and
+                    !self.cancel_requested.swap(true, .seq_cst))
+                {
+                    debug_trace.logf(
+                        "core",
+                        "session picker load cancellation requested reason=deinit generation={d}",
+                        .{self.request.generation},
+                    );
+                }
+                thread.join();
+            }
             if (self.page) |*page| page.deinit(std.heap.c_allocator);
             self.request.deinit();
             std.heap.c_allocator.free(self.home_dir);
@@ -764,6 +782,15 @@ const SessionPickerLoad = struct {
         if (self.task) |task| {
             if (task.request.generation == generation) {
                 self.abandoned_generation = generation;
+                if (!task.done.load(.acquire) and
+                    !task.cancel_requested.swap(true, .seq_cst))
+                {
+                    debug_trace.logf(
+                        "core",
+                        "session picker load cancellation requested reason=cancelled generation={d}",
+                        .{generation},
+                    );
+                }
                 debug_trace.logf(
                     "core",
                     "session picker request abandoned reason=cancelled generation={d}",
@@ -794,16 +821,17 @@ const SessionPickerLoad = struct {
         scope: SessionPickerScope,
         active_id: ?[]const u8,
         limit: usize,
+        intent: Intent,
     ) ?u64 {
         if (self.task) |task| {
             if (self.abandoned_generation != task.request.generation and
-                initialRequestMatches(task.request, scope, active_id, limit))
+                initialRequestMatches(task.request, scope, active_id, limit, intent))
             {
                 return task.request.generation;
             }
         }
         if (self.pending) |request| {
-            if (initialRequestMatches(request, scope, active_id, limit)) {
+            if (initialRequestMatches(request, scope, active_id, limit, intent)) {
                 return request.generation;
             }
         }
@@ -815,9 +843,11 @@ const SessionPickerLoad = struct {
         scope: SessionPickerScope,
         active_id: ?[]const u8,
         limit: usize,
+        intent: Intent,
     ) bool {
         return request.continuation == null and request.scope == scope and
-            request.limit >= limit and optionalStringEql(request.active_id, active_id);
+            request.limit >= limit and request.intent == intent and
+            optionalStringEql(request.active_id, active_id);
     }
 
     fn startPending(self: *SessionPickerLoad, store: *const session_store.Store) !?u64 {
@@ -888,6 +918,7 @@ const SessionPickerLoad = struct {
             return;
         };
         defer read_only.deinit(std.heap.c_allocator);
+        read_only.set_discovery_cancel_flag(&task.cancel_requested);
 
         if (tryListResumableIndexPageForScope(
             read_only,
@@ -897,8 +928,7 @@ const SessionPickerLoad = struct {
             task.request.continuationValue(),
             task.request.limit,
         ) catch |err| {
-            task.failure = err;
-            task.done.store(true, .release);
+            finish_task_error(task, err);
             return;
         }) |page| {
             task.page = page;
@@ -906,7 +936,46 @@ const SessionPickerLoad = struct {
             return;
         }
 
-        debug_trace.logf("core", "session picker cache outcome=miss action=backfill", .{});
+        if (task.request.intent == .prewarm) {
+            var writable = session_store.Store.initFromHome(
+                std.heap.c_allocator,
+                task.home_dir,
+                task.workspace_root,
+            ) catch |err| {
+                debug_trace.logf(
+                    "core",
+                    "session picker prewarm skipped reason=store_unavailable scope={s} err={s}",
+                    .{ @tagName(task.request.scope), @errorName(err) },
+                );
+                task.done.store(true, .release);
+                return;
+            };
+            defer writable.deinit(std.heap.c_allocator);
+            writable.set_discovery_cancel_flag(&task.cancel_requested);
+            if (tryListReconciledResumableIndexPageForScope(
+                writable,
+                std.heap.c_allocator,
+                task.request.scope,
+                task.request.active_id,
+                task.request.continuationValue(),
+                task.request.limit,
+            ) catch |err| {
+                finish_task_error(task, err);
+                return;
+            }) |page| {
+                task.page = page;
+                task.done.store(true, .release);
+                return;
+            }
+            debug_trace.logf(
+                "core",
+                "session picker prewarm skipped reason=index_unavailable scope={s}",
+                .{@tagName(task.request.scope)},
+            );
+            task.done.store(true, .release);
+            return;
+        }
+
         var writable = session_store.Store.initFromHome(
             std.heap.c_allocator,
             task.home_dir,
@@ -925,15 +994,32 @@ const SessionPickerLoad = struct {
                 task.request.continuationValue(),
                 task.request.limit,
             ) catch |fallback_err| {
-                task.failure = fallback_err;
-                task.done.store(true, .release);
+                finish_task_error(task, fallback_err);
                 return;
             };
             task.done.store(true, .release);
             return;
         };
         defer writable.deinit(std.heap.c_allocator);
+        writable.set_discovery_cancel_flag(&task.cancel_requested);
 
+        if (tryListReconciledResumableIndexPageForScope(
+            writable,
+            std.heap.c_allocator,
+            task.request.scope,
+            task.request.active_id,
+            task.request.continuationValue(),
+            task.request.limit,
+        ) catch |err| {
+            finish_task_error(task, err);
+            return;
+        }) |page| {
+            task.page = page;
+            task.done.store(true, .release);
+            return;
+        }
+
+        debug_trace.logf("core", "session picker cache outcome=miss action=backfill", .{});
         task.page = listResumablePageForScope(
             writable,
             std.heap.c_allocator,
@@ -942,6 +1028,10 @@ const SessionPickerLoad = struct {
             task.request.continuationValue(),
             task.request.limit,
         ) catch |err| {
+            if (err == error.Cancelled) {
+                finish_task_error(task, err);
+                return;
+            }
             debug_trace.logf(
                 "core",
                 "session picker cache backfill outcome=failed err={s}",
@@ -955,13 +1045,24 @@ const SessionPickerLoad = struct {
                 task.request.continuationValue(),
                 task.request.limit,
             ) catch |fallback_err| {
-                task.failure = fallback_err;
-                task.done.store(true, .release);
+                finish_task_error(task, fallback_err);
                 return;
             };
             task.done.store(true, .release);
             return;
         };
+        task.done.store(true, .release);
+    }
+
+    fn finish_task_error(task: *Task, err: anyerror) void {
+        task.failure = err;
+        if (err == error.Cancelled) {
+            debug_trace.logf(
+                "core",
+                "session discovery cancelled generation={d} scope={s}",
+                .{ task.request.generation, @tagName(task.request.scope) },
+            );
+        }
         task.done.store(true, .release);
     }
 };
@@ -982,6 +1083,27 @@ fn tryListResumableIndexPageForScope(
     limit: usize,
 ) !?subagent_resume_admission.ActionableSessionPage {
     return subagent_resume_admission.tryListActionableIndexPage(
+        store,
+        alloc,
+        switch (scope) {
+            .current_workspace => .current_workspace,
+            .all_workspaces => .all_workspaces,
+        },
+        active_id,
+        continuation,
+        limit,
+    );
+}
+
+fn tryListReconciledResumableIndexPageForScope(
+    store: session_store.Store,
+    alloc: Allocator,
+    scope: SessionPickerScope,
+    active_id: ?[]const u8,
+    continuation: ?session_store.ResumableSessionContinuation,
+    limit: usize,
+) !?subagent_resume_admission.ActionableSessionPage {
+    return subagent_resume_admission.tryListActionableReconciledIndexPage(
         store,
         alloc,
         switch (scope) {
@@ -2055,7 +2177,7 @@ pub fn Runtime(comptime App: type) type {
             }
 
             var picker = &app.session_persistence.session_picker;
-            if (picker.load_state != .ready) {
+            if (picker.active or picker.load_state != .ready) {
                 app.session_persistence.session_picker_load.cancelGeneration(picker.generation);
             }
             picker.deinit(app.alloc);
@@ -2101,7 +2223,7 @@ pub fn Runtime(comptime App: type) type {
             }
 
             const loader = &app.session_persistence.session_picker_load;
-            if (loader.matchingInitialGeneration(scope, active_id, limit)) |generation| {
+            if (loader.matchingInitialGeneration(scope, active_id, limit, .interactive)) |generation| {
                 picker.generation = generation;
                 return;
             }
@@ -2138,8 +2260,8 @@ pub fn Runtime(comptime App: type) type {
             for ([_]SessionPickerScope{ .current_workspace, .all_workspaces }) |scope| {
                 const cache = sessionPickerCacheForScope(&app.session_persistence, scope);
                 if (cache.matches(active_id, limit) and cache.isFresh(io_mod.nanoTimestamp())) continue;
-                if (loader.matchingInitialGeneration(scope, active_id, limit) != null) continue;
-                const request = SessionPickerLoad.PageRequest.init(
+                if (loader.matchingInitialGeneration(scope, active_id, limit, .prewarm) != null) continue;
+                var request = SessionPickerLoad.PageRequest.init(
                     loader.allocateGeneration(),
                     scope,
                     active_id,
@@ -2153,6 +2275,7 @@ pub fn Runtime(comptime App: type) type {
                     );
                     continue;
                 };
+                request.intent = .prewarm;
                 loader.schedule(store, request) catch |err| {
                     debug_trace.logf(
                         "core",
@@ -2376,7 +2499,7 @@ pub fn Runtime(comptime App: type) type {
 
         pub fn cancelSessionPicker(app: *App) void {
             const picker = &app.session_persistence.session_picker;
-            if (picker.load_state != .ready) {
+            if (picker.active) {
                 app.session_persistence.session_picker_load.cancelGeneration(picker.generation);
             }
             picker.deinit(app.alloc);
@@ -3121,7 +3244,7 @@ pub fn Runtime(comptime App: type) type {
                     return;
                 }
             }
-            closeWritableSession(app, .{});
+            closeWritableSession(app, .{ .commit_lock_deadline_ms = 0 });
         }
 
         pub fn finalizePersistenceWithResumeHandoff(app: *App) ?ResumeHandoff {
@@ -3132,7 +3255,10 @@ pub fn Runtime(comptime App: type) type {
                     return null;
                 }
             }
-            return closeWritableSessionWithResumeHandoff(app, .{});
+            return closeWritableSessionWithResumeHandoff(
+                app,
+                .{ .commit_lock_deadline_ms = 0 },
+            );
         }
 
         pub fn requestResumeHandoff(app: *App) void {
@@ -4502,33 +4628,38 @@ pub fn Runtime(comptime App: type) type {
             else
                 return null;
             var resume_boundary_valid = false;
-            if (handoff_intent != .none) {
-                var settlement_failed = false;
-                settleResumeBoundary(app, loaded, log_options) catch |err| {
-                    settlement_failed = true;
-                    debug_trace.logf(
-                        "session",
-                        "resume handoff boundary invalid session={s} err={s}",
-                        .{ loaded.active_id, @errorName(err) },
-                    );
-                };
-                resume_boundary_valid = !settlement_failed;
-            } else {
-                settleDurableState(app, loaded, log_options) catch |err| {
+            switch (handoff_intent) {
+                .none => settleDurableState(app, loaded, log_options) catch |err| {
                     debug_trace.logf(
                         "session",
                         "final persistence settlement failed session={s} err={s}",
                         .{ loaded.active_id, @errorName(err) },
                     );
+                },
+                .requested => {
+                    resume_boundary_valid = confirmResumeHandoff(app, loaded);
+                },
+                .upgrade_requested => upgrade: {
+                    settleDurableState(app, loaded, log_options) catch |err| {
+                        debug_trace.logf(
+                            "session",
+                            "resume handoff settlement failed session={s} err={s}",
+                            .{ loaded.active_id, @errorName(err) },
+                        );
+                        break :upgrade;
+                    };
+                    resume_boundary_valid = confirmResumeHandoff(app, loaded);
+                },
+            }
+            if (handoff_intent == .none) {
+                loaded.writeCheckpointIfDue(app.alloc, true, log_options) catch |err| {
+                    debug_trace.logf(
+                        "session",
+                        "final checkpoint failed session={s} err={s}",
+                        .{ loaded.active_id, @errorName(err) },
+                    );
                 };
             }
-            loaded.writeCheckpointIfDue(app.alloc, true, log_options) catch |err| {
-                debug_trace.logf(
-                    "session",
-                    "final checkpoint failed session={s} err={s}",
-                    .{ loaded.active_id, @errorName(err) },
-                );
-            };
             const should_create_handoff = resume_boundary_valid and
                 shouldCreateResumeHandoff(.{
                     .intent = handoff_intent,
@@ -4557,6 +4688,26 @@ pub fn Runtime(comptime App: type) type {
             loaded.deinit(app.alloc);
             app.session_persistence.writable = null;
             return handoff;
+        }
+
+        fn confirmResumeHandoff(
+            app: *App,
+            loaded: *session_store.LoadedWritableSession,
+        ) bool {
+            loaded.confirmResumeHandoffBoundary(app.alloc) catch |err| {
+                debug_trace.logf(
+                    "session",
+                    "event=resume_handoff_confirmation mode=metadata outcome=rejected session={s} err={s}",
+                    .{ loaded.active_id, @errorName(err) },
+                );
+                return false;
+            };
+            debug_trace.logf(
+                "session",
+                "event=resume_handoff_confirmation mode=metadata outcome=ready session={s}",
+                .{loaded.active_id},
+            );
+            return true;
         }
 
         fn configureWebFetchArtifacts(
@@ -4714,11 +4865,7 @@ pub fn Runtime(comptime App: type) type {
             log_options: session_log.Options,
         ) !void {
             try convergeDegraded(app, loaded, log_options);
-            const usage_dirty = if (comptime @hasField(@TypeOf(app.session), "usage"))
-                app.session.usage.isDirty()
-            else
-                false;
-            if (loaded.needsFinalStateReplacement(usage_dirty)) {
+            if (loaded.needsFinalStateReplacement(sessionUsageDirty(app))) {
                 try commitCurrentStateReplacementStrict(
                     app,
                     loaded,
@@ -4727,6 +4874,13 @@ pub fn Runtime(comptime App: type) type {
                     false,
                 );
             }
+        }
+
+        fn sessionUsageDirty(app: *App) bool {
+            return if (comptime @hasField(@TypeOf(app.session), "usage"))
+                app.session.usage.isDirty()
+            else
+                false;
         }
 
         fn commitCurrentStateReplacement(
@@ -6217,7 +6371,7 @@ test "upgrade resume handoff owns a validated pristine session" {
     try std.testing.expectEqualStrings(expected_id, handoff.session_id);
 }
 
-test "resume handoff owns the exact non-pristine session id after final replacement" {
+test "requested resume handoff leaves pending replacement work off the exit path" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -6242,14 +6396,24 @@ test "resume handoff owns the exact non-pristine session id after final replacem
         app.session_persistence.writable.?.active_id,
     );
     defer alloc.free(expected_id);
+    const expected_position = app.session_persistence.writable.?.position;
     Runtime(TestApp).requestResumeHandoff(&app);
 
-    var handoff = Runtime(TestApp).finalizePersistenceWithResumeHandoff(&app) orelse
-        return error.TestExpectedResumeHandoff;
-    defer handoff.deinit(alloc);
-
-    try std.testing.expectEqualStrings(expected_id, handoff.session_id);
+    try std.testing.expect(
+        Runtime(TestApp).finalizePersistenceWithResumeHandoff(&app) == null,
+    );
     try std.testing.expect(app.session_persistence.writable == null);
+    var reopened = try app.session_persistence.store.?.resumeForWrite(
+        alloc,
+        expected_id,
+    );
+    defer reopened.deinit(alloc);
+    try std.testing.expectEqual(expected_position.through_seq, reopened.position.through_seq);
+    try std.testing.expectEqual(
+        expected_position.through_event_log_bytes,
+        reopened.position.through_event_log_bytes,
+    );
+    try std.testing.expectEqual(@as(usize, 1), reopened.state.history.len);
 }
 
 test "resume handoff preparation repairs an exactly recoverable live commit watermark" {
@@ -6388,6 +6552,94 @@ test "resume handoff remains available when the derived checkpoint write fails" 
         &app,
         .{ .checkpoint_interval = 0 },
     ) orelse
+        return error.TestExpectedResumeHandoff;
+    defer handoff.deinit(alloc);
+
+    try std.testing.expectEqualStrings(expected_id, handoff.session_id);
+}
+
+test "resume handoff exit leaves derived checkpoint work off the shutdown path" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const paths = try testPaths(alloc, &tmp);
+    defer {
+        alloc.free(paths.home);
+        alloc.free(paths.workspace);
+    }
+    const home = try TestHome.install(alloc, paths.home);
+    defer home.deinit();
+    var app = try TestApp.init(alloc, paths.workspace);
+    defer app.deinit();
+    try configureTestPreferences(&app);
+    try Runtime(TestApp).initializePersistence(&app, true);
+    try Runtime(TestApp).beginFreshPersistedSession(&app);
+    const loaded = &app.session_persistence.writable.?;
+    const expected_id = try alloc.dupe(u8, loaded.active_id);
+    defer alloc.free(expected_id);
+    _ = try loaded.appendEvent(
+        alloc,
+        .{ .preferences_changed = .{ .fast_mode = true } },
+        io_mod.milliTimestamp(),
+        .retry_expected_tail,
+        .{ .checkpoint_interval = 0 },
+    );
+    const session_dir = (try Runtime(TestApp).activeSessionDisplayPath(&app, alloc)) orelse
+        return error.TestExpectedSessionDirectory;
+    defer alloc.free(session_dir);
+    const checkpoint_path = try std.fs.path.join(
+        alloc,
+        &.{ session_dir, "checkpoint.json" },
+    );
+    defer alloc.free(checkpoint_path);
+    try std.testing.expectError(
+        error.FileNotFound,
+        std.Io.Dir.accessAbsolute(io_mod.getIo(), checkpoint_path, .{}),
+    );
+
+    Runtime(TestApp).requestResumeHandoff(&app);
+    var handoff = Runtime(TestApp).closeWritableSessionWithResumeHandoff(
+        &app,
+        .{ .checkpoint_interval = 0 },
+    ) orelse return error.TestExpectedResumeHandoff;
+    defer handoff.deinit(alloc);
+
+    try std.testing.expectEqualStrings(expected_id, handoff.session_id);
+    try std.testing.expectError(
+        error.FileNotFound,
+        std.Io.Dir.accessAbsolute(io_mod.getIo(), checkpoint_path, .{}),
+    );
+}
+
+test "requested resume handoff remains available while usage is dirty" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const paths = try testPaths(alloc, &tmp);
+    defer {
+        alloc.free(paths.home);
+        alloc.free(paths.workspace);
+    }
+    const home = try TestHome.install(alloc, paths.home);
+    defer home.deinit();
+    var app = try TestApp.init(alloc, paths.workspace);
+    defer app.deinit();
+    try configureTestPreferences(&app);
+    try Runtime(TestApp).initializePersistence(&app, true);
+    try Runtime(TestApp).beginFreshPersistedSession(&app);
+    const turn = try session_runtime.makeAssistantTurn(alloc, "question", "answer");
+    defer session_runtime.freeHistoryTurn(alloc, turn);
+    try Runtime(TestApp).appendHistoryTurn(&app, turn);
+    try app.session.usage.recordCommittedLines(1, 0);
+    try std.testing.expect(app.session.usage.isDirty());
+    const expected_id = try alloc.dupe(
+        u8,
+        app.session_persistence.writable.?.active_id,
+    );
+    defer alloc.free(expected_id);
+
+    Runtime(TestApp).requestResumeHandoff(&app);
+    var handoff = Runtime(TestApp).finalizePersistenceWithResumeHandoff(&app) orelse
         return error.TestExpectedResumeHandoff;
     defer handoff.deinit(alloc);
 
@@ -9366,6 +9618,12 @@ test "session picker prewarms current and all workspace pages before opening" {
         0,
     );
     try Runtime(TestApp).beginFreshPersistedSession(&app);
+    var indexed = try app.session_persistence.store.?.listResumablePage(
+        alloc,
+        app.session_persistence.writable.?.active_id,
+        null,
+    );
+    indexed.deinit(alloc);
 
     Runtime(TestApp).primeSessionPicker(&app);
     try waitForSessionPickerPrewarm(&app);
@@ -9386,6 +9644,172 @@ test "session picker prewarms current and all workspace pages before opening" {
         "prewarmed-session",
         app.session_persistence.session_picker.selectedId().?,
     );
+}
+
+test "session picker prewarm overlays deferred updates without discovery" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const paths = try testPaths(alloc, &tmp);
+    defer {
+        alloc.free(paths.home);
+        alloc.free(paths.workspace);
+    }
+    const trace_path = try std.fs.path.join(alloc, &.{ paths.home, "snapshot-trace.log" });
+    defer alloc.free(trace_path);
+
+    const home = try TestHome.install(alloc, paths.home);
+    defer home.deinit();
+
+    var app = try TestApp.init(alloc, paths.workspace);
+    defer app.deinit();
+    try configureTestPreferences(&app);
+    try Runtime(TestApp).initializePersistence(&app, true);
+    const history = [_]types.HistoryTurn{.{ .assistant = .{
+        .user = .{ .text = @constCast("snapshot prompt") },
+        .assistant = @constCast("snapshot response"),
+    } }};
+    try writeSessionFixture(
+        alloc,
+        app.session_persistence.store.?,
+        "snapshot-session",
+        &history,
+        0,
+    );
+    try Runtime(TestApp).beginFreshPersistedSession(&app);
+    var indexed = try app.session_persistence.store.?.listResumablePage(
+        alloc,
+        app.session_persistence.writable.?.active_id,
+        null,
+    );
+    indexed.deinit(alloc);
+
+    var sessions = app.session_persistence.store.?.canonical_root.sessions orelse
+        return error.TestExpectedEqual;
+    var latest = try io_mod.openOrCreateVerifiedPrivateDir(&sessions, "latest");
+    defer latest.close();
+    var deferred = try io_mod.openOrCreateVerifiedPrivateDir(
+        &latest,
+        session_summary_codec.deferred_cache_dir,
+    );
+    defer deferred.close();
+    const token = try session_summary_codec.encodeDeferredCacheToken(
+        alloc,
+        "snapshot-session",
+        paths.workspace,
+        .{
+            .log_generation = [_]u8{0x11} ** 16,
+            .through_seq = 1,
+            .through_event_id = [_]u8{0x22} ** 16,
+            .through_event_log_bytes = 1,
+        },
+    );
+    defer alloc.free(token);
+    try io_mod.durableReplaceVerified(
+        alloc,
+        &deferred,
+        "snapshot-session",
+        token,
+    );
+
+    debug_trace.resetForTest();
+    defer debug_trace.resetForTest();
+    try debug_trace.configureForTestWithScopes(alloc, trace_path, "core");
+
+    Runtime(TestApp).primeSessionPicker(&app);
+    try waitForSessionPickerPrewarm(&app);
+
+    try std.testing.expect(app.session_persistence.session_picker_current_cache.ready);
+    try std.testing.expect(app.session_persistence.session_picker_all_cache.ready);
+    try std.testing.expect(app.session_persistence.session_picker_current_cache.loaded_at_ns > 0);
+    try std.testing.expect(app.session_persistence.session_picker_all_cache.loaded_at_ns > 0);
+
+    try Runtime(TestApp).openAllSessionPicker(&app);
+    try std.testing.expectEqual(.ready, app.session_persistence.session_picker.load_state);
+    try std.testing.expectEqualStrings(
+        "snapshot-session",
+        app.session_persistence.session_picker.selectedId().?,
+    );
+    try waitForSessionPickerLoad(&app);
+    try std.testing.expect(try session_summary_codec.deferredCachePresent(&sessions));
+    debug_trace.shutdown();
+
+    var trace_file = try std.Io.Dir.openFileAbsolute(io_mod.getIo(), trace_path, .{});
+    defer trace_file.close(io_mod.getIo());
+    const trace = try io_mod.readFileToEnd(alloc, &trace_file, 64 * 1024);
+    defer alloc.free(trace);
+    try std.testing.expect(std.mem.find(
+        u8,
+        trace,
+        "session picker cache overlay outcome=ready scope=current_workspace deferred=1",
+    ) != null);
+    try std.testing.expect(std.mem.find(
+        u8,
+        trace,
+        "session discovery mode=read_only_list",
+    ) == null);
+}
+
+test "session picker prewarm skips backfill when the index is unavailable" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const paths = try testPaths(alloc, &tmp);
+    defer {
+        alloc.free(paths.home);
+        alloc.free(paths.workspace);
+    }
+    const trace_path = try std.fs.path.join(alloc, &.{ paths.home, "prewarm-trace.log" });
+    defer alloc.free(trace_path);
+
+    const home = try TestHome.install(alloc, paths.home);
+    defer home.deinit();
+
+    var app = try TestApp.init(alloc, paths.workspace);
+    defer app.deinit();
+    try configureTestPreferences(&app);
+    try Runtime(TestApp).initializePersistence(&app, true);
+    const history = [_]types.HistoryTurn{.{ .assistant = .{
+        .user = .{ .text = @constCast("dirty index prompt") },
+        .assistant = @constCast("dirty index response"),
+    } }};
+    try writeSessionFixture(
+        alloc,
+        app.session_persistence.store.?,
+        "dirty-index-session",
+        &history,
+        0,
+    );
+    try Runtime(TestApp).beginFreshPersistedSession(&app);
+    try app.session_persistence.store.?.invalidateResumableIndex(alloc);
+
+    debug_trace.resetForTest();
+    defer debug_trace.resetForTest();
+    try debug_trace.configureForTestWithScopes(alloc, trace_path, "core");
+
+    Runtime(TestApp).primeSessionPicker(&app);
+    try waitForSessionPickerPrewarm(&app);
+    debug_trace.shutdown();
+
+    try std.testing.expect(!app.session_persistence.session_picker_current_cache.ready);
+    try std.testing.expect(!app.session_persistence.session_picker_all_cache.ready);
+
+    var trace_file = try std.Io.Dir.openFileAbsolute(io_mod.getIo(), trace_path, .{});
+    defer trace_file.close(io_mod.getIo());
+    const trace = try io_mod.readFileToEnd(alloc, &trace_file, 64 * 1024);
+    defer alloc.free(trace);
+    try std.testing.expect(std.mem.find(
+        u8,
+        trace,
+        "session picker prewarm skipped reason=index_unavailable",
+    ) != null);
+    try std.testing.expect(std.mem.find(
+        u8,
+        trace,
+        "session discovery mode=read_only_list",
+    ) == null);
 }
 
 test "session picker rejects a load more completion after switching to a fresh cached scope" {

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -38,6 +38,7 @@ const captured_command = @import("../tooling/captured_command.zig");
 const tool_result_errors = @import("../tooling/tool_result_errors.zig");
 const session_display_metadata = @import("../session/session_display_metadata.zig");
 const session_log = @import("../session/session_log.zig");
+const session_latest_pointer = @import("../session/session_latest_pointer.zig");
 const session_resume_view = @import("../session/session_resume_view.zig");
 const session_store = @import("../session/session_store.zig");
 const session_summary_codec = @import("../session/session_summary_codec.zig");
@@ -6413,6 +6414,67 @@ test "requested resume handoff leaves pending replacement work off the exit path
         expected_position.through_event_log_bytes,
         reopened.position.through_event_log_bytes,
     );
+    try std.testing.expectEqual(@as(usize, 1), reopened.state.history.len);
+}
+
+test "requested resume handoff accepts deferred index publication at a durable boundary" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const paths = try testPaths(alloc, &tmp);
+    defer {
+        alloc.free(paths.home);
+        alloc.free(paths.workspace);
+    }
+    const home = try TestHome.install(alloc, paths.home);
+    defer home.deinit();
+    var app = try TestApp.init(alloc, paths.workspace);
+    defer app.deinit();
+    try configureTestPreferences(&app);
+    try Runtime(TestApp).initializePersistence(&app, true);
+    try Runtime(TestApp).beginFreshPersistedSession(&app);
+
+    var sessions = app.session_persistence.store.?.canonical_root.sessions orelse
+        return error.TestExpectedEqual;
+    var latest_lock = try io_mod.acquireTimedAdvisoryLock(
+        &sessions,
+        session_latest_pointer.latest_sessions_lock_file,
+        2000,
+    );
+    var latest_lock_held = true;
+    defer if (latest_lock_held) latest_lock.release();
+
+    const turn = try session_runtime.makeAssistantTurn(alloc, "question", "answer");
+    defer session_runtime.freeHistoryTurn(alloc, turn);
+    try Runtime(TestApp).appendHistoryTurn(&app, turn);
+    const loaded = &app.session_persistence.writable.?;
+    try std.testing.expect(!loaded.state_replacement_pending);
+    try std.testing.expect(loaded.commit_lifecycle_pending);
+    var deferred = (try session_summary_codec.readDeferredCacheToken(
+        alloc,
+        &sessions,
+        loaded.active_id,
+    )) orelse return error.TestExpectedEqual;
+    defer deferred.deinit(alloc);
+    try std.testing.expectEqualDeep(loaded.position, deferred.position);
+    const expected_id = try alloc.dupe(u8, loaded.active_id);
+    defer alloc.free(expected_id);
+    const expected_position = loaded.position;
+    Runtime(TestApp).requestResumeHandoff(&app);
+
+    var handoff = Runtime(TestApp).finalizePersistenceWithResumeHandoff(&app) orelse
+        return error.TestExpectedResumeHandoff;
+    defer handoff.deinit(alloc);
+    try std.testing.expectEqualStrings(expected_id, handoff.session_id);
+
+    latest_lock.release();
+    latest_lock_held = false;
+    var reopened = try app.session_persistence.store.?.resumeForWrite(
+        alloc,
+        expected_id,
+    );
+    defer reopened.deinit(alloc);
+    try std.testing.expectEqualDeep(expected_position, reopened.position);
     try std.testing.expectEqual(@as(usize, 1), reopened.state.history.len);
 }
 

--- a/src/core/execution/command_runner.zig
+++ b/src/core/execution/command_runner.zig
@@ -25,6 +25,7 @@ pub const Config = struct {
     max_command_output_bytes: usize,
     cancel_flag: ?*std.atomic.Value(bool) = null,
     force_cancel_flag: ?*std.atomic.Value(bool) = null,
+    shutdown_flag: ?*std.atomic.Value(bool) = null,
     output_chunk_lifecycle_id: ?types.ToolLifecycleId = null,
     output_chunk_ctx: ?*anyopaque = null,
     on_output_chunk: ?CommandOutputCallback = null,
@@ -2437,6 +2438,23 @@ fn collectOutput(
                     }
                 }
             }
+        }
+
+        if (cancelRequested(cfg.shutdown_flag) and
+            force_kill_sent and
+            observer.waiter.isReady())
+        {
+            debug_trace.logf(
+                "core",
+                "command output drain abandoned reason=runtime_shutdown wait_ready=true",
+                .{},
+            );
+            recordOutputDrainFailure(
+                &output_incomplete,
+                "runtime_shutdown",
+                error.Cancelled,
+            );
+            break;
         }
 
         const now_ms = io_mod.milliTimestamp();

--- a/src/core/execution/managed_execution.zig
+++ b/src/core/execution/managed_execution.zig
@@ -196,6 +196,7 @@ const Entry = struct {
     error_name: ?[]const u8 = null,
     cancel: std.atomic.Value(bool) = .init(false),
     force_cancel: std.atomic.Value(bool) = .init(false),
+    shutdown: std.atomic.Value(bool) = .init(false),
     start_gate: std.Io.Event = .unset,
     thread: ?std.Thread = null,
     published_running: bool = false,
@@ -431,6 +432,7 @@ const Entry = struct {
             .max_command_output_bytes = self.max_output_bytes,
             .cancel_flag = &self.cancel,
             .force_cancel_flag = &self.force_cancel,
+            .shutdown_flag = &self.shutdown,
             .output_chunk_lifecycle_id = self.output_chunk_lifecycle_id,
             .output_chunk_ctx = self.output_chunk_ctx,
             .on_output_chunk = self.on_output_chunk,
@@ -1078,6 +1080,8 @@ pub const Runtime = struct {
             const entry = candidate orelse continue;
             entry.mutex.lockUncancelable(zio);
             if (!entry.isTerminal()) {
+                entry.shutdown.store(true, .seq_cst);
+                entry.force_cancel.store(true, .seq_cst);
                 entry.cancel.store(true, .seq_cst);
                 entry.start_gate.set(zio);
                 live[live_len] = entry;

--- a/src/core/session/session_log.zig
+++ b/src/core/session/session_log.zig
@@ -558,6 +558,7 @@ pub const LoadedWritableSession = struct {
     generation_base_bytes: u64,
     checkpoint_seq: ?u64 = null,
     checkpoint_sha256: ?session_projection.Digest = null,
+    checkpoint_rejected_position: ?CommitPosition = null,
     projection_status: ProjectionStatus = .current,
     namespace_confirmation_required: bool = false,
     degraded_tail: ?FailedTail = null,
@@ -858,6 +859,7 @@ pub const LoadedWritableSession = struct {
         options: Options,
     ) !void {
         try confirmWritableNamespace(self, alloc, options);
+        if (checkpointRejectedAtCurrentPosition(self)) return;
         if (!checkpointDue(self, options.checkpoint_interval) and
             !(ensure_present and !self.hasCurrentCheckpoint()))
         {
@@ -883,6 +885,50 @@ pub const LoadedWritableSession = struct {
             self.active_id,
             self.position,
         );
+    }
+
+    /// Confirms a clean handoff from bounded metadata reads. Recovery callers
+    /// that need content validation must use validateResumeBoundary instead.
+    pub fn confirmResumeHandoffBoundary(
+        self: *LoadedWritableSession,
+        alloc: Allocator,
+    ) !void {
+        if (self.namespace_confirmation_required) {
+            return error.SessionCommitBoundaryUnavailable;
+        }
+        if (self.degraded_tail != null or self.state_replacement_pending) {
+            return error.SessionPersistenceDegraded;
+        }
+
+        var event_log = try openManagedFile(
+            &self.log.dir,
+            events_file,
+            .read_only,
+        );
+        defer event_log.close(io_mod.getIo());
+        const generation = try session_replay.readFirstGeneration(alloc, event_log);
+        if (!std.mem.eql(u8, &generation, &self.position.log_generation)) {
+            return error.InvalidSessionFormat;
+        }
+        const current = try loadWatermarkPosition(
+            alloc,
+            &self.log.dir,
+            self.active_id,
+            generation,
+        );
+        if (!positionsEqual(current, self.position)) {
+            return error.InvalidSessionFormat;
+        }
+        var manifest = try loadCurrentManifestForOpen(
+            alloc,
+            &self.log.dir,
+            self.active_id,
+            self.authority_id,
+            event_log,
+            self.position,
+        );
+        defer manifest.manifest.deinit(alloc);
+        if (!manifest.event_file_matches) return error.InvalidSessionFormat;
     }
 
     /// Repairs only a corrupt watermark whose writer authority, complete
@@ -3050,20 +3096,6 @@ fn validateLivePosition(
     session_id: []const u8,
     expected: CommitPosition,
 ) !session_projection.EventBoundary {
-    var log = try openManagedFile(dir, events_file, .read_only);
-    defer log.close(io_mod.getIo());
-    const generation = try session_replay.readFirstGeneration(alloc, log);
-    if (!std.mem.eql(u8, &generation, &expected.log_generation)) {
-        return error.InvalidSessionFormat;
-    }
-    const actual = try loadAndValidateWatermark(
-        alloc,
-        dir,
-        session_id,
-        generation,
-        log,
-    );
-    if (!positionsEqual(actual, expected)) return error.InvalidSessionFormat;
     return validateCommitPosition(alloc, dir, session_id, expected);
 }
 
@@ -3104,12 +3136,11 @@ fn validateCommitPosition(
     if (!std.mem.eql(u8, &generation, &position.log_generation)) {
         return error.InvalidSessionFormat;
     }
-    const watermark = try loadAndValidateWatermark(
+    const watermark = try loadWatermarkPosition(
         alloc,
         dir,
         session_id,
         generation,
-        log,
     );
     if (!positionsEqual(position, watermark)) return error.InvalidSessionFormat;
     return session_replay.scanCommitPosition(alloc, log, position);
@@ -4019,9 +4050,14 @@ fn refreshProjections(
 }
 
 fn checkpointDue(loaded: *LoadedWritableSession, interval: u64) bool {
-    return interval > 0 and
+    return !checkpointRejectedAtCurrentPosition(loaded) and interval > 0 and
         (loaded.checkpoint_seq == null or
             loaded.position.through_seq - loaded.checkpoint_seq.? >= interval);
+}
+
+fn checkpointRejectedAtCurrentPosition(loaded: *const LoadedWritableSession) bool {
+    const rejected = loaded.checkpoint_rejected_position orelse return false;
+    return positionsEqual(rejected, loaded.position);
 }
 
 fn writeCheckpointProjection(
@@ -4036,8 +4072,14 @@ fn writeCheckpointProjection(
         .through_event_log_bytes = loaded.position.through_event_log_bytes,
         .state = loaded.state,
     };
-    const bytes = try session_projection.encodeCheckpoint(alloc, checkpoint);
+    const bytes = session_projection.encodeCheckpoint(alloc, checkpoint) catch |err| {
+        if (err == error.CheckpointTooLarge) {
+            loaded.checkpoint_rejected_position = loaded.position;
+        }
+        return err;
+    };
     defer alloc.free(bytes);
+    loaded.checkpoint_rejected_position = null;
     try durableReplace(alloc, &loaded.log.dir, checkpoint_file, bytes);
     loaded.checkpoint_seq = loaded.position.through_seq;
     loaded.checkpoint_sha256 = session_projection.sha256(bytes);
@@ -6555,6 +6597,91 @@ test "checkpoint clean shutdown preserves a valid bounded tail" {
         opened.tail_bytes,
     );
     try std.testing.expect(opened.state.preferences.fast_mode);
+}
+
+test "oversized checkpoint rejection is cached for the current position" {
+    const alloc = std.testing.allocator;
+    var temp = try TempRoot.init(alloc);
+    defer temp.deinit(alloc);
+    var initial = try testState(alloc, "session-oversized-checkpoint", 10);
+    defer initial.deinit(alloc);
+    var loaded = try temp.root.startWritableSession(alloc, initial, .{});
+    defer loaded.deinit(alloc);
+    const response = try alloc.alloc(u8, session_projection.checkpoint_max_bytes);
+    defer alloc.free(response);
+    @memset(response, 'x');
+    const oversized = try stateWithPrompt(
+        alloc,
+        loaded.state,
+        20,
+        "large response",
+        response,
+    );
+    loaded.state.deinit(alloc);
+    loaded.state = oversized;
+
+    try std.testing.expectError(
+        error.CheckpointTooLarge,
+        writeCheckpointProjection(alloc, &loaded),
+    );
+    try std.testing.expect(!checkpointDue(&loaded, 1));
+    loaded.position.through_seq += 1;
+    try std.testing.expect(checkpointDue(&loaded, 1));
+}
+
+test "resume handoff confirmation accepts current durable metadata" {
+    const alloc = std.testing.allocator;
+    var temp = try TempRoot.init(alloc);
+    defer temp.deinit(alloc);
+    var initial = try testState(alloc, "session-fast-handoff-confirmation", 10);
+    defer initial.deinit(alloc);
+    var loaded = try temp.root.startWritableSession(alloc, initial, .{});
+    defer loaded.deinit(alloc);
+
+    try loaded.confirmResumeHandoffBoundary(alloc);
+}
+
+test "resume handoff confirmation rejects a corrupted watermark" {
+    const alloc = std.testing.allocator;
+    var temp = try TempRoot.init(alloc);
+    defer temp.deinit(alloc);
+    var initial = try testState(alloc, "session-fast-handoff-watermark", 10);
+    defer initial.deinit(alloc);
+    var loaded = try temp.root.startWritableSession(alloc, initial, .{});
+    defer loaded.deinit(alloc);
+    const name = try watermarkName(alloc, loaded.position.log_generation);
+    defer alloc.free(name);
+    try durableReplace(alloc, &loaded.log.dir, name, "{bad");
+
+    try std.testing.expectError(
+        error.InvalidSessionFormat,
+        loaded.confirmResumeHandoffBoundary(alloc),
+    );
+}
+
+test "resume handoff confirmation rejects changed event file metadata" {
+    const alloc = std.testing.allocator;
+    var temp = try TempRoot.init(alloc);
+    defer temp.deinit(alloc);
+    var initial = try testState(alloc, "session-fast-handoff-event-stat", 10);
+    defer initial.deinit(alloc);
+    var loaded = try temp.root.startWritableSession(alloc, initial, .{});
+    defer loaded.deinit(alloc);
+    var event_log = try openManagedFile(
+        &loaded.log.dir,
+        events_file,
+        .read_write,
+    );
+    var first: [1]u8 = undefined;
+    _ = try event_log.readPositionalAll(io_mod.getIo(), &first, 0);
+    try event_log.writePositionalAll(io_mod.getIo(), &first, 0);
+    try event_log.sync(io_mod.getIo());
+    event_log.close(io_mod.getIo());
+
+    try std.testing.expectError(
+        error.InvalidSessionFormat,
+        loaded.confirmResumeHandoffBoundary(alloc),
+    );
 }
 
 test "final replacement policy tracks mutations after the last replacement" {

--- a/src/core/session/session_log.zig
+++ b/src/core/session/session_log.zig
@@ -695,11 +695,9 @@ pub const LoadedWritableSession = struct {
             self.state_replacement_pending = true;
             return err;
         };
-        if (cache_deferred) {
+        if (!lifecycle_published) {
             self.state_replacement_pending = replacement_was_pending;
             self.commit_lifecycle_pending = true;
-        } else if (!lifecycle_published) {
-            self.state_replacement_pending = true;
         } else {
             self.state_replacement_pending =
                 self.state_replacement_pending and replacement_was_pending;
@@ -763,13 +761,7 @@ pub const LoadedWritableSession = struct {
             self.state_replacement_pending = true;
             return err;
         };
-        if (cache_deferred) {
-            self.commit_lifecycle_pending = true;
-        } else if (!lifecycle_published) {
-            self.state_replacement_pending = true;
-        } else {
-            self.commit_lifecycle_pending = false;
-        }
+        self.commit_lifecycle_pending = !lifecycle_published;
         return self.position;
     }
 
@@ -1340,7 +1332,7 @@ pub const Root = struct {
                 };
                 created.commit_lifecycle_pending = true;
             } else if (!created.publishCommitLifecycle(alloc)) {
-                created.state_replacement_pending = true;
+                created.commit_lifecycle_pending = true;
             }
         }
         return created;

--- a/src/core/session/session_log.zig
+++ b/src/core/session/session_log.zig
@@ -550,6 +550,9 @@ pub const LoadedWritableSession = struct {
     log: WritableSessionDir,
     freshly_started: bool = false,
     state_replacement_pending: bool = false,
+    /// Derived commit-lifecycle work still needs publication, but does not
+    /// invalidate an otherwise durable canonical session boundary.
+    commit_lifecycle_pending: bool = false,
     child_capability: ?*session_child_store.SessionChildCapability = null,
     commit_lifecycle: ?CommitLifecycle = null,
     position: CommitPosition,
@@ -692,11 +695,15 @@ pub const LoadedWritableSession = struct {
             self.state_replacement_pending = true;
             return err;
         };
-        if (!lifecycle_published) {
+        if (cache_deferred) {
+            self.state_replacement_pending = replacement_was_pending;
+            self.commit_lifecycle_pending = true;
+        } else if (!lifecycle_published) {
             self.state_replacement_pending = true;
         } else {
             self.state_replacement_pending =
                 self.state_replacement_pending and replacement_was_pending;
+            self.commit_lifecycle_pending = false;
         }
         return self.position;
     }
@@ -756,7 +763,13 @@ pub const LoadedWritableSession = struct {
             self.state_replacement_pending = true;
             return err;
         };
-        if (!lifecycle_published) self.state_replacement_pending = true;
+        if (cache_deferred) {
+            self.commit_lifecycle_pending = true;
+        } else if (!lifecycle_published) {
+            self.state_replacement_pending = true;
+        } else {
+            self.commit_lifecycle_pending = false;
+        }
         return self.position;
     }
 
@@ -997,7 +1010,9 @@ pub const LoadedWritableSession = struct {
         self: *const LoadedWritableSession,
         usage_dirty: bool,
     ) bool {
-        return usage_dirty or self.state_replacement_pending;
+        return usage_dirty or
+            self.state_replacement_pending or
+            self.commit_lifecycle_pending;
     }
 
     pub fn cleanupOrphans(
@@ -1323,7 +1338,7 @@ pub const Root = struct {
                     };
                     return err;
                 };
-                created.state_replacement_pending = true;
+                created.commit_lifecycle_pending = true;
             } else if (!created.publishCommitLifecycle(alloc)) {
                 created.state_replacement_pending = true;
             }

--- a/src/core/session/session_store.zig
+++ b/src/core/session/session_store.zig
@@ -2947,7 +2947,7 @@ pub const Store = struct {
             alloc,
             source.id,
         ) catch |err| switch (err) {
-            error.OutOfMemory => return error.OutOfMemory,
+            error.OutOfMemory, error.Cancelled => return err,
             else => {
                 debug_trace.logf(
                     "core",
@@ -3292,9 +3292,9 @@ pub const Store = struct {
             if (probe_managed_children) {
                 candidate.summary.has_managed_children =
                     self.sessionHasManagedChildren(alloc, entry.name) catch |err| switch (err) {
-                        error.OutOfMemory => {
+                        error.OutOfMemory, error.Cancelled => {
                             candidate.deinit(alloc);
-                            return error.OutOfMemory;
+                            return err;
                         },
                         else => false,
                     };
@@ -3344,11 +3344,26 @@ pub const Store = struct {
         return scan;
     }
 
+    fn checkLegacyRelationshipScanCancellation(
+        self: Store,
+        session_id: []const u8,
+    ) !void {
+        self.check_discovery_cancellation() catch |err| {
+            debug_trace.logf(
+                "core",
+                "session managed child legacy scan cancelled session={s}",
+                .{session_id},
+            );
+            return err;
+        };
+    }
+
     fn sessionHasManagedChildren(
         self: Store,
         alloc: Allocator,
         session_id: []const u8,
     ) !bool {
+        try self.check_discovery_cancellation();
         var capability = try self.openListedChildCapabilityReadOnly(
             alloc,
             session_id,
@@ -3364,10 +3379,13 @@ pub const Store = struct {
         };
         if (children_file) |*file| {
             defer file.deinit();
+            try self.check_discovery_cancellation();
             const bytes = try file.readToEnd(alloc, 512 * 1024);
             defer alloc.free(bytes);
+            try self.check_discovery_cancellation();
             var parsed = try std.json.parseFromSlice(std.json.Value, alloc, bytes, .{});
             defer parsed.deinit();
+            try self.check_discovery_cancellation();
             if (parsed.value != .object) return error.InvalidSubagentState;
             const children = parsed.value.object.get("children") orelse
                 return error.InvalidSubagentState;
@@ -3385,17 +3403,25 @@ pub const Store = struct {
             else => return err,
         };
         defer header_file.deinit();
+        try self.check_discovery_cancellation();
         const header_bytes = try header_file.readToEnd(
             alloc,
             relationship_index_codec.max_header_bytes,
         );
         defer alloc.free(header_bytes);
+        try self.check_discovery_cancellation();
         const header = try relationship_index_codec.decodeHeader(header_bytes);
         if (header.active_count_known) return header.active_count != 0;
+        debug_trace.logf(
+            "core",
+            "session managed child legacy scan started session={s} slots={d}",
+            .{ session_id, header.high_watermark },
+        );
 
         var page_number: u64 = 0;
         var offset: u64 = 0;
         while (offset < header.high_watermark) : (page_number += 1) {
+            try self.checkLegacyRelationshipScanCancellation(session_id);
             const page_name = relationship_index_codec.pageFileName(page_number);
             var page_file = try capability.openFileReadOnly(
                 alloc,
@@ -3408,11 +3434,13 @@ pub const Store = struct {
                 relationship_index_codec.max_page_bytes,
             );
             defer alloc.free(page_bytes);
+            try self.checkLegacyRelationshipScanCancellation(session_id);
             const page = try relationship_index_codec.decodePage(
                 page_bytes,
                 page_number,
                 header.storage_epoch,
             );
+            try self.checkLegacyRelationshipScanCancellation(session_id);
             const remaining = header.high_watermark - offset;
             const slots_to_read: usize = @intCast(@min(
                 remaining,
@@ -11584,6 +11612,76 @@ test "session scan probes managed children only when requested" {
     defer probing.deinit(alloc);
     try std.testing.expectEqual(@as(usize, 1), probing.summaries.items.len);
     try std.testing.expect(probing.summaries.items[0].has_managed_children);
+}
+
+test "legacy managed child relationship scan observes cancellation" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var ctx = try initTempStore(alloc, &tmp);
+    defer ctx.deinit(alloc);
+
+    var state = try testDurableState(alloc, "legacy-child-scan-cancel", ctx.workspace);
+    defer state.deinit(alloc);
+    var writable = try ctx.store.startWritableSession(alloc, state);
+    {
+        const current_header = try relationship_index_codec.encodeHeader(alloc, .{
+            .storage_epoch = 7,
+            .generation = 1,
+            .high_watermark = relationship_index_codec.page_slots,
+            .active_count = 0,
+        });
+        defer alloc.free(current_header);
+        const version_offset = relationship_index_codec.header_magic.len;
+        const active_count_offset = version_offset + @sizeOf(u32) +
+            @sizeOf(u64) * 3;
+        var legacy_header: std.ArrayList(u8) = .empty;
+        defer legacy_header.deinit(alloc);
+        try legacy_header.appendSlice(alloc, current_header[0..version_offset]);
+        var legacy_version: [@sizeOf(u32)]u8 = undefined;
+        std.mem.writeInt(u32, &legacy_version, 2, .little);
+        try legacy_header.appendSlice(alloc, &legacy_version);
+        try legacy_header.appendSlice(
+            alloc,
+            current_header[version_offset + @sizeOf(u32) .. active_count_offset],
+        );
+        try legacy_header.appendSlice(
+            alloc,
+            current_header[active_count_offset + @sizeOf(u64) ..],
+        );
+        var capability = try writable.childCapability();
+        var header_file = try capability.createExclusiveFile(
+            alloc,
+            .subagent_control,
+            session_child_store.subagent_relationship_index_file,
+        );
+        defer header_file.deinit();
+        try header_file.writeAll(legacy_header.items);
+        try header_file.sync();
+
+        const page_bytes = try relationship_index_codec.encodePage(
+            alloc,
+            relationship_index_codec.PageData.init(0, 7),
+        );
+        defer alloc.free(page_bytes);
+        const page_name = relationship_index_codec.pageFileName(0);
+        var page_file = try capability.createExclusiveFile(
+            alloc,
+            .subagent_control,
+            &page_name,
+        );
+        defer page_file.deinit();
+        try page_file.writeAll(page_bytes);
+        try page_file.sync();
+    }
+    writable.deinit(alloc);
+
+    var cancel = std.atomic.Value(bool).init(true);
+    ctx.store.set_discovery_cancel_flag(&cancel);
+    try std.testing.expectError(
+        error.Cancelled,
+        ctx.store.sessionHasManagedChildren(alloc, state.id),
+    );
 }
 
 test "resumable discovery observes cancellation before index backfill" {

--- a/src/core/session/session_store.zig
+++ b/src/core/session/session_store.zig
@@ -574,6 +574,21 @@ pub const Store = struct {
     // Carried on the value so it propagates through the by-value page chain;
     // the UI sets it from the visible screen height.
     resume_page_limit: usize = default_resume_page_limit,
+    discovery_cancel_flag: ?*const std.atomic.Value(bool) = null,
+
+    /// Binds a borrowed cancellation flag to this store copy. The caller must
+    /// keep the flag alive until every operation using the copy has returned.
+    pub fn set_discovery_cancel_flag(
+        self: *Store,
+        cancel_flag: *const std.atomic.Value(bool),
+    ) void {
+        self.discovery_cancel_flag = cancel_flag;
+    }
+
+    fn check_discovery_cancellation(self: Store) !void {
+        const cancel_flag = self.discovery_cancel_flag orelse return;
+        if (cancel_flag.load(.seq_cst)) return error.Cancelled;
+    }
 
     /// Narrow, copyable view of this store for the discovery/migration helpers,
     /// so they depend on `StoreContext` instead of the full facade.
@@ -2482,6 +2497,20 @@ pub const Store = struct {
         );
     }
 
+    pub fn tryListReconciledResumableIndexPage(
+        self: Store,
+        alloc: Allocator,
+        active_id: ?[]const u8,
+        continuation: ?ResumableSessionContinuation,
+    ) !?ResumableSessionPage {
+        return self.tryListReconciledResumableIndexPageForScope(
+            alloc,
+            .all_workspaces,
+            active_id,
+            continuation,
+        );
+    }
+
     pub fn listResumableWorkspacePage(
         self: Store,
         alloc: Allocator,
@@ -2510,6 +2539,20 @@ pub const Store = struct {
         );
     }
 
+    pub fn tryListReconciledResumableWorkspaceIndexPage(
+        self: Store,
+        alloc: Allocator,
+        active_id: ?[]const u8,
+        continuation: ?ResumableSessionContinuation,
+    ) !?ResumableSessionPage {
+        return self.tryListReconciledResumableIndexPageForScope(
+            alloc,
+            .current_workspace,
+            active_id,
+            continuation,
+        );
+    }
+
     fn listResumablePageForScope(
         self: Store,
         alloc: Allocator,
@@ -2517,6 +2560,7 @@ pub const Store = struct {
         active_id: ?[]const u8,
         continuation: ?ResumableSessionContinuation,
     ) !ResumableSessionPage {
+        try self.check_discovery_cancellation();
         if (try self.tryListResumableIndexPageForScope(alloc, scope, active_id, continuation)) |page| {
             return page;
         }
@@ -2572,11 +2616,34 @@ pub const Store = struct {
             .continuation = continuation,
             .limit = self.resume_page_limit,
             .resumable_only = true,
+            .cancel_flag = self.discovery_cancel_flag,
         }) catch |err| switch (err) {
-            error.OutOfMemory => return error.OutOfMemory,
+            error.OutOfMemory, error.Cancelled => return err,
             else => return null,
         };
         return try self.hydrateResumablePage(alloc, page);
+    }
+
+    fn tryListReconciledResumableIndexPageForScope(
+        self: Store,
+        alloc: Allocator,
+        scope: ResumableSessionScope,
+        active_id: ?[]const u8,
+        continuation: ?ResumableSessionContinuation,
+    ) !?ResumableSessionPage {
+        if (self.canonical_root.mode != .writable) return null;
+        if (try self.tryListResumableIndexPageForScope(
+            alloc,
+            scope,
+            active_id,
+            continuation,
+        )) |page| return page;
+        return self.tryListResumableOverlayPageForScope(
+            alloc,
+            scope,
+            active_id,
+            continuation,
+        );
     }
 
     fn backfillResumablePageForScope(
@@ -2586,10 +2653,13 @@ pub const Store = struct {
         active_id: ?[]const u8,
         continuation: ?ResumableSessionContinuation,
     ) !ResumableSessionPage {
+        try self.check_discovery_cancellation();
         var sessions = self.canonical_root.sessions orelse return error.SessionStoreUnavailable;
         var summaries = try self.scanSessionSummaries(alloc, .read_only_list);
         defer freeSummaries(alloc, &summaries);
+        try self.check_discovery_cancellation();
         try self.refreshMissingDisplayMetadata(alloc, &summaries);
+        try self.check_discovery_cancellation();
         var page = try self.resumablePageFromSummariesForScope(
             alloc,
             scope,
@@ -2606,6 +2676,7 @@ pub const Store = struct {
         ) catch return page;
         var cache_lock_held = true;
         defer if (cache_lock_held) cache_lock.release();
+        try self.check_discovery_cancellation();
 
         if (try self.tryListResumableIndexPageForScope(alloc, scope, active_id, continuation)) |indexed| {
             page.deinit(alloc);
@@ -2616,14 +2687,18 @@ pub const Store = struct {
             &sessions,
         ) catch return page;
         defer summary_codec.freeDeferredCacheTokens(alloc, &observed);
+        try self.check_discovery_cancellation();
         var repair_summaries = try self.scanSessionSummaries(alloc, .read_only_list);
         defer freeSummaries(alloc, &repair_summaries);
+        try self.check_discovery_cancellation();
         try self.refreshMissingDisplayMetadata(alloc, &repair_summaries);
+        try self.check_discovery_cancellation();
         try writeSessionIndex(alloc, &sessions, repair_summaries.items);
         try removeSessionIndexMarker(&sessions);
         cache_lock.release();
         cache_lock_held = false;
         for (observed.items) |token| {
+            try self.check_discovery_cancellation();
             var root = self.canonical_root;
             var boundary = root.captureReadBoundary(
                 alloc,
@@ -2664,6 +2739,212 @@ pub const Store = struct {
             };
         }
         return page;
+    }
+
+    /// Serves a current in-memory view without the global index lock by
+    /// overlaying the bounded deferred journal on the last atomic snapshot.
+    /// This keeps readers responsive while another fx process publishes.
+    fn tryListResumableOverlayPageForScope(
+        self: Store,
+        alloc: Allocator,
+        scope: ResumableSessionScope,
+        active_id: ?[]const u8,
+        continuation: ?ResumableSessionContinuation,
+    ) !?ResumableSessionPage {
+        try self.check_discovery_cancellation();
+        const sessions = &(self.canonical_root.sessions orelse return null);
+        var observed = summary_codec.readDeferredCacheTokens(
+            alloc,
+            sessions,
+        ) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            else => return null,
+        };
+        defer summary_codec.freeDeferredCacheTokens(alloc, &observed);
+        return switch (scope) {
+            .all_workspaces => self.tryListResumableGlobalOverlayPage(
+                alloc,
+                sessions,
+                observed.items,
+                active_id,
+                continuation,
+            ),
+            .current_workspace => self.tryListResumableWorkspaceOverlayPage(
+                alloc,
+                sessions,
+                observed.items,
+                active_id,
+                continuation,
+            ),
+        };
+    }
+
+    fn tryListResumableGlobalOverlayPage(
+        self: Store,
+        alloc: Allocator,
+        sessions: *const io_mod.VerifiedDir,
+        tokens: []const summary_codec.DeferredCacheToken,
+        active_id: ?[]const u8,
+        continuation: ?ResumableSessionContinuation,
+    ) !?ResumableSessionPage {
+        var snapshot = summary_codec.readSessionIndexSnapshotPrefixPage(alloc, sessions, .{
+            .active_id = active_id,
+            .continuation = continuation,
+            .limit = self.resume_page_limit +| tokens.len,
+            .resumable_only = true,
+            .cancel_flag = self.discovery_cancel_flag,
+        }) catch |err| switch (err) {
+            error.OutOfMemory, error.Cancelled => return err,
+            else => return null,
+        };
+        defer snapshot.deinit(alloc);
+        if (!try self.applyDeferredResumableIndexRows(
+            alloc,
+            &snapshot.summaries,
+            tokens,
+            active_id,
+        )) return null;
+        var page = try self.resumablePageFromSummariesForScope(
+            alloc,
+            .all_workspaces,
+            snapshot.summaries.items,
+            active_id,
+            continuation,
+        );
+        page.has_more = page.has_more or snapshot.has_more;
+        debug_trace.logf(
+            "core",
+            "session picker cache overlay outcome=ready scope=all_workspaces deferred={d}",
+            .{tokens.len},
+        );
+        return try self.hydrateResumablePage(alloc, page);
+    }
+
+    fn tryListResumableWorkspaceOverlayPage(
+        self: Store,
+        alloc: Allocator,
+        sessions: *const io_mod.VerifiedDir,
+        tokens: []const summary_codec.DeferredCacheToken,
+        active_id: ?[]const u8,
+        continuation: ?ResumableSessionContinuation,
+    ) !?ResumableSessionPage {
+        var index = summary_codec.readSessionIndexWorkspaceSnapshot(
+            alloc,
+            sessions,
+            self.workspace_root,
+        ) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            else => return null,
+        };
+        defer freeSummaries(alloc, &index);
+        if (!try self.applyDeferredResumableIndexRows(
+            alloc,
+            &index,
+            tokens,
+            active_id,
+        )) return null;
+        const page = try self.resumablePageFromSummariesForScope(
+            alloc,
+            .current_workspace,
+            index.items,
+            active_id,
+            continuation,
+        );
+        debug_trace.logf(
+            "core",
+            "session picker cache overlay outcome=ready scope=current_workspace deferred={d}",
+            .{tokens.len},
+        );
+        return try self.hydrateResumablePage(alloc, page);
+    }
+
+    fn applyDeferredResumableIndexRows(
+        self: Store,
+        alloc: Allocator,
+        index: *std.ArrayList(SessionSummary),
+        tokens: []const summary_codec.DeferredCacheToken,
+        active_id: ?[]const u8,
+    ) !bool {
+        for (tokens) |token| {
+            try self.check_discovery_cancellation();
+            if (active_id) |id| {
+                if (std.mem.eql(u8, id, token.session_id)) continue;
+            }
+
+            var session_dir = self.openSessionDir(token.session_id) catch |err| switch (err) {
+                else => {
+                    debug_trace.logf(
+                        "core",
+                        "session picker cache overlay outcome=deferred stage=open err={s}",
+                        .{@errorName(err)},
+                    );
+                    return false;
+                },
+            };
+            defer session_dir.close();
+            var candidate = classifyReadOnlyCandidate(
+                alloc,
+                &session_dir,
+                token.session_id,
+            ) catch |err| switch (err) {
+                error.OutOfMemory => return error.OutOfMemory,
+                else => {
+                    debug_trace.logf(
+                        "core",
+                        "session picker cache overlay outcome=deferred stage=projection err={s}",
+                        .{@errorName(err)},
+                    );
+                    return false;
+                },
+            };
+            defer candidate.deinit(alloc);
+            if (candidate.projection_state == .stale) {
+                debug_trace.logf(
+                    "core",
+                    "session picker cache overlay projection=stale id={s}",
+                    .{token.session_id},
+                );
+            }
+            if (!try self.replaceDeferredResumableIndexRow(
+                alloc,
+                index,
+                candidate.summary,
+            )) return false;
+        }
+        return true;
+    }
+
+    fn replaceDeferredResumableIndexRow(
+        self: Store,
+        alloc: Allocator,
+        index: *std.ArrayList(SessionSummary),
+        source: SessionSummary,
+    ) !bool {
+        var replacement = try summary_codec.cloneSessionSummary(alloc, source);
+        var replacement_owned = true;
+        defer if (replacement_owned) replacement.deinit(alloc);
+        replacement.has_managed_children = self.sessionHasManagedChildren(
+            alloc,
+            source.id,
+        ) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            else => {
+                debug_trace.logf(
+                    "core",
+                    "session picker cache overlay outcome=deferred stage=children err={s}",
+                    .{@errorName(err)},
+                );
+                return false;
+            },
+        };
+        try summary_codec.preserveIndexedDisplayMetadata(
+            alloc,
+            index.items,
+            &replacement,
+        );
+        try summary_codec.replaceIndexedSummary(alloc, index, &replacement);
+        replacement_owned = false;
+        return true;
     }
 
     fn listResumablePageFromDiscoveryForScope(
@@ -2728,6 +3009,7 @@ pub const Store = struct {
         summaries: *std.ArrayList(SessionSummary),
     ) !void {
         for (summaries.items) |*summary| {
+            try self.check_discovery_cancellation();
             if (!summaryNeedsDisplayMetadata(summary.*)) continue;
             if (try self.adoptFrozenSidecar(alloc, summary)) continue;
             const source_bytes = self.displayMetadataReplaySourceBytes(summary.id) catch |err| {
@@ -2915,6 +3197,7 @@ pub const Store = struct {
         mode: DiscoveryMode,
         probe_managed_children: bool,
     ) !SessionSummaryScan {
+        try self.check_discovery_cancellation();
         var scan = SessionSummaryScan{};
         errdefer scan.deinit(alloc);
         var replay_scope = self.loadDeferredReplayScope(alloc);
@@ -2924,6 +3207,7 @@ pub const Store = struct {
         if (self.canonical_root.sessions == null) return scan;
         var iter = self.canonical_root.sessions.?.dir.iterate();
         while (try iter.next(io_mod.getIo())) |entry| {
+            try self.check_discovery_cancellation();
             if (entry.kind != .directory) continue;
             if (std.mem.eql(u8, entry.name, latest_sessions_dir)) {
                 continue;
@@ -3018,6 +3302,7 @@ pub const Store = struct {
             };
             candidate.summary = undefined;
         }
+        try self.check_discovery_cancellation();
         sortSummariesNewestFirst(scan.summaries.items);
         if (mode == .global_read_only_last and scan.summaries.items.len > 0) {
             for (metadata.items) |candidate| {
@@ -11230,6 +11515,25 @@ test "session scan probes managed children only when requested" {
     defer probing.deinit(alloc);
     try std.testing.expectEqual(@as(usize, 1), probing.summaries.items.len);
     try std.testing.expect(probing.summaries.items[0].has_managed_children);
+}
+
+test "resumable discovery observes cancellation before index backfill" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var ctx = try initTempStore(alloc, &tmp);
+    defer ctx.deinit(alloc);
+
+    var sessions = ctx.store.canonical_root.sessions orelse
+        return error.TestExpectedEqual;
+    try summary_codec.writeSessionIndexMarker(alloc, &sessions);
+    var cancel = std.atomic.Value(bool).init(true);
+    ctx.store.set_discovery_cancel_flag(&cancel);
+
+    try std.testing.expectError(
+        error.Cancelled,
+        ctx.store.listResumablePage(alloc, null, null),
+    );
 }
 
 test "session discovery accepts the usage recovery name" {

--- a/src/core/session/session_store.zig
+++ b/src/core/session/session_store.zig
@@ -2753,6 +2753,7 @@ pub const Store = struct {
     ) !?ResumableSessionPage {
         try self.check_discovery_cancellation();
         const sessions = &(self.canonical_root.sessions orelse return null);
+        if (summary_codec.sessionIndexPublicationPending(sessions) catch return null) return null;
         var observed = summary_codec.readDeferredCacheTokens(
             alloc,
             sessions,
@@ -8416,7 +8417,8 @@ test "empty session creation survives latest cache contention" {
     );
     var loaded_open = true;
     defer if (loaded_open) loaded.deinit(alloc);
-    if (!loaded.state_replacement_pending) return error.ExpectedDeferredCreation;
+    if (!loaded.commit_lifecycle_pending) return error.ExpectedDeferredCreation;
+    if (loaded.state_replacement_pending) return error.ExpectedCanonicalReplacement;
     if (loaded.state.history.len != 0) return error.ExpectedEmptyCreatedSession;
     var readable = try ctx.store.loadReadOnly(alloc, state.id);
     defer readable.deinit(alloc);
@@ -8456,6 +8458,54 @@ test "empty session creation survives latest cache contention" {
     latest_lock_held = false;
     loaded.deinit(alloc);
     loaded_open = false;
+}
+
+test "reconciled resumable index rejects an unjournaled pending publication" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var ctx = try initTempStore(alloc, &tmp);
+    defer ctx.deinit(alloc);
+
+    try writeWritableHistoryFixture(
+        alloc,
+        ctx.store,
+        "pending-index-older",
+        ctx.workspace,
+        10,
+        "older prompt",
+    );
+    try writeWritableHistoryFixture(
+        alloc,
+        ctx.store,
+        "pending-index-newer",
+        ctx.workspace,
+        20,
+        "newer prompt",
+    );
+
+    var sessions = ctx.store.canonical_root.sessions orelse
+        return error.TestExpectedEqual;
+    const stale_snapshot = [_]SessionSummary{
+        testIndexedSessionSummary("pending-index-older", ctx.workspace, 10),
+    };
+    try summary_codec.writeSessionIndex(alloc, &sessions, &stale_snapshot);
+    try summary_codec.writeSessionIndexMarker(alloc, &sessions);
+
+    try std.testing.expect((try ctx.store.tryListReconciledResumableIndexPageForScope(
+        alloc,
+        .all_workspaces,
+        null,
+        null,
+    )) == null);
+
+    var current = try ctx.store.listResumablePage(alloc, null, null);
+    defer current.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 2), current.summaries.items.len);
+    try std.testing.expectEqualStrings(
+        "pending-index-newer",
+        current.summaries.items[0].id,
+    );
 }
 
 test "read-only session page replays canonical state for a deferred token" {

--- a/src/core/session/session_store.zig
+++ b/src/core/session/session_store.zig
@@ -2682,10 +2682,14 @@ pub const Store = struct {
             page.deinit(alloc);
             return indexed;
         }
-        var observed = summary_codec.readDeferredCacheTokens(
+        var observed = summary_codec.readDeferredCacheTokensCancellable(
             alloc,
             &sessions,
-        ) catch return page;
+            self.discovery_cancel_flag,
+        ) catch |err| switch (err) {
+            error.Cancelled => return err,
+            else => return page,
+        };
         defer summary_codec.freeDeferredCacheTokens(alloc, &observed);
         try self.check_discovery_cancellation();
         var repair_summaries = try self.scanSessionSummaries(alloc, .read_only_list);
@@ -2754,11 +2758,25 @@ pub const Store = struct {
         try self.check_discovery_cancellation();
         const sessions = &(self.canonical_root.sessions orelse return null);
         if (summary_codec.sessionIndexPublicationPending(sessions) catch return null) return null;
-        var observed = summary_codec.readDeferredCacheTokens(
+        debug_trace.logf(
+            "core",
+            "session picker cache overlay stage=deferred begin",
+            .{},
+        );
+        var observed = summary_codec.readDeferredCacheTokensCancellable(
             alloc,
             sessions,
+            self.discovery_cancel_flag,
         ) catch |err| switch (err) {
-            error.OutOfMemory => return error.OutOfMemory,
+            error.OutOfMemory => return err,
+            error.Cancelled => {
+                debug_trace.logf(
+                    "core",
+                    "session picker cache overlay cancelled stage=deferred",
+                    .{},
+                );
+                return err;
+            },
             else => return null,
         };
         defer summary_codec.freeDeferredCacheTokens(alloc, &observed);
@@ -2829,12 +2847,13 @@ pub const Store = struct {
         active_id: ?[]const u8,
         continuation: ?ResumableSessionContinuation,
     ) !?ResumableSessionPage {
-        var index = summary_codec.readSessionIndexWorkspaceSnapshot(
+        var index = summary_codec.readSessionIndexWorkspaceSnapshotCancellable(
             alloc,
             sessions,
             self.workspace_root,
+            self.discovery_cancel_flag,
         ) catch |err| switch (err) {
-            error.OutOfMemory => return error.OutOfMemory,
+            error.OutOfMemory, error.Cancelled => return err,
             else => return null,
         };
         defer freeSummaries(alloc, &index);

--- a/src/core/session/session_summary_codec.zig
+++ b/src/core/session/session_summary_codec.zig
@@ -848,6 +848,57 @@ fn parseSessionIndexForWorkspaceFast(
     return results;
 }
 
+fn parseSessionIndexWorkspaceSnapshotFast(
+    alloc: Allocator,
+    json_text: []const u8,
+    workspace_root: []const u8,
+) !std.ArrayList(SessionSummary) {
+    const prefix = "{\"schema_version\":3,\"sessions\":[";
+    if (!std.mem.startsWith(u8, json_text, prefix) or
+        !std.mem.endsWith(u8, json_text, "]}"))
+    {
+        return error.InvalidSessionIndex;
+    }
+
+    var needle_writer: std.Io.Writer.Allocating = .init(alloc);
+    defer needle_writer.deinit();
+    try needle_writer.writer.writeAll(",\"workspace_root\":");
+    try std.json.Stringify.value(
+        workspace_root,
+        .{},
+        &needle_writer.writer,
+    );
+    const workspace_needle = try needle_writer.toOwnedSlice();
+    defer alloc.free(workspace_needle);
+
+    var results: std.ArrayList(SessionSummary) = .empty;
+    errdefer freeSummaries(alloc, &results);
+    var search_from = prefix.len;
+    while (std.mem.indexOfPos(
+        u8,
+        json_text,
+        search_from,
+        workspace_needle,
+    )) |match_start| {
+        const relative_entry_start = std.mem.lastIndexOfScalar(
+            u8,
+            json_text[prefix.len..match_start],
+            '{',
+        ) orelse return error.InvalidSessionIndex;
+        const entry_start = prefix.len + relative_entry_start;
+        const entry_end = findIndexedSummaryEnd(json_text, entry_start) orelse
+            return error.InvalidSessionIndex;
+        try appendWorkspaceSummaryFromSlice(
+            alloc,
+            &results,
+            json_text[entry_start..entry_end],
+            workspace_root,
+        );
+        search_from = entry_end;
+    }
+    return results;
+}
+
 fn findIndexedSummaryEnd(
     json_text: []const u8,
     entry_start: usize,
@@ -946,6 +997,7 @@ pub const SessionIndexPageOptions = struct {
     continuation: ?ResumableSessionContinuation = null,
     limit: usize,
     resumable_only: bool,
+    cancel_flag: ?*const std.atomic.Value(bool) = null,
 };
 
 const IndexedSummaryView = struct {
@@ -1065,6 +1117,99 @@ fn parseSessionIndexPage(
     return page;
 }
 
+/// Reads a bounded prefix from the canonical writer format. The session index
+/// is derived state; selected rows are still validated against canonical
+/// session storage before resume.
+fn parseSessionIndexSnapshotPrefixPage(
+    alloc: Allocator,
+    json_text: []const u8,
+    options: SessionIndexPageOptions,
+) !ResumableSessionPage {
+    const prefix = "{\"schema_version\":3,\"sessions\":[";
+    if (options.workspace_root != null or
+        !std.mem.startsWith(u8, json_text, prefix) or
+        !std.mem.endsWith(u8, json_text, "]}"))
+    {
+        return error.InvalidSessionIndex;
+    }
+
+    var page: ResumableSessionPage = .{};
+    errdefer page.deinit(alloc);
+    var previous_updated_at_ms: ?i64 = null;
+    var previous_id: [255]u8 = undefined;
+    var previous_id_len: usize = 0;
+    var cursor = prefix.len;
+    const end = json_text.len - 2;
+    while (cursor < end) {
+        try check_cancellation(options.cancel_flag);
+        if (json_text[cursor] != '{') return error.InvalidSessionIndex;
+        const entry_end = findIndexedSummaryEnd(json_text, cursor) orelse
+            return error.InvalidSessionIndex;
+        var parsed = std.json.parseFromSlice(
+            std.json.Value,
+            alloc,
+            json_text[cursor..entry_end],
+            .{},
+        ) catch return error.InvalidSessionIndex;
+        defer parsed.deinit();
+        var summary = try parseIndexedSummary(alloc, parsed.value);
+        var summary_owned = true;
+        defer if (summary_owned) summary.deinit(alloc);
+
+        if (previous_updated_at_ms) |updated_at_ms| {
+            if (summary.updated_at_ms > updated_at_ms or
+                (summary.updated_at_ms == updated_at_ms and
+                    std.mem.order(u8, summary.id, previous_id[0..previous_id_len]) == .gt))
+            {
+                return error.InvalidSessionIndex;
+            }
+        }
+        previous_updated_at_ms = summary.updated_at_ms;
+        previous_id_len = summary.id.len;
+        @memcpy(previous_id[0..previous_id_len], summary.id);
+
+        if (sessionSummaryMatchesPage(summary, options)) {
+            if (page.summaries.items.len == options.limit) {
+                page.has_more = true;
+                return page;
+            }
+            try page.summaries.append(alloc, summary);
+            summary_owned = false;
+        }
+
+        cursor = entry_end;
+        if (cursor == end) break;
+        if (json_text[cursor] != ',') return error.InvalidSessionIndex;
+        cursor += 1;
+    }
+    if (cursor != end) return error.InvalidSessionIndex;
+    return page;
+}
+
+fn sessionSummaryMatchesPage(
+    summary: SessionSummary,
+    options: SessionIndexPageOptions,
+) bool {
+    if (options.resumable_only and
+        summary.history_len == 0 and
+        !summary.has_managed_children)
+    {
+        return false;
+    }
+    if (options.active_id) |active_id| {
+        if (std.mem.eql(u8, summary.id, active_id)) return false;
+    }
+    if (options.continuation) |continuation| {
+        if (summary.updated_at_ms > continuation.updated_at_ms) return false;
+        if (summary.updated_at_ms == continuation.updated_at_ms and
+            std.mem.order(u8, summary.id, continuation.id) != .lt)
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
 fn parseSessionIndexPageRows(
     alloc: Allocator,
     scanner: *std.json.Scanner,
@@ -1074,6 +1219,7 @@ fn parseSessionIndexPageRows(
 ) !void {
     try expectJsonToken(try scanner.next(), .array_begin);
     while (true) {
+        try check_cancellation(options.cancel_flag);
         const token = try scanner.next();
         switch (token) {
             .array_end => return,
@@ -1104,6 +1250,11 @@ fn parseSessionIndexPageRows(
             else => return error.InvalidSessionIndex,
         }
     }
+}
+
+fn check_cancellation(cancel_flag: ?*const std.atomic.Value(bool)) !void {
+    const flag = cancel_flag orelse return;
+    if (flag.load(.seq_cst)) return error.Cancelled;
 }
 
 fn readIndexedSummaryView(
@@ -1323,6 +1474,16 @@ pub fn readSessionIndexForRepair(
     sessions: *const io_mod.VerifiedDir,
 ) !std.ArrayList(SessionSummary) {
     if (try sessionIndexMarkerPresent(sessions)) return error.InvalidSessionIndex;
+    return readSessionIndexSnapshot(alloc, sessions);
+}
+
+/// Reads the last atomically published index without interpreting pending
+/// update markers. Callers must reconcile deferred tokens before treating the
+/// result as current.
+pub fn readSessionIndexSnapshot(
+    alloc: Allocator,
+    sessions: *const io_mod.VerifiedDir,
+) !std.ArrayList(SessionSummary) {
     var file = try openVerifiedSessionIndexFile(sessions, session_index_file);
     defer file.close(io_mod.getIo());
     const bytes = io_mod.readFileToEnd(alloc, &file, max_session_index_bytes) catch |err| switch (err) {
@@ -1331,6 +1492,43 @@ pub fn readSessionIndexForRepair(
     };
     defer alloc.free(bytes);
     return parseSessionIndex(alloc, bytes);
+}
+
+pub fn readSessionIndexSnapshotPrefixPage(
+    alloc: Allocator,
+    sessions: *const io_mod.VerifiedDir,
+    options: SessionIndexPageOptions,
+) !ResumableSessionPage {
+    var file = try openVerifiedSessionIndexFile(sessions, session_index_file);
+    defer file.close(io_mod.getIo());
+    const bytes = io_mod.readFileToEnd(alloc, &file, max_session_index_bytes) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return error.InvalidSessionIndex,
+    };
+    defer alloc.free(bytes);
+    return parseSessionIndexSnapshotPrefixPage(alloc, bytes, options) catch |err| switch (err) {
+        error.OutOfMemory, error.Cancelled => return err,
+        else => return error.InvalidSessionIndex,
+    };
+}
+
+pub fn readSessionIndexWorkspaceSnapshot(
+    alloc: Allocator,
+    sessions: *const io_mod.VerifiedDir,
+    workspace_root: []const u8,
+) !std.ArrayList(SessionSummary) {
+    var file = try openVerifiedSessionIndexFile(sessions, session_index_file);
+    defer file.close(io_mod.getIo());
+    const bytes = io_mod.readFileToEnd(
+        alloc,
+        &file,
+        max_session_index_bytes,
+    ) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return error.InvalidSessionIndex,
+    };
+    defer alloc.free(bytes);
+    return parseSessionIndexWorkspaceSnapshotFast(alloc, bytes, workspace_root);
 }
 
 pub fn readSessionIndexPage(
@@ -1348,7 +1546,7 @@ pub fn readSessionIndexPage(
     };
     defer alloc.free(bytes);
     return parseSessionIndexPage(alloc, bytes, options) catch |err| switch (err) {
-        error.OutOfMemory => return error.OutOfMemory,
+        error.OutOfMemory, error.Cancelled => return err,
         else => return error.InvalidSessionIndex,
     };
 }
@@ -1362,18 +1560,7 @@ pub fn readSessionIndexWorkspaceCandidates(
     workspace_root: []const u8,
 ) !std.ArrayList(SessionSummary) {
     if (try deferredCachePresent(sessions)) return error.InvalidSessionIndex;
-    var file = try openVerifiedSessionIndexFile(sessions, session_index_file);
-    defer file.close(io_mod.getIo());
-    const bytes = io_mod.readFileToEnd(
-        alloc,
-        &file,
-        max_session_index_bytes,
-    ) catch |err| switch (err) {
-        error.OutOfMemory => return error.OutOfMemory,
-        else => return error.InvalidSessionIndex,
-    };
-    defer alloc.free(bytes);
-    return parseSessionIndexForWorkspace(alloc, bytes, workspace_root);
+    return readSessionIndexWorkspaceSnapshot(alloc, sessions, workspace_root);
 }
 
 /// Streams a fixed window of the frozen ordinary-session candidate snapshot.

--- a/src/core/session/session_summary_codec.zig
+++ b/src/core/session/session_summary_codec.zig
@@ -1496,7 +1496,7 @@ pub fn readSessionIndexForRepair(
 /// Reads the last atomically published index without interpreting pending
 /// update markers. Callers must reconcile deferred tokens before treating the
 /// result as current.
-pub fn readSessionIndexSnapshot(
+fn readSessionIndexSnapshot(
     alloc: Allocator,
     sessions: *const io_mod.VerifiedDir,
 ) !std.ArrayList(SessionSummary) {
@@ -1528,7 +1528,7 @@ pub fn readSessionIndexSnapshotPrefixPage(
     };
 }
 
-pub fn readSessionIndexWorkspaceSnapshot(
+fn readSessionIndexWorkspaceSnapshot(
     alloc: Allocator,
     sessions: *const io_mod.VerifiedDir,
     workspace_root: []const u8,

--- a/src/core/session/session_summary_codec.zig
+++ b/src/core/session/session_summary_codec.zig
@@ -1473,7 +1473,7 @@ pub fn readSessionIndexForRepair(
     alloc: Allocator,
     sessions: *const io_mod.VerifiedDir,
 ) !std.ArrayList(SessionSummary) {
-    if (try sessionIndexMarkerPresent(sessions)) return error.InvalidSessionIndex;
+    if (try sessionIndexPublicationPending(sessions)) return error.InvalidSessionIndex;
     return readSessionIndexSnapshot(alloc, sessions);
 }
 
@@ -1537,7 +1537,7 @@ pub fn readSessionIndexPage(
     options: SessionIndexPageOptions,
 ) !ResumableSessionPage {
     if (try deferredCachePresent(sessions)) return error.InvalidSessionIndex;
-    if (try sessionIndexMarkerPresent(sessions)) return error.InvalidSessionIndex;
+    if (try sessionIndexPublicationPending(sessions)) return error.InvalidSessionIndex;
     var file = try openVerifiedSessionIndexFile(sessions, session_index_file);
     defer file.close(io_mod.getIo());
     const bytes = io_mod.readFileToEnd(alloc, &file, max_session_index_bytes) catch |err| switch (err) {
@@ -1837,7 +1837,7 @@ fn openVerifiedSessionIndexFile(
     return file;
 }
 
-fn sessionIndexMarkerPresent(sessions: *const io_mod.VerifiedDir) !bool {
+pub fn sessionIndexPublicationPending(sessions: *const io_mod.VerifiedDir) !bool {
     var file = openVerifiedSessionIndexFile(sessions, session_index_marker_file) catch |err| switch (err) {
         error.SessionIndexNotFound => return false,
         else => return err,

--- a/src/core/session/session_summary_codec.zig
+++ b/src/core/session/session_summary_codec.zig
@@ -216,13 +216,25 @@ pub fn readDeferredCacheTokens(
     alloc: Allocator,
     sessions: *const io_mod.VerifiedDir,
 ) !std.ArrayList(DeferredCacheToken) {
+    return readDeferredCacheTokensCancellable(alloc, sessions, null);
+}
+
+pub fn readDeferredCacheTokensCancellable(
+    alloc: Allocator,
+    sessions: *const io_mod.VerifiedDir,
+    cancel_flag: ?*const std.atomic.Value(bool),
+) !std.ArrayList(DeferredCacheToken) {
+    try check_cancellation(cancel_flag);
     var tokens: std.ArrayList(DeferredCacheToken) = .empty;
     errdefer freeDeferredCacheTokens(alloc, &tokens);
     var deferred = (try openDeferredCacheDirectory(sessions)) orelse return tokens;
     defer deferred.close();
 
     var iter = deferred.dir.iterate();
-    while (try iter.next(io_mod.getIo())) |entry| {
+    while (true) {
+        try check_cancellation(cancel_flag);
+        const entry = (try iter.next(io_mod.getIo())) orelse break;
+        try check_cancellation(cancel_flag);
         if (tokens.items.len >= max_deferred_cache_token_count) {
             return error.InvalidSessionIndex;
         }
@@ -852,7 +864,9 @@ fn parseSessionIndexWorkspaceSnapshotFast(
     alloc: Allocator,
     json_text: []const u8,
     workspace_root: []const u8,
+    cancel_flag: ?*const std.atomic.Value(bool),
 ) !std.ArrayList(SessionSummary) {
+    try check_cancellation(cancel_flag);
     const prefix = "{\"schema_version\":3,\"sessions\":[";
     if (!std.mem.startsWith(u8, json_text, prefix) or
         !std.mem.endsWith(u8, json_text, "]}"))
@@ -874,12 +888,14 @@ fn parseSessionIndexWorkspaceSnapshotFast(
     var results: std.ArrayList(SessionSummary) = .empty;
     errdefer freeSummaries(alloc, &results);
     var search_from = prefix.len;
-    while (std.mem.indexOfPos(
-        u8,
-        json_text,
-        search_from,
-        workspace_needle,
-    )) |match_start| {
+    while (true) {
+        try check_cancellation(cancel_flag);
+        const match_start = std.mem.indexOfPos(
+            u8,
+            json_text,
+            search_from,
+            workspace_needle,
+        ) orelse break;
         const relative_entry_start = std.mem.lastIndexOfScalar(
             u8,
             json_text[prefix.len..match_start],
@@ -1517,6 +1533,21 @@ pub fn readSessionIndexWorkspaceSnapshot(
     sessions: *const io_mod.VerifiedDir,
     workspace_root: []const u8,
 ) !std.ArrayList(SessionSummary) {
+    return readSessionIndexWorkspaceSnapshotCancellable(
+        alloc,
+        sessions,
+        workspace_root,
+        null,
+    );
+}
+
+pub fn readSessionIndexWorkspaceSnapshotCancellable(
+    alloc: Allocator,
+    sessions: *const io_mod.VerifiedDir,
+    workspace_root: []const u8,
+    cancel_flag: ?*const std.atomic.Value(bool),
+) !std.ArrayList(SessionSummary) {
+    try check_cancellation(cancel_flag);
     var file = try openVerifiedSessionIndexFile(sessions, session_index_file);
     defer file.close(io_mod.getIo());
     const bytes = io_mod.readFileToEnd(
@@ -1528,7 +1559,13 @@ pub fn readSessionIndexWorkspaceSnapshot(
         else => return error.InvalidSessionIndex,
     };
     defer alloc.free(bytes);
-    return parseSessionIndexWorkspaceSnapshotFast(alloc, bytes, workspace_root);
+    try check_cancellation(cancel_flag);
+    return parseSessionIndexWorkspaceSnapshotFast(
+        alloc,
+        bytes,
+        workspace_root,
+        cancel_flag,
+    );
 }
 
 pub fn readSessionIndexPage(
@@ -2504,6 +2541,56 @@ test "deferred cache token reader rejects non-private files" {
     try std.testing.expectError(
         error.InvalidSessionIndex,
         readDeferredCacheTokens(alloc, &sessions),
+    );
+}
+
+test "cancellable deferred token reader stops before enumeration" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDir(
+        std.testing.io,
+        "sessions",
+        private_dir_permissions,
+    );
+    var sessions_dir = try tmp.dir.openDir(std.testing.io, "sessions", .{
+        .iterate = true,
+    });
+    defer sessions_dir.close(std.testing.io);
+    var sessions = io_mod.VerifiedDir{ .dir = sessions_dir };
+    var cancelled = std.atomic.Value(bool).init(true);
+
+    try std.testing.expectError(
+        error.Cancelled,
+        readDeferredCacheTokensCancellable(alloc, &sessions, &cancelled),
+    );
+}
+
+test "cancellable workspace snapshot stops before parsing" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDir(
+        std.testing.io,
+        "sessions",
+        private_dir_permissions,
+    );
+    var sessions_dir = try tmp.dir.openDir(std.testing.io, "sessions", .{
+        .iterate = true,
+    });
+    defer sessions_dir.close(std.testing.io);
+    var sessions = io_mod.VerifiedDir{ .dir = sessions_dir };
+    try writeSessionIndex(alloc, &sessions, &.{});
+    var cancelled = std.atomic.Value(bool).init(true);
+
+    try std.testing.expectError(
+        error.Cancelled,
+        readSessionIndexWorkspaceSnapshotCancellable(
+            alloc,
+            &sessions,
+            "/tmp/workspace",
+            &cancelled,
+        ),
     );
 }
 

--- a/src/core/subagent/resume_admission.zig
+++ b/src/core/subagent/resume_admission.zig
@@ -25,8 +25,10 @@ const ManagedProbeBatch = struct {
 
     fn run(self: *ManagedProbeBatch) void {
         while (true) {
+            if (cancellationRequested(self.store.discovery_cancel_flag)) return;
             const index = self.next.fetchAdd(1, .monotonic);
             if (index >= self.summaries.len) return;
+            if (cancellationRequested(self.store.discovery_cancel_flag)) return;
             self.managed[index] = child_state.isManagedChildSession(
                 self.store,
                 std.heap.c_allocator,
@@ -41,6 +43,7 @@ fn probeManagedSessions(
     store: session_store.Store,
     summaries: []const session_store.SessionSummary,
 ) ![]bool {
+    if (cancellationRequested(store.discovery_cancel_flag)) return error.Cancelled;
     const managed = try alloc.alloc(bool, summaries.len);
     errdefer alloc.free(managed);
     @memset(managed, true);
@@ -51,6 +54,7 @@ fn probeManagedSessions(
     };
     if (comptime builtin.single_threaded) {
         batch.run();
+        if (cancellationRequested(store.discovery_cancel_flag)) return error.Cancelled;
         return managed;
     }
 
@@ -62,7 +66,13 @@ fn probeManagedSessions(
     }
     if (started < worker_count) batch.run();
     for (threads[0..started]) |thread| thread.join();
+    if (cancellationRequested(store.discovery_cancel_flag)) return error.Cancelled;
     return managed;
+}
+
+fn cancellationRequested(cancel_flag: ?*const std.atomic.Value(bool)) bool {
+    const flag = cancel_flag orelse return false;
+    return flag.load(.seq_cst);
 }
 
 pub const ActionableContinuation = struct {
@@ -472,6 +482,34 @@ fn ensureLoadedExternalPromptAllowed(
     loaded: *const session_store.LoadedWritableSession,
 ) !void {
     if (loaded.state.subagent_child) return error.OneOffSessionNotResumable;
+}
+
+test "managed session probes stop before claiming cancelled work" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(std.testing.io, "home/.fx");
+    try tmp.dir.createDirPath(std.testing.io, "workspace");
+    const home = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "home");
+    defer alloc.free(home);
+    const workspace = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "workspace");
+    defer alloc.free(workspace);
+    var store = try session_store.Store.initFromHome(alloc, home, workspace);
+    defer store.deinit(alloc);
+    var cancelled = std.atomic.Value(bool).init(true);
+    store.set_discovery_cancel_flag(&cancelled);
+    const summaries = [_]session_store.SessionSummary{.{
+        .id = @constCast("cancelled-probe"),
+        .created_at_ms = 1,
+        .updated_at_ms = 1,
+        .conversation_language = session.ConversationLanguage.literal("en"),
+        .history_len = 1,
+    }};
+
+    try std.testing.expectError(
+        error.Cancelled,
+        probeManagedSessions(alloc, store, &summaries),
+    );
 }
 
 test "managed child marker is hidden from external access" {

--- a/src/core/subagent/resume_admission.zig
+++ b/src/core/subagent/resume_admission.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const child_state = @import("child_state.zig");
 const io_mod = @import("../shared/io.zig");
 const session = @import("../session/session.zig");
@@ -8,6 +9,61 @@ const session_summary_codec = @import("../session/session_summary_codec.zig");
 
 const Allocator = std.mem.Allocator;
 const max_page_limit: usize = 100;
+const max_managed_probe_workers: usize = 8;
+
+const ActionablePageSource = enum {
+    discovery,
+    index,
+    reconciled_index,
+};
+
+const ManagedProbeBatch = struct {
+    store: session_store.Store,
+    summaries: []const session_store.SessionSummary,
+    managed: []bool,
+    next: std.atomic.Value(usize) = .init(0),
+
+    fn run(self: *ManagedProbeBatch) void {
+        while (true) {
+            const index = self.next.fetchAdd(1, .monotonic);
+            if (index >= self.summaries.len) return;
+            self.managed[index] = child_state.isManagedChildSession(
+                self.store,
+                std.heap.c_allocator,
+                self.summaries[index].id,
+            ) catch true;
+        }
+    }
+};
+
+fn probeManagedSessions(
+    alloc: Allocator,
+    store: session_store.Store,
+    summaries: []const session_store.SessionSummary,
+) ![]bool {
+    const managed = try alloc.alloc(bool, summaries.len);
+    errdefer alloc.free(managed);
+    @memset(managed, true);
+    var batch = ManagedProbeBatch{
+        .store = store,
+        .summaries = summaries,
+        .managed = managed,
+    };
+    if (comptime builtin.single_threaded) {
+        batch.run();
+        return managed;
+    }
+
+    var threads: [max_managed_probe_workers]std.Thread = undefined;
+    var started: usize = 0;
+    const worker_count = @min(summaries.len, max_managed_probe_workers);
+    while (started < worker_count) : (started += 1) {
+        threads[started] = std.Thread.spawn(.{}, ManagedProbeBatch.run, .{&batch}) catch break;
+    }
+    if (started < worker_count) batch.run();
+    for (threads[0..started]) |thread| thread.join();
+    return managed;
+}
 
 pub const ActionableContinuation = struct {
     updated_at_ms: i64,
@@ -148,7 +204,7 @@ pub fn listActionablePage(
         active_id,
         continuation,
         limit,
-        false,
+        .discovery,
     )).?;
 }
 
@@ -167,7 +223,26 @@ pub fn tryListActionableIndexPage(
         active_id,
         continuation,
         limit,
-        true,
+        .index,
+    );
+}
+
+pub fn tryListActionableReconciledIndexPage(
+    store: session_store.Store,
+    alloc: Allocator,
+    scope: session_store.SessionListScope,
+    active_id: ?[]const u8,
+    continuation: ?session_store.ResumableSessionContinuation,
+    limit: usize,
+) !?ActionableSessionPage {
+    return listActionablePageInternal(
+        store,
+        alloc,
+        scope,
+        active_id,
+        continuation,
+        limit,
+        .reconciled_index,
     );
 }
 
@@ -178,7 +253,7 @@ fn listActionablePageInternal(
     active_id: ?[]const u8,
     continuation: ?session_store.ResumableSessionContinuation,
     limit: usize,
-    index_only: bool,
+    source: ActionablePageSource,
 ) !?ActionableSessionPage {
     if (limit == 0 or limit > max_page_limit) return error.InvalidSessionListLimit;
 
@@ -193,33 +268,27 @@ fn listActionablePageInternal(
     var scanned: usize = 0;
     while (result.summaries.items.len < limit and scanned < max_page_limit) {
         var scoped = store;
-        scoped.resume_page_limit = @min(
-            limit - result.summaries.items.len,
-            max_page_limit - scanned,
-        );
+        scoped.resume_page_limit = switch (source) {
+            .discovery => @min(
+                limit - result.summaries.items.len,
+                max_page_limit - scanned,
+            ),
+            .index, .reconciled_index => max_page_limit - scanned,
+        };
         const next = if (position) |value| value.view() else null;
-        const maybe_page = if (index_only) switch (scope) {
-            .current_workspace => try scoped.tryListResumableWorkspaceIndexPage(
-                alloc,
-                active_id,
-                next,
-            ),
-            .all_workspaces => try scoped.tryListResumableIndexPage(
-                alloc,
-                active_id,
-                next,
-            ),
-        } else switch (scope) {
-            .current_workspace => try scoped.listResumableWorkspacePage(
-                alloc,
-                active_id,
-                next,
-            ),
-            .all_workspaces => try scoped.listResumablePage(
-                alloc,
-                active_id,
-                next,
-            ),
+        const maybe_page = switch (source) {
+            .index => switch (scope) {
+                .current_workspace => try scoped.tryListResumableWorkspaceIndexPage(alloc, active_id, next),
+                .all_workspaces => try scoped.tryListResumableIndexPage(alloc, active_id, next),
+            },
+            .reconciled_index => switch (scope) {
+                .current_workspace => try scoped.tryListReconciledResumableWorkspaceIndexPage(alloc, active_id, next),
+                .all_workspaces => try scoped.tryListReconciledResumableIndexPage(alloc, active_id, next),
+            },
+            .discovery => switch (scope) {
+                .current_workspace => try scoped.listResumableWorkspacePage(alloc, active_id, next),
+                .all_workspaces => try scoped.listResumablePage(alloc, active_id, next),
+            },
         };
         var page = maybe_page orelse {
             result.deinit(alloc);
@@ -229,22 +298,39 @@ fn listActionablePageInternal(
         result.has_more = page.has_more;
         if (page.summaries.items.len == 0) break;
 
-        for (page.summaries.items) |summary| {
+        const managed = switch (source) {
+            .discovery => null,
+            .index, .reconciled_index => try probeManagedSessions(
+                alloc,
+                store,
+                page.summaries.items,
+            ),
+        };
+        defer if (managed) |values| alloc.free(values);
+
+        for (page.summaries.items, 0..) |summary, page_index| {
+            if (result.summaries.items.len == limit) {
+                result.has_more = true;
+                break;
+            }
             scanned += 1;
             if (position) |*value| value.deinit(alloc);
             position = .{
                 .updated_at_ms = summary.updated_at_ms,
                 .id = try alloc.dupe(u8, summary.id),
             };
-            const managed = child_state.isManagedChildSession(
-                store,
-                alloc,
-                summary.id,
-            ) catch |err| switch (err) {
-                error.OutOfMemory => return error.OutOfMemory,
-                else => true,
-            };
-            if (managed) continue;
+            const is_managed = if (managed) |values|
+                values[page_index]
+            else
+                child_state.isManagedChildSession(
+                    store,
+                    alloc,
+                    summary.id,
+                ) catch |err| switch (err) {
+                    error.OutOfMemory => return error.OutOfMemory,
+                    else => true,
+                };
+            if (is_managed) continue;
             var cloned = try session_summary_codec.cloneSessionSummary(alloc, summary);
             result.summaries.append(alloc, cloned) catch |err| {
                 cloned.deinit(alloc);

--- a/src/core/subagent/resume_admission.zig
+++ b/src/core/subagent/resume_admission.zig
@@ -21,25 +21,48 @@ const ManagedProbeBatch = struct {
     store: session_store.Store,
     summaries: []const session_store.SessionSummary,
     managed: []bool,
+    probe_alloc: Allocator,
     next: std.atomic.Value(usize) = .init(0),
+    out_of_memory: std.atomic.Value(bool) = .init(false),
 
     fn run(self: *ManagedProbeBatch) void {
         while (true) {
             if (cancellationRequested(self.store.discovery_cancel_flag)) return;
+            if (self.out_of_memory.load(.acquire)) return;
             const index = self.next.fetchAdd(1, .monotonic);
             if (index >= self.summaries.len) return;
             if (cancellationRequested(self.store.discovery_cancel_flag)) return;
             self.managed[index] = child_state.isManagedChildSession(
                 self.store,
-                std.heap.c_allocator,
+                self.probe_alloc,
                 self.summaries[index].id,
-            ) catch true;
+            ) catch |err| switch (err) {
+                error.OutOfMemory => {
+                    self.out_of_memory.store(true, .release);
+                    return;
+                },
+                else => true,
+            };
         }
     }
 };
 
 fn probeManagedSessions(
     alloc: Allocator,
+    store: session_store.Store,
+    summaries: []const session_store.SessionSummary,
+) ![]bool {
+    return probeManagedSessionsWithAllocator(
+        alloc,
+        std.heap.c_allocator,
+        store,
+        summaries,
+    );
+}
+
+fn probeManagedSessionsWithAllocator(
+    alloc: Allocator,
+    probe_alloc: Allocator,
     store: session_store.Store,
     summaries: []const session_store.SessionSummary,
 ) ![]bool {
@@ -51,6 +74,7 @@ fn probeManagedSessions(
         .store = store,
         .summaries = summaries,
         .managed = managed,
+        .probe_alloc = probe_alloc,
     };
     if (comptime builtin.single_threaded) {
         batch.run();
@@ -67,6 +91,7 @@ fn probeManagedSessions(
     if (started < worker_count) batch.run();
     for (threads[0..started]) |thread| thread.join();
     if (cancellationRequested(store.discovery_cancel_flag)) return error.Cancelled;
+    if (batch.out_of_memory.load(.acquire)) return error.OutOfMemory;
     return managed;
 }
 
@@ -510,6 +535,61 @@ test "managed session probes stop before claiming cancelled work" {
         error.Cancelled,
         probeManagedSessions(alloc, store, &summaries),
     );
+}
+
+test "managed session probes propagate allocation failure" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(std.testing.io, "home/.fx");
+    try tmp.dir.createDirPath(std.testing.io, "workspace");
+    const home = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "home");
+    defer alloc.free(home);
+    const workspace = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "workspace");
+    defer alloc.free(workspace);
+    var store = try session_store.Store.initFromHome(alloc, home, workspace);
+    defer store.deinit(alloc);
+    var durable = session_codec.DurableSessionState{
+        .id = try alloc.dupe(u8, "allocation-failure-probe"),
+        .origin_workspace_root = try alloc.dupe(u8, workspace),
+        .workspace_root = try alloc.dupe(u8, workspace),
+        .created_at_ms = 1,
+        .updated_at_ms = 1,
+        .conversation_language = session.ConversationLanguage.literal("en"),
+        .history = try alloc.alloc(session.HistoryTurn, 0),
+        .total_input_tokens = 0,
+        .total_output_tokens = 0,
+        .preferences = .{
+            .model = try alloc.dupe(u8, "test"),
+            .effort = .auto,
+            .fast_mode = false,
+        },
+    };
+    defer durable.deinit(alloc);
+    var writable = try store.startWritableSession(alloc, durable);
+    writable.deinit(alloc);
+    const summaries = [_]session_store.SessionSummary{.{
+        .id = @constCast("allocation-failure-probe"),
+        .created_at_ms = 1,
+        .updated_at_ms = 1,
+        .conversation_language = session.ConversationLanguage.literal("en"),
+        .history_len = 1,
+    }};
+    var failing = std.testing.FailingAllocator.init(
+        alloc,
+        .{ .fail_index = 0 },
+    );
+
+    try std.testing.expectError(
+        error.OutOfMemory,
+        probeManagedSessionsWithAllocator(
+            alloc,
+            failing.allocator(),
+            store,
+            &summaries,
+        ),
+    );
+    try std.testing.expect(failing.has_induced_failure);
 }
 
 test "managed child marker is hidden from external access" {

--- a/tests/e2e/tui-resume-brutal.test.ts
+++ b/tests/e2e/tui-resume-brutal.test.ts
@@ -14,7 +14,7 @@ import {
 } from "node:fs";
 import { platform, tmpdir } from "node:os";
 import { join } from "node:path";
-import { FX_BIN } from "../evals/eval-helpers";
+import { FX_BIN, runFx } from "../evals/eval-helpers";
 import {
   FAKE_GATEWAY_MODEL,
   fakeGatewayFinalText,
@@ -238,8 +238,20 @@ async function seedRealSession(paths: Paths, config: Config): Promise<IndexedSum
     gateway.stop();
   }
 
-  const indexPath = join(paths.home, ".fx", "sessions", "index.json");
-  const parsed = JSON.parse(readFileSync(indexPath, "utf8")) as {
+  const listed = await runFx(["sessions", "--all", "--json", "--limit", "1"], {
+    cwd: realpathSync(paths.workspace),
+    env: {
+      HOME: paths.home,
+      AI_GATEWAY_API_KEY: undefined,
+      VERCEL_OIDC_TOKEN: undefined,
+      FX_AUTO_UPGRADE: "0",
+      FX_DISABLE_KEYCHAIN: "1",
+    },
+    timeoutMs: TIMEOUT,
+  });
+  expect(listed.code).toBe(0);
+  expect(listed.stderr).toBe("");
+  const parsed = JSON.parse(listed.stdout) as {
     sessions: IndexedSummary[];
   };
   expect(parsed.sessions).toHaveLength(1);

--- a/tests/e2e/tui-resume-brutal.test.ts
+++ b/tests/e2e/tui-resume-brutal.test.ts
@@ -307,6 +307,7 @@ function installLargeCatalog(
   const indexPath = join(sessionsRoot, "index.json");
   writeFileSync(indexPath, JSON.stringify({ schema_version: 3, sessions: entries }));
   chmodSync(indexPath, 0o600);
+  rmSync(join(sessionsRoot, "index.pending"), { force: true });
   const bytes = statSync(indexPath).size;
   expect(bytes).toBeLessThanOrEqual(16 * 1024 * 1024);
 }

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -611,6 +611,7 @@ test.skipIf(!tmuxAvailable())(
         "explicit session discovery",
       );
 
+      const traceOffset = readFileSync(tracePath, "utf8").length;
       active.sendKeysImmediate(["C-c"]);
       await waitForTraceAfter(
         tracePath,
@@ -707,7 +708,11 @@ test.skipIf(!tmuxAvailable())(
       );
 
       active.sendKeysImmediate(["C-c"]);
-      await Bun.sleep(80);
+      await waitForTraceAfter(
+        tracePath,
+        traceOffset,
+        "ctrl_c_exit_hint_armed",
+      );
       active.sendKeysImmediate(["C-c"]);
       const elapsedMs = await waitForPaneExitWithin(active, 5_000);
       const trace = readFileSync(tracePath, "utf8");

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -612,7 +612,11 @@ test.skipIf(!tmuxAvailable())(
       );
 
       active.sendKeysImmediate(["C-c"]);
-      await Bun.sleep(80);
+      await waitForTraceAfter(
+        tracePath,
+        traceOffset,
+        "ctrl_c_exit_hint_armed",
+      );
       active.sendKeysImmediate(["C-c"]);
       const elapsedMs = await waitForPaneExitWithin(active, 5_000);
 

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -735,6 +735,150 @@ test.skipIf(!tmuxAvailable())(
 );
 
 test.skipIf(!tmuxAvailable())(
+  "second ctrl+c cancels a legacy managed-child relationship scan",
+  async () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "fx-legacy-child-scan-exit-")));
+    const home = join(root, "home");
+    const workspace = join(root, "workspace");
+    const sessionsRoot = join(home, ".fx", "sessions");
+    const stderrPath = join(root, "stderr.log");
+    const tracePath = join(root, "trace.log");
+    mkdirSync(join(home, ".fx"), { recursive: true, mode: 0o700 });
+    mkdirSync(workspace);
+    writeFileSync(
+      join(home, ".fx", "settings.json"),
+      JSON.stringify({ sandbox: "none", permission_mode: "auto", permission: {} }),
+      { mode: 0o600 },
+    );
+    writeFileSync(stderrPath, "");
+    writeFileSync(tracePath, "");
+    const seedGateway = startFakeGateway([fakeGatewayFinalText("LEGACY_SCAN_SESSION")]);
+    let active: TmuxSession | null = null;
+    try {
+      const ask = await runFx(["ask", "--json", "--auto", "Seed the legacy scan fixture."], {
+        cwd: realpathSync(workspace),
+        env: gatewayEnv(home, seedGateway),
+        timeoutMs: TIMEOUT,
+      });
+      expect(ask.code).toBe(0);
+      expect(ask.stderr).toBe("");
+      const sessionId = String(JSON.parse(ask.stdout).session_id);
+
+      active = await TmuxSession.create({
+        cmd: FX_BIN,
+        cwd: realpathSync(workspace),
+        env: {
+          HOME: home,
+          AI_GATEWAY_API_KEY: undefined,
+          VERCEL_OIDC_TOKEN: undefined,
+          FX_AUTO_UPGRADE: "0",
+          FX_TRACE_LOG: tracePath,
+          FX_TRACE_SCOPES: "core,input",
+          NO_COLOR: "1",
+        },
+        stderrPath,
+        width: 100,
+        height: 30,
+        remainOnExit: true,
+      });
+      await active.waitForComposer(TIMEOUT);
+
+      const controlRoot = join(sessionsRoot, sessionId, "subagent");
+      mkdirSync(controlRoot, { recursive: true, mode: 0o700 });
+      chmodSync(controlRoot, 0o700);
+      const pageCount = 4_096;
+      const noSlot = (1n << 64n) - 1n;
+      const u16 = (value: number): Buffer => {
+        const bytes = Buffer.alloc(2);
+        bytes.writeUInt16LE(value);
+        return bytes;
+      };
+      const u32 = (value: number): Buffer => {
+        const bytes = Buffer.alloc(4);
+        bytes.writeUInt32LE(value);
+        return bytes;
+      };
+      const u64 = (value: bigint): Buffer => {
+        const bytes = Buffer.alloc(8);
+        bytes.writeBigUInt64LE(value);
+        return bytes;
+      };
+      const header = Buffer.concat([
+        Buffer.from("FXRELH01"),
+        u32(2),
+        u64(7n),
+        u64(1n),
+        u64(BigInt(pageCount * 64)),
+        u64(noSlot),
+        u64(0n),
+        u64(0n),
+        u64(0n),
+        Buffer.alloc(16),
+        u64(0n),
+        Buffer.from([0]),
+        u64(noSlot),
+        u64(noSlot),
+        u16(0),
+      ]);
+      writeFileSync(join(controlRoot, "relationship-index.bin"), header, { mode: 0o600 });
+      const page = Buffer.alloc(8 + 4 + 8 + 8 + 64 * (1 + 8 + 2));
+      Buffer.from("FXRELP01").copy(page, 0);
+      page.writeUInt32LE(2, 8);
+      page.writeBigUInt64LE(7n, 20);
+      for (let slot = 0; slot < 64; slot += 1) {
+        const slotOffset = 28 + slot * 11;
+        page[slotOffset] = 0;
+        page.writeBigUInt64LE(noSlot, slotOffset + 1);
+        page.writeUInt16LE(0, slotOffset + 9);
+      }
+      for (let pageNumber = 0; pageNumber < pageCount; pageNumber += 1) {
+        page.writeBigUInt64LE(BigInt(pageNumber), 12);
+        writeFileSync(
+          join(controlRoot, `relationship-page-${pageNumber.toString(16).padStart(16, "0")}.bin`),
+          page,
+          { mode: 0o600 },
+        );
+      }
+      writeFileSync(join(sessionsRoot, "index.pending"), "", { mode: 0o600 });
+
+      const traceOffset = readFileSync(tracePath, "utf8").length;
+      active.sendLiteralImmediate("/resume");
+      active.sendKeysImmediate(["Enter"]);
+      await waitForTraceAfter(
+        tracePath,
+        traceOffset,
+        `session managed child legacy scan started session=${sessionId}`,
+      );
+
+      active.sendKeysImmediate(["C-c"]);
+      await waitForTraceAfter(
+        tracePath,
+        traceOffset,
+        "ctrl_c_exit_hint_armed",
+      );
+      active.sendKeysImmediate(["C-c"]);
+      const elapsedMs = await waitForPaneExitWithin(active, 5_000);
+      const trace = readFileSync(tracePath, "utf8");
+
+      expect(elapsedMs).toBeLessThan(500);
+      expect(trace).toContain("session picker load cancellation requested");
+      expect(trace).toContain(
+        `session managed child legacy scan cancelled session=${sessionId}`,
+      );
+      expect(trace).toContain("session discovery cancelled");
+      expect(readFileSync(stderrPath, "utf8")).toBe("");
+      await active.kill();
+      active = null;
+    } finally {
+      if (active) await active.kill();
+      seedGateway.stop();
+      rmSync(root, { recursive: true, force: true });
+    }
+  },
+  TIMEOUT * 2,
+);
+
+test.skipIf(!tmuxAvailable())(
   "contended deferred updates overlay the index without scanning",
   async () => {
     const root = realpathSync(mkdtempSync(join(tmpdir(), "fx-session-snapshot-")));

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -618,6 +618,100 @@ test.skipIf(!tmuxAvailable())(
 );
 
 test.skipIf(!tmuxAvailable())(
+  "second ctrl+c cancels deferred session index reconciliation",
+  async () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "fx-session-overlay-exit-")));
+    const home = join(root, "home");
+    const workspace = join(root, "workspace");
+    const sessionsRoot = join(home, ".fx", "sessions");
+    const latestRoot = join(sessionsRoot, "latest");
+    const deferredRoot = join(latestRoot, "deferred");
+    const stderrPath = join(root, "stderr.log");
+    const tracePath = join(root, "trace.log");
+    mkdirSync(home);
+    mkdirSync(workspace);
+    writeFileSync(stderrPath, "");
+    writeFileSync(tracePath, "");
+    let active: TmuxSession | null = null;
+    try {
+      active = await TmuxSession.create({
+        cmd: FX_BIN,
+        cwd: realpathSync(workspace),
+        env: {
+          HOME: home,
+          AI_GATEWAY_API_KEY: undefined,
+          VERCEL_OIDC_TOKEN: undefined,
+          FX_AUTO_UPGRADE: "0",
+          FX_TRACE_LOG: tracePath,
+          FX_TRACE_SCOPES: "core,input",
+          NO_COLOR: "1",
+        },
+        stderrPath,
+        width: 100,
+        height: 30,
+        remainOnExit: true,
+      });
+      await active.waitForComposer(TIMEOUT);
+
+      mkdirSync(deferredRoot, { recursive: true, mode: 0o700 });
+      chmodSync(latestRoot, 0o700);
+      chmodSync(deferredRoot, 0o700);
+      writeFileSync(
+        join(sessionsRoot, "index.json"),
+        '{"schema_version":3,"sessions":[]}',
+        { mode: 0o600 },
+      );
+      rmSync(join(sessionsRoot, "index.pending"), { force: true });
+      const padding = " ".repeat(3_000);
+      for (let index = 0; index < 4_096; index += 1) {
+        const sessionId = `deferred-cancel-${index.toString().padStart(4, "0")}`;
+        writeFileSync(join(deferredRoot, sessionId), JSON.stringify({
+          schema_version: 1,
+          session_id: sessionId,
+          workspace_root: workspace,
+          position: {
+            log_generation: "11".repeat(16),
+            through_seq: 1,
+            through_event_id: "22".repeat(16),
+            through_event_log_bytes: 1,
+          },
+        }) + padding, { mode: 0o600 });
+      }
+
+      await Bun.sleep(5_100);
+      const traceOffset = readFileSync(tracePath, "utf8").length;
+      await active.sendText("/resume");
+      await waitForCondition(
+        () => readFileSync(tracePath, "utf8").slice(traceOffset).includes(
+          "session picker cache overlay stage=deferred begin",
+        ),
+        "deferred session index reconciliation",
+      );
+
+      active.sendKeysImmediate(["C-c"]);
+      await Bun.sleep(80);
+      active.sendKeysImmediate(["C-c"]);
+      const elapsedMs = await waitForPaneExitWithin(active, 5_000);
+      const trace = readFileSync(tracePath, "utf8");
+
+      expect(elapsedMs).toBeLessThan(500);
+      expect(trace).toContain("session picker load cancellation requested");
+      expect(trace).toContain(
+        "session picker cache overlay cancelled stage=deferred",
+      );
+      expect(trace).toContain("session discovery cancelled");
+      expect(readFileSync(stderrPath, "utf8")).toBe("");
+      await active.kill();
+      active = null;
+    } finally {
+      if (active) await active.kill();
+      rmSync(root, { recursive: true, force: true });
+    }
+  },
+  TIMEOUT * 2,
+);
+
+test.skipIf(!tmuxAvailable())(
   "contended deferred updates overlay the index without scanning",
   async () => {
     const root = realpathSync(mkdtempSync(join(tmpdir(), "fx-session-snapshot-")));

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -269,6 +269,18 @@ async function waitForCondition(
   throw new Error(`Timed out waiting for ${description}.`);
 }
 
+async function waitForPaneExitWithin(
+  session: TmuxSession,
+  timeout: number,
+): Promise<number> {
+  const started = performance.now();
+  while (performance.now() - started < timeout) {
+    if (!session.isPaneAlive()) return performance.now() - started;
+    await Bun.sleep(10);
+  }
+  throw new Error(`Timed out waiting for fx to exit after ${timeout}ms`);
+}
+
 async function waitForPersistedSessionMarker(
   home: string,
   marker: string,
@@ -344,6 +356,288 @@ async function waitForSessionPickerClosed(session: TmuxSession): Promise<string>
 function stripAnsi(text: string): string {
   return text.replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, "");
 }
+
+test.skipIf(!tmuxAvailable())(
+  "resumed session double ctrl+c exits through bounded handoff confirmation",
+  async () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "fx-resumed-fast-exit-")));
+    const home = join(root, "home");
+    const workspace = join(root, "workspace");
+    const stderrPath = join(root, "stderr.log");
+    const tracePath = join(root, "trace.log");
+    const marker = "RESUMED_FAST_EXIT_DURABLE_MARKER";
+    mkdirSync(home);
+    mkdirSync(workspace);
+    writeFileSync(stderrPath, "");
+    writeFileSync(tracePath, "");
+    const seedGateway = startFakeGateway([fakeGatewayFinalText(marker)]);
+    const resumeGateway = startFakeGateway([]);
+    let active: TmuxSession | null = null;
+    try {
+      const seed = await runFx(
+        ["ask", "--json", "--auto", "Seed the resumed fast-exit fixture."],
+        {
+          cwd: realpathSync(workspace),
+          env: gatewayEnv(home, seedGateway),
+          timeoutMs: TIMEOUT,
+        },
+      );
+      expect(seed.code).toBe(0);
+      expect(seed.stderr).toBe("");
+      const sessionId = String(JSON.parse(seed.stdout).session_id);
+
+      active = await TmuxSession.create({
+        cmd: `${FX_BIN} --resume ${sessionId}`,
+        cwd: realpathSync(workspace),
+        env: {
+          ...gatewayEnv(home, resumeGateway),
+          FX_TRACE_LOG: tracePath,
+          FX_TRACE_SCOPES: "input,session",
+        },
+        stderrPath,
+        width: 100,
+        height: 30,
+        remainOnExit: true,
+      });
+      await active.waitForComposer(TIMEOUT);
+      await active.waitForText(marker, TIMEOUT);
+
+      active.sendKeysImmediate(["C-c"]);
+      await Bun.sleep(80);
+      active.sendKeysImmediate(["C-c"]);
+      const elapsedMs = await waitForPaneExitWithin(active, 5_000);
+
+      expect(elapsedMs).toBeLessThan(500);
+      expect(readFileSync(tracePath, "utf8")).toContain(
+        "event=resume_handoff_confirmation mode=metadata outcome=ready",
+      );
+      expect(readFileSync(stderrPath, "utf8")).toBe("");
+      await active.kill();
+      active = null;
+
+      const persisted = await runFx(["session", "--id", sessionId, "--json"], {
+        cwd: realpathSync(workspace),
+        env: { HOME: home },
+        timeoutMs: TIMEOUT,
+      });
+      expect(persisted.code).toBe(0);
+      expect(persisted.stderr).toBe("");
+      expect(persisted.stdout).toContain(marker);
+    } finally {
+      if (active) await active.kill();
+      seedGateway.stop();
+      resumeGateway.stop();
+      rmSync(root, { recursive: true, force: true });
+    }
+  },
+  TIMEOUT * 2,
+);
+
+test.skipIf(!tmuxAvailable())(
+  "second ctrl+c cancels an active session discovery scan",
+  async () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "fx-session-scan-exit-")));
+    const home = join(root, "home");
+    const workspace = join(root, "workspace");
+    const sessionsRoot = join(home, ".fx", "sessions");
+    const stderrPath = join(root, "stderr.log");
+    const tracePath = join(root, "trace.log");
+    mkdirSync(sessionsRoot, { recursive: true });
+    mkdirSync(workspace);
+    writeFileSync(stderrPath, "");
+    writeFileSync(tracePath, "");
+    for (let index = 0; index < 4_000; index += 1) {
+      const sessionDir = join(sessionsRoot, `fixture-${index.toString().padStart(5, "0")}`);
+      mkdirSync(sessionDir);
+      writeFileSync(join(sessionDir, "session.json"), '{"invalid":true}\n');
+    }
+    writeFileSync(join(sessionsRoot, "index.pending"), "");
+
+    let active: TmuxSession | null = null;
+    try {
+      active = await TmuxSession.create({
+        cmd: FX_BIN,
+        cwd: realpathSync(workspace),
+        env: {
+          HOME: home,
+          AI_GATEWAY_API_KEY: undefined,
+          VERCEL_OIDC_TOKEN: undefined,
+          FX_AUTO_UPGRADE: "0",
+          FX_TRACE_LOG: tracePath,
+          FX_TRACE_SCOPES: "core,input",
+          NO_COLOR: "1",
+        },
+        stderrPath,
+        width: 100,
+        height: 30,
+        remainOnExit: true,
+      });
+      await active.waitForComposer(TIMEOUT);
+      await active.sendText("/resume");
+      await waitForCondition(
+        () => readFileSync(tracePath, "utf8").includes(
+          "session picker cache outcome=miss action=backfill",
+        ),
+        "explicit session discovery",
+      );
+
+      active.sendKeysImmediate(["C-c"]);
+      await Bun.sleep(80);
+      active.sendKeysImmediate(["C-c"]);
+      const elapsedMs = await waitForPaneExitWithin(active, 5_000);
+
+      expect(elapsedMs).toBeLessThan(500);
+      const trace = readFileSync(tracePath, "utf8");
+      expect(trace).toContain("session picker load cancellation requested");
+      expect(trace).toContain("session discovery cancelled");
+      expect(readFileSync(stderrPath, "utf8")).toBe("");
+      await active.kill();
+      active = null;
+    } finally {
+      if (active) await active.kill();
+      rmSync(root, { recursive: true, force: true });
+    }
+  },
+  TIMEOUT,
+);
+
+test.skipIf(!tmuxAvailable())(
+  "contended deferred updates overlay the index without scanning",
+  async () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "fx-session-snapshot-")));
+    const home = join(root, "home");
+    const workspace = join(root, "workspace");
+    const sessionsRoot = join(home, ".fx", "sessions");
+    const latestRoot = join(sessionsRoot, "latest");
+    const deferredRoot = join(latestRoot, "deferred");
+    const stderrPath = join(root, "stderr.log");
+    const tracePath = join(root, "trace.log");
+    const lockReadyPath = join(root, "lock.ready");
+    mkdirSync(join(home, ".fx"), { recursive: true, mode: 0o700 });
+    mkdirSync(workspace);
+    writeFileSync(
+      join(home, ".fx", "settings.json"),
+      JSON.stringify({ sandbox: "none", permission_mode: "auto", permission: {} }),
+    );
+    writeFileSync(stderrPath, "");
+    writeFileSync(tracePath, "");
+    chmodSync(join(home, ".fx"), 0o700);
+    const seedGateway = startFakeGateway([fakeGatewayFinalText("SNAPSHOT_INDEX_SESSION")]);
+    let active: TmuxSession | null = null;
+    let lockHolder: ReturnType<typeof Bun.spawn> | null = null;
+    try {
+      const ask = await runFx(["ask", "--json", "--auto", "Seed the index reconciliation fixture."], {
+        cwd: realpathSync(workspace),
+        env: gatewayEnv(home, seedGateway),
+        timeoutMs: TIMEOUT,
+      });
+      expect(ask.code).toBe(0);
+      expect(ask.stderr).toBe("");
+      const seededId = String(JSON.parse(ask.stdout).session_id);
+
+      mkdirSync(deferredRoot, { recursive: true, mode: 0o700 });
+      chmodSync(latestRoot, 0o700);
+      chmodSync(deferredRoot, 0o700);
+      const summaries = Array.from({ length: 4_000 }, (_, index) => ({
+        id: index === 0 ? seededId : `snapshot-${index.toString().padStart(5, "0")}`,
+        created_at_ms: 1,
+        updated_at_ms: 4_000 - index,
+        workspace_root: workspace,
+        conversation_language: "en",
+        history_len: 1,
+        display_metadata_present: true,
+        title: `Snapshot session ${index.toString().padStart(5, "0")}`,
+        preview: `Snapshot session ${index.toString().padStart(5, "0")}`,
+      }));
+      const indexPath = join(sessionsRoot, "index.json");
+      writeFileSync(
+        indexPath,
+        JSON.stringify({ schema_version: 3, sessions: summaries }),
+        { mode: 0o600 },
+      );
+      rmSync(join(sessionsRoot, "index.pending"), { force: true });
+      const deferredPath = join(deferredRoot, seededId);
+      writeFileSync(deferredPath, JSON.stringify({
+        schema_version: 1,
+        session_id: seededId,
+        workspace_root: workspace,
+        position: {
+          log_generation: "11".repeat(16),
+          through_seq: 1,
+          through_event_id: "22".repeat(16),
+          through_event_log_bytes: 1,
+        },
+      }), { mode: 0o600 });
+      lockHolder = Bun.spawn([
+        "python3",
+        "-c",
+        [
+          "import fcntl, os, sys, time",
+          "lock_path, ready_path = sys.argv[1:3]",
+          "lock = open(lock_path, 'a')",
+          "fcntl.flock(lock, fcntl.LOCK_EX)",
+          "open(ready_path, 'w').write(str(os.getpid()))",
+          "time.sleep(30)",
+        ].join("\n"),
+        join(sessionsRoot, "latest.lock"),
+        lockReadyPath,
+      ], { stdout: "ignore", stderr: "ignore" });
+      await waitForCondition(
+        () => existsSync(lockReadyPath),
+        "latest index lock holder",
+      );
+
+      active = await TmuxSession.create({
+        cmd: FX_BIN,
+        cwd: realpathSync(workspace),
+        env: {
+          HOME: home,
+          AI_GATEWAY_API_KEY: undefined,
+          VERCEL_OIDC_TOKEN: undefined,
+          FX_AUTO_UPGRADE: "0",
+          FX_TRACE_LOG: tracePath,
+          FX_TRACE_SCOPES: "core,session,input",
+          NO_COLOR: "1",
+        },
+        stderrPath,
+        width: 100,
+        height: 30,
+        remainOnExit: true,
+      });
+      await active.waitForComposer(TIMEOUT);
+      const started = performance.now();
+      await active.sendText("/resume");
+      await active.waitForPane((pane) =>
+        pane.includes("Snapshot session 00000") && !pane.includes("Loading sessions"),
+      TIMEOUT);
+      const paintMs = performance.now() - started;
+
+      expect(paintMs).toBeLessThan(500);
+      const traceBeforeExit = readFileSync(tracePath, "utf8");
+      expect(traceBeforeExit).toMatch(
+        /session picker cache overlay outcome=ready scope=\w+ deferred=[1-9]/,
+      );
+      expect(traceBeforeExit).not.toContain("session discovery mode=read_only_list");
+
+      active.sendKeysImmediate(["C-c"]);
+      await Bun.sleep(80);
+      active.sendKeysImmediate(["C-c"]);
+      expect(await waitForPaneExitWithin(active, 5_000)).toBeLessThan(500);
+      expect(readFileSync(stderrPath, "utf8")).toBe("");
+      await active.kill();
+      active = null;
+    } finally {
+      if (active) await active.kill();
+      if (lockHolder) {
+        lockHolder.kill("SIGKILL");
+        await lockHolder.exited;
+      }
+      seedGateway.stop();
+      rmSync(root, { recursive: true, force: true });
+    }
+  },
+  TIMEOUT,
+);
 
 type SessionPickerEntry = {
   row: number;
@@ -4493,7 +4787,9 @@ test.skipIf(!tmuxAvailable())(
       const sessionId = sessionIdFromHome(home);
       expect(sessionId).toMatch(/^[A-Za-z0-9_-]{12}$/);
 
-      await active.sendText("/quit");
+      active.sendKeysImmediate(["C-c"]);
+      await Bun.sleep(80);
+      active.sendKeysImmediate(["C-c"]);
       await waitForCondition(
         () => active?.paneStatus().dead === true,
         "the graceful exit pane to stop",

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -434,6 +434,122 @@ test.skipIf(!tmuxAvailable())(
 );
 
 test.skipIf(!tmuxAvailable())(
+  "deferred index publication preserves the fast exit resume handoff",
+  async () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "fx-deferred-exit-handoff-")));
+    const home = join(root, "home");
+    const workspace = join(root, "workspace");
+    const sessionsRoot = join(home, ".fx", "sessions");
+    const stderrPath = join(root, "stderr.log");
+    const resumedStderrPath = join(root, "resumed-stderr.log");
+    const tracePath = join(root, "trace.log");
+    const lockReadyPath = join(root, "lock.ready");
+    const marker = "DEFERRED_INDEX_EXIT_HANDOFF";
+    mkdirSync(home);
+    mkdirSync(workspace);
+    writeFileSync(stderrPath, "");
+    writeFileSync(resumedStderrPath, "");
+    writeFileSync(tracePath, "");
+    const gateway = startFakeGateway([fakeGatewayFinalText(marker)]);
+    const resumeGateway = startFakeGateway([]);
+    let active: TmuxSession | null = null;
+    let resumed: TmuxSession | null = null;
+    let lockHolder: ReturnType<typeof Bun.spawn> | null = null;
+    try {
+      active = await TmuxSession.create({
+        cmd: FX_BIN,
+        cwd: realpathSync(workspace),
+        env: {
+          ...gatewayEnv(home, gateway),
+          FX_TRACE_LOG: tracePath,
+          FX_TRACE_SCOPES: "input,session",
+        },
+        stderrPath,
+        width: 100,
+        height: 30,
+        remainOnExit: true,
+      });
+      await active.waitForComposer(TIMEOUT);
+
+      lockHolder = Bun.spawn([
+        "python3",
+        "-c",
+        [
+          "import fcntl, os, signal, sys",
+          "lock_path, ready_path = sys.argv[1:3]",
+          "lock = open(lock_path, 'a')",
+          "fcntl.flock(lock, fcntl.LOCK_EX)",
+          "open(ready_path, 'w').write(str(os.getpid()))",
+          "signal.pause()",
+        ].join("\n"),
+        join(sessionsRoot, "latest.lock"),
+        lockReadyPath,
+      ], { stdout: "ignore", stderr: "ignore" });
+      await waitForCondition(
+        () => existsSync(lockReadyPath),
+        "latest index lock holder",
+      );
+
+      await active.sendText("Commit this turn while the session index is contended.");
+      await active.waitForText(marker, TIMEOUT);
+      const sessionId = sessionIdFromHome(home);
+      await waitForCondition(
+        () => existsSync(join(sessionsRoot, "latest", "deferred", sessionId)),
+        "deferred session index token",
+      );
+      expect(lockHolder.exitCode).toBeNull();
+
+      active.sendKeysImmediate(["C-c"]);
+      await Bun.sleep(80);
+      active.sendKeysImmediate(["C-c"]);
+      const elapsedMs = await waitForPaneExitWithin(active, 5_000);
+      const scrollback = stripAnsi(await active.captureFullScrollback());
+      const expected = `Continue session with: fx --resume ${sessionId}`;
+
+      expect(elapsedMs).toBeLessThan(500);
+      expect(countOccurrences(scrollback, expected)).toBe(1);
+      expect(readFileSync(tracePath, "utf8")).toContain(
+        "event=resume_handoff_confirmation mode=metadata outcome=ready",
+      );
+      expect(readFileSync(stderrPath, "utf8")).toBe("");
+      await active.kill();
+      active = null;
+
+      lockHolder.kill("SIGKILL");
+      await lockHolder.exited;
+      lockHolder = null;
+      resumed = await TmuxSession.create({
+        cmd: `${FX_BIN} --resume ${sessionId}`,
+        cwd: realpathSync(workspace),
+        env: gatewayEnv(home, resumeGateway),
+        stderrPath: resumedStderrPath,
+        width: 100,
+        height: 30,
+      });
+      await resumed.waitForComposer(TIMEOUT);
+      expect(stripAnsi(await waitForScrollback(resumed, marker))).toContain(marker);
+      expect(resumeGateway.requests).toHaveLength(0);
+      expect(readFileSync(resumedStderrPath, "utf8")).toBe("");
+      await resumed.sendText("/quit");
+      expect(await resumed.waitForSessionEnd()).toBe(true);
+      await resumed.kill();
+      resumed = null;
+    } finally {
+      if (active) await active.kill();
+      if (resumed) await resumed.kill();
+      if (lockHolder) {
+        lockHolder.kill("SIGKILL");
+        await lockHolder.exited;
+      }
+      gateway.stop();
+      resumeGateway.stop();
+      rmSync(root, { recursive: true, force: true });
+    }
+  },
+  TIMEOUT * 2,
+);
+
+test.skipIf(!tmuxAvailable())(
   "second ctrl+c cancels an active session discovery scan",
   async () => {
     const root = realpathSync(mkdtempSync(join(tmpdir(), "fx-session-scan-exit-")));

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -269,6 +269,20 @@ async function waitForCondition(
   throw new Error(`Timed out waiting for ${description}.`);
 }
 
+async function waitForTraceAfter(
+  path: string,
+  offset: number,
+  needle: string,
+  timeout = TIMEOUT,
+): Promise<void> {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    if (readFileSync(path, "utf8").slice(offset).includes(needle)) return;
+    await Bun.sleep(1);
+  }
+  throw new Error(`Timed out waiting for trace event ${needle}.`);
+}
+
 async function waitForPaneExitWithin(
   session: TmuxSession,
   timeout: number,
@@ -681,11 +695,10 @@ test.skipIf(!tmuxAvailable())(
       await Bun.sleep(5_100);
       const traceOffset = readFileSync(tracePath, "utf8").length;
       await active.sendText("/resume");
-      await waitForCondition(
-        () => readFileSync(tracePath, "utf8").slice(traceOffset).includes(
-          "session picker cache overlay stage=deferred begin",
-        ),
-        "deferred session index reconciliation",
+      await waitForTraceAfter(
+        tracePath,
+        traceOffset,
+        "session picker cache overlay stage=deferred begin",
       );
 
       active.sendKeysImmediate(["C-c"]);

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -694,7 +694,8 @@ test.skipIf(!tmuxAvailable())(
 
       await Bun.sleep(5_100);
       const traceOffset = readFileSync(tracePath, "utf8").length;
-      await active.sendText("/resume");
+      active.sendLiteralImmediate("/resume");
+      active.sendKeysImmediate(["Enter"]);
       await waitForTraceAfter(
         tracePath,
         traceOffset,

--- a/tests/e2e/tui-terminal-tool.test.ts
+++ b/tests/e2e/tui-terminal-tool.test.ts
@@ -186,6 +186,31 @@ async function waitForFile(path: string): Promise<void> {
   throw new Error(`Timed out waiting for ${path}`);
 }
 
+async function waitForProcessExit(
+  session: TmuxSession,
+  timeoutMs: number,
+): Promise<number> {
+  const startedAt = performance.now();
+  while (performance.now() - startedAt < timeoutMs) {
+    if (!session.isAlive()) return performance.now() - startedAt;
+    await Bun.sleep(10);
+  }
+  throw new Error(`Timed out waiting for fx to exit after ${timeoutMs}ms`);
+}
+
+async function waitForPidExit(pid: number, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      process.kill(pid, 0);
+    } catch {
+      return;
+    }
+    await Bun.sleep(10);
+  }
+  throw new Error(`Timed out waiting for process ${pid} to exit`);
+}
+
 test.skipIf(!tmuxAvailable())(
   "shell captured empty observation floors short waits without respawn",
   async () => {
@@ -300,6 +325,98 @@ test.skipIf(!tmuxAvailable())(
       "shell_cross_turn_stop",
     )).toContain('\\"state\\":\\"stopped\\"');
     expect(readFileSync(fixture.stderrPath, "utf8")).toBe("");
+  },
+  TIMEOUT,
+);
+
+test.skipIf(!tmuxAvailable())(
+  "second ctrl+c exits promptly when an external process retains command output",
+  async () => {
+    const fixture = createFixture("fx-shell-exit-held-output-");
+    const brokerPath = join(fixture.workspace, "fd-broker.py");
+    const senderPath = join(fixture.workspace, "fd-sender.py");
+    const socketPath = join(fixture.workspace, "broker.sock");
+    const readyPath = join(fixture.workspace, "broker.ready");
+    const heldPath = join(fixture.workspace, "broker.held");
+    const senderPidPath = join(fixture.workspace, "sender.pid");
+    writeFileSync(
+      brokerPath,
+      [
+        "import array, os, socket, sys, time",
+        "socket_path, ready_path, held_path = sys.argv[1:4]",
+        "server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)",
+        "server.bind(socket_path)",
+        "server.listen(1)",
+        "open(ready_path, 'w').write(str(os.getpid()))",
+        "connection, _ = server.accept()",
+        "fds = array.array('i')",
+        "_, ancillary, _, _ = connection.recvmsg(1, socket.CMSG_SPACE(fds.itemsize))",
+        "for level, kind, data in ancillary:",
+        "    if level == socket.SOL_SOCKET and kind == socket.SCM_RIGHTS:",
+        "        fds.frombytes(data[:fds.itemsize])",
+        "if not fds:",
+        "    raise RuntimeError('missing output descriptor')",
+        "open(held_path, 'w').write(str(fds[0]))",
+        "time.sleep(30)",
+      ].join("\n") + "\n",
+    );
+    writeFileSync(
+      senderPath,
+      [
+        "import array, os, socket, sys",
+        "socket_path, pid_path = sys.argv[1:3]",
+        "open(pid_path, 'w').write(str(os.getpid()))",
+        "client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)",
+        "client.connect(socket_path)",
+        "fds = array.array('i', [1])",
+        "client.sendmsg([b'x'], [(socket.SOL_SOCKET, socket.SCM_RIGHTS, fds)])",
+        "client.close()",
+        "print('BROKERED_OUTPUT', flush=True)",
+      ].join("\n") + "\n",
+    );
+
+    const broker = Bun.spawn(
+      ["python3", brokerPath, socketPath, readyPath, heldPath],
+      { stdout: "ignore", stderr: "ignore" },
+    );
+    try {
+      await waitForFile(readyPath);
+      const gateway = startFakeGateway([
+        fakeGatewayToolCall("shell_exit_held_output", "shell", {
+          request: {
+            action: "run",
+            command: `python3 ${JSON.stringify(senderPath)} ${JSON.stringify(socketPath)} ${JSON.stringify(senderPidPath)}`,
+            profile: "clean",
+            yield_time_ms: 0,
+          },
+        }),
+        fakeGatewayFinalText("SHELL_EXIT_READY"),
+      ]);
+      gateways.push(gateway);
+      const active = await launch(fixture, gateway);
+      await active.sendText("Finish the turn while the external process retains command output.");
+      await active.waitForText("SHELL_EXIT_READY", TIMEOUT);
+      await waitForFile(senderPidPath);
+      await waitForFile(heldPath);
+
+      const senderPid = Number(readFileSync(senderPidPath, "utf8"));
+      expect(Number.isSafeInteger(senderPid) && senderPid > 0).toBe(true);
+      await waitForPidExit(senderPid, 3_000);
+      expect(() => process.kill(senderPid, 0)).toThrow();
+      expect(() => process.kill(broker.pid, 0)).not.toThrow();
+
+      active.sendKeysImmediate(["C-c"]);
+      await Bun.sleep(80);
+      active.sendKeysImmediate(["C-c"]);
+      const elapsedMs = await waitForProcessExit(active, 7_000);
+
+      expect(elapsedMs).toBeLessThan(500);
+      expect(() => process.kill(broker.pid, 0)).not.toThrow();
+      expect(readFileSync(fixture.stderrPath, "utf8")).toBe("");
+    } finally {
+      broker.kill("SIGKILL");
+      await broker.exited;
+    }
   },
   TIMEOUT,
 );

--- a/tests/e2e/tui-terminal-tool.test.ts
+++ b/tests/e2e/tui-terminal-tool.test.ts
@@ -84,7 +84,7 @@ async function launch(
       FX_GATEWAY_BASE_URL: gateway.baseUrl,
       FX_GATEWAY_CHAT_URL: gateway.chatUrl,
       FX_TRACE_LOG: fixture.tracePath,
-      FX_TRACE_SCOPES: "shell,terminal,terminal_client,terminal_host,tool,agent",
+      FX_TRACE_SCOPES: "core,shell,terminal,terminal_client,terminal_host,tool,agent",
       FX_TERMINAL_HOST_IDLE_MS: "500",
     },
     width: 120,
@@ -342,7 +342,7 @@ test.skipIf(!tmuxAvailable())(
     writeFileSync(
       brokerPath,
       [
-        "import array, os, socket, sys, time",
+        "import array, os, signal, socket, sys",
         "socket_path, ready_path, held_path = sys.argv[1:4]",
         "server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)",
         "server.bind(socket_path)",
@@ -357,7 +357,7 @@ test.skipIf(!tmuxAvailable())(
         "if not fds:",
         "    raise RuntimeError('missing output descriptor')",
         "open(held_path, 'w').write(str(fds[0]))",
-        "time.sleep(30)",
+        "signal.pause()",
       ].join("\n") + "\n",
     );
     writeFileSync(
@@ -403,7 +403,7 @@ test.skipIf(!tmuxAvailable())(
       expect(Number.isSafeInteger(senderPid) && senderPid > 0).toBe(true);
       await waitForPidExit(senderPid, 3_000);
       expect(() => process.kill(senderPid, 0)).toThrow();
-      expect(() => process.kill(broker.pid, 0)).not.toThrow();
+      expect(broker.exitCode).toBeNull();
 
       active.sendKeysImmediate(["C-c"]);
       await Bun.sleep(80);
@@ -411,7 +411,10 @@ test.skipIf(!tmuxAvailable())(
       const elapsedMs = await waitForProcessExit(active, 7_000);
 
       expect(elapsedMs).toBeLessThan(500);
-      expect(() => process.kill(broker.pid, 0)).not.toThrow();
+      expect(broker.exitCode).toBeNull();
+      expect(readFileSync(fixture.tracePath, "utf8")).toContain(
+        "command output drain abandoned reason=runtime_shutdown wait_ready=true",
+      );
       expect(readFileSync(fixture.stderrPath, "utf8")).toBe("");
     } finally {
       broker.kill("SIGKILL");


### PR DESCRIPTION
## Summary

- Load large session lists from reconciled index snapshots without scanning every stored session.
- Apply deferred session updates to prewarmed picker results so opened lists stay current.
- Fall back to canonical discovery while an unjournaled index publication is pending.
- Cancel active session discovery, index reconciliation, and legacy managed-child scans when the user exits.
- Terminate managed commands promptly even when another process retains their output descriptor.
- Confirm resume handoffs from bounded metadata so large sessions exit without replaying their full event log.
- Preserve the printed resume command after completed turns while usage accounting is still pending.
- Preserve the printed resume command when derived index publication is deferred or fails after the canonical commit.
- Keep ordinary sessions visible by propagating managed-child probe allocation failures.
- Keep checkpoint generation off the exit path and avoid retrying oversized checkpoints at the same committed position.