### PR TITLE
Keep file and model pickers open during active turns

### DIFF
--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -1486,7 +1486,7 @@ pub fn Runtime(comptime App: type) type {
                 },
                 ' ' => {
                     dismissMentionSkillsMenuForSpace(app);
-                    if (!queueReviewOwnsComposer(app) and
+                    if (!queue_rt.ownsComposer(app) and
                         app.input_runtime.edit_state.selectionRange() == null and
                         !commandSkillsMenuActive(app) and
                         completion_rt.hasModelQuery(app))
@@ -1519,7 +1519,7 @@ pub fn Runtime(comptime App: type) type {
                     return;
                 },
                 '\r' => {
-                    const queue_review_owns_composer = queueReviewOwnsComposer(app);
+                    const queue_review_owns_composer = queue_rt.ownsComposer(app);
                     if (try submitSettingsMenuSelection(app)) return;
                     if (try submitHelpMenuSelection(app, max_input_len, max_prompt_history)) return;
                     if (try submitAuthPickerSelection(app)) return;
@@ -2223,13 +2223,6 @@ pub fn Runtime(comptime App: type) type {
             app.shell.render_requests.request(.footer);
         }
 
-        fn queueReviewOwnsComposer(app: *const App) bool {
-            if (comptime @hasField(App, "queued_prompt_review")) {
-                return app.queued_prompt_review.visible;
-            }
-            return false;
-        }
-
         fn closeSkillsMenu(app: *App) bool {
             if (comptime !@hasField(App, "skills")) return false;
             if (!app.skills.menu.active) return false;
@@ -2664,7 +2657,7 @@ pub fn Runtime(comptime App: type) type {
 
         fn submitSlashPickerSelection(app: *App) !bool {
             if (comptime !@hasField(App, "skills")) return false;
-            if (queueReviewOwnsComposer(app)) return false;
+            if (queue_rt.ownsComposer(app)) return false;
             if (nonSlashPickerOwnsEnter(app)) return false;
             const items = app.input_runtime.edit_state.input.items;
             const prefix = command_specs.slashCompletionPrefix(
@@ -2724,7 +2717,7 @@ pub fn Runtime(comptime App: type) type {
             app: *App,
             parsed: ExplicitModelSelectionParse,
         ) !bool {
-            if (queueReviewOwnsComposer(app)) return false;
+            if (queue_rt.ownsComposer(app)) return false;
             switch (parsed) {
                 .none => return false,
                 .invalid => {

--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -6605,6 +6605,31 @@ test "app_input_runtime stream model picker opens navigates and selects" {
     try std.testing.expectEqual(@as(usize, 0), app.submitted_prompt_count);
 }
 
+test "app_input_runtime fast-only model opens the Fast stage while streaming" {
+    const alloc = std.testing.allocator;
+    const model = "provider/fast-only-model";
+    var app = try RoutingFakeApp.init(alloc);
+    defer app.deinit();
+    app.setGatewayControls(model, &.{}, true);
+    app.model_completion_values = &.{model};
+    app.stream.active = true;
+    try app.input_runtime.textReplacementState().replace(alloc, "/model provider/fast");
+
+    try Runtime(RoutingFakeApp).handleByte(&app, '\r', 4096, 100);
+
+    const query = app.input_runtime.picker.activeModelPickerQuery(&app.input_runtime.edit_state) orelse return error.TestExpectedEqual;
+    try std.testing.expectEqual(ModelPickerStage.fast, query.stage);
+    try std.testing.expectEqualStrings("", query.query);
+
+    try Runtime(RoutingFakeApp).handleByte(&app, '\r', 4096, 100);
+
+    try std.testing.expect(app.stream.active);
+    try std.testing.expectEqualStrings(model, app.selected_model.items);
+    try std.testing.expect(app.fast_mode);
+    try std.testing.expectEqual(@as(usize, 1), app.preference_commit_count);
+    try std.testing.expectEqualStrings("Next turn will use " ++ model, app.notice_body.items);
+}
+
 test "app_input_runtime Enter submits a dismissed slash skill query as text" {
     const alloc = std.testing.allocator;
     const skills = [_]skill_runtime.Skill{.{

--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -296,12 +296,16 @@ pub fn Runtime(comptime App: type) type {
                         .character_left => {
                             app.input_runtime.vertical_navigation.reset();
                             if (!intent.extend_selection and
-                                app.input_runtime.edit_state.selectionRange() == null and
-                                !app.stream.active and
-                                (try provider_picker_rt.stepBack(app) or try completion_rt.stepBackModelPicker(app)))
+                                app.input_runtime.edit_state.selectionRange() == null)
                             {
-                                app.shell.render_requests.request(.footer);
-                                return;
+                                if (!app.stream.active and try provider_picker_rt.stepBack(app)) {
+                                    app.shell.render_requests.request(.footer);
+                                    return;
+                                }
+                                if (try completion_rt.stepBackModelPicker(app)) {
+                                    app.shell.render_requests.request(.footer);
+                                    return;
+                                }
                             }
                             _ = app.input_runtime.moveInputCursor(intent);
                         },
@@ -1440,7 +1444,7 @@ pub fn Runtime(comptime App: type) type {
                         app.shell.render_requests.request(.footer);
                     } else if (cycleModelMenuProvider(app, 1) or cycleSkillsMenuSource(app, 1)) {
                         app.shell.render_requests.request(.footer);
-                    } else if (!app.stream.active and picker_state.isBareModelCommandAtCursor(&app.input_runtime.edit_state)) {
+                    } else if (picker_state.isBareModelCommandAtCursor(&app.input_runtime.edit_state)) {
                         try completion_rt.openCurrentModelPicker(app);
                     } else if (completion_rt.hasFileQuery(app)) {
                         if ((try completion_rt.autocompleteFilePickerSelection(app, max_input_len)) == .limit_exceeded) {
@@ -1450,10 +1454,7 @@ pub fn Runtime(comptime App: type) type {
                     } else if (!commandSkillsMenuActive(app) and provider_picker_rt.hasQuery(app)) {
                         if (!app.stream.active) try provider_picker_rt.autocomplete(app);
                     } else if (!commandSkillsMenuActive(app) and completion_rt.hasModelQuery(app)) {
-                        // Mid-turn: list is hidden — do not autocomplete a hidden index.
-                        if (!app.stream.active) {
-                            try completion_rt.autocompleteModelPickerSelection(app);
-                        }
+                        try completion_rt.autocompleteModelPickerSelection(app);
                     } else if (completion_rt.visibleInlineCompletion(app) != null) {
                         if ((try completion_rt.autocompleteInlineCompletion(app, max_input_len)) == .limit_exceeded) {
                             try input_limit_feedback.report(App, app, .composer, 1);
@@ -1550,19 +1551,6 @@ pub fn Runtime(comptime App: type) type {
                         if (try provider_picker_rt.submit(app)) return;
                     }
                     if (completion_rt.hasModelQuery(app)) {
-                        if (app.stream.active) {
-                            if (try submitExplicitModelSelection(
-                                app,
-                                resolveExplicitModelSelection(app, app.input_runtime.edit_state.input.items),
-                            )) return;
-                            try app.writeDomainNotice(.{
-                                .topic = "model",
-                                .tone = .neutral,
-                                .body = "Complete the model selection for the next turn: /model <id> <effort> [normal|fast].",
-                            }, true);
-                            app.shell.render_requests.request(.footer);
-                            return;
-                        }
                         if (try completion_rt.submitModelPicker(app)) return;
                     }
                     if (try submitExplicitModelSelection(
@@ -6397,21 +6385,24 @@ test "active stream Enter commits a complete model choice for the next turn" {
     );
 }
 
-test "active stream Enter explains an incomplete hidden model choice" {
+test "active stream Enter selects the visible model choice" {
     const alloc = std.testing.allocator;
     var app = try RoutingFakeApp.init(alloc);
     defer app.deinit();
+    const model = "provider/plain-model";
+    app.model_completion_values = &.{model};
 
-    try app.input_runtime.textReplacementState().replace(alloc, "/model openai/gpt");
+    try app.input_runtime.textReplacementState().replace(alloc, "/model provider/plain");
     app.stream.active = true;
 
     try Runtime(RoutingFakeApp).handleByte(&app, '\r', 4096, 100);
 
     try std.testing.expect(app.stream.active);
-    try std.testing.expectEqual(@as(usize, 0), app.preference_commit_count);
-    try std.testing.expectEqualStrings("/model openai/gpt", app.input_runtime.edit_state.input.items);
+    try std.testing.expectEqual(@as(usize, 1), app.preference_commit_count);
+    try std.testing.expectEqualStrings(model, app.selected_model.items);
+    try std.testing.expectEqualStrings("", app.input_runtime.edit_state.input.items);
     try std.testing.expectEqualStrings(
-        "Complete the model selection for the next turn: /model <id> <effort> [normal|fast].",
+        "Next turn will use " ++ model,
         app.notice_body.items,
     );
     try std.testing.expectEqual(@as(usize, 0), app.submitted_prompt_count);
@@ -6590,46 +6581,28 @@ test "app_input_runtime bare model Tab keeps current selection beyond completion
     try std.testing.expectEqual(@as(usize, 0), app.preference_commit_count);
 }
 
-test "app_input_runtime stream model-shaped keys stay model-owned" {
+test "app_input_runtime stream model picker opens navigates and selects" {
     const alloc = std.testing.allocator;
-    const skills = [_]skill_runtime.Skill{.{
-        .name = "model-helper",
-        .description = "model helper",
-        .path = "/tmp/model-helper/SKILL.md",
-        .source = .global_fx,
-    }};
-    const completions = [_][]const u8{"xai/grok-build-1"};
-    const cases = [_]struct {
-        input: []const u8,
-        byte: u8,
-        expect_input: []const u8,
-        expect_catalog: bool = false,
-    }{
-        .{ .input = "/model ", .byte = '\r', .expect_input = "/model " },
-        .{ .input = "/model", .byte = '\r', .expect_input = "", .expect_catalog = true },
-        .{ .input = "/model", .byte = '\t', .expect_input = "/model" },
-        .{ .input = "/model ", .byte = '\t', .expect_input = "/model " },
+    const models = [_][]const u8{
+        "provider/first-model",
+        "provider/second-model",
     };
+    var app = try RoutingFakeApp.init(alloc);
+    defer app.deinit();
+    app.model_completion_values = &models;
+    app.stream.active = true;
+    try app.input_runtime.textReplacementState().replace(alloc, "/model");
 
-    for (cases) |case| {
-        var app = try RoutingFakeApp.init(alloc);
-        defer app.deinit();
-        app.skills.items = @constCast(&skills);
-        app.model_completion_values = &completions;
-        app.selected_model.clearRetainingCapacity();
-        try app.selected_model.appendSlice(alloc, "anthropic/claude-opus-4.7");
-        app.stream.active = true;
-        try app.input_runtime.textReplacementState().replace(alloc, case.input);
+    try Runtime(RoutingFakeApp).handleByte(&app, '\t', 4096, 100);
+    try Runtime(RoutingFakeApp).routePlainVertical(&app, .down, 1);
+    try Runtime(RoutingFakeApp).handleByte(&app, '\t', 4096, 100);
+    try Runtime(RoutingFakeApp).handleByte(&app, '\r', 4096, 100);
 
-        try Runtime(RoutingFakeApp).handleByte(&app, case.byte, 4096, 100);
-
-        try std.testing.expectEqualStrings(case.expect_input, app.input_runtime.edit_state.input.items);
-        try std.testing.expectEqual(@as(usize, 0), app.preference_commit_count);
-        try std.testing.expectEqual(@as(usize, 0), app.input_runtime.entities.skill_tokens.items.len);
-        try std.testing.expectEqualStrings("anthropic/claude-opus-4.7", app.selected_model.items);
-        try std.testing.expectEqual(@as(usize, 0), app.submitted_prompt_count);
-        try std.testing.expectEqual(case.expect_catalog, app.model_cache.menu.active);
-    }
+    try std.testing.expect(app.stream.active);
+    try std.testing.expectEqual(@as(usize, 1), app.preference_commit_count);
+    try std.testing.expectEqualStrings(models[1], app.selected_model.items);
+    try std.testing.expectEqualStrings("", app.input_runtime.edit_state.input.items);
+    try std.testing.expectEqual(@as(usize, 0), app.submitted_prompt_count);
 }
 
 test "app_input_runtime Enter submits a dismissed slash skill query as text" {
@@ -7007,7 +6980,27 @@ test "app_input_runtime stale Tab selection requests a footer repaint" {
     try std.testing.expect(app.shell.render_requests.hasReason(.footer));
 }
 
-test "app_input_runtime terminated file tokens submit while streaming queries stay local" {
+test "app_input_runtime stream file picker navigates and selects without submitting" {
+    const alloc = std.testing.allocator;
+    const completions = [_]file_index.Candidate{
+        .{ .path = "first.txt", .kind = .file },
+        .{ .path = "second.txt", .kind = .file },
+    };
+    var app = try RoutingFakeApp.init(alloc);
+    defer app.deinit();
+    app.file_completion_values = &completions;
+    app.stream.active = true;
+    try app.input_runtime.textReplacementState().replace(alloc, "@file");
+
+    try Runtime(RoutingFakeApp).routePlainVertical(&app, .down, 1);
+    try Runtime(RoutingFakeApp).handleByte(&app, '\r', 4096, 100);
+
+    try std.testing.expect(app.stream.active);
+    try std.testing.expectEqualStrings("@second.txt ", app.input_runtime.edit_state.input.items);
+    try std.testing.expectEqual(@as(usize, 0), app.submitted_prompt_count);
+}
+
+test "app_input_runtime terminated and unmatched file tokens submit as prompt text" {
     const alloc = std.testing.allocator;
 
     {
@@ -7024,7 +7017,7 @@ test "app_input_runtime terminated file tokens submit while streaming queries st
         defer app.deinit();
         app.stream.active = true;
         try app.input_runtime.textReplacementState().replace(alloc, "@queued");
-        try std.testing.expect(!Runtime(RoutingFakeApp).nonSlashPickerOwnsEnter(&app));
+        try std.testing.expect(Runtime(RoutingFakeApp).nonSlashPickerOwnsEnter(&app));
         try Runtime(RoutingFakeApp).handleByte(&app, '\r', 4096, 100);
         try std.testing.expectEqualStrings("", app.input_runtime.edit_state.input.items);
         try std.testing.expectEqual(@as(usize, 1), app.submitted_prompt_count);

--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -1486,7 +1486,8 @@ pub fn Runtime(comptime App: type) type {
                 },
                 ' ' => {
                     dismissMentionSkillsMenuForSpace(app);
-                    if (app.input_runtime.edit_state.selectionRange() == null and
+                    if (!queueReviewOwnsComposer(app) and
+                        app.input_runtime.edit_state.selectionRange() == null and
                         !commandSkillsMenuActive(app) and
                         completion_rt.hasModelQuery(app))
                     {
@@ -1518,12 +1519,13 @@ pub fn Runtime(comptime App: type) type {
                     return;
                 },
                 '\r' => {
+                    const queue_review_owns_composer = queueReviewOwnsComposer(app);
                     if (try submitSettingsMenuSelection(app)) return;
                     if (try submitHelpMenuSelection(app, max_input_len, max_prompt_history)) return;
                     if (try submitAuthPickerSelection(app)) return;
-                    if (try submitModelMenuSelection(app)) return;
+                    if (!queue_review_owns_composer and try submitModelMenuSelection(app)) return;
                     if (try submitSkillsMenuSelection(app, max_input_len)) return;
-                    if (try submitSlashPickerSelection(app)) return;
+                    if (!queue_review_owns_composer and try submitSlashPickerSelection(app)) return;
                     if (comptime runtime_profile.allows(App, .durable_sessions)) {
                         if (try submitSessionPickerSelection(app)) return;
                     }
@@ -1534,11 +1536,13 @@ pub fn Runtime(comptime App: type) type {
                         app.shell.render_requests.request(.footer);
                         return;
                     }
-                    if (picker_state.isBareModelCommandAtCursor(&app.input_runtime.edit_state)) {
+                    if (!queue_review_owns_composer and
+                        picker_state.isBareModelCommandAtCursor(&app.input_runtime.edit_state))
+                    {
                         try openModelBrowseCatalog(app);
                         return;
                     }
-                    if (provider_picker_rt.hasQuery(app)) {
+                    if (!queue_review_owns_composer and provider_picker_rt.hasQuery(app)) {
                         if (app.stream.active) {
                             try app.writeDomainNotice(.{
                                 .topic = "provider",
@@ -1550,10 +1554,10 @@ pub fn Runtime(comptime App: type) type {
                         }
                         if (try provider_picker_rt.submit(app)) return;
                     }
-                    if (completion_rt.hasModelQuery(app)) {
+                    if (!queue_review_owns_composer and completion_rt.hasModelQuery(app)) {
                         if (try completion_rt.submitModelPicker(app)) return;
                     }
-                    if (try submitExplicitModelSelection(
+                    if (!queue_review_owns_composer and try submitExplicitModelSelection(
                         app,
                         resolveExplicitModelSelection(app, app.input_runtime.edit_state.input.items),
                     )) return;
@@ -2219,6 +2223,13 @@ pub fn Runtime(comptime App: type) type {
             app.shell.render_requests.request(.footer);
         }
 
+        fn queueReviewOwnsComposer(app: *const App) bool {
+            if (comptime @hasField(App, "queued_prompt_review")) {
+                return app.queued_prompt_review.visible;
+            }
+            return false;
+        }
+
         fn closeSkillsMenu(app: *App) bool {
             if (comptime !@hasField(App, "skills")) return false;
             if (!app.skills.menu.active) return false;
@@ -2653,6 +2664,7 @@ pub fn Runtime(comptime App: type) type {
 
         fn submitSlashPickerSelection(app: *App) !bool {
             if (comptime !@hasField(App, "skills")) return false;
+            if (queueReviewOwnsComposer(app)) return false;
             if (nonSlashPickerOwnsEnter(app)) return false;
             const items = app.input_runtime.edit_state.input.items;
             const prefix = command_specs.slashCompletionPrefix(
@@ -2712,6 +2724,7 @@ pub fn Runtime(comptime App: type) type {
             app: *App,
             parsed: ExplicitModelSelectionParse,
         ) !bool {
+            if (queueReviewOwnsComposer(app)) return false;
             switch (parsed) {
                 .none => return false,
                 .invalid => {
@@ -3397,9 +3410,15 @@ const RoutingWorker = struct {
     queued_count: usize = 0,
     synced_permission_mode: ?types.PermissionMode = null,
     permission_mode_sync_count: usize = 0,
+    queue_review_reason: ?worker_runtime.QueueReviewReason = null,
+    replaced_queue_prompt: [128]u8 = undefined,
+    replaced_queue_prompt_len: usize = 0,
 
-    pub fn queuePreview(_: *RoutingWorker, _: []u8) @import("../agent/worker_runtime.zig").QueuePreview {
-        return .{};
+    pub fn queuePreview(self: *RoutingWorker) @import("../agent/worker_runtime.zig").QueuePreview {
+        return .{
+            .count = self.queued_count,
+            .paused = self.queue_review_reason != null,
+        };
     }
 
     pub fn queuedPromptCount(self: *const RoutingWorker) usize {
@@ -3416,6 +3435,17 @@ const RoutingWorker = struct {
 
     pub fn requestCancel(self: *RoutingWorker) void {
         self.cancel_requested = true;
+    }
+
+    pub fn requestInteractiveCancel(self: *RoutingWorker) bool {
+        self.cancel_requested = true;
+        return self.beginQueueReview(.post_cancel);
+    }
+
+    pub fn beginQueueReview(self: *RoutingWorker, reason: worker_runtime.QueueReviewReason) bool {
+        if (self.queued_count == 0 and self.queue_review_reason == null) return false;
+        self.queue_review_reason = reason;
+        return true;
     }
 
     pub fn interactiveAdmissionSnapshot(self: *RoutingWorker) worker_runtime.InteractiveAdmissionSnapshot {
@@ -3494,6 +3524,59 @@ const RoutingWorker = struct {
     pub fn syncQueuedPromptFastMode(_: *RoutingWorker, _: bool) void {}
 
     pub fn syncQueuedPromptEffort(_: *RoutingWorker, _: types.ReasoningEffort) void {}
+
+    pub fn snapshotQueuedPromptDrafts(
+        _: *RoutingWorker,
+        _: std.mem.Allocator,
+    ) ![]worker_runtime.QueuedPromptDraft {
+        return &.{};
+    }
+
+    pub fn clearQueuedPrompts(
+        self: *RoutingWorker,
+        _: std.mem.Allocator,
+        _: []const types.ImageAttachment,
+    ) void {
+        self.queued_count = 0;
+    }
+
+    pub fn deleteQueuedPromptDraft(
+        self: *RoutingWorker,
+        _: std.mem.Allocator,
+        _: u64,
+        _: []const types.ImageAttachment,
+    ) bool {
+        if (self.queued_count == 0) return false;
+        self.queued_count -= 1;
+        return true;
+    }
+
+    pub fn queueReviewReason(self: *const RoutingWorker) ?worker_runtime.QueueReviewReason {
+        return self.queue_review_reason;
+    }
+
+    pub fn replaceQueuedPromptDrafts(
+        self: *RoutingWorker,
+        _: std.mem.Allocator,
+        drafts: []const worker_runtime.QueuedPromptDraft,
+    ) !bool {
+        if (drafts.len == 0) return true;
+        self.replaced_queue_prompt_len = @min(
+            drafts[0].prompt.len,
+            self.replaced_queue_prompt.len,
+        );
+        @memcpy(
+            self.replaced_queue_prompt[0..self.replaced_queue_prompt_len],
+            drafts[0].prompt[0..self.replaced_queue_prompt_len],
+        );
+        return true;
+    }
+
+    pub fn resumeQueueReview(self: *RoutingWorker) bool {
+        if (self.queue_review_reason == null) return false;
+        self.queue_review_reason = null;
+        return true;
+    }
 };
 
 const RoutingPacer = struct {
@@ -3603,6 +3686,7 @@ const RoutingFakeApp = struct {
     approval_screen: interaction_state.ApprovalScreenState = .{},
     question_prompt: question_prompt.QuestionPrompt = .{},
     input_runtime: core_input_runtime.Runtime = .{},
+    queued_prompt_review: input_queue_runtime.State = .{},
     terminal_input_runtime: test_ui_input.Runtime = .{},
     shell: transcript_runtime.TranscriptRuntime = .{},
     terminal: shell_runtime.TerminalState = .{},
@@ -3709,6 +3793,7 @@ const RoutingFakeApp = struct {
         self.auth.deinit(self.alloc);
         self.approval_prompt.deinit(self.alloc);
         self.question_prompt.deinit(self.alloc);
+        self.queued_prompt_review.deinit(self.alloc);
         self.input_runtime.deinit(self.alloc);
         self.terminal_input_runtime.deinit(self.alloc);
         self.subagents.deinit(self.alloc);
@@ -4040,6 +4125,31 @@ const RoutingFakeApp = struct {
         self.pending_images.clearRetainingCapacity();
     }
 };
+
+fn openRoutingQueueReview(app: *RoutingFakeApp, input: []const u8) !void {
+    const entries = try app.alloc.alloc(input_queue_runtime.ReviewEntry, 1);
+    var entries_owned = true;
+    errdefer if (entries_owned) app.alloc.free(entries);
+    const prompt = try app.alloc.dupe(u8, input);
+    var prompt_owned = true;
+    errdefer if (prompt_owned) app.alloc.free(prompt);
+    entries[0] = .{ .draft = .{
+        .turn_id = 1,
+        .prompt = prompt,
+        .images = &.{},
+        .skill_display_spans = &.{},
+    } };
+    app.queued_prompt_review = .{
+        .entries = entries,
+        .selected_index = 0,
+        .reason = .manual,
+        .visible = true,
+    };
+    entries_owned = false;
+    prompt_owned = false;
+    app.worker.queue_review_reason = .manual;
+    try app.input_runtime.textReplacementState().replace(app.alloc, input);
+}
 
 fn routingOpenUrl(
     _: ?*anyopaque,
@@ -6476,6 +6586,46 @@ test "app_input_runtime Enter on selected model slash completion opens browse on
     try std.testing.expect(app.model_cache.menu.active);
     try std.testing.expectEqualStrings("", app.input_runtime.edit_state.input.items);
     try std.testing.expectEqual(@as(usize, 0), app.transcript.items.len);
+}
+
+test "queue review keeps model-shaped Space in the queued draft" {
+    const alloc = std.testing.allocator;
+    var app = try RoutingFakeApp.init(alloc);
+    defer app.deinit();
+    try openRoutingQueueReview(&app, "/model openai/gpt-5");
+
+    try Runtime(RoutingFakeApp).handleByte(&app, ' ', 4096, 100);
+
+    try std.testing.expectEqualStrings("/model openai/gpt-5 ", app.input_runtime.edit_state.input.items);
+    try std.testing.expect(app.queued_prompt_review.visible);
+    try std.testing.expectEqual(@as(usize, 0), app.preference_commit_count);
+    try std.testing.expect(!app.model_cache.menu.active);
+}
+
+test "queue review Enter submits model-shaped text as the queued draft" {
+    const cases = [_][]const u8{
+        "/model",
+        "/mode",
+        "/model openai/gpt-5 auto normal",
+    };
+    for (cases) |input| {
+        const alloc = std.testing.allocator;
+        var app = try RoutingFakeApp.init(alloc);
+        defer app.deinit();
+        try openRoutingQueueReview(&app, input);
+
+        try Runtime(RoutingFakeApp).handleByte(&app, '\r', 4096, 100);
+
+        try std.testing.expectEqualStrings(
+            input,
+            app.worker.replaced_queue_prompt[0..app.worker.replaced_queue_prompt_len],
+        );
+        try std.testing.expect(!app.queued_prompt_review.active());
+        try std.testing.expectEqual(@as(usize, 0), app.preference_commit_count);
+        try std.testing.expect(!app.model_cache.menu.active);
+        try std.testing.expect(app.last_command == null);
+        try std.testing.expectEqualStrings("test/model", app.selected_model.items);
+    }
 }
 
 test "app_input_runtime bare model Tab opens on current scrolled selection before staging effort" {

--- a/src/core/app/input_completion_runtime.zig
+++ b/src/core/app/input_completion_runtime.zig
@@ -140,7 +140,7 @@ pub fn CompletionRuntime(comptime App: type) type {
             if (comptime @hasField(App, "approval_prompt")) {
                 if (app.approval_prompt.isActive()) return null;
             }
-            if (queueReviewOwnsComposer(app)) {
+            if (queue_rt.ownsComposer(app)) {
                 return if (hasFileQuery(app)) .file else null;
             }
             if (comptime @hasField(App, "stream")) {
@@ -384,7 +384,7 @@ pub fn CompletionRuntime(comptime App: type) type {
                 return true;
             }
             if (hasModelQuery(app)) {
-                if (queueReviewOwnsComposer(app)) return false;
+                if (queue_rt.ownsComposer(app)) return false;
                 navigateModelPicker(app, delta);
                 return true;
             }
@@ -715,14 +715,7 @@ pub fn CompletionRuntime(comptime App: type) type {
                 if (app.approval_prompt.isActive()) return false;
             }
             if (catalogMenuOwnsSurface(app)) return false;
-            return !queueReviewOwnsComposer(app);
-        }
-
-        fn queueReviewOwnsComposer(app: *App) bool {
-            if (comptime @hasField(App, "queued_prompt_review")) {
-                return app.queued_prompt_review.visible;
-            }
-            return false;
+            return !queue_rt.ownsComposer(app);
         }
 
         fn catalogMenuOwnsSurface(app: *App) bool {
@@ -895,7 +888,7 @@ pub fn CompletionRuntime(comptime App: type) type {
         }
 
         pub fn navigateModelPicker(app: *App, delta: i32) void {
-            if (queueReviewOwnsComposer(app)) return;
+            if (queue_rt.ownsComposer(app)) return;
             const query = app.input_runtime.picker.activeModelPickerQuery(&app.input_runtime.edit_state) orelse return;
             switch (query.stage) {
                 .model => navigateModelCompletion(app, query.query, delta),
@@ -979,7 +972,7 @@ pub fn CompletionRuntime(comptime App: type) type {
         }
 
         pub fn autocompleteModelPickerSelection(app: *App) !void {
-            if (queueReviewOwnsComposer(app)) return;
+            if (queue_rt.ownsComposer(app)) return;
             const query = app.input_runtime.picker.activeModelPickerQuery(&app.input_runtime.edit_state) orelse return;
             switch (query.stage) {
                 .model => {
@@ -1016,7 +1009,7 @@ pub fn CompletionRuntime(comptime App: type) type {
         }
 
         pub fn advanceModelPickerOnSpace(app: *App) !bool {
-            if (queueReviewOwnsComposer(app)) return false;
+            if (queue_rt.ownsComposer(app)) return false;
             const query = app.input_runtime.picker.activeModelPickerQuery(&app.input_runtime.edit_state) orelse return false;
             if (app.input_runtime.edit_state.cursor != app.input_runtime.edit_state.input.items.len) return false;
 
@@ -1055,7 +1048,7 @@ pub fn CompletionRuntime(comptime App: type) type {
         }
 
         pub fn submitModelPicker(app: *App) !bool {
-            if (queueReviewOwnsComposer(app)) return false;
+            if (queue_rt.ownsComposer(app)) return false;
             switch (app.input_runtime.picker.model_picker_stage) {
                 .model => {
                     if (app.isModelCacheLoading()) {
@@ -1116,7 +1109,7 @@ pub fn CompletionRuntime(comptime App: type) type {
         }
 
         pub fn openCurrentModelPicker(app: *App) !void {
-            if (queueReviewOwnsComposer(app)) return;
+            if (queue_rt.ownsComposer(app)) return;
             try app.input_runtime.textReplacementState().replace(app.alloc, "/model ");
             app.input_runtime.picker.model_completion_anchor_current = true;
             app.shell.render_requests.request(.footer);
@@ -1156,7 +1149,7 @@ pub fn CompletionRuntime(comptime App: type) type {
         }
 
         pub fn stepBackModelPicker(app: *App) !bool {
-            if (queueReviewOwnsComposer(app)) return false;
+            if (queue_rt.ownsComposer(app)) return false;
             const query = app.input_runtime.picker.activeModelPickerQuery(&app.input_runtime.edit_state) orelse return false;
             if (query.stage == .model) return false;
             if (!app.input_runtime.picker.hasPendingModelPickerSelection()) return false;
@@ -1213,13 +1206,13 @@ pub fn CompletionRuntime(comptime App: type) type {
         }
 
         pub fn shouldPreserveModelPickerInsert(app: *App) bool {
-            if (queueReviewOwnsComposer(app)) return false;
+            if (queue_rt.ownsComposer(app)) return false;
             const query = app.input_runtime.picker.activeModelPickerQuery(&app.input_runtime.edit_state) orelse return false;
             return query.stage != .model and app.input_runtime.edit_state.cursor == app.input_runtime.edit_state.input.items.len;
         }
 
         pub fn shouldPreserveModelPickerBackspace(app: *App) bool {
-            if (queueReviewOwnsComposer(app)) return false;
+            if (queue_rt.ownsComposer(app)) return false;
             const query = app.input_runtime.picker.activeModelPickerQuery(&app.input_runtime.edit_state) orelse return false;
             return query.stage != .model and query.query.len > 0 and app.input_runtime.edit_state.cursor == app.input_runtime.edit_state.input.items.len;
         }

--- a/src/core/app/input_completion_runtime.zig
+++ b/src/core/app/input_completion_runtime.zig
@@ -90,8 +90,8 @@ pub fn CompletionRuntime(comptime App: type) type {
         fn slashCompletionQueryActive(app: *App) bool {
             if (app.input_runtime.picker.isInlinePickerSuppressed(.slash)) return false;
             if (app.input_runtime.picker.inlinePickerTriggerKind(&app.input_runtime.edit_state) != .slash) return false;
-            // Model query always owns this slot. Mid-turn bare `/model` does too
-            // (list stays hidden); idle bare `/model` still surfaces slash rows.
+            // Model query always owns this slot. Mid-turn bare `/model` does too;
+            // idle bare `/model` still surfaces slash rows.
             if (comptime @hasField(App, "stream")) {
                 if (app.stream.active and picker_state.isBareModelCommandAtCursor(&app.input_runtime.edit_state)) return false;
             }
@@ -141,9 +141,8 @@ pub fn CompletionRuntime(comptime App: type) type {
             }
             if (comptime @hasField(App, "stream")) {
                 if (app.stream.active) {
-                    if (queueReviewOwnsComposer(app)) {
-                        return if (hasFileQuery(app)) .file else null;
-                    }
+                    if (hasModelQuery(app)) return .model;
+                    if (hasFileQuery(app)) return .file;
                     if (visibleInlineSlashCompletion(app) != null) return .slash;
                     if (visibleSlashCompletionCount(app) > 0) return .slash;
                     return null;
@@ -376,13 +375,12 @@ pub fn CompletionRuntime(comptime App: type) type {
             if (comptime runtime_profile.allows(App, .durable_sessions)) {
                 if (try routeSessionPickerMove(app, delta)) return true;
             }
-            const stream_suppresses_file_picker = app.stream.active and !queueReviewOwnsComposer(app);
-            if (!stream_suppresses_file_picker and hasFileQuery(app)) {
+            if (hasFileQuery(app)) {
                 navigateFilePicker(app, delta);
                 return true;
             }
             if (hasModelQuery(app)) {
-                if (!app.stream.active) navigateModelPicker(app, delta);
+                navigateModelPicker(app, delta);
                 return true;
             }
             if (provider_picker_runtime.Runtime(App).hasQuery(app)) {
@@ -1761,7 +1759,7 @@ fn expectInlineSkillCompletionInactive(app: *InlineCompletionTestApp) !void {
     );
 }
 
-test "streaming suppresses file selection until queued review owns the composer" {
+test "streaming file selection does not require queued review" {
     const alloc = std.testing.allocator;
     const rt = CompletionRuntime(FilePickerTestApp);
     var app = FilePickerTestApp{
@@ -1773,18 +1771,11 @@ test "streaming suppresses file selection until queued review owns the composer"
     app.stream.active = true;
 
     try std.testing.expectEqual(
-        @as(?edit_contract.InsertResult, null),
-        try rt.submitFilePickerOnEnter(&app, 4096),
-    );
-    try std.testing.expectEqualStrings("review @src/mai", app.input_runtime.edit_state.input.items);
-
-    app.queued_prompt_review.visible = true;
-    try std.testing.expectEqual(
         edit_contract.InsertResult.inserted,
         (try rt.submitFilePickerOnEnter(&app, 4096)).?,
     );
     try std.testing.expectEqualStrings("review @src/main.zig ", app.input_runtime.edit_state.input.items);
-    try std.testing.expect(app.queued_prompt_review.selected_dirty);
+    try std.testing.expect(!app.queued_prompt_review.selected_dirty);
 }
 
 test "file picker rejects paths that would reopen quote grammar" {

--- a/src/core/app/input_completion_runtime.zig
+++ b/src/core/app/input_completion_runtime.zig
@@ -34,6 +34,7 @@ const help_menu_presentation = @import("../../ui/footer/help_menu_presentation.z
 const settings_menu_presentation = @import("../../ui/footer/settings_menu_presentation.zig");
 const surface_frame = @import("../../ui/footer/surface_frame.zig");
 const footer_paint_plan = @import("../../ui/footer/paint_plan.zig");
+const render_request = @import("../../ui/render_request.zig");
 
 const ModelPickerStage = picker_state.ModelPickerStage;
 
@@ -138,6 +139,9 @@ pub fn CompletionRuntime(comptime App: type) type {
             }
             if (comptime @hasField(App, "approval_prompt")) {
                 if (app.approval_prompt.isActive()) return null;
+            }
+            if (queueReviewOwnsComposer(app)) {
+                return if (hasFileQuery(app)) .file else null;
             }
             if (comptime @hasField(App, "stream")) {
                 if (app.stream.active) {
@@ -380,6 +384,7 @@ pub fn CompletionRuntime(comptime App: type) type {
                 return true;
             }
             if (hasModelQuery(app)) {
+                if (queueReviewOwnsComposer(app)) return false;
                 navigateModelPicker(app, delta);
                 return true;
             }
@@ -890,6 +895,7 @@ pub fn CompletionRuntime(comptime App: type) type {
         }
 
         pub fn navigateModelPicker(app: *App, delta: i32) void {
+            if (queueReviewOwnsComposer(app)) return;
             const query = app.input_runtime.picker.activeModelPickerQuery(&app.input_runtime.edit_state) orelse return;
             switch (query.stage) {
                 .model => navigateModelCompletion(app, query.query, delta),
@@ -973,6 +979,7 @@ pub fn CompletionRuntime(comptime App: type) type {
         }
 
         pub fn autocompleteModelPickerSelection(app: *App) !void {
+            if (queueReviewOwnsComposer(app)) return;
             const query = app.input_runtime.picker.activeModelPickerQuery(&app.input_runtime.edit_state) orelse return;
             switch (query.stage) {
                 .model => {
@@ -1009,6 +1016,7 @@ pub fn CompletionRuntime(comptime App: type) type {
         }
 
         pub fn advanceModelPickerOnSpace(app: *App) !bool {
+            if (queueReviewOwnsComposer(app)) return false;
             const query = app.input_runtime.picker.activeModelPickerQuery(&app.input_runtime.edit_state) orelse return false;
             if (app.input_runtime.edit_state.cursor != app.input_runtime.edit_state.input.items.len) return false;
 
@@ -1047,6 +1055,7 @@ pub fn CompletionRuntime(comptime App: type) type {
         }
 
         pub fn submitModelPicker(app: *App) !bool {
+            if (queueReviewOwnsComposer(app)) return false;
             switch (app.input_runtime.picker.model_picker_stage) {
                 .model => {
                     if (app.isModelCacheLoading()) {
@@ -1107,6 +1116,7 @@ pub fn CompletionRuntime(comptime App: type) type {
         }
 
         pub fn openCurrentModelPicker(app: *App) !void {
+            if (queueReviewOwnsComposer(app)) return;
             try app.input_runtime.textReplacementState().replace(app.alloc, "/model ");
             app.input_runtime.picker.model_completion_anchor_current = true;
             app.shell.render_requests.request(.footer);
@@ -1125,7 +1135,11 @@ pub fn CompletionRuntime(comptime App: type) type {
             }
 
             const stage: ModelPickerStage = if (supports_effort) .effort else .fast;
-            try setModelComposerText(app, "/model {s} ", .{model});
+            if (supports_effort) {
+                try setModelComposerText(app, "/model {s} ", .{model});
+            } else {
+                try setModelComposerText(app, "/model {s} auto ", .{model});
+            }
             // Preselect the product effort default and enable Fast mode when supported.
             try app.input_runtime.picker.beginModelPickerFlow(
                 app.alloc,
@@ -1142,6 +1156,7 @@ pub fn CompletionRuntime(comptime App: type) type {
         }
 
         pub fn stepBackModelPicker(app: *App) !bool {
+            if (queueReviewOwnsComposer(app)) return false;
             const query = app.input_runtime.picker.activeModelPickerQuery(&app.input_runtime.edit_state) orelse return false;
             if (query.stage == .model) return false;
             if (!app.input_runtime.picker.hasPendingModelPickerSelection()) return false;
@@ -1198,11 +1213,13 @@ pub fn CompletionRuntime(comptime App: type) type {
         }
 
         pub fn shouldPreserveModelPickerInsert(app: *App) bool {
+            if (queueReviewOwnsComposer(app)) return false;
             const query = app.input_runtime.picker.activeModelPickerQuery(&app.input_runtime.edit_state) orelse return false;
             return query.stage != .model and app.input_runtime.edit_state.cursor == app.input_runtime.edit_state.input.items.len;
         }
 
         pub fn shouldPreserveModelPickerBackspace(app: *App) bool {
+            if (queueReviewOwnsComposer(app)) return false;
             const query = app.input_runtime.picker.activeModelPickerQuery(&app.input_runtime.edit_state) orelse return false;
             return query.stage != .model and query.query.len > 0 and app.input_runtime.edit_state.cursor == app.input_runtime.edit_state.input.items.len;
         }
@@ -1404,6 +1421,7 @@ const InlineCompletionTestApp = struct {
         layout: struct {
             cols: u16 = 80,
         } = .{},
+        render_requests: render_request.RenderRequestState = .{},
     } = .{},
 
     pub fn slashRegistry(_: *const InlineCompletionTestApp) command_specs.SlashRegistry {
@@ -1416,6 +1434,32 @@ const InlineCompletionTestApp = struct {
         self.pending_images.deinit(self.alloc);
     }
 };
+
+test "queue review prevents the model picker from opening over its draft" {
+    const alloc = std.testing.allocator;
+    const rt = CompletionRuntime(InlineCompletionTestApp);
+    var app = InlineCompletionTestApp{ .alloc = alloc };
+    defer app.deinit();
+    app.queued_prompt_review.visible = true;
+    try app.input_runtime.textReplacementState().replace(alloc, "/model");
+
+    try rt.openCurrentModelPicker(&app);
+
+    try std.testing.expectEqualStrings("/model", app.input_runtime.edit_state.input.items);
+    try std.testing.expect(!app.shell.render_requests.hasReason(.footer));
+}
+
+test "queue review excludes an existing model query from picker ownership" {
+    const alloc = std.testing.allocator;
+    const rt = CompletionRuntime(InlineCompletionTestApp);
+    var app = InlineCompletionTestApp{ .alloc = alloc };
+    defer app.deinit();
+    app.queued_prompt_review.visible = true;
+    try app.input_runtime.textReplacementState().replace(alloc, "/model provider/model");
+
+    try std.testing.expect(!rt.dismissVisibleInlinePicker(&app));
+    try std.testing.expect(!app.input_runtime.picker.isInlinePickerSuppressed(.model));
+}
 
 const SkillsNavigationTestWorker = struct {
     fn queuePreview(_: *SkillsNavigationTestWorker) @import("../agent/worker_runtime.zig").QueuePreview {

--- a/src/core/app/input_queue_runtime.zig
+++ b/src/core/app/input_queue_runtime.zig
@@ -104,6 +104,13 @@ pub const PromptAdmission = enum {
 
 pub fn Runtime(comptime App: type) type {
     return struct {
+        pub fn ownsComposer(app: *const App) bool {
+            if (comptime @hasField(App, "queued_prompt_review")) {
+                return app.queued_prompt_review.visible;
+            }
+            return false;
+        }
+
         pub fn requestCancelAndOpen(app: *App) bool {
             return openAfterPause(app, app.worker.requestInteractiveCancel());
         }
@@ -820,6 +827,18 @@ const ReviewTestApp = struct {
         self.pending_images.clearRetainingCapacity();
     }
 };
+
+test "queue review owns the composer only while its draft is visible" {
+    var app = ReviewTestApp{ .alloc = std.testing.allocator };
+    defer app.deinit();
+    const rt = Runtime(ReviewTestApp);
+
+    try std.testing.expect(!rt.ownsComposer(&app));
+    app.queued_prompt_review.reason = .manual;
+    try std.testing.expect(!rt.ownsComposer(&app));
+    app.queued_prompt_review.visible = true;
+    try std.testing.expect(rt.ownsComposer(&app));
+}
 
 fn makeReviewTestPrompt(alloc: std.mem.Allocator, text: []const u8) !worker_runtime.QueuedPrompt {
     const prompt = try alloc.dupe(u8, text);

--- a/src/core/app/input_submit_runtime.zig
+++ b/src/core/app/input_submit_runtime.zig
@@ -489,30 +489,25 @@ pub fn SubmitRuntime(comptime App: type) type {
             const expanded = try paste_blocks.expand(app.alloc, app.input_runtime.edit_state.input.items, app.input_runtime.entities.pasted_blocks.items);
             defer if (expanded.owned) app.alloc.free(expanded.text);
 
-            const queue_review_owns_composer = queueReviewOwnsComposer(app);
-            if (!queue_review_owns_composer) {
+            if (!queue_rt.ownsComposer(app)) {
                 if (directCommand(expanded.text)) |command| {
                     if (comptime @hasDecl(App, "submitDirectTerminal")) {
                         try App.submitDirectTerminal(app, command);
                         return;
                     }
                 }
-            }
 
-            const left_trimmed = std.mem.trimStart(u8, expanded.text, " \t\r\n");
-            const resolved_slash_submission = resolvedSlashSubmission(app, left_trimmed);
-            if (!queue_review_owns_composer) {
+                const left_trimmed = std.mem.trimStart(u8, expanded.text, " \t\r\n");
+                const resolved_slash_submission = resolvedSlashSubmission(app, left_trimmed);
                 if (knownSlashCommand(app, resolved_slash_submission)) |command| {
                     if (requiresPromptCredential(command, resolved_slash_submission) and !try preflightPrompt(app)) return;
                     try submitSlashCommand(app, left_trimmed, null, max_prompt_history);
                     return;
                 }
-            }
-            if (!queue_review_owns_composer and shouldRouteUnknownSlashCommand(app, resolved_slash_submission)) {
-                try submitSlashCommand(app, left_trimmed, null, max_prompt_history);
-                return;
-            }
-            if (!queue_review_owns_composer) {
+                if (shouldRouteUnknownSlashCommand(app, resolved_slash_submission)) {
+                    try submitSlashCommand(app, left_trimmed, null, max_prompt_history);
+                    return;
+                }
                 if (pendingImagesPrefixEnd(
                     app.input_runtime.edit_state.input.items,
                     expanded.text,
@@ -876,13 +871,6 @@ pub fn SubmitRuntime(comptime App: type) type {
         fn resolvedSlashSubmission(app: *App, text: []const u8) []const u8 {
             if (completion_rt.visibleSlashCompletionCount(app) == 0) return text;
             return resolveSlashSubmission(app.slashRegistry(), text, app.input_runtime.picker.slash_completion_index);
-        }
-
-        fn queueReviewOwnsComposer(app: *const App) bool {
-            if (comptime @hasField(App, "queued_prompt_review")) {
-                return app.queued_prompt_review.visible;
-            }
-            return false;
         }
 
         fn enqueuePromptForSubmit(

--- a/src/core/app/input_submit_runtime.zig
+++ b/src/core/app/input_submit_runtime.zig
@@ -489,41 +489,48 @@ pub fn SubmitRuntime(comptime App: type) type {
             const expanded = try paste_blocks.expand(app.alloc, app.input_runtime.edit_state.input.items, app.input_runtime.entities.pasted_blocks.items);
             defer if (expanded.owned) app.alloc.free(expanded.text);
 
-            if (directCommand(expanded.text)) |command| {
-                if (comptime @hasDecl(App, "submitDirectTerminal")) {
-                    try App.submitDirectTerminal(app, command);
-                    return;
+            const queue_review_owns_composer = queueReviewOwnsComposer(app);
+            if (!queue_review_owns_composer) {
+                if (directCommand(expanded.text)) |command| {
+                    if (comptime @hasDecl(App, "submitDirectTerminal")) {
+                        try App.submitDirectTerminal(app, command);
+                        return;
+                    }
                 }
             }
 
             const left_trimmed = std.mem.trimStart(u8, expanded.text, " \t\r\n");
             const resolved_slash_submission = resolvedSlashSubmission(app, left_trimmed);
-            if (knownSlashCommand(app, resolved_slash_submission)) |command| {
-                if (requiresPromptCredential(command, resolved_slash_submission) and !try preflightPrompt(app)) return;
-                try submitSlashCommand(app, left_trimmed, null, max_prompt_history);
-                return;
-            }
-            if (shouldRouteUnknownSlashCommand(app, resolved_slash_submission)) {
-                try submitSlashCommand(app, left_trimmed, null, max_prompt_history);
-                return;
-            }
-            if (pendingImagesPrefixEnd(
-                app.input_runtime.edit_state.input.items,
-                expanded.text,
-                app.input_runtime.entities.pasted_blocks.items,
-                app.input_runtime.entities.image_tokens.items,
-                app.pending_images.items,
-            )) |command_start| {
-                const command_text = expanded.text[command_start..];
-                if (knownSlashCommand(app, command_text)) |command| {
-                    if (requiresPromptCredential(command, command_text) and !try preflightPrompt(app)) return;
-                    try submitSlashCommand(
-                        app,
-                        command_text,
-                        expanded.text[0..command_start],
-                        max_prompt_history,
-                    );
+            if (!queue_review_owns_composer) {
+                if (knownSlashCommand(app, resolved_slash_submission)) |command| {
+                    if (requiresPromptCredential(command, resolved_slash_submission) and !try preflightPrompt(app)) return;
+                    try submitSlashCommand(app, left_trimmed, null, max_prompt_history);
                     return;
+                }
+            }
+            if (!queue_review_owns_composer and shouldRouteUnknownSlashCommand(app, resolved_slash_submission)) {
+                try submitSlashCommand(app, left_trimmed, null, max_prompt_history);
+                return;
+            }
+            if (!queue_review_owns_composer) {
+                if (pendingImagesPrefixEnd(
+                    app.input_runtime.edit_state.input.items,
+                    expanded.text,
+                    app.input_runtime.entities.pasted_blocks.items,
+                    app.input_runtime.entities.image_tokens.items,
+                    app.pending_images.items,
+                )) |command_start| {
+                    const command_text = expanded.text[command_start..];
+                    if (knownSlashCommand(app, command_text)) |command| {
+                        if (requiresPromptCredential(command, command_text) and !try preflightPrompt(app)) return;
+                        try submitSlashCommand(
+                            app,
+                            command_text,
+                            expanded.text[0..command_start],
+                            max_prompt_history,
+                        );
+                        return;
+                    }
                 }
             }
 
@@ -869,6 +876,13 @@ pub fn SubmitRuntime(comptime App: type) type {
         fn resolvedSlashSubmission(app: *App, text: []const u8) []const u8 {
             if (completion_rt.visibleSlashCompletionCount(app) == 0) return text;
             return resolveSlashSubmission(app.slashRegistry(), text, app.input_runtime.picker.slash_completion_index);
+        }
+
+        fn queueReviewOwnsComposer(app: *const App) bool {
+            if (comptime @hasField(App, "queued_prompt_review")) {
+                return app.queued_prompt_review.visible;
+            }
+            return false;
         }
 
         fn enqueuePromptForSubmit(

--- a/src/ui/footer/input_presentation.zig
+++ b/src/ui/footer/input_presentation.zig
@@ -283,7 +283,7 @@ pub fn cappedInputRows(total_rows: usize, content_bottom: u16, input_visible: bo
 pub fn slashCompletionPickerPrefix(ctx: RenderContext, modal_active: bool, show_model_query: bool, show_file_query: bool) ?[]const u8 {
     if (ctx.input.picker.isInlinePickerSuppressed(.slash) or modal_active or show_model_query or show_file_query) return null;
     if (ctx.input.picker.inlinePickerTriggerKind(&ctx.input.edit_state) != .slash) return null;
-    // Mid-turn model-shaped input owns the footer slot even while the model list is hidden.
+    // Mid-turn bare `/model` owns the footer slot before the staged picker opens.
     if (ctx.stream.active and ctx.input.picker.isModelShapedInput(&ctx.input.edit_state)) return null;
     const prefix = slashInputPrefix(ctx.slash_registry, ctx.input.edit_state.input.items);
     return if (prefix.len > 0) prefix else null;

--- a/src/ui/footer/surface_frame.zig
+++ b/src/ui/footer/surface_frame.zig
@@ -402,7 +402,8 @@ fn buildFooterSurfaceProjection(
     const show_models_menu = !viewer_active and !show_auth_picker and !show_settings_menu and !show_mcp_menu and !show_help_menu and !show_session_menu and !modal_active and ctx.model_menu.active;
     const show_inline_catalog = show_settings_menu or show_mcp_menu or show_help_menu or show_session_menu or show_models_menu;
     const show_skills_query = !viewer_active and !show_auth_picker and !show_inline_catalog and !modal_active and ctx.skills_menu.active;
-    const show_model_query = !viewer_active and !show_auth_picker and !show_inline_catalog and !show_skills_query and !modal_active and ctx.model_query_active;
+    const show_model_query = !viewer_active and !show_auth_picker and !show_inline_catalog and !show_skills_query and !modal_active and
+        !ctx.queued_editor_active and ctx.model_query_active;
     const show_provider_query = !viewer_active and !show_auth_picker and !show_inline_catalog and !show_skills_query and !modal_active and !ctx.stream.active and
         !ctx.queued_editor_active and ctx.provider_query_active and !show_model_query;
     const show_file_query = !viewer_active and !show_inline_catalog and !show_skills_query and !modal_active and ctx.file_query_active and !show_model_query and !show_provider_query;
@@ -1879,6 +1880,25 @@ test "surface footer exposes model picker while a response streams" {
     try std.testing.expect(visible.show_picker);
     try std.testing.expectEqual(PickerKind.model_stage, visible.picker_kind);
     try std.testing.expect(visible.picker_rows > 0);
+}
+
+test "surface footer keeps model picker out of queued review" {
+    const alloc = std.testing.allocator;
+    var approval = ApprovalPrompt{};
+    defer approval.deinit(alloc);
+    var input = InputRuntime{};
+    defer input.deinit(alloc);
+    var shell = surfaceTestShell(24, 80);
+    defer shell.deinit(alloc);
+    var ctx = surfaceTestContext(&input);
+    ctx.stream.active = true;
+    ctx.queued_editor_active = true;
+    ctx.model_query_active = true;
+    ctx.model_completions = &.{"provider/model"};
+
+    var measurement = try measureSurfaceFooter(alloc, &shell, approval.projection(), ctx);
+    defer measurement.deinit(alloc);
+    try std.testing.expect(!measurement.show_picker);
 }
 
 test "surface footer measurement reserves only the compact auth picker rows" {

--- a/src/ui/footer/surface_frame.zig
+++ b/src/ui/footer/surface_frame.zig
@@ -402,11 +402,10 @@ fn buildFooterSurfaceProjection(
     const show_models_menu = !viewer_active and !show_auth_picker and !show_settings_menu and !show_mcp_menu and !show_help_menu and !show_session_menu and !modal_active and ctx.model_menu.active;
     const show_inline_catalog = show_settings_menu or show_mcp_menu or show_help_menu or show_session_menu or show_models_menu;
     const show_skills_query = !viewer_active and !show_auth_picker and !show_inline_catalog and !modal_active and ctx.skills_menu.active;
-    const stream_suppresses_file_query = ctx.stream.active and !ctx.queued_editor_active;
-    const show_model_query = !viewer_active and !show_auth_picker and !show_inline_catalog and !show_skills_query and !modal_active and !ctx.stream.active and ctx.model_query_active;
+    const show_model_query = !viewer_active and !show_auth_picker and !show_inline_catalog and !show_skills_query and !modal_active and ctx.model_query_active;
     const show_provider_query = !viewer_active and !show_auth_picker and !show_inline_catalog and !show_skills_query and !modal_active and !ctx.stream.active and
         !ctx.queued_editor_active and ctx.provider_query_active and !show_model_query;
-    const show_file_query = !viewer_active and !show_inline_catalog and !show_skills_query and !modal_active and !stream_suppresses_file_query and ctx.file_query_active and !show_model_query and !show_provider_query;
+    const show_file_query = !viewer_active and !show_inline_catalog and !show_skills_query and !modal_active and ctx.file_query_active and !show_model_query and !show_provider_query;
     const prepared_slash_prefix = if (!show_auth_picker and
         !show_inline_catalog and
         !show_skills_query)
@@ -1842,7 +1841,7 @@ test "surface footer measurement reserves capped picker rows for active list pic
     try expectMeasuredPickerRows(alloc, &file_empty_shell, approval.projection(), file_ctx, .file, expected_rows);
 }
 
-test "queued editor exposes only its file picker while a response streams" {
+test "surface footer exposes file picker while a response streams" {
     const alloc = std.testing.allocator;
     var approval = ApprovalPrompt{};
     defer approval.deinit(alloc);
@@ -1855,24 +1854,31 @@ test "queued editor exposes only its file picker while a response streams" {
     ctx.file_query_active = true;
     ctx.file_completions = &.{.{ .path = "src/main.zig", .kind = .file, .matched_spans = &.{} }};
 
-    var hidden = try measureSurfaceFooter(alloc, &shell, approval.projection(), ctx);
-    defer hidden.deinit(alloc);
-    try std.testing.expect(!hidden.show_picker);
-
-    ctx.queued_editor_active = true;
     var visible = try measureSurfaceFooter(alloc, &shell, approval.projection(), ctx);
     defer visible.deinit(alloc);
     try std.testing.expect(visible.show_picker);
     try std.testing.expectEqual(PickerKind.file, visible.picker_kind);
     try std.testing.expect(visible.picker_rows > 0);
+}
 
-    ctx.file_query_active = false;
-    ctx.file_completions = &.{};
+test "surface footer exposes model picker while a response streams" {
+    const alloc = std.testing.allocator;
+    var approval = ApprovalPrompt{};
+    defer approval.deinit(alloc);
+    var input = InputRuntime{};
+    defer input.deinit(alloc);
+    var shell = surfaceTestShell(24, 80);
+    defer shell.deinit(alloc);
+    var ctx = surfaceTestContext(&input);
+    ctx.stream.active = true;
     ctx.model_query_active = true;
-    ctx.model_completions = &.{"provider/queued-hidden-model"};
-    var hidden_model = try measureSurfaceFooter(alloc, &shell, approval.projection(), ctx);
-    defer hidden_model.deinit(alloc);
-    try std.testing.expect(!hidden_model.show_picker);
+    ctx.model_completions = &.{"provider/visible-model"};
+
+    var visible = try measureSurfaceFooter(alloc, &shell, approval.projection(), ctx);
+    defer visible.deinit(alloc);
+    try std.testing.expect(visible.show_picker);
+    try std.testing.expectEqual(PickerKind.model_stage, visible.picker_kind);
+    try std.testing.expect(visible.picker_rows > 0);
 }
 
 test "surface footer measurement reserves only the compact auth picker rows" {

--- a/src/ui/resize_tests.zig
+++ b/src/ui/resize_tests.zig
@@ -6015,7 +6015,7 @@ test "footer renders slash completions while stream is active" {
     try expectGridContains(&h, "/model");
 }
 
-test "footer keeps model picker suppressed while stream is active" {
+test "footer renders model picker while stream is active" {
     const alloc = std.testing.allocator;
     var h = try Harness.init(alloc, 80, 24, 4);
     defer h.deinit();
@@ -6040,7 +6040,7 @@ test "footer keeps model picker suppressed while stream is active" {
     try h.flush();
 
     try expectGridContains(&h, "/model g");
-    try expectGridNotContains(&h, "gpt-test-model");
+    try expectGridContains(&h, "gpt-test-model");
 }
 
 test "footer suppresses slash skill rows for streaming model-shaped input" {
@@ -6077,7 +6077,7 @@ test "footer suppresses slash skill rows for streaming model-shaped input" {
     try expectGridNotContains(&h, "model-helper");
 }
 
-test "footer keeps file picker suppressed while stream is active" {
+test "footer renders file picker while stream is active" {
     const alloc = std.testing.allocator;
     var h = try Harness.init(alloc, 80, 24, 4);
     defer h.deinit();
@@ -6102,7 +6102,7 @@ test "footer keeps file picker suppressed while stream is active" {
     try h.flush();
 
     try expectGridContains(&h, "@sr");
-    try expectGridNotContains(&h, "src/main.zig");
+    try expectGridContains(&h, "src/main.zig");
 }
 
 test "typed file picker survives one hundred tiny and wide resize oscillations with selection intact" {

--- a/tests/e2e/tui-file-picker.test.ts
+++ b/tests/e2e/tui-file-picker.test.ts
@@ -455,11 +455,11 @@ describe("@ file picker", () => {
         expect(gateway?.requests).toHaveLength(1);
         held.release("IN_FLIGHT_FILE_PICKER_COMPLETE");
         await active.waitForText("IN_FLIGHT_FILE_PICKER_COMPLETE", TIMEOUT);
+        expectCleanRuntime(current, active);
         await clearComposer(active);
         await active.sendText("/quit");
         expect(await active.waitForSessionEnd(TIMEOUT)).toBe(true);
         session = null;
-        expectCleanRuntime(current, active);
       } finally {
         held.dispose();
       }

--- a/tests/e2e/tui-file-picker.test.ts
+++ b/tests/e2e/tui-file-picker.test.ts
@@ -17,6 +17,7 @@ import { FX_BIN, HAS_API_KEY, runFx } from "../evals/eval-helpers";
 import {
   FAKE_GATEWAY_MODEL,
   fakeGatewayFinalText,
+  heldFakeGatewayFinalText,
   isComposerLine,
   startFakeGateway,
   TmuxSession,
@@ -426,6 +427,46 @@ async function replayTape(current: Fixture): Promise<void> {
 }
 
 describe("@ file picker", () => {
+  tmuxTest(
+    "opens and selects a file while a turn is in flight",
+    async () => {
+      const current = createFixture("fx-file-picker-in-flight-");
+      initGit(current.workspace);
+      writeFileSync(join(current.workspace, "in-flight-context.txt"), "context");
+      git(current.workspace, "add", "in-flight-context.txt");
+      const held = heldFakeGatewayFinalText();
+
+      try {
+        const active = await startMockFx(current, [held.response], 1_000);
+        await active.sendText("Keep this turn active.");
+        await waitForGatewayRequestCount(1);
+
+        await active.sendLiteral("@in-flight");
+        await active.waitForPane(
+          (pane) => pane.includes("in-flight-context.txt"),
+          5_000,
+        );
+        await active.sendKeys("Enter");
+        await active.waitForPane(
+          (pane) => composerTextFromPane(pane).includes("@in-flight-context.txt"),
+          5_000,
+        );
+
+        expect(gateway?.requests).toHaveLength(1);
+        held.release("IN_FLIGHT_FILE_PICKER_COMPLETE");
+        await active.waitForText("IN_FLIGHT_FILE_PICKER_COMPLETE", TIMEOUT);
+        await clearComposer(active);
+        await active.sendText("/quit");
+        expect(await active.waitForSessionEnd(TIMEOUT)).toBe(true);
+        session = null;
+        expectCleanRuntime(current, active);
+      } finally {
+        held.dispose();
+      }
+    },
+    TIMEOUT,
+  );
+
   tmuxTest(
     "keeps the completed result visible through rapid large-index refreshes",
     async () => {

--- a/tests/e2e/tui-slash-menu.test.ts
+++ b/tests/e2e/tui-slash-menu.test.ts
@@ -3036,18 +3036,29 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
     async () => {
       const fixture = createModelsMenuFixture();
       const currentModel = "anthropic/claude-opus-4.8";
+      const fastOnlyModel = "provider/fast-only-model";
       const held = heldFakeGatewayFinalText();
       gateway = startFakeGateway([held.response], {
-        models: [{
-          id: currentModel,
-          type: "language",
-          released: 100,
-          tags: ["reasoning", "tool-use"],
-          reasoning_options: [{ type: "effort", values: ["high", "xhigh"] }],
-          fast_options: [{ type: "toggle" }],
-          context_window: 1_000_000,
-          max_tokens: 32_000,
-        }],
+        models: [
+          {
+            id: currentModel,
+            type: "language",
+            released: 100,
+            tags: ["reasoning", "tool-use"],
+            reasoning_options: [{ type: "effort", values: ["high", "xhigh"] }],
+            fast_options: [{ type: "toggle" }],
+            context_window: 1_000_000,
+            max_tokens: 32_000,
+          },
+          {
+            id: fastOnlyModel,
+            type: "language",
+            released: 90,
+            tags: ["tool-use"],
+            fast_options: [{ type: "toggle" }],
+            context_window: 128_000,
+          },
+        ],
       });
 
       try {
@@ -3091,6 +3102,15 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
         );
         await session.sendKeys("Enter");
         await session.waitForText(`Next turn will use ${currentModel}`, 5_000);
+
+        await session.sendLiteralText(`/model ${fastOnlyModel}`);
+        await session.sendKeys("Enter");
+        await session.waitForPane(
+          (pane) => pane.includes("normal") && pane.includes("fast"),
+          5_000,
+        );
+        await session.sendKeys("Enter");
+        await session.waitForText(`Next turn will use ${fastOnlyModel}`, 5_000);
 
         expect(gateway.requests).toHaveLength(1);
         held.release("IN_FLIGHT_MODEL_PICKER_COMPLETE");

--- a/tests/e2e/tui-slash-menu.test.ts
+++ b/tests/e2e/tui-slash-menu.test.ts
@@ -21,6 +21,7 @@ import {
   fakeGatewayFinalText,
   fakeGatewayToolCall,
   hasEmptyComposer,
+  heldFakeGatewayFinalText,
   isComposerLine,
   startFakeGateway,
   TmuxSession,
@@ -3026,6 +3027,81 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       await session.sendText("/quit");
       expect(await session.waitForSessionEnd(TIMEOUT)).toBe(true);
       session = null;
+    },
+    TEST_TIMEOUT,
+  );
+
+  test(
+    "model picker completes every stage while a turn is in flight",
+    async () => {
+      const fixture = createModelsMenuFixture();
+      const currentModel = "anthropic/claude-opus-4.8";
+      const held = heldFakeGatewayFinalText();
+      gateway = startFakeGateway([held.response], {
+        models: [{
+          id: currentModel,
+          type: "language",
+          released: 100,
+          tags: ["reasoning", "tool-use"],
+          reasoning_options: [{ type: "effort", values: ["high", "xhigh"] }],
+          fast_options: [{ type: "toggle" }],
+          context_window: 1_000_000,
+          max_tokens: 32_000,
+        }],
+      });
+
+      try {
+        session = await TmuxSession.create({
+          cwd: fixture.workspace,
+          stderrPath: fixture.stderrPath,
+          env: {
+            HOME: fixture.home,
+            AI_GATEWAY_API_KEY: "fake-in-flight-model-picker-key",
+            VERCEL_OIDC_TOKEN: undefined,
+            FX_GATEWAY_BASE_URL: gateway.baseUrl,
+            FX_GATEWAY_CHAT_URL: gateway.chatUrl,
+            FX_E2E_GATEWAY_MODELS_URL: `${gateway.baseUrl}/coding-agent/v1/models`,
+            FX_MODEL: currentModel,
+            FX_AUTO_UPGRADE: "0",
+          },
+          width: 120,
+          height: 32,
+        });
+        await session.waitForComposer(10_000);
+        await session.sendText("Keep this model turn active.");
+        await session.waitForText("Thinking", 10_000);
+
+        await session.sendLiteralText("/model");
+        await session.sendKeys("Tab");
+        await session.waitForPane(
+          (pane) => pane.split("\n").some((line) =>
+            !isComposerLine(line) && line.includes(currentModel)
+          ),
+          5_000,
+        );
+        await session.sendKeys("Enter");
+        await session.waitForPane(
+          (pane) => pane.includes("default") && pane.includes("xhigh"),
+          5_000,
+        );
+        await session.sendKeys("Enter");
+        await session.waitForPane(
+          (pane) => pane.includes("normal") && pane.includes("fast"),
+          5_000,
+        );
+        await session.sendKeys("Enter");
+        await session.waitForText(`Next turn will use ${currentModel}`, 5_000);
+
+        expect(gateway.requests).toHaveLength(1);
+        held.release("IN_FLIGHT_MODEL_PICKER_COMPLETE");
+        await session.waitForText("IN_FLIGHT_MODEL_PICKER_COMPLETE", 10_000);
+        expect(readFileSync(fixture.stderrPath, "utf8")).toBe("");
+        await session.sendText("/quit");
+        expect(await session.waitForSessionEnd(TIMEOUT)).toBe(true);
+        session = null;
+      } finally {
+        held.dispose();
+      }
     },
     TEST_TIMEOUT,
   );


### PR DESCRIPTION
## Summary

- Keep file selection available while a response is in flight.
- Keep model and reasoning-effort selection available while a response is in flight.
- Open Fast mode selection for models with or without configurable effort.
- Keep model selection from taking ownership of queued-draft editing.
- Apply model changes to the next turn and queued prompts without interrupting the active response.