### PR TITLE
Show cancellation immediately on Escape

### DIFF
--- a/src/core/agent/worker_runtime.zig
+++ b/src/core/agent/worker_runtime.zig
@@ -779,6 +779,13 @@ pub const WorkerRuntime = struct {
         return self.worker_cancel_requested.load(.seq_cst);
     }
 
+    pub fn cancellationStopsTurn(self: *WorkerRuntime) bool {
+        self.worker_mutex.lockUncancelable(io_mod.getIo());
+        defer self.worker_mutex.unlock(io_mod.getIo());
+        return self.worker_cancel_requested.load(.seq_cst) and
+            self.steering_cancel_turn_id != self.active_turn_id;
+    }
+
     pub fn isConnectivityWaitActive(self: *const WorkerRuntime) bool {
         return self.worker_connectivity_wait_active.load(.seq_cst);
     }
@@ -3833,6 +3840,7 @@ test "immediate steering owns and clears only its cancellation" {
     try runtime.admitInteractivePrompt(alloc, try makePrompt(alloc, "first", "model"));
     try runtime.admitInteractivePrompt(alloc, try makePrompt(alloc, "second", "model"));
     try std.testing.expect(runtime.isCancelRequested());
+    try std.testing.expect(!runtime.cancellationStopsTurn());
     var steering_snapshot = try runtime.snapshotState(alloc);
     defer steering_snapshot.deinit(alloc);
     try std.testing.expect(steering_snapshot.cancel_requested);
@@ -3861,6 +3869,7 @@ test "explicit interrupt overrides immediate steering cancellation" {
 
     try runtime.admitInteractivePrompt(alloc, try makePrompt(alloc, "steer", "model"));
     _ = runtime.requestInteractiveCancel();
+    try std.testing.expect(runtime.cancellationStopsTurn());
     var interrupt_snapshot = try runtime.snapshotState(alloc);
     defer interrupt_snapshot.deinit(alloc);
     try std.testing.expect(interrupt_snapshot.cancel_requested);

--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -10349,17 +10349,20 @@ test "app_input_runtime active Ctrl-C cancels stream and arms exit window" {
 
     try std.testing.expect(!app.stream.active);
     try std.testing.expect(app.worker.cancel_requested);
-    try std.testing.expectEqualStrings("● System: cancelled", app.transcript.items);
-    try std.testing.expectEqualStrings("system", app.notice_topic.items);
-    try std.testing.expectEqual(types.NoticeTone.cancelled, app.notice_tone);
-    try std.testing.expectEqualStrings("cancelled", app.notice_body.items);
+    var rendered = try app.shell.prepareTranscriptSource(alloc, null);
+    defer rendered.deinit(alloc);
+    try std.testing.expect(std.mem.find(u8, rendered.bytes, "Cancelled") != null);
+    try std.testing.expect(std.mem.find(u8, rendered.bytes, "What can fx do differently?") != null);
+    try std.testing.expect(std.mem.find(u8, rendered.bytes, "System:") == null);
+    try std.testing.expect(std.mem.find(u8, rendered.bytes, "Cancelling") == null);
+    try std.testing.expectEqual(@as(usize, 0), app.notice_write_count);
     try std.testing.expect(app.input_runtime.gestures.ctrlCExitArmed());
     try std.testing.expect(app.input_runtime.gestures.ctrlCExitArmedAt() != null);
     try std.testing.expect(!app.should_exit);
     try std.testing.expect(app.shell.render_requests.hasReason(.footer));
 }
 
-test "app_input_runtime active tool Escape waits for terminal feedback before repainting" {
+test "app_input_runtime active tool Escape presents final cancellation immediately" {
     const alloc = std.testing.allocator;
     var app = try RoutingFakeApp.init(alloc);
     defer app.deinit();
@@ -10377,10 +10380,16 @@ test "app_input_runtime active tool Escape waits for terminal feedback before re
 
     try std.testing.expect(app.stream.active);
     try std.testing.expect(app.worker.cancel_requested);
-    try std.testing.expectEqualStrings("", app.transcript.items);
+    var rendered = try app.shell.prepareTranscriptSource(alloc, null);
+    defer rendered.deinit(alloc);
+    try std.testing.expect(std.mem.find(u8, rendered.bytes, "Cancelled") != null);
+    try std.testing.expect(std.mem.find(u8, rendered.bytes, "What can fx do differently?") != null);
+    try std.testing.expect(std.mem.find(u8, rendered.bytes, "System:") == null);
+    try std.testing.expect(std.mem.find(u8, rendered.bytes, "Cancelling") == null);
+    try std.testing.expectEqual(@as(usize, 1), app.shell.activeToolActivityCount());
     try std.testing.expectEqualStrings("", app.notice_topic.items);
     try std.testing.expectEqualStrings("", app.notice_body.items);
-    try std.testing.expect(!app.shell.render_requests.hasReason(.footer));
+    try std.testing.expect(app.shell.render_requests.hasReason(.footer));
 }
 
 test "app_input_runtime second Ctrl-C after active cancellation exits without duplicate notice" {
@@ -10393,8 +10402,13 @@ test "app_input_runtime second Ctrl-C after active cancellation exits without du
     try Runtime(RoutingFakeApp).handleByte(&app, 3, 4096, 100);
 
     try std.testing.expect(app.should_exit);
-    try std.testing.expectEqualStrings("● System: cancelled", app.transcript.items);
-    try std.testing.expectEqual(types.NoticeTone.cancelled, app.notice_tone);
+    var rendered = try app.shell.prepareTranscriptSource(alloc, null);
+    defer rendered.deinit(alloc);
+    try std.testing.expectEqual(
+        @as(usize, 1),
+        std.mem.count(u8, rendered.bytes, "What can fx do differently?"),
+    );
+    try std.testing.expect(std.mem.find(u8, rendered.bytes, "System:") == null);
 }
 
 test "app_input_runtime pending Ctrl-C exits before repeating active cancellation" {

--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -674,6 +674,25 @@ pub fn Runtime(comptime App: type) type {
             const settings_snapshot = app_commands.settingsCatalogSnapshot(app);
             const now_ms = io_mod.milliTimestamp();
             var visible_stream = app.stream;
+            if (visible_stream.active) {
+                const cancel_requested = if (comptime @hasField(App, "worker"))
+                    if (comptime @hasDecl(@TypeOf(app.worker), "isCancelRequested"))
+                        app.worker.isCancelRequested()
+                    else
+                        false
+                else
+                    false;
+                if (cancel_requested) {
+                    const stops_turn = if (comptime @hasDecl(
+                        @TypeOf(app.worker),
+                        "cancellationStopsTurn",
+                    ))
+                        app.worker.cancellationStopsTurn()
+                    else
+                        true;
+                    if (stops_turn) visible_stream.active = false;
+                }
+            }
             if (!visible_stream.active) {
                 if (app.pacer.completedAssistantPresentationTokenProgress()) |progress| {
                     visible_stream.token_progress = progress;
@@ -3196,9 +3215,19 @@ const CoordinatorTestWorker = struct {
     submitted_permission: ?types.ToolPermissionDecision = null,
     queued_count: usize = 0,
     paused: bool = false,
+    cancel_requested: bool = false,
+    cancel_continues_turn: bool = false,
 
     pub fn queuePreview(self: *@This()) worker_runtime.QueuePreview {
         return .{ .count = self.queued_count, .paused = self.paused };
+    }
+
+    pub fn isCancelRequested(self: *const @This()) bool {
+        return self.cancel_requested;
+    }
+
+    pub fn cancellationStopsTurn(self: *const @This()) bool {
+        return self.cancel_requested and !self.cancel_continues_turn;
     }
 
     pub fn submitPermissionResponse(
@@ -3464,6 +3493,66 @@ test "core.app_render_runtime keeps final token progress during paced response t
         ),
         .none, .tool_slot => return error.TestUnexpectedResult,
     }
+}
+
+test "core.app_render_runtime hides loading after active tool cancellation" {
+    const alloc = std.testing.allocator;
+    var app = CoordinatorTestApp{
+        .alloc = alloc,
+        .shell = .{},
+        .stream = .{ .active = true },
+    };
+    defer app.deinit();
+    app.worker.cancel_requested = true;
+    _ = try app.shell.applyToolLifecycle(alloc, .{ .authoritative_started = .{
+        .id = .{ .turn_id = 1, .call_id = "command" },
+        .reconciles_provisional_call_id = null,
+        .tool_name = "run_command",
+        .activity_kind = .command,
+    } });
+
+    var upgrade_status_buf: [64]u8 = undefined;
+    const queued_cards: QueuedCardProjection = .{};
+    const ctx = Runtime(CoordinatorTestApp).footerContext(
+        &app,
+        &upgrade_status_buf,
+        0,
+        &queued_cards,
+    );
+
+    try std.testing.expect(!ctx.stream.active);
+    var activity_buf: [128]u8 = undefined;
+    try std.testing.expect(
+        render_input.frameOwnedActivityProjection(
+            &activity_buf,
+            &app.shell,
+            ctx,
+            null,
+        ) == .none,
+    );
+}
+
+test "core.app_render_runtime keeps loading while cancellation continues the turn" {
+    const alloc = std.testing.allocator;
+    var app = CoordinatorTestApp{
+        .alloc = alloc,
+        .shell = .{},
+        .stream = .{ .active = true },
+    };
+    defer app.deinit();
+    app.worker.cancel_requested = true;
+    app.worker.cancel_continues_turn = true;
+
+    var upgrade_status_buf: [64]u8 = undefined;
+    const queued_cards: QueuedCardProjection = .{};
+    const ctx = Runtime(CoordinatorTestApp).footerContext(
+        &app,
+        &upgrade_status_buf,
+        0,
+        &queued_cards,
+    );
+
+    try std.testing.expect(ctx.stream.active);
 }
 
 test "core.app_render_runtime keeps configured controls visible while model capabilities load" {

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -3280,6 +3280,16 @@ pub fn Runtime(comptime App: type) type {
                     try self.app.writeTranscript(text, true);
                 }
 
+                fn appendTurnCancellation(self: *Self) !void {
+                    const line = try transcript_runtime.formatHistoricalToolStatusLine(
+                        self.app.alloc,
+                        .cancelled,
+                        "Cancelled",
+                    );
+                    defer self.app.alloc.free(line);
+                    try self.appendRaw(line);
+                }
+
                 fn appendToolStatus(
                     self: *Self,
                     kind: types.ToolOutcomeKind,
@@ -3515,6 +3525,16 @@ pub fn Runtime(comptime App: type) type {
 
                 fn appendRaw(self: *Self, text: []const u8) !void {
                     _ = try self.projection.appendRawClassified(text, .unknown_raw);
+                }
+
+                fn appendTurnCancellation(self: *Self) !void {
+                    const line = try transcript_runtime.formatHistoricalToolStatusLine(
+                        self.projection.alloc,
+                        .cancelled,
+                        "Cancelled",
+                    );
+                    defer self.projection.alloc.free(line);
+                    try self.appendRaw(line);
                 }
 
                 fn appendToolStatus(
@@ -3810,7 +3830,14 @@ pub fn Runtime(comptime App: type) type {
                         if (entry.cancelled_command) |presentation| {
                             try writeCancelledCommandPresentation(app, sink, entry.tool_call.?, presentation);
                         }
-                        try sink.appendNotice(session_runtime.interruptedTurnNotice(entry));
+                        switch (entry.terminal_reason) {
+                            .cancelled => if (entry.cancelled_command == null) {
+                                try sink.appendTurnCancellation();
+                            },
+                            .failed => try sink.appendNotice(
+                                session_runtime.interruptedTurnNotice(entry),
+                            ),
+                        }
                         if (entry.execution.turn_summary) |summary| {
                             try sink.appendTurnSummary(summary);
                         }
@@ -8212,6 +8239,7 @@ test "resumeRequestedSession replays persisted model Markdown without parsing ge
         .code_block,
         .thematic_rule,
         .text,
+        .raw_transcript,
     };
     try std.testing.expectEqualSlices(
         AssistantPresentationEvent,
@@ -8235,9 +8263,11 @@ test "resumeRequestedSession replays persisted model Markdown without parsing ge
         app.assistant_code_blocks.items[0].code,
     );
     try std.testing.expectEqual(@as(usize, 1), app.assistant_thematic_rule_count);
-    try std.testing.expectEqual(@as(usize, 0), app.transcript.items.len);
-    try std.testing.expectEqual(@as(usize, 2), app.notices.items.len);
-    try std.testing.expectEqualStrings("● System: cancelled", app.notices.items[1]);
+    try std.testing.expect(std.mem.find(u8, app.transcript.items, "Cancelled") != null);
+    try std.testing.expect(std.mem.find(u8, app.transcript.items, "What can fx do differently?") != null);
+    try std.testing.expect(std.mem.find(u8, app.transcript.items, "System:") == null);
+    try std.testing.expect(std.mem.find(u8, app.transcript.items, "Cancelling") == null);
+    try std.testing.expectEqual(@as(usize, 1), app.notices.items.len);
 }
 
 test "resume Markdown replay releases undelivered table payloads once" {
@@ -8361,10 +8391,12 @@ test "resumeRequestedSession replays active-tool interruption with live cancella
 
     try std.testing.expectEqual(@as(usize, 1), app.cards.items.len);
     try std.testing.expectEqualStrings("inspect the browser", app.cards.items[0].text);
-    try std.testing.expectEqual(@as(usize, 0), app.transcript.items.len);
-    try std.testing.expectEqual(@as(usize, 2), app.notices.items.len);
+    try std.testing.expect(std.mem.find(u8, app.transcript.items, "Cancelled") != null);
+    try std.testing.expect(std.mem.find(u8, app.transcript.items, "What can fx do differently?") != null);
+    try std.testing.expect(std.mem.find(u8, app.transcript.items, "System:") == null);
+    try std.testing.expect(std.mem.find(u8, app.transcript.items, "Cancelling") == null);
+    try std.testing.expectEqual(@as(usize, 1), app.notices.items.len);
     try std.testing.expectEqualStrings("● Session resumed: inspect the browser", app.notices.items[0]);
-    try std.testing.expectEqualStrings("● System: cancelled", app.notices.items[1]);
     try std.testing.expect(std.mem.find(u8, app.transcript.items, "localhost") == null);
 }
 

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -3287,7 +3287,11 @@ pub fn Runtime(comptime App: type) type {
                         "Cancelled",
                     );
                     defer self.app.alloc.free(line);
-                    try self.appendRaw(line);
+                    try self.app.writeTranscriptClassified(
+                        line,
+                        true,
+                        .turn_cancellation,
+                    );
                 }
 
                 fn appendToolStatus(
@@ -3534,7 +3538,10 @@ pub fn Runtime(comptime App: type) type {
                         "Cancelled",
                     );
                     defer self.projection.alloc.free(line);
-                    try self.appendRaw(line);
+                    _ = try self.projection.appendRawClassified(
+                        line,
+                        .turn_cancellation,
+                    );
                 }
 
                 fn appendToolStatus(
@@ -5269,6 +5276,7 @@ const TestApp = struct {
     notices: std.ArrayList([]u8) = .empty,
     cards: std.ArrayList(PromptCard) = .empty,
     transcript: std.ArrayList(u8) = .empty,
+    raw_transcript_classes: std.ArrayList(transcript_runtime.RawEntryClass) = .empty,
     completed_tool_statuses: std.ArrayList([]u8) = .empty,
     completed_tool_outcomes: std.ArrayList(types.ToolOutcomeKind) = .empty,
     next_transcript_entry_id: u32 = 1,
@@ -5370,6 +5378,7 @@ const TestApp = struct {
         for (self.cards.items) |*card| card.deinit(self.alloc);
         self.cards.deinit(self.alloc);
         self.transcript.deinit(self.alloc);
+        self.raw_transcript_classes.deinit(self.alloc);
         for (self.completed_tool_statuses.items) |status| self.alloc.free(status);
         self.completed_tool_statuses.deinit(self.alloc);
         self.completed_tool_outcomes.deinit(self.alloc);
@@ -5446,14 +5455,20 @@ const TestApp = struct {
     }
 
     fn writeTranscript(self: *TestApp, text: []const u8, record: bool) !void {
-        _ = record;
-        try self.transcript.appendSlice(self.alloc, text);
-        try self.replay_events.append(self.alloc, .raw_transcript);
-        try self.assistant_presentation_events.append(self.alloc, .raw_transcript);
+        try self.writeTranscriptClassified(text, record, .unknown_raw);
     }
 
-    fn writeTranscriptClassified(self: *TestApp, text: []const u8, record: bool, _: anytype) !void {
-        try self.writeTranscript(text, record);
+    fn writeTranscriptClassified(
+        self: *TestApp,
+        text: []const u8,
+        record: bool,
+        class: transcript_runtime.RawEntryClass,
+    ) !void {
+        _ = record;
+        try self.transcript.appendSlice(self.alloc, text);
+        try self.raw_transcript_classes.append(self.alloc, class);
+        try self.replay_events.append(self.alloc, .raw_transcript);
+        try self.assistant_presentation_events.append(self.alloc, .raw_transcript);
     }
 
     fn writeCompletedToolStatus(
@@ -8267,6 +8282,10 @@ test "resumeRequestedSession replays persisted model Markdown without parsing ge
     try std.testing.expect(std.mem.find(u8, app.transcript.items, "What can fx do differently?") != null);
     try std.testing.expect(std.mem.find(u8, app.transcript.items, "System:") == null);
     try std.testing.expect(std.mem.find(u8, app.transcript.items, "Cancelling") == null);
+    try std.testing.expectEqual(
+        transcript_runtime.RawEntryClass.turn_cancellation,
+        app.raw_transcript_classes.getLast(),
+    );
     try std.testing.expectEqual(@as(usize, 1), app.notices.items.len);
 }
 

--- a/src/core/app/input_interrupt_runtime.zig
+++ b/src/core/app/input_interrupt_runtime.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
 const debug_trace = @import("../shared/debug_trace.zig");
 const worker_runtime = @import("../agent/worker_runtime.zig");
-const session_runtime = @import("../session/session.zig");
 const shell_runtime = @import("../../ui/shell_runtime.zig");
 const input_queue_runtime = @import("input_queue_runtime.zig");
 
@@ -88,10 +87,25 @@ pub fn InterruptRuntime(comptime App: type) type {
             };
             app.pacer.clear(app.alloc);
             if (comptime @hasDecl(App, "playCancelSound")) app.playCancelSound();
-            if (!tool_active) {
-                try app.writeDomainNotice(session_runtime.interrupted_turn_notice, true);
+            if (tool_active) {
+                _ = try shell_runtime.presentActiveToolCancellation(
+                    app.alloc,
+                    &app.shell,
+                );
+            } else {
+                if (comptime @hasField(App, "metrics")) {
+                    try shell_runtime.writeTurnCancellation(
+                        app.alloc,
+                        &app.shell,
+                        &app.metrics,
+                        true,
+                    );
+                }
             }
-            if (tool_active and !queue_review_opened) return;
+            if (tool_active and !queue_review_opened) {
+                app.shell.render_requests.request(.footer);
+                return;
+            }
             app.stream = .{};
             app.shell.render_requests.request(.footer);
         }

--- a/src/core/output/activity_runtime.zig
+++ b/src/core/output/activity_runtime.zig
@@ -13,6 +13,7 @@ pub const ToolPresentationRecord = struct {
     tool_name: ?[]const u8,
     activity_kind: types.ToolActivityKind,
     captured_command: bool = false,
+    cancellation_presented: bool = false,
     phase: ToolLifecyclePhase,
     focus_seq: u64,
 };

--- a/src/core/output/activity_runtime.zig
+++ b/src/core/output/activity_runtime.zig
@@ -7,13 +7,20 @@ pub const ToolLifecyclePhase = enum {
     terminal,
 };
 
+pub const CancellationPresentation = enum {
+    none,
+    tool_status,
+    turn_notice,
+    replaced,
+};
+
 pub const ToolPresentationRecord = struct {
     id: types.ToolLifecycleId,
     entry_id: u32,
     tool_name: ?[]const u8,
     activity_kind: types.ToolActivityKind,
     captured_command: bool = false,
-    cancellation_presented: bool = false,
+    cancellation_presentation: CancellationPresentation = .none,
     phase: ToolLifecyclePhase,
     focus_seq: u64,
 };
@@ -179,6 +186,30 @@ pub const ToolActivityState = struct {
             if (record_ptr.phase != .terminal) count += 1;
         }
         return count;
+    }
+
+    pub fn needsTurnCancellationNoticeAfterTerminal(
+        self: *const ToolActivityState,
+        id: types.ToolLifecycleId,
+    ) bool {
+        const settling = self.record(id) orelse return false;
+        switch (settling.cancellation_presentation) {
+            .none, .turn_notice => return false,
+            .tool_status, .replaced => {},
+        }
+        var iterator = self.records.valueIterator();
+        while (iterator.next()) |record_ptr| {
+            if (record_ptr.id.turn_id != id.turn_id or
+                std.mem.eql(u8, record_ptr.id.call_id, id.call_id))
+            {
+                continue;
+            }
+            switch (record_ptr.cancellation_presentation) {
+                .tool_status, .turn_notice => return false,
+                .none, .replaced => {},
+            }
+        }
+        return true;
     }
 
     pub fn focusedRecord(

--- a/src/core/output/activity_runtime.zig
+++ b/src/core/output/activity_runtime.zig
@@ -9,9 +9,15 @@ pub const ToolLifecyclePhase = enum {
 
 pub const CancellationPresentation = enum {
     none,
+    pending,
     tool_status,
-    turn_notice,
     replaced,
+};
+
+const TurnCancellationState = struct {
+    turn_id: u64,
+    interrupted: bool = false,
+    notice_presented: bool = false,
 };
 
 pub const ToolPresentationRecord = struct {
@@ -145,6 +151,7 @@ pub const ToolActivityState = struct {
     records: RecordMap = .empty,
     batch_finalized_turn_watermark: ?u64 = null,
     finalized_turn_watermark: u64 = 0,
+    turn_cancellation: ?TurnCancellationState = null,
     next_focus_seq: u64 = 0,
 
     pub fn deinit(self: *ToolActivityState, alloc: std.mem.Allocator) void {
@@ -192,10 +199,17 @@ pub const ToolActivityState = struct {
         self: *const ToolActivityState,
         id: types.ToolLifecycleId,
     ) bool {
+        const cancellation = self.turn_cancellation orelse return false;
+        if (cancellation.turn_id != id.turn_id or
+            !cancellation.interrupted or
+            cancellation.notice_presented)
+        {
+            return false;
+        }
         const settling = self.record(id) orelse return false;
         switch (settling.cancellation_presentation) {
-            .none, .turn_notice => return false,
-            .tool_status, .replaced => {},
+            .none => return false,
+            .pending, .tool_status, .replaced => {},
         }
         var iterator = self.records.valueIterator();
         while (iterator.next()) |record_ptr| {
@@ -205,11 +219,55 @@ pub const ToolActivityState = struct {
                 continue;
             }
             switch (record_ptr.cancellation_presentation) {
-                .tool_status, .turn_notice => return false,
+                .pending, .tool_status => return false,
                 .none, .replaced => {},
             }
         }
         return true;
+    }
+
+    pub fn needsTurnCancellationNoticeAfterTurnFinished(
+        self: *const ToolActivityState,
+        turn_id: u64,
+    ) bool {
+        const cancellation = self.turn_cancellation orelse return false;
+        if (cancellation.turn_id != turn_id or cancellation.notice_presented) {
+            return false;
+        }
+        var iterator = self.records.valueIterator();
+        while (iterator.next()) |record_ptr| {
+            if (record_ptr.id.turn_id != turn_id) continue;
+            switch (record_ptr.cancellation_presentation) {
+                .pending, .tool_status => return false,
+                .none, .replaced => {},
+            }
+        }
+        return true;
+    }
+
+    pub fn markTurnCancellationPresented(
+        self: *ToolActivityState,
+        turn_id: u64,
+    ) void {
+        self.turn_cancellation = .{ .turn_id = turn_id };
+    }
+
+    pub fn markTurnInterrupted(
+        self: *ToolActivityState,
+        turn_id: u64,
+    ) void {
+        if (self.turn_cancellation) |*cancellation| {
+            if (cancellation.turn_id == turn_id) cancellation.interrupted = true;
+        }
+    }
+
+    pub fn markTurnCancellationNoticePresented(
+        self: *ToolActivityState,
+        turn_id: u64,
+    ) void {
+        if (self.turn_cancellation) |*cancellation| {
+            if (cancellation.turn_id == turn_id) cancellation.notice_presented = true;
+        }
     }
 
     pub fn focusedRecord(
@@ -263,6 +321,10 @@ pub const ToolActivityState = struct {
             .entry_id = entry_id,
             .tool_name = tool_name,
             .activity_kind = activity_kind,
+            .cancellation_presentation = if (self.turn_cancellation) |cancellation|
+                if (cancellation.turn_id == id.turn_id) .pending else .none
+            else
+                .none,
             .phase = phase,
             .focus_seq = focus_seq,
         }, .{});

--- a/src/ui/render_engine/transcript_blocks.zig
+++ b/src/ui/render_engine/transcript_blocks.zig
@@ -123,6 +123,7 @@ pub const RawEntryClass = enum {
     command_output,
     diff_block,
     question_resolution,
+    turn_cancellation,
     subagent_status,
     unknown_raw,
 };
@@ -193,6 +194,7 @@ pub fn blockKindForRawClass(class: RawEntryClass) TranscriptBlockKind {
         .command_output => .command_output,
         .diff_block => .diff_block,
         .question_resolution => .cancel_notice,
+        .turn_cancellation => .cancel_notice,
         .subagent_status => .subagent_status,
         .unknown_raw => .unknown_raw,
     };
@@ -252,6 +254,7 @@ pub fn entryClassForEntry(entry: TranscriptEntry) TranscriptEntryClass {
             .command_output => .command_output,
             .diff_block => .diff_block,
             .question_resolution => .cancel_notice,
+            .turn_cancellation => .cancel_notice,
             .subagent_status => .subagent_status,
             .unknown_raw => .unknown_raw,
         },
@@ -2572,6 +2575,10 @@ pub fn footerBoundaryGapRowsForTail(kind: ?TranscriptBlockKind) u16 {
 }
 
 test "footer boundary gap applies to response-like and notice tail blocks" {
+    try std.testing.expectEqual(
+        TranscriptBlockKind.cancel_notice,
+        blockKindForRawClass(.turn_cancellation),
+    );
     try std.testing.expectEqual(@as(u16, 1), footerBoundaryGapRowsForTail(.assistant_turn));
     try std.testing.expectEqual(@as(u16, 1), footerBoundaryGapRowsForTail(.turn_summary));
     try std.testing.expectEqual(@as(u16, 1), footerBoundaryGapRowsForTail(.tool_status));

--- a/src/ui/shell_runtime.zig
+++ b/src/ui/shell_runtime.zig
@@ -400,6 +400,28 @@ pub fn activeToolActivityCount(shell: anytype) usize {
     return shell.activeToolActivityCount();
 }
 
+pub fn presentActiveToolCancellation(
+    alloc: Allocator,
+    shell: anytype,
+) !bool {
+    const Shell = @TypeOf(shell.*);
+    if (comptime !@hasDecl(Shell, "presentActiveToolCancellation")) {
+        return false;
+    }
+    return shell.presentActiveToolCancellation(alloc);
+}
+
+pub fn writeTurnCancellation(
+    alloc: Allocator,
+    shell: anytype,
+    metrics: *Metrics,
+    record: bool,
+) !void {
+    const Shell = @TypeOf(shell.*);
+    if (comptime !@hasDecl(Shell, "writeTurnCancellation")) return;
+    try shell.writeTurnCancellation(alloc, metrics, record);
+}
+
 pub fn requestRedraw(
     shell: *TranscriptRuntime,
     metrics: *Metrics,

--- a/src/ui/transcript/runtime.zig
+++ b/src/ui/transcript/runtime.zig
@@ -4600,6 +4600,67 @@ pub const TranscriptRuntime = struct {
         return self.lifecycle_state.activeCount();
     }
 
+    /// Publishes the terminal cancellation presentation immediately while the
+    /// worker retains lifecycle ownership until each tool actually settles.
+    pub fn presentActiveToolCancellation(
+        self: *TranscriptRuntime,
+        alloc: Allocator,
+    ) !bool {
+        const focused = self.lifecycle_state.focusedRecord() orelse return false;
+        const active = try self.lifecycle_state.collectFallbackRecords(
+            alloc,
+            focused.id.turn_id,
+        );
+        defer alloc.free(active);
+        if (active.len == 0) return false;
+
+        const line = try lifecycleTerminalLine(alloc, .cancelled, "Cancelled");
+        defer alloc.free(line);
+        const updates = try alloc.alloc(transcript_store.LifecycleEntryUpdate, active.len);
+        defer alloc.free(updates);
+        var detail_starts: std.ArrayList(PendingToolDetailStart) = .empty;
+        defer {
+            for (detail_starts.items) |*detail_start| detail_start.deinit(alloc);
+            detail_starts.deinit(alloc);
+        }
+        try detail_starts.ensureTotalCapacity(alloc, active.len);
+        var missing_detail_count: usize = 0;
+        for (active, 0..) |entry, index| {
+            if (self.toolDetailPtr(entry.record.entry_id) == null) {
+                missing_detail_count += 1;
+            }
+            detail_starts.appendAssumeCapacity(try self.prepareToolDetailStart(
+                alloc,
+                entry.record.entry_id,
+                entry.record.id,
+                entry.record.tool_name orelse "tool",
+                entry.record.activity_kind,
+                null,
+            ));
+            updates[index] = .{
+                .entry_id = entry.record.entry_id,
+                .bytes = line,
+            };
+        }
+        try transcript_store.replacePinnedToolStatusesAtomic(
+            self,
+            alloc,
+            updates,
+            missing_detail_count,
+        );
+        for (active, detail_starts.items) |entry, *detail_start| {
+            self.commitToolDetailStart(
+                alloc,
+                entry.record.entry_id,
+                detail_start,
+            );
+            const detail = self.toolDetailPtr(entry.record.entry_id).?;
+            detail.outcome = .cancelled;
+            detail.fallback_disposition = null;
+        }
+        return true;
+    }
+
     pub fn finalizedToolTurnWatermark(self: *const TranscriptRuntime) u64 {
         return self.lifecycle_state.finalized_turn_watermark;
     }
@@ -9203,6 +9264,24 @@ pub const TranscriptRuntime = struct {
             line,
             record,
             .tool_status,
+        );
+    }
+
+    pub fn writeTurnCancellation(
+        self: *TranscriptRuntime,
+        alloc: Allocator,
+        metrics: *Metrics,
+        record: bool,
+    ) !void {
+        const line = try lifecycleTerminalLine(alloc, .cancelled, "Cancelled");
+        defer alloc.free(line);
+        try transcript_writer.writeTranscriptClassified(
+            self,
+            alloc,
+            metrics,
+            line,
+            record,
+            .turn_cancellation,
         );
     }
 

--- a/src/ui/transcript/runtime.zig
+++ b/src/ui/transcript/runtime.zig
@@ -4649,7 +4649,7 @@ pub const TranscriptRuntime = struct {
             missing_detail_count,
         );
         for (active, detail_starts.items) |entry, *detail_start| {
-            entry.record.cancellation_presented = true;
+            entry.record.cancellation_presentation = .tool_status;
             self.commitToolDetailStart(
                 alloc,
                 entry.record.entry_id,
@@ -5054,16 +5054,15 @@ pub const TranscriptRuntime = struct {
             );
             return error.UnknownToolLifecycleIdentity;
         };
-        const presentation_outcome = if (record.cancellation_presented and outcome.kind != .cancelled)
-            types.ToolOutcome{ .kind = .cancelled, .summary = "Cancelled" }
-        else
-            outcome;
-        const line = try lifecycleTerminalLine(
-            alloc,
-            presentation_outcome.kind,
-            presentation_outcome.summary,
-        );
+        const line = try lifecycleTerminalLine(alloc, outcome.kind, outcome.summary);
         defer alloc.free(line);
+        const append_turn_cancellation = outcome.kind != .cancelled and
+            self.lifecycle_state.needsTurnCancellationNoticeAfterTerminal(id);
+        const turn_cancellation_line = if (append_turn_cancellation)
+            try lifecycleTerminalLine(alloc, .cancelled, "Cancelled")
+        else
+            null;
+        defer if (turn_cancellation_line) |value| alloc.free(value);
         var detail_start: ?PendingToolDetailStart = if (self.toolDetailPtr(record.entry_id) == null)
             try self.prepareToolDetailStart(
                 alloc,
@@ -5093,8 +5092,17 @@ pub const TranscriptRuntime = struct {
             line,
             @intFromBool(detail_start != null),
             @intFromBool(detail_update.command_process_entry != null),
+            turn_cancellation_line,
         )) return error.MissingLifecycleTranscriptEntry;
         record.phase = .terminal;
+        record.cancellation_presentation = if (append_turn_cancellation)
+            .turn_notice
+        else if (outcome.kind == .cancelled)
+            .tool_status
+        else if (record.cancellation_presentation != .none)
+            .replaced
+        else
+            .none;
         if (detail_start) |*pending| {
             self.commitLifecycleToolDetailStart(
                 alloc,
@@ -5107,7 +5115,7 @@ pub const TranscriptRuntime = struct {
             alloc,
             record.entry_id,
             record.activity_kind,
-            if (record.cancellation_presented) .cancelled else outcome.kind,
+            outcome.kind,
             &detail_update,
         );
         return null;
@@ -5199,6 +5207,10 @@ pub const TranscriptRuntime = struct {
             self.commitToolDetailStart(alloc, fallback.record.entry_id, detail_start);
             const detail = self.toolDetailPtr(fallback.record.entry_id).?;
             detail.outcome = fallback_outcome;
+            fallback.record.cancellation_presentation = if (fallback_outcome == .cancelled)
+                .tool_status
+            else
+                .none;
             detail.fallback_disposition = lifecycleFallbackDisposition(
                 finished.outcome,
                 fallback.was_provisional,

--- a/src/ui/transcript/runtime.zig
+++ b/src/ui/transcript/runtime.zig
@@ -4649,6 +4649,7 @@ pub const TranscriptRuntime = struct {
             missing_detail_count,
         );
         for (active, detail_starts.items) |entry, *detail_start| {
+            entry.record.cancellation_presented = true;
             self.commitToolDetailStart(
                 alloc,
                 entry.record.entry_id,
@@ -5053,7 +5054,15 @@ pub const TranscriptRuntime = struct {
             );
             return error.UnknownToolLifecycleIdentity;
         };
-        const line = try lifecycleTerminalLine(alloc, outcome.kind, outcome.summary);
+        const presentation_outcome = if (record.cancellation_presented and outcome.kind != .cancelled)
+            types.ToolOutcome{ .kind = .cancelled, .summary = "Cancelled" }
+        else
+            outcome;
+        const line = try lifecycleTerminalLine(
+            alloc,
+            presentation_outcome.kind,
+            presentation_outcome.summary,
+        );
         defer alloc.free(line);
         var detail_start: ?PendingToolDetailStart = if (self.toolDetailPtr(record.entry_id) == null)
             try self.prepareToolDetailStart(
@@ -5098,7 +5107,7 @@ pub const TranscriptRuntime = struct {
             alloc,
             record.entry_id,
             record.activity_kind,
-            outcome.kind,
+            if (record.cancellation_presented) .cancelled else outcome.kind,
             &detail_update,
         );
         return null;

--- a/src/ui/transcript/runtime.zig
+++ b/src/ui/transcript/runtime.zig
@@ -4647,7 +4647,9 @@ pub const TranscriptRuntime = struct {
             alloc,
             updates,
             missing_detail_count,
+            null,
         );
+        self.lifecycle_state.markTurnCancellationPresented(focused.id.turn_id);
         for (active, detail_starts.items) |entry, *detail_start| {
             entry.record.cancellation_presentation = .tool_status;
             self.commitToolDetailStart(
@@ -5083,6 +5085,7 @@ pub const TranscriptRuntime = struct {
             result_memory,
             command_artifact_handle,
             null,
+            @as(u32, @intFromBool(append_turn_cancellation)),
         );
         defer detail_update.deinit(alloc);
         if (!try transcript_store.replacePinnedToolStatusForTerminalAtomic(
@@ -5095,14 +5098,15 @@ pub const TranscriptRuntime = struct {
             turn_cancellation_line,
         )) return error.MissingLifecycleTranscriptEntry;
         record.phase = .terminal;
-        record.cancellation_presentation = if (append_turn_cancellation)
-            .turn_notice
-        else if (outcome.kind == .cancelled)
+        record.cancellation_presentation = if (outcome.kind == .cancelled)
             .tool_status
         else if (record.cancellation_presentation != .none)
             .replaced
         else
             .none;
+        if (append_turn_cancellation) {
+            self.lifecycle_state.markTurnCancellationNoticePresented(id.turn_id);
+        }
         if (detail_start) |*pending| {
             self.commitLifecycleToolDetailStart(
                 alloc,
@@ -5179,12 +5183,28 @@ pub const TranscriptRuntime = struct {
                 .bytes = line,
             };
         }
+        const fallback_outcome: ?types.ToolOutcomeKind = switch (finished.outcome) {
+            .completed => .completed,
+            .interrupted => .cancelled,
+            .failed => .failed,
+            .paused => null,
+        };
+        const append_turn_cancellation = finished.outcome == .interrupted and
+            self.lifecycle_state.needsTurnCancellationNoticeAfterTurnFinished(
+                finished.turn_id,
+            );
+        const turn_cancellation_line = if (append_turn_cancellation)
+            try lifecycleTerminalLine(alloc, .cancelled, "Cancelled")
+        else
+            null;
+        defer if (turn_cancellation_line) |value| alloc.free(value);
         const replace_result = if (preserve_normal_buffer_anchor)
             transcript_store.replacePinnedToolStatusesPreservingNormalBufferAnchorAtomic(
                 self,
                 alloc,
                 updates,
                 missing_detail_count,
+                turn_cancellation_line,
             )
         else
             transcript_store.replacePinnedToolStatusesAtomic(
@@ -5192,16 +5212,11 @@ pub const TranscriptRuntime = struct {
                 alloc,
                 updates,
                 missing_detail_count,
+                turn_cancellation_line,
             );
         replace_result catch |err| {
             traceLifecycleFailure("turn_finished", finished.turn_id, err);
             return err;
-        };
-        const fallback_outcome: ?types.ToolOutcomeKind = switch (finished.outcome) {
-            .completed => .completed,
-            .interrupted => .cancelled,
-            .failed => .failed,
-            .paused => null,
         };
         for (fallbacks, detail_starts.items) |fallback, *detail_start| {
             self.commitToolDetailStart(alloc, fallback.record.entry_id, detail_start);
@@ -5215,6 +5230,12 @@ pub const TranscriptRuntime = struct {
                 finished.outcome,
                 fallback.was_provisional,
             );
+        }
+        if (finished.outcome == .interrupted) {
+            self.lifecycle_state.markTurnInterrupted(finished.turn_id);
+            if (append_turn_cancellation) {
+                self.lifecycle_state.markTurnCancellationNoticePresented(finished.turn_id);
+            }
         }
         if (finished.outcome == .paused) {
             const entry_ids = try self.lifecycle_state.pausedTurnEntryIds(
@@ -5710,6 +5731,7 @@ pub const TranscriptRuntime = struct {
             result_memory,
             command_artifact_handle,
             command_output_entry_id_override,
+            0,
         );
         defer pending.deinit(alloc);
         if (self.toolDetailPtr(entry_id) == null) {
@@ -5727,6 +5749,7 @@ pub const TranscriptRuntime = struct {
         result_memory: ?types.ToolResultMemory,
         command_artifact_handle: ?[]const u8,
         command_output_entry_id_override: ?u32,
+        command_process_entry_offset: u32,
     ) !PendingToolDetailTerminal {
         var pending: PendingToolDetailTerminal = .{};
         errdefer pending.deinit(alloc);
@@ -5756,6 +5779,7 @@ pub const TranscriptRuntime = struct {
             pending.command_process_entry = try self.prepareCommandProcessPresentationEntry(
                 alloc,
                 lifecycle_id,
+                command_process_entry_offset,
             );
             pending.command_output_entry_id = pending.command_process_entry.?.entry_id;
         }
@@ -5838,8 +5862,11 @@ pub const TranscriptRuntime = struct {
         self: *TranscriptRuntime,
         alloc: Allocator,
         lifecycle_id: ?types.ToolLifecycleId,
+        entry_id_offset: u32,
     ) !PendingCommandProcessEntry {
-        var pending: PendingCommandProcessEntry = .{ .entry_id = self.next_entry_id };
+        var pending: PendingCommandProcessEntry = .{
+            .entry_id = self.next_entry_id +% entry_id_offset,
+        };
         errdefer pending.deinit(alloc);
         pending.bytes = try alloc.alloc(u8, 0);
 

--- a/src/ui/transcript/runtime_tests.zig
+++ b/src/ui/transcript/runtime_tests.zig
@@ -14834,41 +14834,57 @@ test "active tool cancellation is presented immediately without closing lifecycl
     try std.testing.expectEqual(@as(usize, 1), runtime.activeToolActivityCount());
 }
 
-test "active tool cancellation survives late successful settlement" {
+test "late successful settlement preserves its result and one turn cancellation" {
     const alloc = std.testing.allocator;
-    var runtime = lifecycleTestRuntime(null);
-    defer runtime.deinit(alloc);
+    for ([_]bool{ false, true }) |finish_before_terminal| {
+        var runtime = lifecycleTestRuntime(null);
+        defer runtime.deinit(alloc);
 
-    const id = lifecycleId(1, "late-success");
-    _ = try runtime.applyToolLifecycle(alloc, .{ .authoritative_started = .{
-        .id = id,
-        .reconciles_provisional_call_id = null,
-        .tool_name = "read_file",
-        .activity_kind = .read,
-    } });
+        const id = lifecycleId(1, "late-success");
+        _ = try runtime.applyToolLifecycle(alloc, .{ .authoritative_started = .{
+            .id = id,
+            .reconciles_provisional_call_id = null,
+            .tool_name = "read_file",
+            .activity_kind = .read,
+        } });
 
-    try std.testing.expect(try runtime.presentActiveToolCancellation(alloc));
-    _ = try runtime.applyToolLifecycle(alloc, .{ .terminal = .{
-        .id = id,
-        .outcome = .{ .kind = .completed, .summary = "Read the file" },
-        .result = "late result",
-    } });
-    _ = try runtime.applyToolLifecycle(alloc, .{ .turn_finished = .{
-        .turn_id = id.turn_id,
-        .outcome = .interrupted,
-    } });
+        try std.testing.expect(try runtime.presentActiveToolCancellation(alloc));
+        if (finish_before_terminal) {
+            _ = try runtime.applyToolLifecycle(alloc, .{ .turn_finished = .{
+                .turn_id = id.turn_id,
+                .outcome = .interrupted,
+            } });
+        }
+        _ = try runtime.applyToolLifecycle(alloc, .{ .terminal = .{
+            .id = id,
+            .outcome = .{ .kind = .completed, .summary = "Read the file" },
+            .result = "late result",
+        } });
+        if (!finish_before_terminal) {
+            _ = try runtime.applyToolLifecycle(alloc, .{ .turn_finished = .{
+                .turn_id = id.turn_id,
+                .outcome = .interrupted,
+            } });
+        }
 
-    var rendered = try runtime.prepareTranscriptSource(alloc, null);
-    defer rendered.deinit(alloc);
-    try std.testing.expectEqual(
-        @as(usize, 1),
-        std.mem.count(u8, rendered.bytes, "What can fx do differently?"),
-    );
-    try std.testing.expect(std.mem.find(u8, rendered.bytes, "Read the file") == null);
-    try std.testing.expectEqual(
-        types.ToolOutcomeKind.cancelled,
-        runtime.toolDetailForEntry(runtime.toolActivityRecord(id).?.entry_id).?.outcome.?,
-    );
+        var rendered = try runtime.prepareTranscriptSource(alloc, null);
+        defer rendered.deinit(alloc);
+        try std.testing.expectEqual(
+            @as(usize, 1),
+            std.mem.count(u8, rendered.bytes, "What can fx do differently?"),
+        );
+        try std.testing.expectEqual(
+            @as(usize, 1),
+            std.mem.count(u8, rendered.bytes, "Read the file"),
+        );
+        try std.testing.expectEqual(
+            RawEntryClass.turn_cancellation,
+            runtime.entries.getLast().raw_bytes.class,
+        );
+        const detail = runtime.toolDetailForEntry(runtime.toolActivityRecord(id).?.entry_id).?;
+        try std.testing.expectEqualStrings("late result", detail.result.?);
+        try std.testing.expectEqual(types.ToolOutcomeKind.completed, detail.outcome.?);
+    }
 }
 
 fn expectRawEntryBytes(

--- a/src/ui/transcript/runtime_tests.zig
+++ b/src/ui/transcript/runtime_tests.zig
@@ -14834,6 +14834,43 @@ test "active tool cancellation is presented immediately without closing lifecycl
     try std.testing.expectEqual(@as(usize, 1), runtime.activeToolActivityCount());
 }
 
+test "active tool cancellation survives late successful settlement" {
+    const alloc = std.testing.allocator;
+    var runtime = lifecycleTestRuntime(null);
+    defer runtime.deinit(alloc);
+
+    const id = lifecycleId(1, "late-success");
+    _ = try runtime.applyToolLifecycle(alloc, .{ .authoritative_started = .{
+        .id = id,
+        .reconciles_provisional_call_id = null,
+        .tool_name = "read_file",
+        .activity_kind = .read,
+    } });
+
+    try std.testing.expect(try runtime.presentActiveToolCancellation(alloc));
+    _ = try runtime.applyToolLifecycle(alloc, .{ .terminal = .{
+        .id = id,
+        .outcome = .{ .kind = .completed, .summary = "Read the file" },
+        .result = "late result",
+    } });
+    _ = try runtime.applyToolLifecycle(alloc, .{ .turn_finished = .{
+        .turn_id = id.turn_id,
+        .outcome = .interrupted,
+    } });
+
+    var rendered = try runtime.prepareTranscriptSource(alloc, null);
+    defer rendered.deinit(alloc);
+    try std.testing.expectEqual(
+        @as(usize, 1),
+        std.mem.count(u8, rendered.bytes, "What can fx do differently?"),
+    );
+    try std.testing.expect(std.mem.find(u8, rendered.bytes, "Read the file") == null);
+    try std.testing.expectEqual(
+        types.ToolOutcomeKind.cancelled,
+        runtime.toolDetailForEntry(runtime.toolActivityRecord(id).?.entry_id).?.outcome.?,
+    );
+}
+
 fn expectRawEntryBytes(
     runtime: *const TranscriptRuntime,
     entry_id: u32,

--- a/src/ui/transcript/runtime_tests.zig
+++ b/src/ui/transcript/runtime_tests.zig
@@ -14797,6 +14797,43 @@ test "transcript lifecycle terminal markers preserve ANSI summaries and normaliz
     ));
 }
 
+test "active tool cancellation is presented immediately without closing lifecycle state" {
+    const alloc = std.testing.allocator;
+    var runtime = lifecycleTestRuntime(null);
+    defer runtime.deinit(alloc);
+
+    const ids = [_]types.ToolLifecycleId{
+        lifecycleId(1, "read"),
+        lifecycleId(1, "command"),
+    };
+    for (ids) |id| {
+        _ = try runtime.applyToolLifecycle(alloc, .{ .authoritative_started = .{
+            .id = id,
+            .reconciles_provisional_call_id = null,
+            .tool_name = if (std.mem.eql(u8, id.call_id, "read")) "read_file" else "run_command",
+            .activity_kind = if (std.mem.eql(u8, id.call_id, "read")) .read else .command,
+        } });
+    }
+
+    try std.testing.expect(try runtime.presentActiveToolCancellation(alloc));
+    try std.testing.expectEqual(@as(usize, 2), runtime.activeToolActivityCount());
+
+    var rendered = try runtime.prepareTranscriptSource(alloc, null);
+    defer rendered.deinit(alloc);
+    try std.testing.expectEqual(
+        @as(usize, 2),
+        std.mem.count(u8, rendered.bytes, "What can fx do differently?"),
+    );
+    try std.testing.expect(std.mem.find(u8, rendered.bytes, "System:") == null);
+    try std.testing.expect(std.mem.find(u8, rendered.bytes, "Cancelling") == null);
+
+    _ = try runtime.applyToolLifecycle(alloc, .{ .terminal = .{
+        .id = ids[1],
+        .outcome = .{ .kind = .cancelled, .summary = "Cancelled sleep 30" },
+    } });
+    try std.testing.expectEqual(@as(usize, 1), runtime.activeToolActivityCount());
+}
+
 fn expectRawEntryBytes(
     runtime: *const TranscriptRuntime,
     entry_id: u32,

--- a/src/ui/transcript/runtime_tests.zig
+++ b/src/ui/transcript/runtime_tests.zig
@@ -14887,6 +14887,175 @@ test "late successful settlement preserves its result and one turn cancellation"
     }
 }
 
+test "post-cancel sibling settlement preserves one turn cancellation" {
+    const alloc = std.testing.allocator;
+    for ([_]bool{ false, true }) |sibling_reports_terminal| {
+        var runtime = lifecycleTestRuntime(null);
+        defer runtime.deinit(alloc);
+
+        const first = lifecycleId(1, "first");
+        _ = try runtime.applyToolLifecycle(alloc, .{ .authoritative_started = .{
+            .id = first,
+            .reconciles_provisional_call_id = null,
+            .tool_name = "read_file",
+            .activity_kind = .read,
+        } });
+        try std.testing.expect(try runtime.presentActiveToolCancellation(alloc));
+        _ = try runtime.applyToolLifecycle(alloc, .{ .terminal = .{
+            .id = first,
+            .outcome = .{ .kind = .completed, .summary = "Read first" },
+        } });
+
+        const sibling = lifecycleId(1, "sibling");
+        _ = try runtime.applyToolLifecycle(alloc, .{ .authoritative_started = .{
+            .id = sibling,
+            .reconciles_provisional_call_id = null,
+            .tool_name = "grep_files",
+            .activity_kind = .read,
+        } });
+        if (sibling_reports_terminal) {
+            _ = try runtime.applyToolLifecycle(alloc, .{ .terminal = .{
+                .id = sibling,
+                .outcome = .{ .kind = .cancelled, .summary = "Search cancelled" },
+            } });
+        }
+        _ = try runtime.applyToolLifecycle(alloc, .{ .turn_finished = .{
+            .turn_id = first.turn_id,
+            .outcome = .interrupted,
+        } });
+
+        var rendered = try runtime.prepareTranscriptSource(alloc, null);
+        defer rendered.deinit(alloc);
+        try std.testing.expectEqual(
+            @as(usize, 1),
+            std.mem.count(u8, rendered.bytes, "What can fx do differently?"),
+        );
+        try std.testing.expectEqual(
+            @as(usize, 1),
+            std.mem.count(u8, rendered.bytes, "Read first"),
+        );
+    }
+}
+
+test "late zero-output command settlement reserves distinct presentation entries" {
+    const alloc = std.testing.allocator;
+    for ([_]bool{ false, true }) |finish_before_terminal| {
+        var runtime = lifecycleTestRuntime(null);
+        defer runtime.deinit(alloc);
+
+        const id = lifecycleId(1, "zero-output-command");
+        _ = try runtime.applyToolLifecycle(alloc, .{ .authoritative_started = .{
+            .id = id,
+            .reconciles_provisional_call_id = null,
+            .tool_name = "shell",
+            .activity_kind = .command,
+            .arguments_json = "{\"request\":{\"action\":\"run\",\"command\":\"true\"}}",
+        } });
+        try std.testing.expect(try runtime.presentActiveToolCancellation(alloc));
+        if (finish_before_terminal) {
+            _ = try runtime.applyToolLifecycle(alloc, .{ .turn_finished = .{
+                .turn_id = id.turn_id,
+                .outcome = .interrupted,
+            } });
+        }
+        _ = try runtime.applyToolLifecycle(alloc, .{ .terminal = .{
+            .id = id,
+            .outcome = .{ .kind = .completed, .summary = "Ran true" },
+            .result = "exit_code=0\n",
+            .result_memory = .{
+                .command_process_presentation = .{ .exit_code = 0 },
+            },
+        } });
+        if (!finish_before_terminal) {
+            _ = try runtime.applyToolLifecycle(alloc, .{ .turn_finished = .{
+                .turn_id = id.turn_id,
+                .outcome = .interrupted,
+            } });
+        }
+
+        var rendered = try runtime.prepareTranscriptSource(alloc, null);
+        defer rendered.deinit(alloc);
+        try std.testing.expectEqual(
+            @as(usize, 1),
+            std.mem.count(u8, rendered.bytes, "What can fx do differently?"),
+        );
+        try std.testing.expectEqual(
+            @as(usize, 1),
+            std.mem.count(u8, rendered.bytes, "Ran true"),
+        );
+        const detail = runtime.toolDetailForEntry(runtime.toolActivityRecord(id).?.entry_id).?;
+        try std.testing.expectEqual(types.ToolOutcomeKind.completed, detail.outcome.?);
+        try std.testing.expectEqual(
+            types.CommandProcessPresentation{ .exit_code = 0 },
+            detail.command_process_presentation.?,
+        );
+        try std.testing.expectEqual(
+            RawEntryClass.command_output,
+            runtime.rawEntryClass(detail.command_output_entry_id.?).?,
+        );
+        for (runtime.entries.items, 0..) |entry, entry_index| {
+            for (runtime.entries.items[entry_index + 1 ..]) |other| {
+                try std.testing.expect(entry.id() != other.id());
+            }
+        }
+    }
+}
+
+fn checkLateZeroOutputCommandCancellationAllocationFailuresImpl(alloc: Allocator) !void {
+    var runtime = lifecycleTestRuntime(null);
+    defer runtime.deinit(alloc);
+
+    const id = lifecycleId(1, "allocation-command");
+    _ = try runtime.applyToolLifecycle(alloc, .{ .authoritative_started = .{
+        .id = id,
+        .reconciles_provisional_call_id = null,
+        .tool_name = "shell",
+        .activity_kind = .command,
+        .arguments_json = "{\"request\":{\"action\":\"run\",\"command\":\"true\"}}",
+    } });
+    try std.testing.expect(try runtime.presentActiveToolCancellation(alloc));
+    _ = try runtime.applyToolLifecycle(alloc, .{ .turn_finished = .{
+        .turn_id = id.turn_id,
+        .outcome = .interrupted,
+    } });
+    _ = try runtime.applyToolLifecycle(alloc, .{ .terminal = .{
+        .id = id,
+        .outcome = .{ .kind = .completed, .summary = "Ran true" },
+        .result = "exit_code=0\n",
+        .result_memory = .{
+            .command_process_presentation = .{ .exit_code = 0 },
+        },
+    } });
+
+    const detail = runtime.toolDetailForEntry(runtime.toolActivityRecord(id).?.entry_id).?;
+    try std.testing.expectEqual(types.ToolOutcomeKind.completed, detail.outcome.?);
+    try std.testing.expectEqual(
+        RawEntryClass.command_output,
+        runtime.rawEntryClass(detail.command_output_entry_id.?).?,
+    );
+    var rendered = try runtime.prepareTranscriptSource(alloc, null);
+    defer rendered.deinit(alloc);
+    try std.testing.expectEqual(
+        @as(usize, 1),
+        std.mem.count(u8, rendered.bytes, "What can fx do differently?"),
+    );
+}
+
+fn checkLateZeroOutputCommandCancellationAllocationFailures(alloc: Allocator) !void {
+    return checkLateZeroOutputCommandCancellationAllocationFailuresImpl(alloc) catch |err| switch (err) {
+        error.WriteFailed => error.OutOfMemory,
+        else => err,
+    };
+}
+
+test "late zero-output command cancellation remains atomic across allocation failures" {
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        checkLateZeroOutputCommandCancellationAllocationFailures,
+        .{},
+    );
+}
+
 fn expectRawEntryBytes(
     runtime: *const TranscriptRuntime,
     entry_id: u32,

--- a/src/ui/transcript/store.zig
+++ b/src/ui/transcript/store.zig
@@ -1570,6 +1570,7 @@ pub fn replacePinnedToolStatusesAtomic(
     alloc: Allocator,
     updates: []const LifecycleEntryUpdate,
     additional_tool_detail_capacity: usize,
+    turn_cancellation_line: ?[]const u8,
 ) !void {
     return replacePinnedToolStatusesAtomicWithRewriteMode(
         self,
@@ -1577,6 +1578,7 @@ pub fn replacePinnedToolStatusesAtomic(
         updates,
         .strict,
         additional_tool_detail_capacity,
+        turn_cancellation_line,
     );
 }
 
@@ -1585,6 +1587,7 @@ pub fn replacePinnedToolStatusesPreservingNormalBufferAnchorAtomic(
     alloc: Allocator,
     updates: []const LifecycleEntryUpdate,
     additional_tool_detail_capacity: usize,
+    turn_cancellation_line: ?[]const u8,
 ) !void {
     return replacePinnedToolStatusesAtomicWithRewriteMode(
         self,
@@ -1592,6 +1595,7 @@ pub fn replacePinnedToolStatusesPreservingNormalBufferAnchorAtomic(
         updates,
         .preserve_same_epoch,
         additional_tool_detail_capacity,
+        turn_cancellation_line,
     );
 }
 
@@ -1601,8 +1605,9 @@ fn replacePinnedToolStatusesAtomicWithRewriteMode(
     updates: []const LifecycleEntryUpdate,
     rewrite_mode: TranscriptSourceRewriteMode,
     additional_tool_detail_capacity: usize,
+    turn_cancellation_line: ?[]const u8,
 ) !void {
-    if (updates.len == 0) return;
+    if (updates.len == 0 and turn_cancellation_line == null) return;
     try self.assertCanMutateTranscript();
 
     var shadow = try cloneMutationState(self, alloc);
@@ -1610,6 +1615,10 @@ fn replacePinnedToolStatusesAtomicWithRewriteMode(
     try shadow.tool_details.ensureUnusedCapacity(
         alloc,
         additional_tool_detail_capacity,
+    );
+    try shadow.entries.ensureUnusedCapacity(
+        alloc,
+        @intFromBool(turn_cancellation_line != null),
     );
     for (updates) |update| {
         const entry_index = rawEntryIndex(&shadow, update.entry_id) orelse
@@ -1622,10 +1631,23 @@ fn replacePinnedToolStatusesAtomicWithRewriteMode(
         shadow.entries.items[entry_index].raw_bytes.bytes = replacement;
         shadow.entries.items[entry_index].raw_bytes.class = .tool_status;
     }
+    var turn_cancellation_entry_id: ?u32 = null;
+    if (turn_cancellation_line) |line| {
+        const owned = try alloc.dupe(u8, line);
+        var handed_off = false;
+        errdefer if (!handed_off) alloc.free(owned);
+        turn_cancellation_entry_id = try appendRawBytesEntryClassified(
+            &shadow,
+            alloc,
+            owned,
+            .turn_cancellation,
+        );
+        handed_off = true;
+    }
     const retention_changed = try enforceStructuredRetentionAndReport(
         &shadow,
         alloc,
-        null,
+        turn_cancellation_entry_id,
     );
     try rebuildTranscriptCacheFromEntries(
         &shadow,
@@ -1635,16 +1657,21 @@ fn replacePinnedToolStatusesAtomicWithRewriteMode(
     shadow.recomputeCursorFromTranscript();
     requestTranscriptPaint(&shadow);
 
-    var dirty_entry_index = rawEntryIndex(&shadow, updates[0].entry_id) orelse
-        return error.MissingLifecycleTranscriptEntry;
-    for (updates[1..]) |update| {
-        dirty_entry_index = @min(
-            dirty_entry_index,
-            rawEntryIndex(&shadow, update.entry_id) orelse
-                return error.MissingLifecycleTranscriptEntry,
-        );
+    var dirty_entry_id: u32 = undefined;
+    if (updates.len > 0) {
+        var dirty_entry_index = rawEntryIndex(&shadow, updates[0].entry_id) orelse
+            return error.MissingLifecycleTranscriptEntry;
+        for (updates[1..]) |update| {
+            dirty_entry_index = @min(
+                dirty_entry_index,
+                rawEntryIndex(&shadow, update.entry_id) orelse
+                    return error.MissingLifecycleTranscriptEntry,
+            );
+        }
+        dirty_entry_id = shadow.entries.items[dirty_entry_index].id();
+    } else {
+        dirty_entry_id = turn_cancellation_entry_id.?;
     }
-    const dirty_entry_id = shadow.entries.items[dirty_entry_index].id();
     try commitAuthoritativeRecordedMutationStateFromEntry(
         self,
         &shadow,

--- a/src/ui/transcript/store.zig
+++ b/src/ui/transcript/store.zig
@@ -1449,6 +1449,7 @@ pub fn replacePinnedToolStatusForTerminalAtomic(
     new_bytes: []const u8,
     additional_tool_detail_capacity: usize,
     additional_command_output_capacity: usize,
+    turn_cancellation_line: ?[]const u8,
 ) !bool {
     return replacePinnedToolStatusAtomicInternal(
         self,
@@ -1460,6 +1461,7 @@ pub fn replacePinnedToolStatusForTerminalAtomic(
         .{
             .tool_details = additional_tool_detail_capacity,
             .command_output_entries = additional_command_output_capacity,
+            .turn_cancellation_line = turn_cancellation_line,
         },
     );
 }
@@ -1467,9 +1469,12 @@ pub fn replacePinnedToolStatusForTerminalAtomic(
 const LifecycleStatusReservations = struct {
     tool_details: usize = 0,
     command_output_entries: usize = 0,
+    turn_cancellation_line: ?[]const u8 = null,
 
     fn empty(self: LifecycleStatusReservations) bool {
-        return self.tool_details == 0 and self.command_output_entries == 0;
+        return self.tool_details == 0 and
+            self.command_output_entries == 0 and
+            self.turn_cancellation_line == null;
     }
 };
 
@@ -1504,7 +1509,11 @@ fn replacePinnedToolStatusAtomicInternal(
     var shadow = try cloneMutationState(self, alloc);
     defer shadow.deinit(alloc);
     try shadow.tool_details.ensureUnusedCapacity(alloc, reservations.tool_details);
-    try shadow.entries.ensureUnusedCapacity(alloc, reservations.command_output_entries);
+    try shadow.entries.ensureUnusedCapacity(
+        alloc,
+        reservations.command_output_entries +
+            @intFromBool(reservations.turn_cancellation_line != null),
+    );
     try shadow.command_output_blocks.ensureUnusedCapacity(
         alloc,
         reservations.command_output_entries,
@@ -1519,10 +1528,23 @@ fn replacePinnedToolStatusAtomicInternal(
         const entry = shadow.entries.orderedRemove(shadow_index);
         shadow.entries.appendAssumeCapacity(entry);
     }
+    var retention_anchor = entry_id;
+    if (reservations.turn_cancellation_line) |cancellation_line| {
+        const owned = try alloc.dupe(u8, cancellation_line);
+        var handed_off = false;
+        errdefer if (!handed_off) alloc.free(owned);
+        retention_anchor = try appendRawBytesEntryClassified(
+            &shadow,
+            alloc,
+            owned,
+            .turn_cancellation,
+        );
+        handed_off = true;
+    }
     const retention_changed = try enforceStructuredRetentionAndReport(
         &shadow,
         alloc,
-        entry_id,
+        retention_anchor,
     );
     try rebuildTranscriptCacheFromEntries(
         &shadow,

--- a/src/ui/transcript/store.zig
+++ b/src/ui/transcript/store.zig
@@ -2919,6 +2919,7 @@ fn themeOwnsRawEntry(class: RawEntryClass) bool {
         .tool_status,
         .diff_block,
         .question_resolution,
+        .turn_cancellation,
         .subagent_status,
         => true,
         .command_output, .unknown_raw => false,

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -1521,9 +1521,15 @@ tmuxTest(
     await Bun.sleep(300);
     const cancelStarted = Date.now();
     await session.sendKeys("C-c");
-    await session.waitForText("System: cancelled", TIMEOUT);
+    const cancelledPane = await session.waitForText(
+      "What can fx do differently?",
+      TIMEOUT,
+    );
     await session.waitForComposer(TIMEOUT);
-    expect(Date.now() - cancelStarted).toBeLessThan(3_000);
+    expect(Date.now() - cancelStarted).toBeLessThan(500);
+    expect(cancelledPane).toContain("■ Cancelled");
+    expect(cancelledPane).not.toContain("System: cancelled");
+    expect(cancelledPane).not.toContain("Cancelling");
     expect(session.isAlive()).toBe(true);
     expect(readFileSync(stderrPath, "utf8")).toBe("");
   },

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -2342,12 +2342,14 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
         TIMEOUT,
       );
       await session!.sendKeys("Escape");
-      await session!.waitForText("cancelled", TIMEOUT);
+      await session!.waitForText("What can fx do differently?", TIMEOUT);
       await session!.waitForComposer(TIMEOUT);
       const scrollback = await session!.captureFullScrollback();
 
       expect(queuedGateway.requests).toHaveLength(3);
-      expect(scrollback).toContain("cancelled");
+      expect(scrollback).toContain("What can fx do differently?");
+      expect(scrollback).not.toContain("System: cancelled");
+      expect(scrollback).not.toContain("Cancelling");
       expect(scrollback).not.toContain("request failed: ModelError");
       expect(scrollback).not.toContain("must not send");
       expect(readFileSync(stderrPath, "utf8")).toBe("");
@@ -2738,7 +2740,10 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
         rowContaining(preEnterGrid, submittedPrompt),
       );
       await session.sendKeys("C-c");
-      const cancelledPane = await session.waitForText("cancelled", TIMEOUT);
+      const cancelledPane = await session.waitForText(
+        "What can fx do differently?",
+        TIMEOUT,
+      );
 
       execFileSync(FX_BIN, ["replay", tapePath, "--frames-dir", framesRoot], {
         encoding: "utf8",
@@ -2822,7 +2827,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       await session.waitForText("Thinking", TIMEOUT);
       await Bun.sleep(250);
       await session.sendKeys("C-c");
-      await session.waitForText("cancelled", TIMEOUT);
+      await session.waitForText("What can fx do differently?", TIMEOUT);
 
       execFileSync(FX_BIN, ["replay", tapePath, "--frames-dir", framesRoot], {
         encoding: "utf8",
@@ -3900,13 +3905,20 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       await session.waitForText("Thinking", TIMEOUT);
 
       await session.sendKeys("C-c");
-      const afterFirst = await session.waitForText("cancelled", TIMEOUT);
+      const afterFirst = await session.waitForText(
+        "What can fx do differently?",
+        TIMEOUT,
+      );
       await waitForCondition(() => hold.cancelled, "stream cancellation");
-      expect(afterFirst).toContain("cancelled");
+      expect(afterFirst).toContain("■ Cancelled");
+      expect(afterFirst).not.toContain("System: cancelled");
+      expect(afterFirst).not.toContain("Cancelling");
       expect(session.isPaneAlive()).toBe(true);
 
       const scrollbackAfterFirst = await session.captureFullScrollbackEscapes();
-      expect(countOccurrences(scrollbackAfterFirst, "cancelled")).toBe(1);
+      expect(
+        countOccurrences(scrollbackAfterFirst, "What can fx do differently?"),
+      ).toBe(1);
 
       await session.sendKeys("C-c");
       await waitForCondition(
@@ -3917,8 +3929,12 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
 
       const scrollback = await session.captureFullScrollback();
       const trace = readFileSync(tracePath, "utf8");
-      expect(scrollback).toContain("cancelled");
-      expect(countOccurrences(scrollback, "cancelled")).toBe(1);
+      expect(scrollback).toContain("What can fx do differently?");
+      expect(
+        countOccurrences(scrollback, "What can fx do differently?"),
+      ).toBe(1);
+      expect(scrollback).not.toContain("System: cancelled");
+      expect(scrollback).not.toContain("Cancelling");
       expect(countOccurrences(trace, "source=input_active_stream")).toBe(1);
       expect(readFileSync(stderrPath, "utf8")).toBe("");
       expect(existsSync(tapePath)).toBe(true);

--- a/tests/e2e/tui-interrupt-recovery.test.ts
+++ b/tests/e2e/tui-interrupt-recovery.test.ts
@@ -16,6 +16,7 @@ import { findFooterBlocks, readTrace } from "./tui-render-assertions";
 import {
   FAKE_GATEWAY_MODEL,
   fakeGatewayFinalText,
+  fakeGatewayToolCall,
   fakeShellRun,
   startFakeGateway,
   TmuxSession,
@@ -460,6 +461,88 @@ while :; do sleep 1; done
       expect(gateway.requests).toHaveLength(1);
       expect(readFileSync(stderrPath, "utf8")).toBe("");
       expect(session.isAlive()).toBe(true);
+      expect(session.isPaneAlive()).toBe(true);
+    },
+    TIMEOUT * 2,
+  );
+
+  test(
+    "late successful tool settlement stays truthful after Escape",
+    async () => {
+      root = realpathSync(mkdtempSync(join(tmpdir(), "fx-late-tool-success-")));
+      const home = join(root, "home");
+      const workspace = join(root, "workspace");
+      const corpus = join(workspace, "corpus");
+      const stderrPath = join(root, "stderr.log");
+      const tracePath = join(root, "trace.log");
+      const pattern = "LATE_SUCCESS_NEEDLE";
+      const callId = "late_success_grep";
+      mkdirSync(join(home, ".fx"), { recursive: true });
+      mkdirSync(corpus, { recursive: true });
+      writeFileSync(join(home, ".fx", "settings.json"), "{}");
+      for (let index = 0; index < 30_000; index += 1) {
+        writeFileSync(
+          join(corpus, `candidate-${String(index).padStart(5, "0")}.txt`),
+          "ordinary corpus text\n",
+        );
+      }
+
+      gateway = startFakeGateway([
+        fakeGatewayToolCall(callId, "grep_files", {
+          path: "corpus",
+          pattern,
+          head_limit: 5,
+        }),
+      ]);
+      session = await TmuxSession.create({
+        cwd: realpathSync(workspace),
+        stderrPath,
+        width: 120,
+        height: 40,
+        env: {
+          HOME: home,
+          AI_GATEWAY_API_KEY: "fake-late-tool-success-key",
+          VERCEL_OIDC_TOKEN: undefined,
+          FX_AUTO_UPGRADE: "0",
+          FX_GATEWAY_BASE_URL: gateway.baseUrl,
+          FX_GATEWAY_CHAT_URL: gateway.chatUrl,
+          FX_E2E_GATEWAY_CHAT_URL: gateway.chatUrl,
+          FX_MODEL: FAKE_GATEWAY_MODEL,
+          FX_TRACE_SCOPES: `${TRACE_SCOPES},tool,ui_activity`,
+          FX_TRACE_LOG: tracePath,
+        },
+      });
+      await session.waitForComposer(TIMEOUT);
+
+      await session.sendText("Search the prepared corpus.");
+      await session.waitForText(`Searching ${pattern}`, TIMEOUT);
+      expect(readTrace(tracePath)).not.toContain(
+        `event=after_tool_execution call_id=${callId}`,
+      );
+
+      const cancelStartedAt = Date.now();
+      await session.sendKeys("Escape");
+      await session.waitForText("What can fx do differently?", TIMEOUT);
+      expect(Date.now() - cancelStartedAt).toBeLessThan(500);
+      await waitForTrace(tracePath, `event=after_tool_execution`, TIMEOUT);
+      await waitForTrace(tracePath, "finish processing queued=0", TIMEOUT);
+
+      const trace = readTrace(tracePath);
+      const completedTool = trace.split("\n").find((line) =>
+        line.includes("event=after_tool_execution") &&
+        line.includes(`call_id=${callId}`) &&
+        line.includes("name=grep_files") &&
+        line.includes("result_kind=model_output")
+      );
+      expect(completedTool).toBeDefined();
+      await session.waitForText(`Searched ${pattern}`, TIMEOUT);
+      const scrollback = await session.captureFullScrollback();
+      expect(scrollback).toContain(`Searched ${pattern}`);
+      expect(countOccurrences(scrollback, "What can fx do differently?")).toBe(1);
+      expect(scrollback).not.toContain("System: cancelled");
+      expect(scrollback).not.toContain("Cancelling");
+      expect(gateway.requests).toHaveLength(1);
+      expect(readFileSync(stderrPath, "utf8")).toBe("");
       expect(session.isPaneAlive()).toBe(true);
     },
     TIMEOUT * 2,

--- a/tests/e2e/tui-interrupt-recovery.test.ts
+++ b/tests/e2e/tui-interrupt-recovery.test.ts
@@ -12,7 +12,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { readTrace } from "./tui-render-assertions";
+import { findFooterBlocks, readTrace } from "./tui-render-assertions";
 import {
   FAKE_GATEWAY_MODEL,
   fakeGatewayFinalText,
@@ -220,7 +220,18 @@ describe.skipIf(SKIP)("tui: interrupt recovery", () => {
       await session.sendKeys("Escape");
       await waitForCondition(() => held.cancelled, "gateway stream cancellation");
       await waitForTrace(tracePath, "event=interrupt_persisted", TIMEOUT);
-      await session.waitForText("cancelled", TIMEOUT);
+      await session.waitForText("What can fx do differently?", TIMEOUT);
+      const cancelledGrid = await session.capturePaneGrid();
+      const footer = findFooterBlocks(cancelledGrid).at(-1);
+      const cancelledRow = cancelledGrid.findIndex((row) => row.includes("■ Cancelled"));
+      expect(footer).toBeDefined();
+      expect(cancelledRow).toBeGreaterThanOrEqual(0);
+      expect(cancelledRow).toBeLessThan(footer!.topDivider);
+      const gapRows = cancelledGrid.slice(cancelledRow + 1, footer!.topDivider);
+      expect(gapRows.length).toBeGreaterThanOrEqual(1);
+      expect(gapRows.map((row) => row.trim())).toEqual(
+        Array.from({ length: gapRows.length }, () => ""),
+      );
       await session.sendText(`/model ${FOLLOW_UP_MODEL}`);
       await waitForCondition(
         () => JSON.parse(readFileSync(settingsPath, "utf8")).models?.gateway === FOLLOW_UP_MODEL,
@@ -231,7 +242,11 @@ describe.skipIf(SKIP)("tui: interrupt recovery", () => {
       for (const chunk of VISIBLE_PARTIAL_CHUNKS) {
         expect(interruptedScrollback).toContain(chunk.trim());
       }
-      expect(countOccurrences(interruptedScrollback, "cancelled")).toBe(1);
+      expect(
+        countOccurrences(interruptedScrollback, "What can fx do differently?"),
+      ).toBe(1);
+      expect(interruptedScrollback).not.toContain("System: cancelled");
+      expect(interruptedScrollback).not.toContain("Cancelling");
 
       await session.waitForText(FOLLOW_UP_RESPONSE, TIMEOUT);
       await waitForCondition(
@@ -244,7 +259,11 @@ describe.skipIf(SKIP)("tui: interrupt recovery", () => {
         expect(finalScrollback).toContain(chunk.trim());
       }
       expect(finalScrollback).toContain(FOLLOW_UP_RESPONSE);
-      expect(countOccurrences(finalScrollback, "cancelled")).toBe(1);
+      expect(
+        countOccurrences(finalScrollback, "What can fx do differently?"),
+      ).toBe(1);
+      expect(finalScrollback).not.toContain("System: cancelled");
+      expect(finalScrollback).not.toContain("Cancelling");
       expect(gateway.requests).toHaveLength(2);
       expect(held.cancelCount).toBe(1);
       expect(countOccurrences(readTrace(tracePath), "event=interrupt_persisted")).toBe(1);
@@ -391,7 +410,16 @@ while :; do sleep 1; done
       );
 
       const command = `/workspace add ${sharedRoot}`;
+      const cancelStartedAt = Date.now();
       await session.sendKeys("Escape");
+      const immediateCancellation = await session.waitForText(
+        "What can fx do differently?",
+        TIMEOUT,
+      );
+      expect(Date.now() - cancelStartedAt).toBeLessThan(500);
+      expect(immediateCancellation).toContain("■ Cancelled");
+      expect(immediateCancellation).not.toContain("System: cancelled");
+      expect(immediateCancellation).not.toContain("Cancelling");
       await waitForTrace(
         tracePath,
         "event=cancel_requested source=input_active_stream",

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -17,6 +17,7 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { FX_BIN, runFx } from "../evals/eval-helpers";
+import { findFooterBlocks } from "./tui-render-assertions";
 import {
   FAKE_GATEWAY_MODEL,
   fakeGatewayFinalText,
@@ -6386,6 +6387,37 @@ test.skipIf(!tmuxAvailable())(
 
       await active.sendKeys("Escape");
       await waitForCondition(() => hold.cancelled, "Escape to cancel the held response");
+      expect(readFileSync(stderrPath, "utf8")).toBe("");
+
+      await active.sendText("/quit");
+      expect(await active.waitForSessionEnd()).toBe(true);
+      await active.kill();
+      active = null;
+
+      const resumedGateway = startFakeGateway([]);
+      gateways.push(resumedGateway);
+      active = await TmuxSession.create({
+        cmd: `${FX_BIN} resume last`,
+        cwd: workspaceRoot,
+        env: gatewayEnv(home, resumedGateway),
+        stderrPath,
+        width: 120,
+        height: 40,
+      });
+      await active.waitForComposer(TIMEOUT);
+      await active.waitForText("What can fx do differently?", TIMEOUT);
+      const resumedGrid = await active.capturePaneGrid();
+      const footer = findFooterBlocks(resumedGrid).at(-1);
+      const cancelledRow = resumedGrid.findIndex((row) => row.includes("■ Cancelled"));
+      expect(footer).toBeDefined();
+      expect(cancelledRow).toBeGreaterThanOrEqual(0);
+      expect(cancelledRow).toBeLessThan(footer!.topDivider);
+      const gapRows = resumedGrid.slice(cancelledRow + 1, footer!.topDivider);
+      expect(gapRows.length).toBeGreaterThanOrEqual(1);
+      expect(gapRows.map((row) => row.trim())).toEqual(
+        Array.from({ length: gapRows.length }, () => ""),
+      );
+      expect(resumedGateway.requests).toHaveLength(0);
       expect(readFileSync(stderrPath, "utf8")).toBe("");
 
       await active.sendText("/quit");

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -6651,15 +6651,20 @@ test.skipIf(!tmuxAvailable())(
         height: 32,
       });
       await active.waitForComposer(TIMEOUT);
-      const resumed = stripAnsi(await waitForScrollback(active, "● System: cancelled", timeout));
+      const resumed = stripAnsi(await waitForScrollback(
+        active,
+        "What can fx do differently?",
+        timeout,
+      ));
       const cancelledIndex = resumed.indexOf("Cancelled");
-      const cancellationNoticeIndex = resumed.indexOf("● System: cancelled");
       expect(cancelledIndex).toBeGreaterThanOrEqual(0);
-      expect(cancellationNoticeIndex).toBeGreaterThan(cancelledIndex);
-      expect(countOccurrences(resumed, "● System: cancelled")).toBe(1);
+      expect(resumed).toContain("■ Cancelled");
+      expect(countOccurrences(resumed, "What can fx do differently?")).toBe(1);
+      expect(resumed).not.toContain("System: cancelled");
+      expect(resumed).not.toContain("Cancelling");
       expect(resumed).not.toContain("Interrupted by user after completing");
       expect(resumed).not.toContain("<turn_aborted>");
-      const restoredPresentation = resumed.slice(cancelledIndex, cancellationNoticeIndex);
+      const restoredPresentation = resumed.slice(cancelledIndex);
       expect(
         restoredPresentation.split("\n").some((line) => line.trimStart().startsWith("│")),
       ).toBe(false);


### PR DESCRIPTION
## Summary

- Show final cancellation feedback immediately when Escape stops an active response or tool.
- Preserve each tool’s authoritative result while retaining one cancellation marker when settlement races Escape.
- Use the same cancellation wording for live and resumed turns.
- Hide turn activity after explicit cancellation while keeping steering activity visible.
- Preserve the blank row between text-generation cancellation and the composer, including after resume.
- Keep workspace changes blocked until cancelled tool cleanup finishes.