### PR TITLE
Render pending steering messages with dotted rails

### DIFF
--- a/sdk/tests/test-term.mjs
+++ b/sdk/tests/test-term.mjs
@@ -180,7 +180,7 @@ if (!(streamStartedAt < secondRequestAt)) throw new Error("terminal started stee
 if (!(draftVisibleAt < steeringSubmittedAt)) throw new Error("terminal did not render the steering draft before submission");
 if (!(steeringSubmittedAt <= secondRequestAt)) throw new Error("terminal started steering before submission");
 if (!(secondRequestAt < streamFinishedAt)) throw new Error("terminal waited for the active response before steering");
-if (postSubmitText.includes(`${liveDraft} · Esc to steer now`)) throw new Error("terminal exposed tool-only pending UI during immediate steering");
+if (postSubmitText.includes(`┋ ${liveDraft}`)) throw new Error("terminal exposed tool-only pending UI during immediate steering");
 if (!postSubmitText.includes(liveDraft)) throw new Error("terminal did not commit the steering user row after cutoff");
 if (!postSubmitText.includes("Thinking")) throw new Error("terminal hid activity during immediate steering");
 const steeringUser = secondRequestBody.prompt?.filter((message) => message.role === "user").at(-1);

--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -1211,7 +1211,7 @@ pub fn Runtime(comptime App: type) type {
                 &queued_cards,
             );
             var footer_ctx = main_footer_ctx;
-            const render_reconciliation = switch (try reconcileBeforeFrameRender(app, render_input.queuedBannerRows(footer_ctx))) {
+            const render_reconciliation = switch (try reconcileBeforeFrameRender(app, render_input.queuedBannerRows(footer_ctx, app.shell.layout.cols))) {
                 .inline_render => |inline_render| inline_render,
                 .file_approval_screen => return renderApprovalScreen(app),
                 .frame_result => |result| return result,

--- a/src/ui/footer/input_presentation.zig
+++ b/src/ui/footer/input_presentation.zig
@@ -80,14 +80,17 @@ pub fn composeQueuedSummaryRow(
     return row;
 }
 
-pub fn composeSteeringMessageRow(
+pub fn composeSteeringMessageRows(
     alloc: Allocator,
     message: []const u8,
-    show_escape_hint: bool,
     width: u16,
-) !std.ArrayList(u8) {
-    var row: std.ArrayList(u8) = .empty;
-    try row.appendSlice(alloc, ui_render.hint_style);
+    row_limit: u16,
+) !ComposedInputRows {
+    var composed: ComposedInputRows = .{};
+    errdefer composed.deinit(alloc);
+    const max_rows = @min(row_limit, render_input.max_steering_message_rows);
+    if (max_rows == 0) return composed;
+
     var safe_message = try text_utils.encodeTerminalSafe(
         alloc,
         message,
@@ -95,20 +98,54 @@ pub fn composeSteeringMessageRow(
     );
     defer safe_message.deinit(alloc);
 
-    const escape_hint = " · Esc to steer now";
-    const width_usize: usize = width;
-    const escape_width = display_width.visibleWidth(escape_hint);
-    if (show_escape_hint and width_usize > escape_width) {
-        try row_text.appendSingleLineMiddleEllipsized(
-            alloc,
-            &row,
-            safe_message.bytes,
-            width_usize - escape_width,
-        );
-        try row.appendSlice(alloc, escape_hint);
-    } else {
-        try row_text.appendSingleLineMiddleEllipsized(alloc, &row, safe_message.bytes, width_usize);
+    const content_width: usize = width -| 2;
+    const visible_width = display_width.visibleWidth(safe_message.bytes);
+    const natural_rows: usize = if (content_width == 0 or visible_width == 0)
+        1
+    else
+        1 + (visible_width - 1) / content_width;
+    const row_count = @min(@as(usize, max_rows), natural_rows);
+
+    var projected: std.ArrayList(u8) = .empty;
+    defer projected.deinit(alloc);
+    try row_text.appendSingleLineMiddleEllipsized(
+        alloc,
+        &projected,
+        safe_message.bytes,
+        content_width * row_count,
+    );
+
+    var remaining = projected.items;
+    for (0..row_count) |_| {
+        const content = display_width.prefixByWidth(remaining, content_width);
+        var row: std.ArrayList(u8) = .empty;
+        errdefer row.deinit(alloc);
+        try row.appendSlice(alloc, ui_render.dim_style);
+        try row_text.appendClipped(alloc, &row, "┋", width);
+        if (width > 1) try row_text.appendClipped(alloc, &row, " ", width - 1);
+        if (width > 2) try row_text.appendClipped(alloc, &row, content, width - 2);
+        try row.appendSlice(alloc, ui_render.reset_style);
+        try composed.rows.append(alloc, row);
+        remaining = remaining[content.len..];
     }
+    return composed;
+}
+
+pub fn composeImmediateSteeringMessageRow(
+    alloc: Allocator,
+    message: []const u8,
+    width: u16,
+) !std.ArrayList(u8) {
+    var row: std.ArrayList(u8) = .empty;
+    errdefer row.deinit(alloc);
+    try row.appendSlice(alloc, ui_render.hint_style);
+    var safe_message = try text_utils.encodeTerminalSafe(
+        alloc,
+        message,
+        std.math.maxInt(usize),
+    );
+    defer safe_message.deinit(alloc);
+    try row_text.appendSingleLineMiddleEllipsized(alloc, &row, safe_message.bytes, width);
     try row.appendSlice(alloc, ui_render.reset_style);
     return row;
 }
@@ -142,33 +179,42 @@ test "collapsed queue banner counts the waiting prompts and offers the review" {
     try std.testing.expect(std.mem.find(u8, many.items, "3 queued messages · ↑ to edit") != null);
 }
 
-test "steering rows show actual messages and only the final escape hint" {
-    var first = try composeSteeringMessageRow(std.testing.allocator, "First steer", false, 80);
+test "steering rows use the dotted rail without an escape hint" {
+    var first = try composeSteeringMessageRows(std.testing.allocator, "First steer", 80, 2);
     defer first.deinit(std.testing.allocator);
-    var final = try composeSteeringMessageRow(std.testing.allocator, "Second steer", true, 80);
-    defer final.deinit(std.testing.allocator);
+    var second = try composeSteeringMessageRows(std.testing.allocator, "Second steer", 80, 2);
+    defer second.deinit(std.testing.allocator);
 
-    try std.testing.expect(std.mem.find(u8, first.items, "First steer") != null);
-    try std.testing.expect(std.mem.find(u8, first.items, "Esc to steer now") == null);
-    try std.testing.expect(std.mem.find(u8, final.items, "Second steer · Esc to steer now") != null);
+    try std.testing.expectEqual(@as(usize, 1), first.rows.items.len);
+    try std.testing.expectEqual(@as(usize, 1), second.rows.items.len);
+    try std.testing.expect(std.mem.find(u8, first.rows.items[0].items, "┋ First steer") != null);
+    try std.testing.expect(std.mem.find(u8, second.rows.items[0].items, "┋ Second steer") != null);
+    try std.testing.expect(std.mem.find(u8, first.rows.items[0].items, "Esc to steer now") == null);
+    try std.testing.expect(std.mem.find(u8, second.rows.items[0].items, "Esc to steer now") == null);
 }
 
-test "narrow steering row preserves distinguishing message ends and the escape hint" {
+test "narrow steering row preserves distinguishing message ends without the escape hint" {
     const message = "BEGIN change the implementation direction and retain this unique END";
-    var row = try composeSteeringMessageRow(std.testing.allocator, message, true, 48);
-    defer row.deinit(std.testing.allocator);
+    var rows = try composeSteeringMessageRows(std.testing.allocator, message, 48, 2);
+    defer rows.deinit(std.testing.allocator);
 
-    try std.testing.expect(std.mem.find(u8, row.items, "BEGIN") != null);
-    try std.testing.expect(std.mem.find(u8, row.items, "END") != null);
-    try std.testing.expect(std.mem.find(u8, row.items, "Esc to steer now") != null);
-    try std.testing.expect(display_width.visibleWidthIgnoringAnsi(row.items) <= 48);
+    try std.testing.expectEqual(@as(usize, 2), rows.rows.items.len);
+    try std.testing.expect(std.mem.find(u8, rows.rows.items[0].items, "┋ BEGIN") != null);
+    try std.testing.expect(std.mem.find(u8, rows.rows.items[1].items, "┋ ") != null);
+    try std.testing.expect(std.mem.find(u8, rows.rows.items[1].items, "END") != null);
+    for (rows.rows.items) |row| {
+        try std.testing.expect(std.mem.find(u8, row.items, "Esc to steer now") == null);
+        try std.testing.expect(display_width.visibleWidthIgnoringAnsi(row.items) <= 48);
+    }
 }
 
 test "steering rows visibly escape terminal control bytes" {
-    var unsafe = try composeSteeringMessageRow(std.testing.allocator, "before\x1b[2Jafter", true, 80);
+    var unsafe = try composeSteeringMessageRows(std.testing.allocator, "before\x1b[2Jafter", 80, 2);
     defer unsafe.deinit(std.testing.allocator);
-    try std.testing.expect(std.mem.find(u8, unsafe.items, "before\\x1b[2Jafter · Esc to steer now") != null);
-    try std.testing.expect(std.mem.find(u8, unsafe.items, "\x1b[2J") == null);
+    try std.testing.expectEqual(@as(usize, 1), unsafe.rows.items.len);
+    try std.testing.expect(std.mem.find(u8, unsafe.rows.items[0].items, "┋ before\\x1b[2Jafter") != null);
+    try std.testing.expect(std.mem.find(u8, unsafe.rows.items[0].items, "Esc to steer now") == null);
+    try std.testing.expect(std.mem.find(u8, unsafe.rows.items[0].items, "\x1b[2J") == null);
 }
 
 test "collapsed queue banner drops the affordance while the review is paused" {

--- a/src/ui/footer/input_presentation.zig
+++ b/src/ui/footer/input_presentation.zig
@@ -80,6 +80,22 @@ pub fn composeQueuedSummaryRow(
     return row;
 }
 
+fn appendSteeringMessageRow(
+    alloc: Allocator,
+    composed: *ComposedInputRows,
+    content: []const u8,
+    width: u16,
+) !void {
+    var row: std.ArrayList(u8) = .empty;
+    errdefer row.deinit(alloc);
+    try row.appendSlice(alloc, ui_render.dim_style);
+    try row_text.appendClipped(alloc, &row, "┋", width);
+    if (width > 1) try row_text.appendClipped(alloc, &row, " ", width - 1);
+    if (width > 2) try row_text.appendClipped(alloc, &row, content, width - 2);
+    try row.appendSlice(alloc, ui_render.reset_style);
+    try composed.rows.append(alloc, row);
+}
+
 pub fn composeSteeringMessageRows(
     alloc: Allocator,
     message: []const u8,
@@ -100,34 +116,37 @@ pub fn composeSteeringMessageRows(
 
     const content_width: usize = width -| 2;
     const visible_width = display_width.visibleWidth(safe_message.bytes);
-    const natural_rows: usize = if (content_width == 0 or visible_width == 0)
-        1
-    else
-        1 + (visible_width - 1) / content_width;
-    const row_count = @min(@as(usize, max_rows), natural_rows);
-
-    var projected: std.ArrayList(u8) = .empty;
-    defer projected.deinit(alloc);
-    try row_text.appendSingleLineMiddleEllipsized(
-        alloc,
-        &projected,
-        safe_message.bytes,
-        content_width * row_count,
-    );
-
-    var remaining = projected.items;
-    for (0..row_count) |_| {
-        const content = display_width.prefixByWidth(remaining, content_width);
-        var row: std.ArrayList(u8) = .empty;
-        errdefer row.deinit(alloc);
-        try row.appendSlice(alloc, ui_render.dim_style);
-        try row_text.appendClipped(alloc, &row, "┋", width);
-        if (width > 1) try row_text.appendClipped(alloc, &row, " ", width - 1);
-        if (width > 2) try row_text.appendClipped(alloc, &row, content, width - 2);
-        try row.appendSlice(alloc, ui_render.reset_style);
-        try composed.rows.append(alloc, row);
-        remaining = remaining[content.len..];
+    if (content_width == 0 or max_rows == 1 or visible_width <= content_width) {
+        var content: std.ArrayList(u8) = .empty;
+        defer content.deinit(alloc);
+        try row_text.appendSingleLineMiddleEllipsized(
+            alloc,
+            &content,
+            safe_message.bytes,
+            content_width,
+        );
+        try appendSteeringMessageRow(alloc, &composed, content.items, width);
+        return composed;
     }
+
+    const first = text_utils.prefixTerminalSafeByWidth(safe_message.bytes, content_width);
+    try appendSteeringMessageRow(alloc, &composed, first, width);
+
+    const remaining = safe_message.bytes[first.len..];
+    var second: std.ArrayList(u8) = .empty;
+    defer second.deinit(alloc);
+    if (display_width.visibleWidth(remaining) <= content_width) {
+        try second.appendSlice(alloc, remaining);
+    } else {
+        try second.appendSlice(alloc, "…");
+        if (content_width > 1) {
+            try second.appendSlice(
+                alloc,
+                text_utils.suffixTerminalSafeByWidth(remaining, content_width - 1),
+            );
+        }
+    }
+    try appendSteeringMessageRow(alloc, &composed, second.items, width);
     return composed;
 }
 
@@ -206,6 +225,15 @@ test "narrow steering row preserves distinguishing message ends without the esca
         try std.testing.expect(std.mem.find(u8, row.items, "Esc to steer now") == null);
         try std.testing.expect(display_width.visibleWidthIgnoringAnsi(row.items) <= 48);
     }
+}
+
+test "two steering rows preserve a wide glyph tail when cells do not pack evenly" {
+    var rows = try composeSteeringMessageRows(std.testing.allocator, "界海語", 5, 2);
+    defer rows.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), rows.rows.items.len);
+    try std.testing.expect(std.mem.find(u8, rows.rows.items[0].items, "┋ 界") != null);
+    try std.testing.expect(std.mem.find(u8, rows.rows.items[1].items, "┋ …語") != null);
 }
 
 test "steering rows visibly escape terminal control bytes" {

--- a/src/ui/footer/paint_plan.zig
+++ b/src/ui/footer/paint_plan.zig
@@ -583,28 +583,65 @@ fn pushQueuedPromptBannerRows(
     if (ctx.queued_prompt_cards.len == 0) {
         var painted: u16 = 0;
         if (ctx.steering_messages.len > 0) {
-            const visible_count = @min(
-                ctx.steering_messages.len,
-                @as(usize, plan.footer.banner_rows),
-            );
-            const visible_start = ctx.steering_messages.len - visible_count;
+            const gap_rows: u16 = @intFromBool(plan.footer.banner_rows > 1);
+            const steering_row_budget = plan.footer.banner_rows -| gap_rows;
+            var visible_start = ctx.steering_messages.len;
+            var remaining_rows = steering_row_budget;
+            var oldest_row_limit: u16 = 0;
+            while (visible_start > 0 and remaining_rows > 0) {
+                const candidate = visible_start - 1;
+                const candidate_rows = if (ctx.steering_waits_for_tool)
+                    render_input.steeringMessageRows(
+                        ctx.steering_messages[candidate],
+                        width,
+                    )
+                else
+                    1;
+                visible_start = candidate;
+                oldest_row_limit = @min(candidate_rows, remaining_rows);
+                if (candidate_rows >= remaining_rows) break;
+                remaining_rows -= candidate_rows;
+            }
             for (ctx.steering_messages[visible_start..], visible_start..) |message, index| {
                 if (painted >= plan.footer.banner_rows) break;
-                var row = try input_presentation.composeSteeringMessageRow(
-                    alloc,
-                    message,
-                    ctx.steering_waits_for_tool and
-                        index + 1 == ctx.steering_messages.len,
-                    width,
-                );
-                try pushFooterBandRow(
-                    alloc,
-                    frame,
-                    plan,
-                    plan.footer.banner +| painted,
-                    &row,
-                );
-                painted +|= 1;
+                if (ctx.steering_waits_for_tool) {
+                    const row_limit = if (index == visible_start)
+                        oldest_row_limit
+                    else
+                        render_input.max_steering_message_rows;
+                    var rows = try input_presentation.composeSteeringMessageRows(
+                        alloc,
+                        message,
+                        width,
+                        row_limit,
+                    );
+                    defer rows.deinit(alloc);
+                    for (rows.rows.items) |*row| {
+                        if (painted >= steering_row_budget) break;
+                        try pushFooterBandRow(
+                            alloc,
+                            frame,
+                            plan,
+                            plan.footer.banner +| painted,
+                            row,
+                        );
+                        painted +|= 1;
+                    }
+                } else {
+                    var row = try input_presentation.composeImmediateSteeringMessageRow(
+                        alloc,
+                        message,
+                        width,
+                    );
+                    try pushFooterBandRow(
+                        alloc,
+                        frame,
+                        plan,
+                        plan.footer.banner +| painted,
+                        &row,
+                    );
+                    painted +|= 1;
+                }
             }
         } else {
             var summary = try input_presentation.composeQueuedSummaryRow(
@@ -1373,6 +1410,23 @@ fn expectFrameRowTextTrimmed(frame: *const footer_viewport.ComposedFooterFrame, 
     return error.TestUnexpectedResult;
 }
 
+fn expectFrameRowContains(frame: *const footer_viewport.ComposedFooterFrame, row_number: u16, width: u16, expected: []const u8) !void {
+    for (frame.rows.items) |row| {
+        if (row.row == row_number) {
+            var grid = try vt_emulator.Grid.init(std.testing.allocator, width, 1);
+            defer grid.deinit();
+            try grid.feed(row.text.items);
+
+            var text: std.ArrayList(u8) = .empty;
+            defer text.deinit(std.testing.allocator);
+            try grid.rowTextTrimmed(1, &text);
+            try std.testing.expect(std.mem.find(u8, text.items, expected) != null);
+            return;
+        }
+    }
+    return error.TestUnexpectedResult;
+}
+
 fn expectFrameCellForeground(frame: *const footer_viewport.ComposedFooterFrame, row_number: u16, width: u16, col: u16, expected: vt_emulator.Color) !void {
     for (frame.rows.items) |row| {
         if (row.row == row_number) {
@@ -1566,7 +1620,7 @@ test "queued prompts collapse to a single summary row until the review opens" {
 
     var ctx = testContext(&input);
     ctx.queued_count = 2;
-    const banner_rows = render_input.queuedBannerRows(ctx);
+    const banner_rows = render_input.queuedBannerRows(ctx, shell.layout.cols);
     const planner_input: FooterPlannerInput = .{
         .active_label = null,
         .ctx = ctx,
@@ -1592,7 +1646,7 @@ test "queued prompts collapse to a single summary row until the review opens" {
     try std.testing.expect(frame_plan.paint.footer.input_base >= banner + 2);
 }
 
-test "clamped steering banner keeps newest messages and escape hint" {
+test "steering banner wraps one message onto dotted rails above a blank composer gap" {
     const alloc = std.testing.allocator;
 
     var input = InputRuntime{};
@@ -1615,7 +1669,7 @@ test "clamped steering banner keeps newest messages and escape hint" {
     };
     defer shell.deinit(alloc);
 
-    const messages = [_][]const u8{ "first hidden", "second hidden", "third visible", "fourth visible" };
+    const messages = [_][]const u8{"FOURTH_BEGIN change the implementation direction while keeping this distinguishing FOURTH_END"};
     var ctx = testContext(&input);
     ctx.queued_count = messages.len;
     ctx.steering_messages = &messages;
@@ -1628,9 +1682,9 @@ test "clamped steering banner keeps newest messages and escape hint" {
         .input_visible = true,
         .composer_top_chrome_rows = composerTopChromeRows(),
         .picker_rows = 0,
-        .footer_extra_rows = 2,
+        .footer_extra_rows = 3,
         .banner_active = true,
-        .banner_rows = 2,
+        .banner_rows = 3,
     };
 
     const frame_plan = planFooterPaint(&shell, planner_input);
@@ -1638,13 +1692,10 @@ test "clamped steering banner keeps newest messages and escape hint" {
     defer frame.deinit(alloc);
 
     const banner = frame_plan.paint.footer.banner;
-    try expectFrameRowTextTrimmed(&frame, banner, shell.layout.cols, "third visible");
-    try expectFrameRowTextTrimmed(
-        &frame,
-        banner + 1,
-        shell.layout.cols,
-        "fourth visible · Esc to steer now",
-    );
+    try expectFrameRowContains(&frame, banner, shell.layout.cols, "┋ FOURTH_BEGIN");
+    try expectFrameRowContains(&frame, banner + 1, shell.layout.cols, "FOURTH_END");
+    try expectFrameRowTextTrimmed(&frame, banner + 2, shell.layout.cols, "");
+    try expectFrameCellForeground(&frame, banner, shell.layout.cols, 1, .{ .indexed = 245 });
 }
 
 test "a hidden paused review keeps the summary row above its hint" {
@@ -1674,7 +1725,7 @@ test "a hidden paused review keeps the summary row above its hint" {
     ctx.queued_count = 1;
     ctx.queued_paused = true;
     ctx.queued_cancel_all_available = true;
-    const banner_rows = render_input.queuedBannerRows(ctx);
+    const banner_rows = render_input.queuedBannerRows(ctx, shell.layout.cols);
     const planner_input: FooterPlannerInput = .{
         .active_label = null,
         .ctx = ctx,

--- a/src/ui/footer/render_input.zig
+++ b/src/ui/footer/render_input.zig
@@ -16,6 +16,7 @@ const command_specs = @import("../../core/slash_commands/command_specs.zig");
 const settings_catalog = @import("../../core/config/settings_catalog.zig");
 const skill_runtime = @import("../../core/skills/skill_runtime.zig");
 const display_width = @import("../../core/shared/display_width.zig");
+const text_utils = @import("../../core/shared/text_utils.zig");
 const types = @import("../../core/shared/types.zig");
 const workspace_access = @import("../../core/workspace/workspace_access.zig");
 const file_index = @import("../../core/workspace/file_index.zig");
@@ -494,6 +495,7 @@ pub fn activeCompactCommandMenu(ctx: RenderContext) ?CompactCommandMenuProjectio
 
 // Trailing blank row that keeps the collapsed summary off the composer.
 pub const collapsed_queue_banner_gap_rows: u16 = 1;
+pub const max_steering_message_rows: u16 = 2;
 
 // Expanded cards plus one blank row between adjacent prompts, so queued drafts
 // read as separate items instead of a single connected block.
@@ -537,16 +539,30 @@ pub fn queuedBannerRowsForFacts(facts: QueuedBannerFacts) u16 {
     return 1 +| paused_hint_rows +| collapsed_queue_banner_gap_rows;
 }
 
-pub fn queuedBannerRows(ctx: RenderContext) u16 {
+pub fn steeringMessageRows(message: []const u8, width: u16) u16 {
+    const content_width = width -| 2;
+    if (content_width == 0) return 1;
+    return if (text_utils.terminalSafeVisibleWidth(message) <= content_width) 1 else max_steering_message_rows;
+}
+
+fn steeringRows(ctx: RenderContext, width: u16) u16 {
+    if (!ctx.steering_waits_for_tool) {
+        return @intCast(@min(ctx.steering_messages.len, std.math.maxInt(u16)));
+    }
+    var rows: u16 = 0;
+    for (ctx.steering_messages) |message| {
+        rows +|= steeringMessageRows(message, width);
+    }
+    return rows;
+}
+
+pub fn queuedBannerRows(ctx: RenderContext, width: u16) u16 {
     return queuedBannerRowsForFacts(.{
         .queued_count = ctx.queued_count,
         .paused = ctx.queued_paused,
         .card_count = ctx.queued_prompt_cards.len,
         .card_rows = ctx.queued_prompt_card_rows,
-        .steering_rows = @intCast(@min(
-            ctx.steering_messages.len,
-            @as(usize, std.math.maxInt(u16)),
-        )),
+        .steering_rows = steeringRows(ctx, width),
     });
 }
 

--- a/src/ui/footer/surface_frame.zig
+++ b/src/ui/footer/surface_frame.zig
@@ -334,12 +334,13 @@ fn applyResolvedBottomReservation(
 
 fn queuedBannerRowsForLayout(
     ctx: RenderContext,
+    terminal_cols: u16,
     terminal_rows: u16,
     input_visible: bool,
     composer_top_chrome_rows: u16,
     input_extra: u16,
 ) u16 {
-    const requested = render_input.queuedBannerRows(ctx);
+    const requested = render_input.queuedBannerRows(ctx, terminal_cols);
     return clampQueuedBannerRows(
         requested,
         terminal_rows,
@@ -515,6 +516,7 @@ fn buildFooterSurfaceProjection(
     const file_request = if (sizing_request) |request| request.file else null;
     const banner_rows = if (viewer_active) 0 else queuedBannerRowsForLayout(
         ctx,
+        shell.layout.cols,
         shell.layout.rows,
         input_visible,
         composer_top_chrome_rows,
@@ -1264,6 +1266,7 @@ pub noinline fn resolveSurfaceFooterReservation(
     const composer_top_chrome_rows_for_transient = footer_paint_plan.composerTopChromeRows();
     const banner_rows_for_transient = queuedBannerRowsForLayout(
         ctx,
+        shell.layout.cols,
         shell.layout.rows,
         input_visible_for_transient,
         composer_top_chrome_rows_for_transient,
@@ -1363,6 +1366,7 @@ fn prepareSurfaceFooterFrameInternal(
         const composer_top_chrome_rows_for_transient = footer_paint_plan.composerTopChromeRows();
         const banner_rows_for_transient = queuedBannerRowsForLayout(
             ctx,
+            shell.layout.cols,
             shell.layout.rows,
             input_visible_for_transient,
             composer_top_chrome_rows_for_transient,

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -2908,7 +2908,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       await session.sendText(SPLIT_NEW_USER_PROMPT);
       const cutoffPane = await session.capturePane();
       expect(cutoffPane).not.toContain(
-        `${SPLIT_NEW_USER_PROMPT} · Esc to steer now`,
+        `┋ ${SPLIT_NEW_USER_PROMPT}`,
       );
       expect(cutoffPane).toMatch(/Thinking|Generating/);
       await waitForCondition(
@@ -3160,7 +3160,8 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       await Bun.sleep(150);
       const pendingPane = await session.capturePane();
       expect(toolHandoff.cancelled).toBe(false);
-      expect(pendingPane).toContain(`${steering} · Esc to steer now`);
+      expect(pendingPane).toContain(`┋ ${steering}`);
+      expect(pendingPane).not.toContain("Esc to steer now");
       expect(handoffGateway.requests).toHaveLength(1);
 
       toolHandoff.release?.();
@@ -3251,16 +3252,23 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       await session.sendText(thirdSteering);
       await Bun.sleep(150);
       const pendingPane = await session.capturePane();
-      expect(pendingPane).toContain(firstSteering);
-      expect(pendingPane).toContain(secondSteering);
-      expect(pendingPane).toContain(`${thirdSteering} · Esc to steer now`);
+      expect(pendingPane).toContain(`┋ ${firstSteering}`);
+      expect(pendingPane).toContain(`┋ ${secondSteering}`);
+      expect(pendingPane).toContain(`┋ ${thirdSteering}`);
       expect(pendingPane.indexOf(firstSteering)).toBeLessThan(
         pendingPane.indexOf(secondSteering),
       );
       expect(pendingPane.indexOf(secondSteering)).toBeLessThan(
         pendingPane.indexOf(thirdSteering),
       );
-      expect(countOccurrences(pendingPane, "Esc to steer now")).toBe(1);
+      expect(pendingPane).not.toContain("Esc to steer now");
+      const pendingLines = pendingPane.split("\n");
+      const pendingComposer = pendingLines.findLastIndex(isComposerLine);
+      const pendingSteering = pendingLines.findLastIndex((line) =>
+        line.trimStart().startsWith("┋ ")
+      );
+      expect(pendingComposer - pendingSteering).toBe(2);
+      expect(pendingLines[pendingSteering + 1]!.trim()).toBe("");
       expect(pendingPane).not.toContain("Waiting for tool");
       expect(pendingPane).not.toContain("pending message");
       expect(pendingPane).not.toContain("queued 1");
@@ -3278,7 +3286,17 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       ]) {
         expect(narrowPane).toContain(marker);
       }
-      expect(countOccurrences(narrowPane, "Esc to steer now")).toBe(1);
+      expect(narrowPane).not.toContain("Esc to steer now");
+      const narrowLines = narrowPane.split("\n");
+      expect(
+        narrowLines.filter((line) => line.trimStart().startsWith("┋ ")),
+      ).toHaveLength(6);
+      const narrowComposer = narrowLines.findLastIndex(isComposerLine);
+      const narrowSteering = narrowLines.findLastIndex((line) =>
+        line.trimStart().startsWith("┋ ")
+      );
+      expect(narrowComposer - narrowSteering).toBe(2);
+      expect(narrowLines[narrowSteering + 1]!.trim()).toBe("");
       expect(narrowPane).not.toContain("queued message");
       await session.resizeWindow(120, 40);
 
@@ -3374,7 +3392,9 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       await session.sendText(`/image ${imagePath}`);
       await session.waitForText("attached image: steering-image.png", TIMEOUT);
       await session.sendText(steering);
-      await session.waitForText(`${steering} · Esc to steer now`, TIMEOUT);
+      const pendingPane = await session.waitForText("┋", TIMEOUT);
+      expect(pendingPane).toContain(steering);
+      expect(pendingPane).not.toContain("Esc to steer now");
       expect(steeringGateway.requests).toHaveLength(1);
 
       writeFileSync(releasePath, "release\n");
@@ -3473,7 +3493,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       await session.sendText("Run the failed steering tool fixture.");
       await session.waitForText("Running while", TIMEOUT);
       await session.sendText(steering);
-      await session.waitForText(`${steering} · Esc to steer now`, TIMEOUT);
+      await session.waitForText(`┋ ${steering}`, TIMEOUT);
       expect(steeringGateway.requests).toHaveLength(1);
 
       writeFileSync(releasePath, "release\n");
@@ -3550,7 +3570,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       await session.sendText("Run the immediate steering fixture.");
       await session.waitForText("Running sleep 30", TIMEOUT);
       await session.sendText(steering);
-      await session.waitForText(`${steering} · Esc to steer now`, TIMEOUT);
+      await session.waitForText(`┋ ${steering}`, TIMEOUT);
       expect(steeringGateway.requests).toHaveLength(1);
 
       await session.sendKeys("Escape");


### PR DESCRIPTION
## Summary

- Show tool-blocked steering messages with a dim dotted rail above the composer.
- Wrap each held message to at most two rows.
- Keep one blank row between held messages and the composer.
- Remove the escape hint without changing Escape steering behavior.