### PR TITLE
Keep first prompts responsive during credential refresh

### DIFF
--- a/src/core/app/app_auth_runtime.zig
+++ b/src/core/app/app_auth_runtime.zig
@@ -1448,7 +1448,7 @@ pub fn Runtime(comptime App: type) type {
                     return switch (app.auth.beginPromptCredentialRefresh()) {
                         .started, .pending => .pending,
                         .not_needed => if (app.auth.gatewayCredential() != null) .current else .rejected,
-                        .failed => .rejected,
+                        .failed => if (try admitPromptCredential(app)) .current else .rejected,
                     };
                 },
                 .pending => return .pending,
@@ -1483,7 +1483,7 @@ pub fn Runtime(comptime App: type) type {
             return switch (app.auth.beginPromptCredentialRefresh()) {
                 .started, .pending => .pending,
                 .not_needed => if (app.auth.gatewayCredential() != null) .current else .rejected,
-                .failed => .rejected,
+                .failed => if (try preparePromptCredential(app)) .current else .rejected,
             };
         }
 
@@ -1960,10 +1960,36 @@ const TestAuth = struct {
     sign_in_code_submit_succeeds: bool = true,
     inventory_refresh_action: ?auth_runtime.InventoryRefreshAction = null,
     inventory_refresh_fails: bool = false,
+    prompt_refresh_start: auth_runtime.PromptCredentialRefreshStart = .not_needed,
 
     fn credentialSource(self: *const TestAuth) ?credentials.Source {
         return self.active_source;
     }
+
+    fn view(self: *const TestAuth) auth_runtime.View {
+        return .{
+            .active_source = self.active_source,
+            .available_inactive_sources = .empty,
+            .selected_team = null,
+            .refreshable = if (self.active_source) |source|
+                credentials.sourceRefreshable(source)
+            else
+                false,
+            .stored_key_status = .not_attempted,
+            .fx_login_status = .not_attempted,
+            .onboarding_skipped = false,
+        };
+    }
+
+    fn beginPromptCredentialRefresh(self: *TestAuth) auth_runtime.PromptCredentialRefreshStart {
+        return self.prompt_refresh_start;
+    }
+
+    fn pollPromptCredentialRefresh(_: *TestAuth) auth_runtime.PromptCredentialRefreshPoll {
+        return .idle;
+    }
+
+    fn cancelPromptCredentialRefresh(_: *TestAuth) void {}
 
     fn selectSource(self: *TestAuth, _: std.mem.Allocator, source: credentials.Source) !?bool {
         self.selected_source = source;
@@ -2085,6 +2111,14 @@ const TestAuth = struct {
         return if (self.gateway_ready) .{ .api_key = "refreshed-key" } else null;
     }
 
+    fn adoptPreparedCredential(
+        self: *TestAuth,
+        _: std.mem.Allocator,
+        _: *credentials.Credential,
+    ) auth_transition.CredentialChange {
+        return self.refresh_change;
+    }
+
     fn modelCatalogAccess(self: *const TestAuth) credentials.CatalogAccess {
         return if (self.catalog_ready)
             credentials.catalogAccessForCredential(.fx_login, "refreshed-key", "team_123")
@@ -2099,6 +2133,10 @@ const TestAuth = struct {
 
     fn refreshSourceInventory(self: *TestAuth, _: std.mem.Allocator) !void {
         self.source_inventory_refresh_count += 1;
+    }
+
+    fn openOnboardingPicker(self: *TestAuth, _: std.mem.Allocator) void {
+        self.picker_opened = true;
     }
 
     fn refreshSourceInventoryForLogout(self: *TestAuth, _: std.mem.Allocator) !void {
@@ -2794,4 +2832,27 @@ test "prompt credential refresh allows only OutOfMemory to escape" {
     try std.testing.expect(!app.shell.render_requests.footer_requested);
     try std.testing.expectEqual(@as(usize, 0), app.auth.source_inventory_refresh_count);
     try std.testing.expect(!app.auth.picker_opened);
+}
+
+test "prompt credential refresh falls back when its task cannot start" {
+    var app: TestApp = .{};
+    defer app.deinit();
+    app.auth.active_source = .fx_login;
+    app.auth.prompt_refresh_start = .failed;
+    app.auth.gateway_ready = false;
+    app.auth.gateway_ready_after_refresh_count = 1;
+
+    try std.testing.expectEqual(
+        PendingPromptCredentialReadiness.current,
+        try Runtime(TestApp).collectPendingPromptCredential(&app),
+    );
+    try std.testing.expectEqual(@as(usize, 1), app.auth.refresh_count);
+
+    app.auth.gateway_ready = false;
+    app.auth.gateway_ready_after_refresh_count = 2;
+    try std.testing.expectEqual(
+        PendingPromptCredentialReadiness.current,
+        try Runtime(TestApp).retryPendingPromptCredential(&app),
+    );
+    try std.testing.expectEqual(@as(usize, 2), app.auth.refresh_count);
 }

--- a/src/core/app/app_auth_runtime.zig
+++ b/src/core/app/app_auth_runtime.zig
@@ -85,6 +85,12 @@ const TeamCatalogValidation = union(enum) {
     }
 };
 
+pub const PendingPromptCredentialReadiness = enum {
+    pending,
+    current,
+    rejected,
+};
+
 pub fn Runtime(comptime App: type) type {
     return struct {
         fn ensurePromptCredential(app: *App) !bool {
@@ -689,6 +695,7 @@ pub fn Runtime(comptime App: type) type {
                 .tone = .neutral,
                 .body = "Using automatic credential precedence again.",
             }, true);
+            try resumePromptAfterAuth(app);
         }
 
         fn forgetCredentialSource(app: *App) void {
@@ -733,6 +740,7 @@ pub fn Runtime(comptime App: type) type {
                 .tone = .neutral,
                 .body = body,
             }, true);
+            try resumePromptAfterAuth(app);
             return true;
         }
 
@@ -1381,6 +1389,13 @@ pub fn Runtime(comptime App: type) type {
 
         fn refreshFxLoginCredentialIfNeeded(app: *App) !void {
             const change = try app.auth.refreshSelectedCredentialIfNeeded(app.alloc);
+            applyCredentialRefreshChange(app, change);
+        }
+
+        fn applyCredentialRefreshChange(
+            app: *App,
+            change: auth_transition.CredentialChange,
+        ) void {
             if (change == .none) return;
             reconcileGatewayCredential(app);
             if (app.auth.modelCatalogAccess().authorizationCredential() == null) return;
@@ -1402,6 +1417,68 @@ pub fn Runtime(comptime App: type) type {
             }
             if (!try ensurePromptCredential(app)) return false;
             return preparePromptCredential(app);
+        }
+
+        pub fn startPromptCredentialPrewarm(app: *App) void {
+            if (comptime !@hasDecl(@TypeOf(app.auth), "beginPromptCredentialRefresh")) return;
+            const outcome = app.auth.beginPromptCredentialRefresh();
+            debug_trace.logf(
+                "auth",
+                "prompt credential prewarm start outcome={s}",
+                .{@tagName(outcome)},
+            );
+        }
+
+        pub fn collectPendingPromptCredential(
+            app: *App,
+        ) !PendingPromptCredentialReadiness {
+            if (!try ensurePromptCredential(app)) return .rejected;
+            const source = app.auth.credentialSource() orelse return .rejected;
+            if (!credentials.sourceRefreshable(source)) {
+                return if (app.auth.gatewayCredential() != null) .current else .rejected;
+            }
+
+            var refresh = app.auth.pollPromptCredentialRefresh();
+            defer refresh.deinit();
+            switch (refresh) {
+                .idle => {
+                    return switch (app.auth.beginPromptCredentialRefresh()) {
+                        .started, .pending => .pending,
+                        .not_needed => if (app.auth.gatewayCredential() != null) .current else .rejected,
+                        .failed => .rejected,
+                    };
+                },
+                .pending => return .pending,
+                .failed => |failure| {
+                    _ = try recoverCredentialFailure(app, failure.source, failure.err);
+                    return .rejected;
+                },
+                .ready => |*refreshed| {
+                    var owned = try refreshed.clone(app.alloc);
+                    defer owned.deinit(app.alloc);
+                    const change = app.auth.adoptPreparedCredential(app.alloc, &owned);
+                    applyCredentialRefreshChange(app, change);
+                    return if (app.auth.gatewayCredential() != null) .current else .pending;
+                },
+            }
+        }
+
+        pub fn retryPendingPromptCredential(
+            app: *App,
+        ) !PendingPromptCredentialReadiness {
+            if (comptime @hasDecl(@TypeOf(app.auth), "credentialFailure")) {
+                if (app.auth.credentialFailure()) |failure| {
+                    if (!failure.retryable()) {
+                        return if (try preparePromptCredential(app)) .current else .rejected;
+                    }
+                }
+            }
+            app.auth.cancelPromptCredentialRefresh();
+            return switch (app.auth.beginPromptCredentialRefresh()) {
+                .started, .pending => .pending,
+                .not_needed => if (app.auth.gatewayCredential() != null) .current else .rejected,
+                .failed => .rejected,
+            };
         }
 
         fn preparePromptCredential(app: *App) !bool {
@@ -1529,6 +1606,9 @@ pub fn Runtime(comptime App: type) type {
 
         fn applyCredentialChange(app: *App, changed: bool) void {
             if (!changed) return;
+            if (comptime @hasDecl(@TypeOf(app.auth), "cancelPromptCredentialRefresh")) {
+                app.auth.cancelPromptCredentialRefresh();
+            }
             reconcileGatewayCredential(app);
             app.model_cache.reset();
             if (comptime @hasDecl(App, "startModelCacheWarmup")) {

--- a/src/core/app/app_auth_runtime.zig
+++ b/src/core/app/app_auth_runtime.zig
@@ -1432,6 +1432,9 @@ pub fn Runtime(comptime App: type) type {
         pub fn collectPendingPromptCredential(
             app: *App,
         ) !PendingPromptCredentialReadiness {
+            if (comptime host_target.is_wasm) {
+                return if (try admitPromptCredential(app)) .current else .rejected;
+            }
             if (!try ensurePromptCredential(app)) return .rejected;
             const source = app.auth.credentialSource() orelse return .rejected;
             if (!credentials.sourceRefreshable(source)) {
@@ -1466,6 +1469,9 @@ pub fn Runtime(comptime App: type) type {
         pub fn retryPendingPromptCredential(
             app: *App,
         ) !PendingPromptCredentialReadiness {
+            if (comptime host_target.is_wasm) {
+                return if (try admitPromptCredential(app)) .current else .rejected;
+            }
             if (comptime @hasDecl(@TypeOf(app.auth), "credentialFailure")) {
                 if (app.auth.credentialFailure()) |failure| {
                     if (!failure.retryable()) {

--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -11956,7 +11956,7 @@ test "app_input_runtime submit resolves slash completion through core command sp
     try std.testing.expect(app.shell.render_requests.hasReason(.footer));
 }
 
-test "app_input_runtime idle submit installs one pending owner before queue effects" {
+test "app_input_runtime idle submit commits its frame before credential preflight" {
     const alloc = std.testing.allocator;
     var app = FakeSubmitApp{ .alloc = alloc };
     defer app.deinit();
@@ -11973,12 +11973,22 @@ test "app_input_runtime idle submit installs one pending owner before queue effe
         app.submission.pending.?.phase,
     );
     try std.testing.expect(app.worker.held);
+    try std.testing.expectEqual(@as(usize, 0), app.preflight_count);
     try std.testing.expectEqual(@as(usize, 0), app.queue_accept_count);
     try std.testing.expect(app.last_prompt == null);
     try std.testing.expectEqual(@as(usize, 1), app.input_runtime.composer_history.count());
     try std.testing.expectEqual(@as(usize, 0), app.input_runtime.edit_state.input.items.len);
     try std.testing.expect(app.shell.render_requests.hasReason(.transcript));
     try std.testing.expect(app.shell.render_requests.hasReason(.footer));
+
+    input_submit_runtime.SubmitRuntime(FakeSubmitApp).noteCommittedFrame(&app);
+    input_submit_runtime.SubmitRuntime(FakeSubmitApp).collectPendingSubmissionFacts(&app);
+
+    try std.testing.expectEqual(@as(usize, 1), app.preflight_count);
+    try std.testing.expectEqual(
+        input_submit_runtime.PendingPhase.queued,
+        app.submission.pending.?.phase,
+    );
 }
 
 test "app_input_runtime second Enter preserves the newer draft until pending acknowledgement" {
@@ -11998,7 +12008,7 @@ test "app_input_runtime second Enter preserves the newer draft until pending ack
     try std.testing.expectEqualStrings("newer draft", app.input_runtime.edit_state.input.items);
     try std.testing.expectEqual(@as(usize, 0), app.queue_accept_count);
     try std.testing.expectEqual(@as(usize, 1), app.input_runtime.composer_history.count());
-    try std.testing.expectEqual(@as(usize, 1), app.preflight_count);
+    try std.testing.expectEqual(@as(usize, 0), app.preflight_count);
     try std.testing.expectEqual(@as(usize, 0), app.command_count);
     try std.testing.expectEqual(@as(usize, 0), app.capture_count);
     try std.testing.expect(app.worker.held);
@@ -12009,7 +12019,7 @@ test "app_input_runtime second Enter preserves the newer draft until pending ack
     try Runtime(FakeSubmitApp).submit(&app, 100);
 
     try std.testing.expectEqualStrings("/help", app.input_runtime.edit_state.input.items);
-    try std.testing.expectEqual(@as(usize, 1), app.preflight_count);
+    try std.testing.expectEqual(@as(usize, 0), app.preflight_count);
     try std.testing.expectEqual(@as(usize, 0), app.command_count);
 }
 

--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -260,6 +260,12 @@ fn buildPendingCardProjection(
     };
 }
 
+fn pendingPromptActivityVisible(app: anytype) bool {
+    if (comptime !@hasField(@TypeOf(app.*), "submission")) return false;
+    const pending = app.submission.pending orelse return false;
+    return pending.phase != .awaiting_auth;
+}
+
 fn pendingCardTerminalWireBytes(
     alloc: std.mem.Allocator,
     logical: []const u8,
@@ -604,6 +610,7 @@ pub fn Runtime(comptime App: type) type {
             return .{
                 .slash_registry = app.slashRegistry(),
                 .stream = visible_stream,
+                .pending_prompt_activity = pendingPromptActivityVisible(app),
                 .completed_assistant_presentation_tail = app.pacer.hasCompletedAssistantPresentationTail(),
                 .writing_response = app.pacer.hasPending(),
                 .has_api_key = app.auth.credentialSource() != null,

--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -162,6 +162,27 @@ const PendingCardPaintContext = struct {
     row: u16,
     max_rows: u16,
 
+    fn init(
+        card: PendingCardProjection,
+        band: render_engine.paint_plan.FrameBand,
+        canonical_cursor_row: ?u16,
+        activity_visible: bool,
+    ) ?PendingCardPaintContext {
+        if (band.isEmpty()) return null;
+        const row = if (canonical_cursor_row) |base|
+            @max(base +| card.leading_advance_rows, band.top)
+        else
+            band.top;
+        if (row > band.bottom) return null;
+        const blank_rows: u16 = @intFromBool(activity_visible and band.bottom > row);
+        const bottom = band.bottom - blank_rows;
+        const max_rows = @min(card.paint_row_count, bottom - row + 1);
+        if (max_rows == 0) return null;
+        var lines = std.mem.splitScalar(u8, card.bytes, '\n');
+        for (0..card.paint_row_count - max_rows) |_| _ = lines.next();
+        return .{ .bytes = lines.rest(), .row = row, .max_rows = max_rows };
+    }
+
     fn paint(
         raw: *anyopaque,
         surface: *render_engine.frame_surface.FrameSurface,
@@ -1549,14 +1570,15 @@ pub fn Runtime(comptime App: type) type {
                     .paint => .paint,
                     .retain_committed => |retained| .{ .retain = retained },
                 } else .paint;
-            var pending_paint_ctx: ?PendingCardPaintContext = if (pending_card) |card| .{
-                .bytes = card.bytes,
-                .row = (if (prepared_transcript) |*prepared|
-                    prepared.cursor.cursor_row
-                else
-                    presentation_shell.cursor_row) +| card.leading_advance_rows,
-                .max_rows = card.paint_row_count,
-            } else null;
+            var pending_paint_ctx = if (pending_card) |card|
+                PendingCardPaintContext.init(
+                    card,
+                    footer_frame.paint.transcript_band,
+                    if (prepared_transcript) |*prepared| prepared.cursor.cursor_row else null,
+                    !footer_frame.paint.activity_band.isEmpty(),
+                )
+            else
+                null;
             if (pending_paint_ctx) |paint_ctx| switch (transcript_body) {
                 .paint => {},
                 .retain => |retained_source| {
@@ -1711,7 +1733,7 @@ pub fn Runtime(comptime App: type) type {
                 .animation_visible = frame_ctx.activity_result.painted,
                 .yolo_warning_visible = !render_reconciliation.alternate_screen_owns_rendering and
                     footer_frame.composed.danger_status_visible,
-                .pending_prompt_presented = pending_card != null,
+                .pending_prompt_presented = pending_paint_ctx != null,
             };
         }
 
@@ -2476,6 +2498,55 @@ test "pending prompt uses the canonical user turn boundary" {
         @as(u16, 1),
         pendingCardLeadingAdvanceRows(19, 47, 20),
     );
+}
+
+test "pending prompt painting fits the solved transcript band" {
+    const card: PendingCardProjection = .{
+        .bytes = @constCast("first\r\nsecond\r\nlast"),
+        .paint_row_count = 3,
+        .row_count = 5,
+        .leading_advance_rows = 2,
+    };
+    const clipped = PendingCardPaintContext.init(card, .{
+        .top = 1,
+        .bottom = 3,
+        .owner = .transcript,
+    }, null, true).?;
+    try std.testing.expectEqual(@as(u16, 1), clipped.row);
+    try std.testing.expectEqual(@as(u16, 2), clipped.max_rows);
+    try std.testing.expectEqualStrings("second\r\nlast", clipped.bytes);
+
+    const tiny = PendingCardPaintContext.init(card, .{
+        .top = 1,
+        .bottom = 1,
+        .owner = .transcript,
+    }, null, false).?;
+    try std.testing.expectEqual(@as(u16, 1), tiny.max_rows);
+    try std.testing.expectEqualStrings("last", tiny.bytes);
+    try std.testing.expect(PendingCardPaintContext.init(
+        card,
+        .empty(.transcript),
+        null,
+        true,
+    ) == null);
+
+    const following = PendingCardPaintContext.init(card, .{
+        .top = 1,
+        .bottom = 8,
+        .owner = .transcript,
+    }, 3, true).?;
+    try std.testing.expectEqual(@as(u16, 5), following.row);
+    try std.testing.expectEqual(@as(u16, 3), following.max_rows);
+    try std.testing.expectEqualStrings(card.bytes, following.bytes);
+
+    const last_row = PendingCardPaintContext.init(card, .{
+        .top = 1,
+        .bottom = 8,
+        .owner = .transcript,
+    }, 6, true).?;
+    try std.testing.expectEqual(@as(u16, 8), last_row.row);
+    try std.testing.expectEqual(@as(u16, 1), last_row.max_rows);
+    try std.testing.expectEqualStrings("last", last_row.bytes);
 }
 
 test "assistant tail writability changes remain traceable" {

--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -200,7 +200,7 @@ fn buildPendingCardProjection(
     const pending = app.submission.pending orelse return null;
     switch (pending.phase) {
         .awaiting_frame, .awaiting_adoption => {},
-        .adopted, .queued => return null,
+        .adopted, .awaiting_auth, .queued => return null,
     }
 
     const spans = pending.draft.skill_display_spans;
@@ -902,6 +902,11 @@ pub fn Runtime(comptime App: type) type {
                 render_request.animation_interval_ms,
                 result.animation_visible,
             );
+            if (comptime @hasDecl(App, "startPromptCredentialPrewarm")) {
+                if (snapshot.reasons.contains(.first_frame)) {
+                    App.startPromptCredentialPrewarm(app);
+                }
+            }
             if (comptime @hasDecl(App, "notePendingFrameCommitted")) {
                 if (result.pending_prompt_presented) {
                     App.notePendingFrameCommitted(app);

--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -1265,10 +1265,17 @@ pub fn Runtime(comptime App: type) type {
                     measurement.frameLayoutMeasurement()
                 else
                     footerMeasurementFromRows(footer_frame.paint.footer);
-                const frame_activity = if (footer_measurement) |*measurement|
+                var frame_activity = if (footer_measurement) |*measurement|
                     frameActivityStateFromMeasurement(presentation_shell, measurement)
                 else
                     activityStateFromPlacement(footer_frame.paint.activity);
+                if (pending_card != null and frame_activity == .thinking) {
+                    // The pending tail already includes the transcript cursor's blank row.
+                    frame_activity.thinking.gap_above_activity = render_engine.transcript_blocks.blockGapRowsBetween(
+                        .user_turn,
+                        .assistant_turn,
+                    ) -| 1;
+                }
                 const target_activity_projection: activity_runtime.ActivityProjection = if (footer_measurement) |*measurement|
                     measurement.activity_projection
                 else

--- a/src/core/app/input_submit_runtime.zig
+++ b/src/core/app/input_submit_runtime.zig
@@ -15,6 +15,7 @@ pub const PendingPhase = enum {
     awaiting_frame,
     awaiting_adoption,
     adopted,
+    awaiting_auth,
     queued,
 };
 
@@ -136,6 +137,11 @@ pub fn SubmitRuntime(comptime App: type) type {
 
         pub fn cancelPromptRetryAfterAuth(app: *App) void {
             app.submission.retry_after_auth = false;
+            const pending = app.submission.pending orelse return;
+            if (pending.phase != .awaiting_auth) return;
+            clearPendingSubmission(app, "auth_retry_cancelled");
+            app.shell.render_requests.request(.transcript);
+            app.shell.render_requests.request(.footer);
         }
 
         fn takePromptRetryAfterAuth(app: *App) bool {
@@ -144,8 +150,25 @@ pub fn SubmitRuntime(comptime App: type) type {
             return pending;
         }
 
+        fn resumePendingPromptAfterAuth(app: *App, trigger: []const u8) bool {
+            const pending = if (app.submission.pending) |*value| value else return false;
+            if (pending.phase != .awaiting_auth) return false;
+            pending.phase = .adopted;
+            app.submission.retry_after_auth = false;
+            app.shell.render_requests.request(.footer);
+            debug_trace.eventf(
+                "input",
+                "pending_prompt_auth_resumed",
+                .{ .turn_id = pending.draft.turn_id },
+                "trigger={s}",
+                .{trigger},
+            );
+            return true;
+        }
+
         pub fn resumePromptAfterAuth(app: *App, max_prompt_history: usize) !void {
             if (!takePromptRetryAfterAuth(app)) return;
+            if (resumePendingPromptAfterAuth(app, "auth_completion")) return;
             try submit(app, max_prompt_history);
         }
         const completion_rt = input_completion_runtime.CompletionRuntime(App);
@@ -226,6 +249,48 @@ pub fn SubmitRuntime(comptime App: type) type {
                 pending = &app.submission.pending.?;
             }
             if (pending.phase != .adopted) return;
+
+            if (comptime @hasDecl(App, "collectPendingPromptCredential")) {
+                const readiness = App.collectPendingPromptCredential(app) catch |err| {
+                    finishPendingSubmissionFailure(app, err);
+                    return;
+                };
+                switch (readiness) {
+                    .pending => return,
+                    .current => {},
+                    .rejected => {
+                        pending = &app.submission.pending.?;
+                        pending.phase = .awaiting_auth;
+                        requestPromptRetryAfterAuth(app);
+                        debug_trace.eventf(
+                            "input",
+                            "pending_prompt_awaiting_auth",
+                            .{ .turn_id = pending.draft.turn_id },
+                            "",
+                            .{},
+                        );
+                        return;
+                    },
+                }
+            } else if (comptime @hasDecl(App, "ensurePromptCredential")) {
+                const admitted = preflightPrompt(app) catch |err| {
+                    finishPendingSubmissionFailure(app, err);
+                    return;
+                };
+                pending = &app.submission.pending.?;
+                if (!admitted) {
+                    pending.phase = .awaiting_auth;
+                    requestPromptRetryAfterAuth(app);
+                    debug_trace.eventf(
+                        "input",
+                        "pending_prompt_awaiting_auth",
+                        .{ .turn_id = pending.draft.turn_id },
+                        "",
+                        .{},
+                    );
+                    return;
+                }
+            }
 
             if (comptime @hasDecl(App, "collectPendingSkillRefresh")) {
                 const readiness = App.collectPendingSkillRefresh(app, pending) catch |err| {
@@ -473,14 +538,49 @@ pub fn SubmitRuntime(comptime App: type) type {
         pub fn submit(app: *App, max_prompt_history: usize) !void {
             if (comptime @hasField(App, "submission")) {
                 if (app.submission.pending) |pending| {
-                    debug_trace.eventf(
-                        "input",
-                        "prompt_submit_deferred_for_pending",
-                        .{ .turn_id = pending.draft.turn_id },
-                        "phase={s}",
-                        .{@tagName(pending.phase)},
-                    );
-                    return;
+                    const route_local_command = pending.phase == .awaiting_auth and
+                        pendingAuthRoutesLocalCommand(app);
+                    if (!route_local_command and
+                        pending.phase == .awaiting_auth and
+                        app.input_runtime.edit_state.input.items.len == 0)
+                    {
+                        if (comptime @hasDecl(App, "retryPendingPromptCredential")) {
+                            switch (try App.retryPendingPromptCredential(app)) {
+                                .pending => {
+                                    app.submission.retry_after_auth = false;
+                                    app.submission.pending.?.phase = .adopted;
+                                    app.shell.render_requests.request(.footer);
+                                },
+                                .current => {
+                                    const resumed = resumePendingPromptAfterAuth(app, "submit");
+                                    std.debug.assert(resumed);
+                                },
+                                .rejected => {},
+                            }
+                        } else if (try preflightPrompt(app)) {
+                            const resumed = resumePendingPromptAfterAuth(app, "submit");
+                            std.debug.assert(resumed);
+                        }
+                        return;
+                    }
+                    if (route_local_command) {
+                        debug_trace.eventf(
+                            "input",
+                            "pending_prompt_auth_command_routed",
+                            .{ .turn_id = pending.draft.turn_id },
+                            "",
+                            .{},
+                        );
+                    } else {
+                        debug_trace.eventf(
+                            "input",
+                            "prompt_submit_deferred_for_pending",
+                            .{ .turn_id = pending.draft.turn_id },
+                            "phase={s}",
+                            .{@tagName(pending.phase)},
+                        );
+                        return;
+                    }
                 }
             }
             const expanded_len = paste_blocks.expandedLen(
@@ -548,7 +648,6 @@ pub fn SubmitRuntime(comptime App: type) type {
 
             if (trimmed.len == 0) {
                 if (app.pending_images.items.len > 0) {
-                    if (!try preflightPrompt(app)) return;
                     const admission = try enqueuePromptForSubmit(app, "", &.{});
                     if (admission == .rejected) return;
                     releasePendingImages(app);
@@ -598,8 +697,6 @@ pub fn SubmitRuntime(comptime App: type) type {
 
             const has_inline_images = extracted.images.len > 0;
             const effective_text = if (has_inline_images) extracted.text else expanded.text;
-
-            if (!try preflightPrompt(app)) return;
 
             var staged_images = if (app.pending_images.items.len > 0 or extracted.images.len > 0)
                 try stagePendingImages(app.alloc, app.pending_images.items, extracted.images)
@@ -711,6 +808,17 @@ pub fn SubmitRuntime(comptime App: type) type {
                 return App.ensurePromptCredential(app);
             }
             return true;
+        }
+
+        fn pendingAuthRoutesLocalCommand(app: *App) bool {
+            const input = std.mem.trimStart(
+                u8,
+                app.input_runtime.edit_state.input.items,
+                " \t\r\n",
+            );
+            const submission = resolvedSlashSubmission(app, input);
+            const command = knownSlashCommand(app, submission) orelse return false;
+            return !requiresPromptCredential(command, submission);
         }
 
         fn knownSlashCommand(app: *const App, text: []const u8) ?*const command_specs.SlashSpec {
@@ -895,6 +1003,7 @@ pub fn SubmitRuntime(comptime App: type) type {
                 .installed => return .pending,
                 .unavailable => {},
             }
+            if (!try preflightPrompt(app)) return .rejected;
             const accepted = if (comptime @hasDecl(App, "enqueuePromptWithSkillBindings"))
                 try App.enqueuePromptWithSkillBindings(app, prompt, skill_tokens)
             else

--- a/src/core/app/input_submit_runtime.zig
+++ b/src/core/app/input_submit_runtime.zig
@@ -37,6 +37,7 @@ pub const PendingPromptDraft = struct {
 pub const PendingSubmission = struct {
     draft: PendingPromptDraft,
     phase: PendingPhase = .awaiting_frame,
+    credential_admitted: bool = false,
     skill_refresh_generation: ?u64 = null,
 
     fn init(draft: PendingPromptDraft) PendingSubmission {
@@ -250,16 +251,36 @@ pub fn SubmitRuntime(comptime App: type) type {
             }
             if (pending.phase != .adopted) return;
 
-            if (comptime @hasDecl(App, "collectPendingPromptCredential")) {
-                const readiness = App.collectPendingPromptCredential(app) catch |err| {
-                    finishPendingSubmissionFailure(app, err);
-                    return;
-                };
-                switch (readiness) {
-                    .pending => return,
-                    .current => {},
-                    .rejected => {
-                        pending = &app.submission.pending.?;
+            if (!pending.credential_admitted) {
+                if (comptime @hasDecl(App, "collectPendingPromptCredential")) {
+                    const readiness = App.collectPendingPromptCredential(app) catch |err| {
+                        finishPendingSubmissionFailure(app, err);
+                        return;
+                    };
+                    switch (readiness) {
+                        .pending => return,
+                        .current => {},
+                        .rejected => {
+                            pending = &app.submission.pending.?;
+                            pending.phase = .awaiting_auth;
+                            requestPromptRetryAfterAuth(app);
+                            debug_trace.eventf(
+                                "input",
+                                "pending_prompt_awaiting_auth",
+                                .{ .turn_id = pending.draft.turn_id },
+                                "",
+                                .{},
+                            );
+                            return;
+                        },
+                    }
+                } else if (comptime @hasDecl(App, "ensurePromptCredential")) {
+                    const admitted = preflightPrompt(app) catch |err| {
+                        finishPendingSubmissionFailure(app, err);
+                        return;
+                    };
+                    pending = &app.submission.pending.?;
+                    if (!admitted) {
                         pending.phase = .awaiting_auth;
                         requestPromptRetryAfterAuth(app);
                         debug_trace.eventf(
@@ -270,26 +291,10 @@ pub fn SubmitRuntime(comptime App: type) type {
                             .{},
                         );
                         return;
-                    },
+                    }
                 }
-            } else if (comptime @hasDecl(App, "ensurePromptCredential")) {
-                const admitted = preflightPrompt(app) catch |err| {
-                    finishPendingSubmissionFailure(app, err);
-                    return;
-                };
+                app.submission.pending.?.credential_admitted = true;
                 pending = &app.submission.pending.?;
-                if (!admitted) {
-                    pending.phase = .awaiting_auth;
-                    requestPromptRetryAfterAuth(app);
-                    debug_trace.eventf(
-                        "input",
-                        "pending_prompt_awaiting_auth",
-                        .{ .turn_id = pending.draft.turn_id },
-                        "",
-                        .{},
-                    );
-                    return;
-                }
             }
 
             if (comptime @hasDecl(App, "collectPendingSkillRefresh")) {
@@ -2127,6 +2132,8 @@ test "pending draft construction frees every partial allocation" {
 }
 
 const PendingLifecycleFake = struct {
+    const CredentialReadiness = enum { pending, current, rejected };
+
     alloc: std.mem.Allocator,
     submission: State = .{},
     worker: struct {
@@ -2171,6 +2178,7 @@ const PendingLifecycleFake = struct {
     finalization_count: usize = 0,
     finalization_error: bool = false,
     notice_count: usize = 0,
+    credential_checks: usize = 0,
     skill_refresh: enum { pending, current, failed } = .current,
     skill_refresh_checks: usize = 0,
 
@@ -2196,6 +2204,13 @@ const PendingLifecycleFake = struct {
         self.finalization_count += 1;
         if (self.finalization_error) return error.InjectedFinalizationFailure;
         self.worker.queued_turn_id = draft.turn_id;
+    }
+
+    pub fn collectPendingPromptCredential(
+        self: *PendingLifecycleFake,
+    ) !CredentialReadiness {
+        self.credential_checks += 1;
+        return .current;
     }
 
     pub fn collectPendingSkillRefresh(
@@ -2310,13 +2325,18 @@ test "pending submission waits for its skill catalog generation before queueing"
     Runtime.collectPendingSubmissionFacts(&app);
     try std.testing.expectEqual(PendingPhase.adopted, app.submission.pending.?.phase);
     try std.testing.expect(app.worker.held);
+    try std.testing.expectEqual(@as(usize, 1), app.credential_checks);
     try std.testing.expectEqual(@as(usize, 0), app.finalization_count);
     try std.testing.expectEqual(@as(?u64, 1), app.submission.pending.?.skill_refresh_generation);
+
+    Runtime.collectPendingSubmissionFacts(&app);
+    try std.testing.expectEqual(@as(usize, 1), app.credential_checks);
 
     app.skill_refresh = .current;
     Runtime.collectPendingSubmissionFacts(&app);
     try std.testing.expectEqual(PendingPhase.queued, app.submission.pending.?.phase);
     try std.testing.expect(!app.worker.held);
+    try std.testing.expectEqual(@as(usize, 1), app.credential_checks);
     try std.testing.expectEqual(@as(usize, 1), app.finalization_count);
 }
 

--- a/src/core/auth/auth_runtime.zig
+++ b/src/core/auth/auth_runtime.zig
@@ -2270,6 +2270,7 @@ pub const Runtime = struct {
     }
 
     pub fn beginPromptCredentialRefresh(self: *Self) PromptCredentialRefreshStart {
+        if (comptime host_target.is_wasm) return .not_needed;
         if (self.auth_mode == .host_managed) return .not_needed;
         if (self.prompt_credential_refresh_task != null) return .pending;
         const credential = self.selected_credential orelse return .not_needed;

--- a/src/core/auth/auth_runtime.zig
+++ b/src/core/auth/auth_runtime.zig
@@ -577,6 +577,133 @@ const InventoryRefreshDeps = struct {
     probe: InventoryProbeFn,
 };
 
+pub const PromptCredentialRefreshStart = enum {
+    not_needed,
+    started,
+    pending,
+    failed,
+};
+
+pub const PromptCredentialRefreshPoll = union(enum) {
+    idle,
+    pending,
+    ready: credentials.Credential,
+    failed: struct {
+        source: credentials.Source,
+        err: anyerror,
+    },
+
+    pub fn deinit(self: *PromptCredentialRefreshPoll) void {
+        switch (self.*) {
+            .ready => |*credential| credential.deinit(std.heap.c_allocator),
+            .idle, .pending, .failed => {},
+        }
+        self.* = .idle;
+    }
+};
+
+const PromptCredentialRefreshTask = struct {
+    transport: oauth_transport.Provider,
+    source: credentials.Source,
+    expected_account_id: ?[]u8,
+    thread: ?std.Thread = null,
+    cancel_requested: std.atomic.Value(bool) = .init(false),
+    done: std.atomic.Value(bool) = .init(false),
+    credential: ?credentials.Credential = null,
+    failure: ?anyerror = null,
+
+    fn start(
+        transport: oauth_transport.Provider,
+        source: credentials.Source,
+        expected_account_id: ?[]const u8,
+    ) !*PromptCredentialRefreshTask {
+        const alloc = std.heap.c_allocator;
+        const task = try alloc.create(PromptCredentialRefreshTask);
+        errdefer alloc.destroy(task);
+        const owned_account_id = if (expected_account_id) |account_id|
+            try alloc.dupe(u8, account_id)
+        else
+            null;
+        errdefer if (owned_account_id) |account_id| alloc.free(account_id);
+        task.* = .{
+            .transport = transport,
+            .source = source,
+            .expected_account_id = owned_account_id,
+        };
+        task.thread = try std.Thread.spawn(.{}, workerMain, .{task});
+        return task;
+    }
+
+    fn workerMain(self: *PromptCredentialRefreshTask) void {
+        self.credential = refreshCredentialForAccount(
+            self.cancellableTransport(),
+            std.heap.c_allocator,
+            self.source,
+            .if_needed,
+            self.expected_account_id,
+        ) catch |err| {
+            self.failure = err;
+            self.done.store(true, .release);
+            return;
+        };
+        if (self.credential == null) self.failure = error.CredentialRefreshUnavailable;
+        self.done.store(true, .release);
+    }
+
+    fn cancellableTransport(self: *PromptCredentialRefreshTask) oauth_transport.Provider {
+        return .{
+            .context = self,
+            .execute_fn = executeCancellable,
+        };
+    }
+
+    fn executeCancellable(
+        raw: ?*anyopaque,
+        alloc: Allocator,
+        request: oauth_transport.Request,
+    ) !oauth_transport.Response {
+        const self: *PromptCredentialRefreshTask = @ptrCast(@alignCast(raw.?));
+        var bounded = request;
+        bounded.cancel_flag = &self.cancel_requested;
+        return self.transport.execute(alloc, bounded);
+    }
+
+    fn poll(self: *const PromptCredentialRefreshTask) bool {
+        return self.done.load(.acquire);
+    }
+
+    fn takeResult(self: *PromptCredentialRefreshTask) PromptCredentialRefreshPoll {
+        if (self.thread) |thread| thread.join();
+        self.thread = null;
+        const result: PromptCredentialRefreshPoll = if (self.credential) |credential|
+            .{ .ready = credential }
+        else
+            .{ .failed = .{
+                .source = self.source,
+                .err = self.failure orelse error.CredentialRefreshUnavailable,
+            } };
+        self.credential = null;
+        self.destroy();
+        return result;
+    }
+
+    fn deinit(self: *PromptCredentialRefreshTask) void {
+        self.cancel_requested.store(true, .seq_cst);
+        if (self.thread) |thread| thread.join();
+        self.thread = null;
+        if (self.credential) |*credential| credential.deinit(std.heap.c_allocator);
+        self.credential = null;
+        self.destroy();
+    }
+
+    fn destroy(self: *PromptCredentialRefreshTask) void {
+        const alloc = std.heap.c_allocator;
+        if (self.expected_account_id) |account_id| alloc.free(account_id);
+        self.expected_account_id = null;
+        alloc.destroy(self);
+    }
+};
+
 const InventoryRefreshTask = struct {
     alloc: Allocator,
     thread: ?std.Thread = null,
@@ -1103,6 +1230,7 @@ pub const Runtime = struct {
     api_key_returns_to_root: bool = false,
     api_key_save: ApiKeySaveRuntime = .{},
     inventory_refresh_task: ?*InventoryRefreshTask = null,
+    prompt_credential_refresh_task: ?*PromptCredentialRefreshTask = null,
 
     pub fn init(
         validator: api_key_validator.Provider,
@@ -1145,7 +1273,7 @@ pub const Runtime = struct {
         auth_mode: credentials.AuthMode,
     ) void {
         comptime {
-            if (std.meta.fields(Self).len != 28) {
+            if (std.meta.fields(Self).len != 29) {
                 @compileError("update Runtime.initInto for the changed field set");
             }
         }
@@ -1178,11 +1306,14 @@ pub const Runtime = struct {
         storage.api_key_returns_to_root = false;
         storage.api_key_save = .{};
         storage.inventory_refresh_task = null;
+        storage.prompt_credential_refresh_task = null;
     }
 
     pub fn deinit(self: *Self, alloc: Allocator) void {
         if (self.inventory_refresh_task) |task| task.deinit();
         self.inventory_refresh_task = null;
+        if (self.prompt_credential_refresh_task) |task| task.deinit();
+        self.prompt_credential_refresh_task = null;
         self.api_key_save.deinit(alloc);
         self.sign_in_flow.deinit(alloc);
         self.clearSignInCodeInput(alloc, .runtime_deinit);
@@ -2136,6 +2267,32 @@ pub const Runtime = struct {
                     loadRuntimeCredentialSource,
                 )),
         };
+    }
+
+    pub fn beginPromptCredentialRefresh(self: *Self) PromptCredentialRefreshStart {
+        if (self.auth_mode == .host_managed) return .not_needed;
+        if (self.prompt_credential_refresh_task != null) return .pending;
+        const credential = self.selected_credential orelse return .not_needed;
+        if (!credentials.sourceRefreshable(credential.source)) return .not_needed;
+        self.prompt_credential_refresh_task = PromptCredentialRefreshTask.start(
+            self.oauth_transport,
+            credential.source,
+            credential.accountId(),
+        ) catch return .failed;
+        return .started;
+    }
+
+    pub fn pollPromptCredentialRefresh(self: *Self) PromptCredentialRefreshPoll {
+        const task = self.prompt_credential_refresh_task orelse return .idle;
+        if (!task.poll()) return .pending;
+        self.prompt_credential_refresh_task = null;
+        return task.takeResult();
+    }
+
+    pub fn cancelPromptCredentialRefresh(self: *Self) void {
+        const task = self.prompt_credential_refresh_task orelse return;
+        self.prompt_credential_refresh_task = null;
+        task.deinit();
     }
 
     pub fn refreshSelectedCredentialIfNeeded(

--- a/src/core/auth/auth_runtime.zig
+++ b/src/core/auth/auth_runtime.zig
@@ -2185,6 +2185,7 @@ pub const Runtime = struct {
         credential: *credentials.Credential,
     ) auth_transition.CredentialChange {
         const change = self.preparedCredentialChange(credential.*);
+        self.cancelPromptCredentialRefresh();
         const source = credential.source;
         if (self.selected_credential) |*selected| selected.deinit(alloc);
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -955,6 +955,24 @@ const App = struct {
         return AuthAppRuntime.admitPromptCredential(self);
     }
 
+    pub fn startPromptCredentialPrewarm(self: *App) void {
+        if (comptime !host_target.is_wasm) {
+            AuthAppRuntime.startPromptCredentialPrewarm(self);
+        }
+    }
+
+    pub fn collectPendingPromptCredential(
+        self: *App,
+    ) !app_auth_runtime.PendingPromptCredentialReadiness {
+        return AuthAppRuntime.collectPendingPromptCredential(self);
+    }
+
+    pub fn retryPendingPromptCredential(
+        self: *App,
+    ) !app_auth_runtime.PendingPromptCredentialReadiness {
+        return AuthAppRuntime.retryPendingPromptCredential(self);
+    }
+
     pub fn runProviderCommand(self: *App) !void {
         try AuthAppRuntime.runProviderCommand(self);
     }

--- a/src/ui/footer/render_input.zig
+++ b/src/ui/footer/render_input.zig
@@ -408,6 +408,7 @@ const max_static_status_activity_rows: u16 = 3;
 pub const RenderContext = struct {
     slash_registry: command_specs.SlashRegistry = .{},
     stream: StreamState,
+    pending_prompt_activity: bool = false,
     completed_assistant_presentation_tail: bool = false,
     // Pacer emitting visible text, including the post-finish tail drain.
     writing_response: bool = false,
@@ -617,6 +618,9 @@ fn turnActivityProjection(
 ) ActivityProjection {
     _ = shell;
     if (!ctx.stream.active) {
+        if (ctx.pending_prompt_activity) {
+            return .{ .turn_thinking = .{ .label = "• Thinking" } };
+        }
         if (!ctx.writing_response and !ctx.completed_assistant_presentation_tail) return .none;
         return .{ .turn_thinking = .{
             .label = activity_status.buildCompletedTurnLabel(buf, ctx.stream),
@@ -825,6 +829,27 @@ test "frame-owned thinking activity projects the thinking label" {
 
     var dot_buf: [128]u8 = undefined;
     switch (frameOwnedActivityProjection(&dot_buf, &shell, ctx, null)) {
+        .turn_thinking => |thinking| try std.testing.expectEqualStrings("• Thinking", thinking.label),
+        .none, .tool_slot => return error.TestUnexpectedResult,
+    }
+}
+
+test "pending prompt projects thinking before the worker stream starts" {
+    var input = InputRuntime{};
+    defer input.deinit(std.testing.allocator);
+    var shell = TranscriptRuntime{};
+    defer shell.deinit(std.testing.allocator);
+    const ctx: RenderContext = .{
+        .stream = .{},
+        .pending_prompt_activity = true,
+        .has_api_key = true,
+        .model = "gpt-5.1",
+        .queued_count = 0,
+        .input = &input,
+    };
+
+    var label_buf: [128]u8 = undefined;
+    switch (frameOwnedActivityProjection(&label_buf, &shell, ctx, null)) {
         .turn_thinking => |thinking| try std.testing.expectEqualStrings("• Thinking", thinking.label),
         .none, .tool_slot => return error.TestUnexpectedResult,
     }

--- a/src/ui/footer/render_input.zig
+++ b/src/ui/footer/render_input.zig
@@ -601,6 +601,9 @@ pub fn frameOwnedActivityProjection(
     approval: ?approval_prompt.Projection,
 ) ActivityProjection {
     if (approval != null or ctx.question != null) return .none;
+    if (!ctx.stream.active and ctx.pending_prompt_activity) {
+        return .{ .turn_thinking = .{ .label = "• Thinking" } };
+    }
     switch (ctx.activity) {
         .tool_slot => {},
         .turn_thinking => |thinking| {
@@ -618,9 +621,6 @@ fn turnActivityProjection(
 ) ActivityProjection {
     _ = shell;
     if (!ctx.stream.active) {
-        if (ctx.pending_prompt_activity) {
-            return .{ .turn_thinking = .{ .label = "• Thinking" } };
-        }
         if (!ctx.writing_response and !ctx.completed_assistant_presentation_tail) return .none;
         return .{ .turn_thinking = .{
             .label = activity_status.buildCompletedTurnLabel(buf, ctx.stream),
@@ -850,6 +850,16 @@ test "pending prompt projects thinking before the worker stream starts" {
 
     var label_buf: [128]u8 = undefined;
     switch (frameOwnedActivityProjection(&label_buf, &shell, ctx, null)) {
+        .turn_thinking => |thinking| try std.testing.expectEqualStrings("• Thinking", thinking.label),
+        .none, .tool_slot => return error.TestUnexpectedResult,
+    }
+
+    var retry_ctx = ctx;
+    retry_ctx.activity = .{ .turn_thinking = .{
+        .label = "Previous request failed",
+        .tone = .danger,
+    } };
+    switch (frameOwnedActivityProjection(&label_buf, &shell, retry_ctx, null)) {
         .turn_thinking => |thinking| try std.testing.expectEqualStrings("• Thinking", thinking.label),
         .none, .tool_slot => return error.TestUnexpectedResult,
     }

--- a/src/ui/footer/render_input.zig
+++ b/src/ui/footer/render_input.zig
@@ -844,7 +844,6 @@ test "pending prompt projects thinking before the worker stream starts" {
         .pending_prompt_activity = true,
         .has_api_key = true,
         .model = "gpt-5.1",
-        .queued_count = 0,
         .input = &input,
     };
 

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -5083,8 +5083,6 @@ tmuxTest(
     expect(oauth.requests.map((request) => `${request.method} ${request.path}`)).toEqual([
       "GET /.well-known/openid-configuration",
       "POST /oauth/token",
-      "GET /.well-known/openid-configuration",
-      "POST /oauth/token",
     ]);
     expect(readFileSync(stderrPath, "utf8")).toBe("");
   },

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -4445,6 +4445,10 @@ tmuxTest(
     const prompt = "PRESERVE_DURING_LOGIN_REPAIR";
     await session.sendText(prompt);
     await waitForTrace(tracePath, "event=pending_prompt_frame_committed", 1_000);
+    await session.waitForPane(
+      (pane) => pane.includes(prompt) && pane.includes("Thinking"),
+      1_000,
+    );
     const responsiveDraft = "TERMINAL_RESPONSIVE_DURING_CREDENTIAL_REFRESH";
     await session.sendLiteral(responsiveDraft);
     await session.waitForPane(
@@ -4453,7 +4457,10 @@ tmuxTest(
     );
     await session.sendKeys("C-u");
     await session.sendKeys("C-k");
-    await session.waitForText("fx login sign-in expired.", TIMEOUT);
+    await session.waitForPane(
+      (pane) => pane.includes("fx login sign-in expired.") && !pane.includes("Thinking"),
+      TIMEOUT,
+    );
     expect(oauth.requests.filter((request) => request.grantType === "refresh_token")).toHaveLength(1);
 
     await session.sendKeys("Enter");

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -1305,6 +1305,48 @@ tmuxTest(
 );
 
 tmuxTest(
+  "provider switch before the first prompt discards the previous credential prewarm",
+  async () => {
+    home = mkdtempSync(join(tmpdir(), "fx-tui-prewarm-provider-switch-"));
+    stderrPath = join(home, "stderr.log");
+    const tracePath = join(home, "trace.log");
+    writeFileSync(stderrPath, "");
+    gateway = startFakeGateway([]);
+    oauth = startFakeOAuth(null);
+    chatgptOauth = startFakeChatGptOAuth();
+    writeSeededFxLogin(home, Date.now() + 60 * 60 * 1000, oauth.issuerUrl, "team_123");
+    writeSeededChatGptLogin(home, chatgptOauth.accessToken);
+    writeFileSync(
+      join(home, ".fx", "settings.json"),
+      JSON.stringify({ credential_source: "fx_login" }) + "\n",
+      { mode: 0o600 },
+    );
+
+    session = await startFx(home, stderrPath, gateway, oauth.issuerUrl, tracePath, {
+      ...chatgptOauth.env,
+      FX_MODEL: undefined,
+    });
+    await session.waitForComposer(TIMEOUT);
+    await waitForTrace(tracePath, "prompt credential prewarm start outcome=started");
+    await openProviderPicker(session);
+    await session.sendKeys("Down");
+    await session.sendKeys("Enter");
+    await session.waitForText("Switched to Codex subscription", TIMEOUT);
+
+    await session.sendText("Use the selected subscription for the first prompt.");
+    await session.waitForText("CHATGPT_DIRECT_RESPONSE", 10_000);
+    const responses = chatgptOauth.requests.filter(
+      (request) => request.path === "/chatgpt/responses",
+    );
+    expect(responses).toHaveLength(1);
+    expect(responses[0]!.authorization).toBe(`Bearer ${chatgptOauth.accessToken}`);
+    expect(gateway.requests).toHaveLength(0);
+    expect(readFileSync(stderrPath, "utf8")).toBe("");
+  },
+  60_000,
+);
+
+tmuxTest(
   "provider switch reauthenticates current Codex and replaces an unavailable model",
   async () => {
     home = mkdtempSync(join(tmpdir(), "fx-tui-chatgpt-success-"));

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -1874,6 +1874,21 @@ async function waitForModelRequestCount(
   }
 }
 
+async function waitForOAuthRequestCount(
+  fakeOAuth: ReturnType<typeof startFakeOAuth>,
+  count: number,
+): Promise<void> {
+  const started = Date.now();
+  while (fakeOAuth.requests.length < count) {
+    if (Date.now() - started >= TIMEOUT) {
+      throw new Error(
+        `Timed out waiting for ${count} OAuth requests; saw ${fakeOAuth.requests.length}`,
+      );
+    }
+    await Bun.sleep(25);
+  }
+}
+
 async function waitForTrace(
   tracePath: string,
   needle: string,
@@ -4722,7 +4737,7 @@ tmuxTest(
 );
 
 tmuxTest(
-  "expired saved login discovers models without refreshing prompt credentials",
+  "expired saved login prewarms credentials while model discovery stays anonymous",
   async () => {
     home = mkdtempSync(join(tmpdir(), "fx-tui-auth-expired-models-"));
     stderrPath = join(home, "stderr.log");
@@ -4741,7 +4756,11 @@ tmuxTest(
     );
     await session.waitForComposer(TIMEOUT);
     await waitForModelRequestCount(gateway, 1);
-    expect(oauth.requests).toEqual([]);
+    await waitForOAuthRequestCount(oauth, 2);
+    expect(oauth.requests.map((request) => `${request.method} ${request.path}`)).toEqual([
+      "GET /.well-known/openid-configuration",
+      "POST /oauth/token",
+    ]);
     expect(gateway.modelRequests[0].headers.get("authorization")).toBeNull();
     expect(gateway.modelRequests[0].headers.get("x-vercel-ai-gateway-team")).toBeNull();
 
@@ -4754,7 +4773,10 @@ tmuxTest(
       TIMEOUT,
     );
 
-    expect(oauth.requests).toEqual([]);
+    expect(oauth.requests.map((request) => `${request.method} ${request.path}`)).toEqual([
+      "GET /.well-known/openid-configuration",
+      "POST /oauth/token",
+    ]);
     expect(gateway.requests).toHaveLength(0);
     expect(gateway.modelRequests).toHaveLength(1);
     expect(readFileSync(stderrPath, "utf8")).toBe("");
@@ -4865,7 +4887,7 @@ tmuxTest(
 );
 
 tmuxTest(
-  "an invalid refreshed lifetime retires the login and keeps model discovery anonymous",
+  "an immediately expired prewarm retires the login and keeps model discovery anonymous",
   async () => {
     home = mkdtempSync(join(tmpdir(), "fx-tui-auth-expired-refresh-models-"));
     stderrPath = join(home, "stderr.log");
@@ -4980,7 +5002,11 @@ tmuxTest(
     );
     await session.waitForComposer(TIMEOUT);
     await waitForModelRequestCount(gateway, 1);
-    expect(oauth.requests).toEqual([]);
+    await waitForOAuthRequestCount(oauth, 2);
+    expect(oauth.requests.map((request) => `${request.method} ${request.path}`)).toEqual([
+      "GET /.well-known/openid-configuration",
+      "POST /oauth/token",
+    ]);
     expect(gateway.modelRequests[0].headers.get("authorization")).toBeNull();
     expect(creditsGateway.requests).toEqual([]);
 
@@ -5032,7 +5058,11 @@ tmuxTest(
     );
     await session.waitForComposer(TIMEOUT);
     await waitForModelRequestCount(gateway, 1);
-    expect(oauth.requests).toEqual([]);
+    await waitForOAuthRequestCount(oauth, 2);
+    expect(oauth.requests.map((request) => `${request.method} ${request.path}`)).toEqual([
+      "GET /.well-known/openid-configuration",
+      "POST /oauth/token",
+    ]);
     expect(gateway.modelRequests[0].headers.get("authorization")).toBeNull();
     expect(gateway.modelRequests[0].headers.get("x-vercel-ai-gateway-team")).toBeNull();
     expect(creditsGateway.requests).toEqual([]);
@@ -5051,6 +5081,8 @@ tmuxTest(
     expect(gateway.modelRequests).toHaveLength(1);
     expect(creditsGateway.requests).toHaveLength(0);
     expect(oauth.requests.map((request) => `${request.method} ${request.path}`)).toEqual([
+      "GET /.well-known/openid-configuration",
+      "POST /oauth/token",
       "GET /.well-known/openid-configuration",
       "POST /oauth/token",
     ]);

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -15,6 +15,7 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { FX_BIN, REPO_ROOT, runFx } from "../evals/eval-helpers";
+import { readTapeFrames } from "./render-lab/tape";
 import {
   FAKE_GATEWAY_MODEL,
   fakeGatewayFinalText,
@@ -4427,6 +4428,8 @@ tmuxTest(
     home = mkdtempSync(join(tmpdir(), "fx-tui-auth-repair-"));
     stderrPath = join(home, "stderr.log");
     const tracePath = join(home, "trace.log");
+    const tapePath = join(home, "pending-activity.fxtape");
+    const replayPath = join(home, "pending-activity-replay");
     writeFileSync(stderrPath, "");
     gateway = startFakeGateway([fakeGatewayFinalText(REFRESH_RECOVERY_RESPONSE)]);
     oauth = startFakeOAuth(ACQUIRED_LOGIN_TOKEN, undefined, 3600, Number.POSITIVE_INFINITY, {
@@ -4439,6 +4442,8 @@ tmuxTest(
     session = await startFx(home, stderrPath, gateway, oauth.issuerUrl, tracePath, {
       AI_GATEWAY_API_KEY: undefined,
       FX_TRACE_SCOPES: "auth,input",
+      FX_RECORD: tapePath,
+      FX_RECORD_INPUT: "1",
     });
     await session.waitForComposer(TIMEOUT);
     await waitForTrace(tracePath, "prompt credential prewarm start outcome=started", 1_000);
@@ -4462,6 +4467,33 @@ tmuxTest(
       TIMEOUT,
     );
     expect(oauth.requests.filter((request) => request.grantType === "refresh_token")).toHaveLength(1);
+
+    const frames = readTapeFrames(tapePath);
+    const promptInput = frames.findIndex((frame) => frame.kind === 2 && frame.payload.includes(prompt));
+    expect(promptInput).toBeGreaterThanOrEqual(0);
+    const enter = frames.findIndex((frame, index) =>
+      index > promptInput && frame.kind === 2 && frame.payload.equals(Buffer.from("\r"))
+    );
+    expect(enter).toBeGreaterThan(promptInput);
+    const firstOutput = frames.slice(enter + 1).find((frame) => frame.kind === 1);
+    expect(firstOutput).toBeDefined();
+    expect(firstOutput!.payload.includes(prompt)).toBe(true);
+    expect(firstOutput!.payload.includes("Thinking")).toBe(true);
+
+    const replay = await runFx(["replay", tapePath, "--frames-dir", replayPath]);
+    expect(replay.code).toBe(0);
+    const grids = readdirSync(join(replayPath, "frames"))
+      .filter((name) => name.endsWith(".grid.txt"))
+      .sort()
+      .map((name) => readFileSync(join(replayPath, "frames", name), "utf8"));
+    const thinkingGrids = grids.filter((grid) => grid.includes("Thinking"));
+    expect(thinkingGrids.length).toBeGreaterThan(0);
+    for (const grid of thinkingGrids) {
+      const rows = grid.split("\n");
+      const promptRow = rows.findIndex((row) => row.includes(prompt));
+      expect(promptRow).toBeGreaterThanOrEqual(0);
+      expect(rows.findIndex((row) => row.includes("Thinking"))).toBe(promptRow + 2);
+    }
 
     await session.sendKeys("Enter");
     await session.waitForText("Waiting for authorization", TIMEOUT);

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -1874,9 +1874,13 @@ async function waitForModelRequestCount(
   }
 }
 
-async function waitForTrace(tracePath: string, needle: string): Promise<void> {
+async function waitForTrace(
+  tracePath: string,
+  needle: string,
+  timeoutMs = TIMEOUT,
+): Promise<void> {
   const started = Date.now();
-  while (Date.now() - started < TIMEOUT) {
+  while (Date.now() - started < timeoutMs) {
     if (existsSync(tracePath) && readFileSync(tracePath, "utf8").includes(needle)) return;
     await Bun.sleep(25);
   }
@@ -4387,9 +4391,6 @@ tmuxTest(
     await session.sendKeys("C-u");
     await session.sendKeys("C-k");
     await selectEnvKeyCredential(session);
-    await session.waitForComposer(TIMEOUT);
-    await session.sendLiteral(`${promptHead}${promptTail}`);
-    await session.sendKeys("Enter");
     await session.waitForText(REFRESH_RECOVERY_RESPONSE, TIMEOUT);
 
     expect(gateway.requests).toHaveLength(1);
@@ -4410,6 +4411,7 @@ tmuxTest(
   async () => {
     home = mkdtempSync(join(tmpdir(), "fx-tui-auth-repair-"));
     stderrPath = join(home, "stderr.log");
+    const tracePath = join(home, "trace.log");
     writeFileSync(stderrPath, "");
     gateway = startFakeGateway([fakeGatewayFinalText(REFRESH_RECOVERY_RESPONSE)]);
     oauth = startFakeOAuth(ACQUIRED_LOGIN_TOKEN, undefined, 3600, Number.POSITIVE_INFINITY, {
@@ -4419,12 +4421,23 @@ tmuxTest(
     });
     writeSeededFxLogin(home, Date.now() - 60_000, oauth.issuerUrl);
 
-    session = await startFx(home, stderrPath, gateway, oauth.issuerUrl, undefined, {
+    session = await startFx(home, stderrPath, gateway, oauth.issuerUrl, tracePath, {
       AI_GATEWAY_API_KEY: undefined,
+      FX_TRACE_SCOPES: "auth,input",
     });
     await session.waitForComposer(TIMEOUT);
+    await waitForTrace(tracePath, "prompt credential prewarm start outcome=started", 1_000);
     const prompt = "PRESERVE_DURING_LOGIN_REPAIR";
     await session.sendText(prompt);
+    await waitForTrace(tracePath, "event=pending_prompt_frame_committed", 1_000);
+    const responsiveDraft = "TERMINAL_RESPONSIVE_DURING_CREDENTIAL_REFRESH";
+    await session.sendLiteral(responsiveDraft);
+    await session.waitForPane(
+      (pane) => pane.includes(responsiveDraft),
+      1_000,
+    );
+    await session.sendKeys("C-u");
+    await session.sendKeys("C-k");
     await session.waitForText("fx login sign-in expired.", TIMEOUT);
     expect(oauth.requests.filter((request) => request.grantType === "refresh_token")).toHaveLength(1);
 


### PR DESCRIPTION
## Summary

- Prewarm refreshable credentials after the first terminal frame.
- Show Thinking as soon as a submitted prompt appears while admission work finishes.
- Keep submitted prompts and composer input responsive while credential refresh is running.
- Fall back to credential admission after the prompt is visible if the background task cannot start.
- Resume pending prompts after successful credential repair without replaying prompts from cancelled repair.