### PR TITLE
Retire unusable OAuth sessions after refresh

### DIFF
--- a/src/core/app/app_auth_runtime.zig
+++ b/src/core/app/app_auth_runtime.zig
@@ -8,7 +8,6 @@ const io_mod = @import("../shared/io.zig");
 const credentials = @import("../auth/credentials.zig");
 const auth_runtime = @import("../auth/auth_runtime.zig");
 const login_flow = @import("../auth/login_flow.zig");
-const oauth = @import("../auth/oauth.zig");
 const chatgpt_oauth = @import("../auth/chatgpt_oauth.zig");
 const grok_oauth = @import("../auth/grok_oauth.zig");
 const provider_catalog = @import("../auth/provider_catalog.zig");
@@ -1145,16 +1144,11 @@ pub fn Runtime(comptime App: type) type {
                 // A session file that exists but can no longer be refreshed is
                 // not a listing failure: there is nothing to list until the
                 // user signs in again.
-                switch (err) {
-                    error.NoSession,
-                    error.NoRefreshToken,
-                    error.SessionChanged,
-                    oauth.OAuthError.InvalidClient,
-                    oauth.OAuthError.ExpiredToken,
-                    oauth.OAuthError.AccessDenied,
-                    oauth.OAuthError.InvalidGrant,
-                    => return .needs_sign_in,
-                    else => {},
+                if (err == error.NoSession or
+                    err == error.SessionChanged or
+                    !auth_runtime.classifyCredentialFailure(.fx_login, err).retryable())
+                {
+                    return .needs_sign_in;
                 }
                 try app.writeDomainNotice(.{
                     .topic = "auth",

--- a/src/core/auth/auth_runtime.zig
+++ b/src/core/auth/auth_runtime.zig
@@ -82,6 +82,8 @@ pub fn classifyCredentialFailure(
             error.AccessDenied,
             error.ExpiredToken,
             error.InvalidClient,
+            error.NoRefreshToken,
+            error.CredentialRefreshRejected,
             error.CredentialRefreshUnavailable,
             => .invalid_credential,
             error.InvalidAuthSession,
@@ -92,6 +94,7 @@ pub fn classifyCredentialFailure(
             error.KeychainWriteFailed,
             error.OAuthSessionKeychainWriteMismatch,
             error.OAuthSessionCleanupUncertain,
+            error.CredentialRefreshPersistenceUncertain,
             => .persistence_uncertain,
             error.CredentialAuthorityChanged,
             error.ChatGptAccountChanged,
@@ -2656,8 +2659,11 @@ test "credential refresh failures preserve repair and retry semantics" {
         expected_retryable: bool,
     }{
         .{ .err = error.InvalidGrant, .expected_reason = .invalid_credential, .expected_retryable = false },
+        .{ .err = error.NoRefreshToken, .expected_reason = .invalid_credential, .expected_retryable = false },
+        .{ .err = error.CredentialRefreshRejected, .expected_reason = .invalid_credential, .expected_retryable = false },
         .{ .err = error.InvalidAuthSession, .expected_reason = .invalid_storage, .expected_retryable = false },
         .{ .err = error.OAuthSessionKeychainWriteMismatch, .expected_reason = .persistence_uncertain, .expected_retryable = false },
+        .{ .err = error.CredentialRefreshPersistenceUncertain, .expected_reason = .persistence_uncertain, .expected_retryable = false },
         .{ .err = error.CredentialAuthorityChanged, .expected_reason = .authority_changed, .expected_retryable = false },
         .{ .err = error.ConnectionResetByPeer, .expected_reason = .temporary_unavailable, .expected_retryable = true },
     };

--- a/src/core/auth/chatgpt_oauth.zig
+++ b/src/core/auth/chatgpt_oauth.zig
@@ -435,16 +435,55 @@ fn refreshSession(
     try body.writer.writeAll(",\"grant_type\":\"refresh_token\",\"refresh_token\":");
     try std.json.Stringify.value(session.refresh_token, .{}, &body.writer);
     try body.writer.writeByte('}');
-    var token = try requestRefreshToken(alloc, transport, body.written());
+    var token = requestRefreshToken(alloc, transport, body.written()) catch |err| switch (err) {
+        error.CredentialRefreshRejected,
+        error.InvalidChatGptOAuthResponse,
+        => {
+            debug_trace.logf("auth", "retiring terminal Codex session reason={s}", .{@errorName(err)});
+            try retire_refresh_session(mutation);
+            return error.CredentialRefreshRejected;
+        },
+        else => return err,
+    };
     defer token.deinit(alloc);
 
+    var replacement = refresh_replacement(alloc, &token, session.*) catch |err| {
+        if (err == error.OutOfMemory) return err;
+        debug_trace.logf("auth", "retiring unusable Codex refresh reason={s}", .{@errorName(err)});
+        try retire_refresh_session(mutation);
+        if (err == error.ChatGptAccountChanged) return err;
+        return error.CredentialRefreshRejected;
+    };
+    errdefer replacement.deinit(alloc);
+    mutation.save(alloc, replacement) catch |err| {
+        debug_trace.logf("auth", "retiring Codex session after refresh save failed err={s}", .{@errorName(err)});
+        retire_refresh_session(mutation) catch |cleanup_err| {
+            debug_trace.logf("auth", "Codex session retirement failed err={s}", .{@errorName(cleanup_err)});
+        };
+        return error.CredentialRefreshPersistenceUncertain;
+    };
+
+    session.deinit(alloc);
+    session.* = replacement;
+    replacement.access_token = &.{};
+    replacement.refresh_token = &.{};
+    replacement.account_id = &.{};
+}
+
+fn refresh_replacement(
+    alloc: Allocator,
+    token: *RefreshTokenResponse,
+    current: chatgpt_session.Session,
+) !chatgpt_session.Session {
     const account_id = try extractAccountId(alloc, token.access_token);
     errdefer alloc.free(account_id);
-    if (!std.mem.eql(u8, account_id, session.account_id)) {
+    if (!std.mem.eql(u8, account_id, current.account_id)) {
         return error.ChatGptAccountChanged;
     }
-    const refresh_token = if (token.refresh_token) |rotated| rotated else try alloc.dupe(u8, session.refresh_token);
-    if (token.refresh_token != null) token.refresh_token = null;
+    const refresh_token = if (token.refresh_token) |rotated|
+        rotated
+    else
+        try alloc.dupe(u8, current.refresh_token);
     errdefer secret.zeroAndFree(alloc, refresh_token);
     const expires_at_ms = if (token.expires_in) |expires_in| blk: {
         const duration_ms = std.math.mul(i64, expires_in, std.time.ms_per_s) catch
@@ -452,21 +491,20 @@ fn refreshSession(
         break :blk std.math.add(i64, io_mod.milliTimestamp(), duration_ms) catch
             return error.InvalidChatGptOAuthResponse;
     } else try accessTokenExpiresAtMs(alloc, token.access_token);
-    var replacement = chatgpt_session.Session{
+    const replacement = chatgpt_session.Session{
         .access_token = token.access_token,
         .refresh_token = refresh_token,
         .expires_at_ms = expires_at_ms,
         .account_id = account_id,
     };
     token.access_token = &.{};
-    errdefer replacement.deinit(alloc);
-    try mutation.save(alloc, replacement);
+    if (token.refresh_token != null) token.refresh_token = null;
+    return replacement;
+}
 
-    session.deinit(alloc);
-    session.* = replacement;
-    replacement.access_token = &.{};
-    replacement.refresh_token = &.{};
-    replacement.account_id = &.{};
+fn retire_refresh_session(mutation: *chatgpt_session.Mutation) !void {
+    const outcome = mutation.delete() catch return error.CredentialRefreshPersistenceUncertain;
+    if (outcome == .deleted_not_durable) return error.CredentialRefreshPersistenceUncertain;
 }
 
 const RefreshTokenResponse = struct {
@@ -488,13 +526,20 @@ fn requestRefreshToken(
 ) !RefreshTokenResponse {
     const endpoint_url = try configuredEndpoint(alloc, e2e_token_url_env, token_url);
     defer alloc.free(endpoint_url);
-    const bytes = try requestAccepted(
-        alloc,
-        transport,
-        .post_json,
-        endpoint_url,
-        payload,
-    );
+    var response = try transport.execute(alloc, .{
+        .method = .post_json,
+        .url = endpoint_url,
+        .payload = payload,
+    });
+    defer response.deinit(alloc);
+    if (response.disposition != .accepted) {
+        debug_trace.logf("auth", "Codex refresh request rejected", .{});
+        if (chat_gpt_refresh_requires_sign_in(response.body)) {
+            return error.CredentialRefreshRejected;
+        }
+        return error.ChatGptOAuthRequestFailed;
+    }
+    const bytes = response.takeBody();
     defer secret.zeroAndFree(alloc, bytes);
     var parsed = try std.json.parseFromSlice(std.json.Value, alloc, bytes, .{});
     defer parsed.deinit();
@@ -516,6 +561,19 @@ fn requestRefreshToken(
         .refresh_token = refresh_token,
         .expires_in = expires_in,
     };
+}
+
+fn chat_gpt_refresh_requires_sign_in(body: []const u8) bool {
+    const terminal_codes = [_][]const u8{
+        "\"refresh_token_expired\"",
+        "\"refresh_token_reused\"",
+        "\"refresh_token_invalidated\"",
+        "\"invalid_grant\"",
+    };
+    for (terminal_codes) |code| {
+        if (std.mem.find(u8, body, code) != null) return true;
+    }
+    return false;
 }
 
 fn accessTokenExpiresAtMs(alloc: Allocator, token: []const u8) !i64 {

--- a/src/core/auth/credentials.zig
+++ b/src/core/auth/credentials.zig
@@ -750,24 +750,66 @@ pub fn refreshFxSession(
     defer metadata.deinit(alloc);
     try oauth_session.validateE2EEndpoint(issuer_url, metadata.token_endpoint);
 
-    var refreshed = try oauth.refreshToken(
+    var refreshed = oauth.refreshToken(
         alloc,
         transport,
         metadata,
         session.client_id,
         session.refresh_token,
-    );
+    ) catch |err| {
+        if (err == error.InvalidOAuthResponse) {
+            debug_trace.logf("auth", "retiring fx login session reason={s}", .{@errorName(err)});
+            try retire_fx_session(alloc, mutation);
+            return error.NoRefreshToken;
+        }
+        if (refresh_rejection_requires_sign_in(err)) {
+            debug_trace.logf("auth", "retiring terminal fx login session reason={s}", .{@errorName(err)});
+            try retire_fx_session(alloc, mutation);
+        }
+        return err;
+    };
     defer refreshed.deinit(alloc);
+
+    const rotated_refresh_token = refreshed.refresh_token orelse {
+        debug_trace.logf("auth", "retiring fx login session reason=NoRefreshToken", .{});
+        try retire_fx_session(alloc, mutation);
+        return error.NoRefreshToken;
+    };
+    const expires_at_ms = oauth.expiry_timestamp_ms(
+        io_mod.milliTimestamp(),
+        refreshed.expires_in,
+    ) catch |err| {
+        debug_trace.logf("auth", "retiring fx login session reason={s}", .{@errorName(err)});
+        try retire_fx_session(alloc, mutation);
+        return error.NoRefreshToken;
+    };
+
+    const replacement = oauth_session.Session{
+        .issuer = session.issuer,
+        .client_id = session.client_id,
+        .access_token = refreshed.access_token,
+        .refresh_token = rotated_refresh_token,
+        .expires_at_ms = expires_at_ms,
+        .scope = refreshed.scope,
+        .token_type = refreshed.token_type,
+        .team_slug = session.team_slug,
+        .team_id = session.team_id,
+    };
+    mutation.save(alloc, replacement) catch |err| {
+        debug_trace.logf("auth", "retiring fx login session after refresh save failed err={s}", .{@errorName(err)});
+        retire_fx_session(alloc, mutation) catch |cleanup_err| {
+            debug_trace.logf("auth", "fx login session retirement failed err={s}", .{@errorName(cleanup_err)});
+        };
+        return error.OAuthSessionCleanupUncertain;
+    };
 
     secret.zeroAndFree(alloc, session.access_token);
     session.access_token = refreshed.access_token;
     refreshed.access_token = &.{};
 
-    if (refreshed.refresh_token) |value| {
-        secret.zeroAndFree(alloc, session.refresh_token);
-        session.refresh_token = value;
-        refreshed.refresh_token = null;
-    }
+    secret.zeroAndFree(alloc, session.refresh_token);
+    session.refresh_token = rotated_refresh_token;
+    refreshed.refresh_token = null;
 
     alloc.free(session.scope);
     session.scope = refreshed.scope;
@@ -777,8 +819,26 @@ pub fn refreshFxSession(
     session.token_type = refreshed.token_type;
     refreshed.token_type = &.{};
 
-    session.expires_at_ms = try oauth.expiry_timestamp_ms(io_mod.milliTimestamp(), refreshed.expires_in);
-    try mutation.save(alloc, session.*);
+    session.expires_at_ms = expires_at_ms;
+}
+
+fn refresh_rejection_requires_sign_in(err: anyerror) bool {
+    return switch (err) {
+        error.InvalidGrant,
+        error.AccessDenied,
+        error.ExpiredToken,
+        error.InvalidClient,
+        => true,
+        else => false,
+    };
+}
+
+fn retire_fx_session(
+    alloc: std.mem.Allocator,
+    mutation: *oauth_session.Mutation,
+) !void {
+    const result = mutation.delete(alloc) catch return error.OAuthSessionCleanupUncertain;
+    if (result.local_cleanup_failed) return error.OAuthSessionCleanupUncertain;
 }
 
 fn takeCredentialFromSession(session: *oauth_session.Session, refreshed_at_ms: ?i64) Credential {
@@ -1401,6 +1461,141 @@ const ExpiredFxLoginFixture = struct {
         self.tmp.cleanup();
     }
 };
+
+const FxLoginRefreshProbe = struct {
+    token_disposition: oauth_transport.Disposition,
+    token_body: []const u8,
+    auth_path_to_make_read_only: ?[]const u8 = null,
+    calls: usize = 0,
+
+    fn provider(self: *FxLoginRefreshProbe) oauth_transport.Provider {
+        return .{ .context = self, .execute_fn = execute };
+    }
+
+    fn execute(
+        raw: ?*anyopaque,
+        alloc: std.mem.Allocator,
+        request: oauth_transport.Request,
+    ) !oauth_transport.Response {
+        const self: *FxLoginRefreshProbe = @ptrCast(@alignCast(raw.?));
+        const response_body = switch (self.calls) {
+            0 => blk: {
+                if (request.method != .get) return error.UnexpectedOAuthRequest;
+                break :blk "{\"issuer\":\"https://vercel.com\",\"device_authorization_endpoint\":\"https://vercel.com/oauth/device\",\"token_endpoint\":\"https://vercel.com/oauth/token\"}";
+            },
+            1 => blk: {
+                if (request.method != .post_form) return error.UnexpectedOAuthRequest;
+                if (self.auth_path_to_make_read_only) |auth_path| {
+                    var file = try std.Io.Dir.openFileAbsolute(io_mod.getIo(), auth_path, .{ .mode = .read_write });
+                    defer file.close(io_mod.getIo());
+                    try file.setPermissions(
+                        io_mod.getIo(),
+                        std.Io.File.Permissions.fromMode(0o400),
+                    );
+                }
+                break :blk self.token_body;
+            },
+            else => return error.UnexpectedOAuthRequest,
+        };
+        const disposition: oauth_transport.Disposition = if (self.calls == 0)
+            .accepted
+        else
+            self.token_disposition;
+        self.calls += 1;
+        return .{
+            .disposition = disposition,
+            .body = try alloc.dupe(u8, response_body),
+        };
+    }
+};
+
+test "an invalid fx login refresh retires the rejected session" {
+    const alloc = std.testing.allocator;
+    var fixture = try ExpiredFxLoginFixture.install(alloc);
+    defer fixture.deinit();
+    var refresh = FxLoginRefreshProbe{
+        .token_disposition = .rejected,
+        .token_body = "{\"error\":\"invalid_grant\"}",
+    };
+
+    try std.testing.expectError(
+        error.InvalidGrant,
+        refreshFxLoginCredential(alloc, refresh.provider()),
+    );
+    try std.testing.expectEqual(@as(usize, 2), refresh.calls);
+
+    var persisted = try oauth_session.load(alloc);
+    defer if (persisted) |*session| session.deinit(alloc);
+    try std.testing.expect(persisted == null);
+}
+
+test "an fx login refresh without a rotated refresh token retires the session" {
+    const alloc = std.testing.allocator;
+    var fixture = try ExpiredFxLoginFixture.install(alloc);
+    defer fixture.deinit();
+    var refresh = FxLoginRefreshProbe{
+        .token_disposition = .accepted,
+        .token_body = "{\"access_token\":\"new-access\",\"expires_in\":3600,\"scope\":\"openid offline_access\",\"token_type\":\"Bearer\"}",
+    };
+
+    if (refreshFxLoginCredential(alloc, refresh.provider())) |maybe_credential| {
+        if (maybe_credential) |credential_value| {
+            var credential = credential_value;
+            credential.deinit(alloc);
+        }
+        return error.TestExpectedMissingRefreshToken;
+    } else |err| {
+        try std.testing.expectEqual(error.NoRefreshToken, err);
+    }
+    try std.testing.expectEqual(@as(usize, 2), refresh.calls);
+
+    var persisted = try oauth_session.load(alloc);
+    defer if (persisted) |*session| session.deinit(alloc);
+    try std.testing.expect(persisted == null);
+}
+
+test "a malformed successful fx login refresh retires the session" {
+    const alloc = std.testing.allocator;
+    var fixture = try ExpiredFxLoginFixture.install(alloc);
+    defer fixture.deinit();
+    var refresh = FxLoginRefreshProbe{
+        .token_disposition = .accepted,
+        .token_body = "{}",
+    };
+
+    try std.testing.expectError(
+        error.NoRefreshToken,
+        refreshFxLoginCredential(alloc, refresh.provider()),
+    );
+    try std.testing.expectEqual(@as(usize, 2), refresh.calls);
+
+    var persisted = try oauth_session.load(alloc);
+    defer if (persisted) |*session| session.deinit(alloc);
+    try std.testing.expect(persisted == null);
+}
+
+test "an fx login refresh retires the consumed token when durable replacement fails" {
+    const alloc = std.testing.allocator;
+    var fixture = try ExpiredFxLoginFixture.install(alloc);
+    defer fixture.deinit();
+    const auth_path = try std.fs.path.join(alloc, &.{ fixture.home, ".fx", "auth.json" });
+    defer alloc.free(auth_path);
+    var refresh = FxLoginRefreshProbe{
+        .token_disposition = .accepted,
+        .token_body = "{\"access_token\":\"new-access\",\"refresh_token\":\"rotated-refresh\",\"expires_in\":3600,\"scope\":\"openid offline_access\",\"token_type\":\"Bearer\"}",
+        .auth_path_to_make_read_only = auth_path,
+    };
+
+    try std.testing.expectError(
+        error.OAuthSessionCleanupUncertain,
+        refreshFxLoginCredential(alloc, refresh.provider()),
+    );
+    try std.testing.expectEqual(@as(usize, 2), refresh.calls);
+
+    var persisted = try oauth_session.load(alloc);
+    defer if (persisted) |*session| session.deinit(alloc);
+    try std.testing.expect(persisted == null);
+}
 
 test "a disabled store still reports why the fx login was silent" {
     const alloc = std.testing.allocator;

--- a/src/core/auth/grok_oauth.zig
+++ b/src/core/auth/grok_oauth.zig
@@ -535,38 +535,76 @@ fn refreshSession(
     try form.append(&body.writer, "grant_type", "refresh_token");
     try form.append(&body.writer, "client_id", client_id);
     try form.append(&body.writer, "refresh_token", session.refresh_token);
-    var token = try requestRefreshToken(alloc, transport, body.written());
+    var token = requestRefreshToken(alloc, transport, body.written()) catch |err| switch (err) {
+        error.CredentialRefreshRejected,
+        error.InvalidGrokOAuthResponse,
+        => {
+            debug_trace.logf("auth", "retiring terminal Grok session reason={s}", .{@errorName(err)});
+            try retire_refresh_session(mutation);
+            return error.CredentialRefreshRejected;
+        },
+        else => return err,
+    };
     defer token.deinit(alloc);
 
-    const account_id = try fetchAccountId(alloc, transport, token.access_token);
-    errdefer alloc.free(account_id);
-    if (!std.mem.eql(u8, account_id, session.account_id)) {
-        return error.GrokAccountChanged;
-    }
-    const refresh_token = if (token.refresh_token) |rotated| rotated else try alloc.dupe(u8, session.refresh_token);
-    if (token.refresh_token != null) token.refresh_token = null;
-    errdefer secret.zeroAndFree(alloc, refresh_token);
-    const expires_at_ms = if (token.expires_in) |expires_in| blk: {
-        const duration_ms = std.math.mul(i64, expires_in, std.time.ms_per_s) catch
-            return error.InvalidGrokOAuthResponse;
-        break :blk std.math.add(i64, io_mod.milliTimestamp(), duration_ms) catch
-            return error.InvalidGrokOAuthResponse;
-    } else return error.InvalidGrokOAuthResponse;
-    var replacement = grok_session.Session{
-        .access_token = token.access_token,
-        .refresh_token = refresh_token,
-        .expires_at_ms = expires_at_ms,
-        .account_id = account_id,
+    var replacement = refresh_replacement(alloc, transport, &token, session.*) catch |err| {
+        if (err == error.OutOfMemory) return err;
+        debug_trace.logf("auth", "retiring unusable Grok refresh reason={s}", .{@errorName(err)});
+        try retire_refresh_session(mutation);
+        if (err == error.GrokAccountChanged) return err;
+        return error.CredentialRefreshRejected;
     };
-    token.access_token = &.{};
     errdefer replacement.deinit(alloc);
-    try mutation.save(alloc, replacement);
+    mutation.save(alloc, replacement) catch |err| {
+        debug_trace.logf("auth", "retiring Grok session after refresh save failed err={s}", .{@errorName(err)});
+        retire_refresh_session(mutation) catch |cleanup_err| {
+            debug_trace.logf("auth", "Grok session retirement failed err={s}", .{@errorName(cleanup_err)});
+        };
+        return error.CredentialRefreshPersistenceUncertain;
+    };
 
     session.deinit(alloc);
     session.* = replacement;
     replacement.access_token = &.{};
     replacement.refresh_token = &.{};
     replacement.account_id = &.{};
+}
+
+fn refresh_replacement(
+    alloc: Allocator,
+    transport: oauth_transport.Provider,
+    token: *RefreshTokenResponse,
+    current: grok_session.Session,
+) !grok_session.Session {
+    const account_id = try fetchAccountId(alloc, transport, token.access_token);
+    errdefer alloc.free(account_id);
+    if (!std.mem.eql(u8, account_id, current.account_id)) {
+        return error.GrokAccountChanged;
+    }
+    const refresh_token = if (token.refresh_token) |rotated|
+        rotated
+    else
+        try alloc.dupe(u8, current.refresh_token);
+    errdefer secret.zeroAndFree(alloc, refresh_token);
+    const expires_in = token.expires_in orelse return error.InvalidGrokOAuthResponse;
+    const duration_ms = std.math.mul(i64, expires_in, std.time.ms_per_s) catch
+        return error.InvalidGrokOAuthResponse;
+    const expires_at_ms = std.math.add(i64, io_mod.milliTimestamp(), duration_ms) catch
+        return error.InvalidGrokOAuthResponse;
+    const replacement = grok_session.Session{
+        .access_token = token.access_token,
+        .refresh_token = refresh_token,
+        .expires_at_ms = expires_at_ms,
+        .account_id = account_id,
+    };
+    token.access_token = &.{};
+    if (token.refresh_token != null) token.refresh_token = null;
+    return replacement;
+}
+
+fn retire_refresh_session(mutation: *grok_session.Mutation) !void {
+    const outcome = mutation.delete() catch return error.CredentialRefreshPersistenceUncertain;
+    if (outcome == .deleted_not_durable) return error.CredentialRefreshPersistenceUncertain;
 }
 
 const RefreshTokenResponse = struct {
@@ -588,13 +626,20 @@ fn requestRefreshToken(
 ) !RefreshTokenResponse {
     const endpoint_url = try configuredEndpoint(alloc, e2e_token_url_env, token_url);
     defer alloc.free(endpoint_url);
-    const bytes = try requestAccepted(
-        alloc,
-        transport,
-        .post_form,
-        endpoint_url,
-        payload,
-    );
+    var response = try transport.execute(alloc, .{
+        .method = .post_form,
+        .url = endpoint_url,
+        .payload = payload,
+    });
+    defer response.deinit(alloc);
+    if (response.disposition != .accepted) {
+        debug_trace.logf("auth", "Grok refresh request rejected", .{});
+        if (std.mem.find(u8, response.body, "\"invalid_grant\"") != null) {
+            return error.CredentialRefreshRejected;
+        }
+        return error.GrokOAuthRequestFailed;
+    }
+    const bytes = response.takeBody();
     defer secret.zeroAndFree(alloc, bytes);
     var parsed = try std.json.parseFromSlice(std.json.Value, alloc, bytes, .{});
     defer parsed.deinit();

--- a/tests/e2e/auth-refresh.test.ts
+++ b/tests/e2e/auth-refresh.test.ts
@@ -57,6 +57,7 @@ function startFakeOAuth(
   tokens: string[],
   issuerPath = "",
   beforeTokenResponse?: () => Promise<void>,
+  refreshTokens: string[] = [],
 ) {
   const requests: Array<{
     method: string;
@@ -91,7 +92,7 @@ function startFakeOAuth(
         if (!accessToken) return new Response("unexpected refresh", { status: 500 });
         return Response.json({
           access_token: accessToken,
-          refresh_token: "rotated-refresh-token",
+          refresh_token: refreshTokens.shift() ?? "rotated-refresh-token",
           expires_in: 3600,
           scope: "openid offline_access use:ai-gateway",
           token_type: "Bearer",
@@ -225,7 +226,12 @@ test(
   "fx ask refreshes an expired login then forces one refresh and retry after 401",
   async () => {
     const home = mkdtempSync(join(tmpdir(), "fx-auth-refresh-e2e-"));
-    const oauth = startFakeOAuth([EXPIRED_REFRESH_TOKEN, RETRY_REFRESH_TOKEN]);
+    const oauth = startFakeOAuth(
+      [EXPIRED_REFRESH_TOKEN, RETRY_REFRESH_TOKEN],
+      "",
+      undefined,
+      ["first-rotated-refresh-token", "second-rotated-refresh-token"],
+    );
     writeFxLogin(home, oauth.issuerUrl);
     const gateway = startFakeGateway([
       new Response(JSON.stringify({ error: { message: "expired" } }), {
@@ -278,12 +284,13 @@ test(
       expect(oauth.requests[1].body).toContain("client_id=test-client");
       expect(oauth.requests[1].body).toContain("refresh_token=seeded-refresh-token");
       expect(oauth.requests[3].body).toContain("client_id=test-client");
-      expect(oauth.requests[3].body).toContain("refresh_token=rotated-refresh-token");
+      expect(oauth.requests[3].body).toContain("refresh_token=first-rotated-refresh-token");
 
       const persisted = JSON.parse(
         readFileSync(join(home, ".fx", "auth.json"), "utf8"),
       );
       expect(persisted.access_token).toBe(RETRY_REFRESH_TOKEN);
+      expect(persisted.refresh_token).toBe("second-rotated-refresh-token");
       expect(result.stdout).not.toContain(EXPIRED_REFRESH_TOKEN);
       expect(result.stdout).not.toContain(RETRY_REFRESH_TOKEN);
       expect(result.stderr).not.toContain(EXPIRED_REFRESH_TOKEN);

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -217,7 +217,11 @@ afterEach(async () => {
   stderrPath = null;
 });
 
-function writeSeededChatGptLogin(testHome: string, accessToken = chatgptAccessToken()): void {
+function writeSeededChatGptLogin(
+  testHome: string,
+  accessToken = chatgptAccessToken(),
+  expiresAtMs = Date.now() + 60 * 60 * 1000,
+): void {
   const fxDir = join(testHome, ".fx");
   mkdirSync(fxDir, { recursive: true, mode: 0o700 });
   chmodSync(fxDir, 0o700);
@@ -226,13 +230,18 @@ function writeSeededChatGptLogin(testHome: string, accessToken = chatgptAccessTo
     version: 1,
     access_token: accessToken,
     refresh_token: "chatgpt-refresh",
-    expires_at_ms: Date.now() + 60 * 60 * 1000,
+    expires_at_ms: expiresAtMs,
     account_id: "acct_e2e",
   }) + "\n", { mode: 0o600 });
   chmodSync(authPath, 0o600);
 }
 
-function writeSeededGrokLogin(testHome: string, accessToken: string, accountId = "acct_grok_e2e"): void {
+function writeSeededGrokLogin(
+  testHome: string,
+  accessToken: string,
+  accountId = "acct_grok_e2e",
+  expiresAtMs = Date.now() + 60 * 60 * 1000,
+): void {
   const fxDir = join(testHome, ".fx");
   mkdirSync(fxDir, { recursive: true, mode: 0o700 });
   chmodSync(fxDir, 0o700);
@@ -241,7 +250,7 @@ function writeSeededGrokLogin(testHome: string, accessToken: string, accountId =
     version: 1,
     access_token: accessToken,
     refresh_token: "grok-refresh",
-    expires_at_ms: Date.now() + 60 * 60 * 1000,
+    expires_at_ms: expiresAtMs,
     account_id: accountId,
   }) + "\n", { mode: 0o600 });
   chmodSync(authPath, 0o600);
@@ -398,6 +407,7 @@ function startFakeOAuth(
     rejectAllDeviceClients?: boolean;
     tokenDelayMs?: number;
     rejectRefreshGrant?: boolean;
+    beforeRefreshResponse?: () => void | Promise<void>;
     teams?: Array<{ id: string; slug: string; name: string }>;
   } = {},
 ) {
@@ -461,6 +471,9 @@ function startFakeOAuth(
           recordedRequest.clientId = typeof clientId === "string" ? clientId : undefined;
           const grantType = form.get("grant_type");
           recordedRequest.grantType = typeof grantType === "string" ? grantType : undefined;
+          if (grantType === "refresh_token") {
+            await options.beforeRefreshResponse?.();
+          }
           tokenResponseCount += 1;
           if (
             (options.rejectRefreshGrant && grantType === "refresh_token") ||
@@ -531,6 +544,8 @@ function startFakeChatGptOAuth(
     tokenDelayMs?: number;
     responseDelayMs?: number;
     unauthorizedResponses?: number;
+    rejectRefresh?: boolean;
+    beforeRefreshResponse?: () => void | Promise<void>;
   } = {},
 ) {
   const accessToken = chatgptAccessToken();
@@ -571,6 +586,11 @@ function startFakeChatGptOAuth(
       }
       if (url.pathname === "/chatgpt/token") {
         if (options.tokenDelayMs) await Bun.sleep(options.tokenDelayMs);
+        const refresh = body?.includes('"grant_type":"refresh_token"') ?? false;
+        if (refresh) await options.beforeRefreshResponse?.();
+        if (options.rejectRefresh && refresh) {
+          return Response.json({ error: { code: "refresh_token_reused" } }, { status: 401 });
+        }
         return Response.json({
           access_token: accessToken,
           refresh_token: "chatgpt-refresh",
@@ -620,6 +640,8 @@ function startFakeChatGptOAuth(
 
 function startFakeGrokOAuth(options: {
   unauthorizedResponses?: number;
+  rejectRefresh?: boolean;
+  beforeRefreshResponse?: () => void | Promise<void>;
   revokeStatus?: number;
   userinfoSub?: string;
 } = {}) {
@@ -691,6 +713,10 @@ function startFakeGrokOAuth(options: {
         tokenCalls += 1;
         const form = new URLSearchParams(body ?? "");
         const refresh = form.get("grant_type") === "refresh_token";
+        if (refresh) await options.beforeRefreshResponse?.();
+        if (refresh && options.rejectRefresh) {
+          return Response.json({ error: "invalid_grant" }, { status: 400 });
+        }
         return Response.json({
           access_token: refresh ? refreshedAccessToken : initialAccessToken,
           refresh_token: refresh ? "grok-refresh-next" : "grok-refresh",
@@ -1529,6 +1555,173 @@ tmuxTest(
   },
   60_000,
 );
+
+tmuxTest(
+  "a rejected Codex refresh retires the session without using Gateway credentials",
+  async () => {
+    home = mkdtempSync(join(tmpdir(), "fx-tui-chatgpt-rejected-refresh-"));
+    stderrPath = join(home, "stderr.log");
+    writeFileSync(stderrPath, "");
+    gateway = startFakeGateway([]);
+    chatgptOauth = startFakeChatGptOAuth({ rejectRefresh: true });
+    writeSeededChatGptLogin(home, chatgptOauth.accessToken, Date.now() - 60_000);
+    writeFileSync(
+      join(home, ".fx", "settings.json"),
+      JSON.stringify({ provider: "codex", codex_model: "gpt-5.6-sol" }) + "\n",
+      { mode: 0o600 },
+    );
+
+    session = await startFx(
+      home,
+      stderrPath,
+      gateway,
+      undefined,
+      undefined,
+      { ...chatgptOauth.env, FX_MODEL: undefined },
+    );
+    await session.waitForComposer(TIMEOUT);
+    await session.sendText("retire the rejected Codex login");
+    await session.waitForPane(
+      (pane) =>
+        pane.includes("Codex subscription sign-in expired.") &&
+        pane.includes("Press Enter to sign in again."),
+      TIMEOUT,
+    );
+
+    const refreshRequests = chatgptOauth.requests.filter(
+      (request) => request.path === "/chatgpt/token" && request.body?.includes('"grant_type":"refresh_token"'),
+    );
+    expect(refreshRequests).toHaveLength(1);
+    expect(existsSync(join(home, ".fx", "chatgpt-auth.json"))).toBe(false);
+    expect(gateway.requests).toHaveLength(0);
+    expect(readFileSync(stderrPath, "utf8")).toBe("");
+  },
+  60_000,
+);
+
+tmuxTest(
+  "a rejected Grok refresh retires the session without using Gateway credentials",
+  async () => {
+    home = mkdtempSync(join(tmpdir(), "fx-tui-grok-rejected-refresh-"));
+    stderrPath = join(home, "stderr.log");
+    writeFileSync(stderrPath, "");
+    gateway = startFakeGateway([]);
+    const grok = startFakeGrokOAuth({ rejectRefresh: true });
+    writeSeededGrokLogin(home, grok.initialAccessToken, "acct_grok_e2e", Date.now() - 60_000);
+    writeFileSync(
+      join(home, ".fx", "settings.json"),
+      JSON.stringify({ provider: "grok", grok_model: "grok-4.20" }) + "\n",
+      { mode: 0o600 },
+    );
+
+    try {
+      session = await startFx(
+        home,
+        stderrPath,
+        gateway,
+        undefined,
+        undefined,
+        { ...grok.env, FX_MODEL: undefined },
+      );
+      await session.waitForComposer(TIMEOUT);
+      await session.sendText("retire the rejected Grok login");
+      await session.waitForPane(
+        (pane) =>
+          pane.includes("Grok subscription sign-in expired.") &&
+          pane.includes("Press Enter to sign in again."),
+        TIMEOUT,
+      );
+
+      expect(grok.requests.filter(
+        (request) => request.path === "/oauth2/token" && request.body?.includes("grant_type=refresh_token"),
+      )).toHaveLength(1);
+      expect(existsSync(join(home, ".fx", "grok-auth.json"))).toBe(false);
+      expect(gateway.requests).toHaveLength(0);
+      expect(readFileSync(stderrPath, "utf8")).toBe("");
+    } finally {
+      grok.stop();
+    }
+  },
+  60_000,
+);
+
+test("Codex refresh save failure retires the consumed session", async () => {
+  home = mkdtempSync(join(tmpdir(), "fx-chatgpt-refresh-save-failure-"));
+  gateway = startFakeGateway([]);
+  const authPath = join(home, ".fx", "chatgpt-auth.json");
+  chatgptOauth = startFakeChatGptOAuth({
+    beforeRefreshResponse() {
+      chmodSync(authPath, 0o400);
+    },
+  });
+  writeSeededChatGptLogin(home, chatgptOauth.accessToken, Date.now() - 60_000);
+  writeFileSync(
+    join(home, ".fx", "settings.json"),
+    JSON.stringify({ provider: "codex", codex_model: "gpt-5.6-sol" }) + "\n",
+    { mode: 0o600 },
+  );
+
+  const result = await runFx(["ask", "--json", "--no-save", "do not use another credential"], {
+    env: {
+      HOME: home,
+      AI_GATEWAY_API_KEY: ENV_TOKEN,
+      VERCEL_OIDC_TOKEN: undefined,
+      FX_DISABLE_KEYCHAIN: "1",
+      FX_AUTO_UPGRADE: "0",
+      FX_GATEWAY_BASE_URL: gateway.baseUrl,
+      ...chatgptOauth.env,
+    },
+    timeoutMs: TIMEOUT,
+  });
+
+  expect(
+    result.code,
+    `signal: ${result.signal}\nstdout: ${result.stdout}\nstderr: ${result.stderr}`,
+  ).toBe(1);
+  expect(existsSync(authPath)).toBe(false);
+  expect(gateway.requests).toHaveLength(0);
+});
+
+test("Grok refresh save failure retires the consumed session", async () => {
+  home = mkdtempSync(join(tmpdir(), "fx-grok-refresh-save-failure-"));
+  gateway = startFakeGateway([]);
+  const authPath = join(home, ".fx", "grok-auth.json");
+  const grok = startFakeGrokOAuth({
+    beforeRefreshResponse() {
+      chmodSync(authPath, 0o400);
+    },
+  });
+  writeSeededGrokLogin(home, grok.initialAccessToken, "acct_grok_e2e", Date.now() - 60_000);
+  writeFileSync(
+    join(home, ".fx", "settings.json"),
+    JSON.stringify({ provider: "grok", grok_model: "grok-4.20" }) + "\n",
+    { mode: 0o600 },
+  );
+
+  try {
+    const result = await runFx(["ask", "--json", "--no-save", "do not use another credential"], {
+      env: {
+        HOME: home,
+        AI_GATEWAY_API_KEY: ENV_TOKEN,
+        VERCEL_OIDC_TOKEN: undefined,
+        FX_DISABLE_KEYCHAIN: "1",
+        FX_AUTO_UPGRADE: "0",
+        FX_GATEWAY_BASE_URL: gateway.baseUrl,
+        ...grok.env,
+      },
+      timeoutMs: TIMEOUT,
+    });
+
+    expect(
+      result.code,
+      `signal: ${result.signal}\nstdout: ${result.stdout}\nstderr: ${result.stderr}`,
+    ).toBe(1);
+    expect(existsSync(authPath)).toBe(false);
+    expect(gateway.requests).toHaveLength(0);
+  } finally {
+    grok.stop();
+  }
+});
 
 tmuxTest(
   "provider picker walks every column and Left steps back",
@@ -2824,12 +3017,7 @@ test("Grok 401 replay refuses a different account before the second provider sen
     });
     expect(ask.code).toBe(1);
     expect(grok.requests.filter((request) => request.path === "/v1/responses")).toHaveLength(1);
-    const saved = JSON.parse(readFileSync(join(home, ".fx", "grok-auth.json"), "utf8")) as {
-      access_token: string;
-      account_id: string;
-    };
-    expect(saved.access_token).toBe(grok.initialAccessToken);
-    expect(saved.account_id).toBe("acct_grok_e2e");
+    expect(existsSync(join(home, ".fx", "grok-auth.json"))).toBe(false);
     for (const request of [...gateway.requests, ...gateway.modelRequests]) {
       expect(request.headers.get("authorization")).not.toContain("grok-");
     }
@@ -4316,15 +4504,55 @@ tmuxTest(
 );
 
 tmuxTest(
-  "explicit login replaces a saved session rejected during team loading",
+  "refresh save failure retires the session and starts a fresh sign-in",
+  async () => {
+    home = mkdtempSync(join(tmpdir(), "fx-tui-auth-refresh-save-failure-"));
+    stderrPath = join(home, "stderr.log");
+    writeFileSync(stderrPath, "");
+    gateway = startFakeGateway([]);
+    const authPath = join(home, ".fx", "auth.json");
+    oauth = startFakeOAuth(ACQUIRED_LOGIN_TOKEN, undefined, 3600, Number.POSITIVE_INFINITY, {
+      tokenDelayMs: 5_000,
+      beforeRefreshResponse() {
+        chmodSync(authPath, 0o400);
+      },
+    });
+    writeSeededFxLogin(home, Date.now() - 60_000, oauth.issuerUrl);
+
+    session = await startFx(home, stderrPath, gateway, oauth.issuerUrl);
+    await session.waitForComposer(TIMEOUT);
+    await session.sendText("/login");
+    await session.waitForPane(
+      (pane) => pane.includes("vercel") && pane.includes("codex") && pane.includes("grok"),
+      TIMEOUT,
+    );
+    await session.sendKeys("Enter");
+    await session.waitForPane(
+      (pane) => pane.includes("oauth") && pane.includes("api-key"),
+      TIMEOUT,
+    );
+    await session.sendKeys("Enter");
+    await session.waitForText("Waiting for authorization", TIMEOUT);
+
+    expect(oauth.requests.filter((request) => request.grantType === "refresh_token")).toHaveLength(1);
+    expect(oauth.requests.filter((request) => request.path === "/oauth/device")).toHaveLength(1);
+    expect(existsSync(authPath)).toBe(false);
+    expect(gateway.requests).toHaveLength(0);
+    expect(readFileSync(stderrPath, "utf8")).toBe("");
+  },
+  60_000,
+);
+
+tmuxTest(
+  "a rejected saved session is retired before a later explicit login",
   async () => {
     home = mkdtempSync(join(tmpdir(), "fx-tui-auth-rejected-session-login-"));
     stderrPath = join(home, "stderr.log");
     writeFileSync(stderrPath, "");
-    gateway = startFakeGateway([]);
+    gateway = startFakeGateway([fakeGatewayFinalText(REFRESH_RECOVERY_RESPONSE)]);
     oauth = startFakeOAuth(ACQUIRED_LOGIN_TOKEN, undefined, 3600, Number.POSITIVE_INFINITY, {
       rejectRefreshGrant: true,
-      tokenDelayMs: 1_000,
+      tokenDelayMs: 5_000,
       teams: [{ id: "team_123", slug: "team-harness", name: "Team Harness" }],
     });
     writeSeededFxLogin(home, Date.now() - 60_000, oauth.issuerUrl);
@@ -4346,11 +4574,41 @@ tmuxTest(
 
     expect(oauth.requests.filter((request) => request.grantType === "refresh_token")).toHaveLength(1);
     expect(oauth.requests.filter((request) => request.path === "/oauth/device")).toHaveLength(1);
+    await session.sendKeys("Escape");
+    await session.waitForPane(
+      (pane) => !pane.includes("Waiting for authorization"),
+      TIMEOUT,
+    );
+    await session.sendKeys("C-u");
+    await session.sendText("/login");
+    await session.waitForPane(
+      (pane) => pane.includes("vercel") && pane.includes("codex") && pane.includes("grok"),
+      TIMEOUT,
+    );
+    await session.sendKeys("Enter");
+    await session.waitForPane(
+      (pane) => pane.includes("oauth") && pane.includes("api-key"),
+      TIMEOUT,
+    );
+    await session.sendKeys("Enter");
+    await session.waitForText("Waiting for authorization", TIMEOUT);
+
+    expect(oauth.requests.filter((request) => request.grantType === "refresh_token")).toHaveLength(1);
+    expect(oauth.requests.filter((request) => request.path === "/oauth/device")).toHaveLength(2);
     await session.waitForText("Team Harness", TIMEOUT);
     await session.sendKeys("Enter");
     await session.waitForText("Changed Vercel team to Team Harness", TIMEOUT);
     expect(savedCredentialSource(home)).toBe("fx_login");
-    expect(gateway.requests).toHaveLength(0);
+
+    await session.sendText("use the repaired login after retiring the rejected token");
+    await session.waitForText(REFRESH_RECOVERY_RESPONSE, TIMEOUT);
+    expect(gateway.requests).toHaveLength(1);
+    expect(gateway.requests[0]!.headers.get("authorization")).toBe(
+      `Bearer ${ACQUIRED_LOGIN_TOKEN}`,
+    );
+    expect(gateway.requests[0]!.headers.get("authorization")).not.toBe(
+      `Bearer ${ENV_TOKEN}`,
+    );
     expect(readFileSync(stderrPath, "utf8")).toBe("");
   },
   60_000,
@@ -4588,7 +4846,7 @@ tmuxTest(
 );
 
 tmuxTest(
-  "immediately expired refresh keeps model discovery anonymous and later prompts blocked",
+  "an invalid refreshed lifetime retires the login and keeps model discovery anonymous",
   async () => {
     home = mkdtempSync(join(tmpdir(), "fx-tui-auth-expired-refresh-models-"));
     stderrPath = join(home, "stderr.log");
@@ -4619,14 +4877,15 @@ tmuxTest(
     const firstFailure = await session.waitForPane(
       (pane) =>
         pane.includes(firstPrompt) &&
-        pane.includes("fx login credential refresh failed.") &&
-        pane.includes("Check your connection and press Enter to retry.") &&
+        pane.includes("fx login sign-in expired.") &&
+        pane.includes("Press Enter to sign in again.") &&
         !pane.includes("Model provider"),
       TIMEOUT,
     );
     expect(firstFailure).not.toContain("Choose another source");
     expect(gateway.requests).toHaveLength(0);
     expect(gateway.modelRequests).toHaveLength(1);
+    expect(existsSync(join(home, ".fx", "auth.json"))).toBe(false);
     expect(oauth.requests.map((request) => `${request.method} ${request.path}`)).toEqual([
       "GET /.well-known/openid-configuration",
       "POST /oauth/token",
@@ -4644,22 +4903,9 @@ tmuxTest(
     await session.sendKeys("Escape");
     await session.waitForPane((pane) => !pane.includes("Esc Close"), TIMEOUT);
     await session.waitForComposer(TIMEOUT);
-
-    const secondPrompt = "a subsequent prompt remains blocked";
-    await session.sendText(secondPrompt);
-    await session.waitForPane(
-      (pane) =>
-        pane.includes(secondPrompt) &&
-        pane.includes("fx login credential refresh failed.") &&
-        pane.includes("Check your connection and press Enter to retry.") &&
-        !pane.includes("Model provider"),
-      TIMEOUT,
-    );
     expect(gateway.requests).toHaveLength(0);
     expect(gateway.modelRequests).toHaveLength(1);
     expect(oauth.requests.map((request) => `${request.method} ${request.path}`)).toEqual([
-      "GET /.well-known/openid-configuration",
-      "POST /oauth/token",
       "GET /.well-known/openid-configuration",
       "POST /oauth/token",
     ]);


### PR DESCRIPTION
## Summary

- Stop retrying expired, reused, or malformed Vercel, Codex, and Grok refresh credentials.
- Start the selected provider's sign-in flow after terminal refresh failure without switching to an API key.
- Publish rotated credentials only after durable storage succeeds.
- Retire consumed credentials and return a recoverable authentication error when local storage fails.
- Preserve one safe 401 replay with the refreshed credential across the TUI, CLI, and ACP.
