### PR TITLE
Clarify rejected Shell requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ With `--json`, `output` contains accumulated assistant Markdown across the reque
 
 Foreground terminal commands run with an explicit finite deadline. fx uses durable terminal sessions for services, watchers, GUI applications, and other long-lived work, and keeps captured foreground output available through an opaque bounded-read handle for the active session or `--no-save` process.
 
+Invalid Shell requests return the specific argument problems before any command runs. When the intended repair is unambiguous, the error includes a `retry_with` request for the agent to submit through normal validation and permissions. Repeated equivalent corrections stop the tool loop.
+
 fx starts in `auto` permission mode. Routine understood development actions run directly. Each unresolved action receives one narrow review of the exact pending action for concrete security danger. Prepared file mutations and static tools are reviewed without task text; reviewed commands, dynamic tools, and delegated actions also receive bounded trusted root-request context. A clear result authorizes only that action. A caution or unavailable review holds the action and returns advice to the agent without opening a permission prompt or ending the turn. See [Permissions](https://fx.sh/docs/configure-fx/permissions) for other modes and persistent rules.
 
 JSON and quiet requests stay noninteractive by default. Add `--prompt-permissions` to allow configured approval prompts when stdin is a TTY. Automatic safety review never opens that prompt. Prompt text is written to stderr, so JSON stdout stays parseable and quiet stdout stays empty. Piped or redirected stdin remains noninteractive and fails instead of waiting for approval.

--- a/src/core/agent/runtime/tool_admission.zig
+++ b/src/core/agent/runtime/tool_admission.zig
@@ -403,6 +403,34 @@ test "terminal validation retry state retains independent batch corrections" {
     try std.testing.expect(state.finishBatch());
 }
 
+test "shell request corrections stop after the complete repeated batch" {
+    const alloc = std.testing.allocator;
+    const shell = @import("../../../tools/shell/shell.zig");
+    var state: TerminalValidationRetryState = .{};
+    defer state.deinit(alloc);
+    const inputs = [_][]const u8{
+        "{\"command\":\"true\",\"yield_time_ms\":\"1000\"}",
+        "{\"yield_time_ms\":\"1000\",\"command\":\"true\"}",
+    };
+    for (inputs, 0..) |args, index| {
+        const call: ToolCall = .{ .id = "invalid", .name = "shell", .arguments_json = args };
+        state.beginBatch();
+        const decoded = try shell.decode(.{ .allocator = alloc }, args);
+        switch (decoded) {
+            .failure => |failure| {
+                defer alloc.free(failure);
+                try state.observe(alloc, call, failure);
+            },
+            .input => |input| {
+                input.deinit(alloc);
+                return error.TestUnexpectedResult;
+            },
+        }
+        try state.observe(alloc, call, "ordinary successful neighboring result");
+        try std.testing.expectEqual(index == 1, state.finishBatch());
+    }
+}
+
 test "shell execution failures retain independent batch identities" {
     const alloc = std.testing.allocator;
     const first: ToolCall = .{

--- a/src/core/tooling/tool_result_errors.zig
+++ b/src/core/tooling/tool_result_errors.zig
@@ -84,6 +84,16 @@ pub fn inspectTerminalActionFieldCorrection(
         .string => |value| value,
         else => return null,
     };
+    if (std.mem.eql(u8, code, "invalid_shell_request")) {
+        const executed = error_value.get("executed") orelse return null;
+        if (executed != .bool or executed.bool) return null;
+        const problems = error_value.get("problems") orelse return null;
+        if (problems != .array or problems.array.items.len == 0) return null;
+        for (problems.array.items) |problem| {
+            if (problem != .string) return null;
+        }
+        return .{ .invalid_field_count = problems.array.items.len };
+    }
     if (!std.mem.eql(u8, code, terminal_action_field_error_code)) return null;
     const action = error_value.get("action") orelse return null;
     if (action != .string) return null;

--- a/src/core/tooling/tool_runtime.zig
+++ b/src/core/tooling/tool_runtime.zig
@@ -5818,8 +5818,9 @@ test "shell run rejects legacy background input without creating state" {
     });
 
     try std.testing.expectEqual(tool_contracts.ToolExecutionStatus.failure, result.status);
-    try expectContains(result.model_output, "\"code\":\"invalid_action_fields\"");
-    try expectContains(result.model_output, "\"invalid_fields\":[\"background\"]");
+    try expectContains(result.model_output, "\"code\":\"invalid_shell_request\"");
+    try expectContains(result.model_output, "request.background is not accepted for run.");
+    try std.testing.expect(std.mem.find(u8, result.model_output, "retry_with") == null);
 }
 
 const PermissionThreadState = struct {

--- a/src/tools/shell/shell.zig
+++ b/src/tools/shell/shell.zig
@@ -101,6 +101,14 @@ pub fn decode(
     ctx: tool_dispatch.DispatchContext,
     args_json: []const u8,
 ) tool_dispatch.DispatchError!tool_dispatch.DecodeResult {
+    if (try decode_input(ctx, args_json)) |input| return .{ .input = input };
+    return .{ .failure = try request_correction(ctx.allocator, args_json, ctx.session_child_capability != null) };
+}
+
+fn decode_input(
+    ctx: tool_dispatch.DispatchContext,
+    args_json: []const u8,
+) tool_dispatch.DispatchError!?tool_dispatch.ToolInput {
     var arena_state = std.heap.ArenaAllocator.init(ctx.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
@@ -109,12 +117,15 @@ pub fn decode(
         arena,
         args_json,
         .{ .allocate = .alloc_always },
-    ) catch return decodeFailure(ctx);
-    if (raw != .object) return decodeFailure(ctx);
-    const raw_action = raw.object.get("action") orelse return decodeFailure(ctx);
-    if (raw_action != .string) return decodeFailure(ctx);
+    ) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return null,
+    };
+    if (raw != .object) return null;
+    const raw_action = raw.object.get("action") orelse return null;
+    if (raw_action != .string) return null;
     const action = std.meta.stringToEnum(Action, raw_action.string) orelse
-        return decodeFailure(ctx);
+        return null;
     elideKnownNullFields(&raw.object);
 
     var correction_scratch: ActionFieldCorrectionScratch = .{};
@@ -124,31 +135,29 @@ pub fn decode(
         action,
         raw.object,
         &correction_scratch,
-    )) |correction| {
-        return .{ .failure = try tool_result_errors.terminalActionFieldCorrectionJson(
-            ctx.allocator,
-            correction,
-        ) };
-    }
+    ) != null) return null;
     normalizeCompositeArgument(arena, &raw, "shell") catch |err| switch (err) {
         error.OutOfMemory => return error.OutOfMemory,
-        else => return decodeFailure(ctx),
+        else => return null,
     };
-    var input = std.json.parseFromValueLeaky(Input, arena, raw, .{}) catch
-        return decodeFailure(ctx);
+    var input = std.json.parseFromValueLeaky(Input, arena, raw, .{}) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return null,
+    };
     if (raw.object.get("yield_time_ms") == null) {
         input.yield_time_ms = defaultYieldTime(action);
     }
+    if (argument_problem(input) != null) return null;
     const owned = try ctx.allocator.create(OwnedInput);
     owned.* = .{
         .arena_state = arena_state.state,
         .value = input,
     };
     arena_state.state = .init;
-    return .{ .input = .{
+    return .{
         .ptr = owned,
         .deinit_fn = inputDeinit,
-    } };
+    };
 }
 
 fn defaultYieldTime(action: Action) u32 {
@@ -169,13 +178,185 @@ fn effective_interact_yield_time(has_input: bool, requested_ms: u32) u32 {
     return @min(requested_ms, managed_contract.max_yield_time_ms);
 }
 
-fn decodeFailure(
-    ctx: tool_dispatch.DispatchContext,
-) tool_dispatch.DispatchError!tool_dispatch.DecodeResult {
-    return .{ .failure = try ctx.allocator.dupe(
-        u8,
-        "shell arguments must match the advertised action schema",
-    ) };
+// Advisory only: none of these values enters the executable decode path.
+fn request_correction(alloc: Allocator, args_json: []const u8, supports_tty: bool) Allocator.Error![]u8 {
+    var arena_state = std.heap.ArenaAllocator.init(alloc);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    if (args_json.len > 16 * 1024) {
+        return correction_json(alloc, &.{"Request is too large to suggest a repair; submit the intended action with only its required fields."}, null);
+    }
+    const raw = std.json.parseFromSliceLeaky(std.json.Value, arena, args_json, .{}) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return correction_json(alloc, &.{"Shell arguments must be a JSON object."}, null),
+    };
+    if (raw != .object or raw.object.count() > 32) {
+        return correction_json(alloc, &.{"Shell arguments must be one bounded request object."}, null);
+    }
+
+    var problems: std.ArrayList([]const u8) = .empty;
+    var repairable = true;
+    var object = raw.object;
+    if (raw.object.get("request")) |wrapper| {
+        var request = wrapper;
+        if (request == .string) {
+            try problems.append(arena, "request must be an object, not a JSON string.");
+            request = std.json.parseFromSliceLeaky(std.json.Value, arena, request.string, .{}) catch |err| switch (err) {
+                error.OutOfMemory => return error.OutOfMemory,
+                else => return correction_json(alloc, problems.items, null),
+            };
+        }
+        if (request != .object or request.object.count() > 32) {
+            return correction_json(alloc, &.{"request must be one object containing the intended action."}, null);
+        }
+        object = request.object;
+        if (raw.object.count() > 1) {
+            try problems.append(arena, "Only request is allowed at the top level; put action fields inside request.");
+            var outer = raw.object.iterator();
+            while (outer.next()) |entry| {
+                const name = entry.key_ptr.*;
+                if (std.mem.eql(u8, name, "request")) continue;
+                if (object.contains(name)) {
+                    repairable = false;
+                } else {
+                    try object.put(arena, name, entry.value_ptr.*);
+                }
+            }
+        }
+    }
+    elideKnownNullFields(&object);
+    const action_value = object.get("action");
+    const action: Action = if (action_value) |value| blk: {
+        if (value == .string) {
+            if (std.meta.stringToEnum(Action, value.string)) |action| break :blk action;
+        }
+        try problems.append(arena, "request.action must be run, interact, or stop.");
+        return correction_json(alloc, problems.items, null);
+    } else blk: {
+        try problems.append(arena, "request.action is required.");
+        const command = object.get("command") orelse return correction_json(alloc, problems.items, null);
+        if (command != .string or object.contains("session_id") or object.contains("chars") or object.contains("force")) {
+            return correction_json(alloc, problems.items, null);
+        }
+        try object.put(arena, "action", .{ .string = "run" });
+        break :blk .run;
+    };
+
+    var scratch: ActionFieldCorrectionScratch = .{};
+    if (try actionFieldCorrection(arena, action, object, &scratch)) |correction| {
+        for (correction.invalid_fields) |name| {
+            try problems.append(arena, try std.fmt.allocPrint(
+                arena,
+                "request.{s} is not accepted for {s}.",
+                .{ text_utils.utf8PrefixByBytes(name, 64), @tagName(action) },
+            ));
+            // A non-null unknown field can express intent that cannot be reconstructed.
+            if (object.get(name).? != .null) repairable = false;
+            _ = object.orderedRemove(name);
+        }
+        for (correction.missing_fields) |name| {
+            try problems.append(arena, try std.fmt.allocPrint(arena, "request.{s} is required.", .{name}));
+            repairable = false;
+        }
+        for (correction.conflicts) |conflict| {
+            try problems.append(arena, try std.fmt.allocPrint(arena, "Choose either request.{s} or request.{s}.", .{ conflict[0], conflict[1] }));
+            repairable = false;
+        }
+    }
+
+    var canonical: std.json.ObjectMap = .empty;
+    inline for (@typeInfo(Input).@"struct".fields) |field| {
+        if (object.get(field.name)) |original| {
+            var value = original;
+            const T = if (@typeInfo(field.type) == .optional) @typeInfo(field.type).optional.child else field.type;
+            const expected = comptime switch (@typeInfo(T)) {
+                .int => "an integer",
+                .bool => "a boolean",
+                .pointer => "a string",
+                .@"enum" => "an advertised value",
+                else => "an object matching its schema",
+            };
+            var type_reported = false;
+            if (comptime @typeInfo(T) == .int) {
+                if (value == .string) {
+                    try problems.append(arena, "request." ++ field.name ++ " must be an integer.");
+                    type_reported = true;
+                    if (std.fmt.parseInt(T, value.string, 10)) |number| {
+                        value = if (std.math.cast(i64, number)) |integer|
+                            .{ .integer = integer }
+                        else
+                            .{ .number_string = try std.fmt.allocPrint(arena, "{d}", .{number}) };
+                    } else |_| {
+                        repairable = false;
+                    }
+                }
+            }
+            if (std.json.parseFromValueLeaky(field.type, arena, value, .{})) |_| {} else |err| {
+                if (err == error.OutOfMemory) return error.OutOfMemory;
+                if (!type_reported) try problems.append(arena, "request." ++ field.name ++ " must be " ++ expected ++ ".");
+                repairable = false;
+            }
+            try canonical.put(arena, field.name, value);
+        }
+    }
+    const candidate = std.json.parseFromValueLeaky(Input, arena, .{ .object = canonical }, .{}) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return correction_json(alloc, problems.items, null),
+    };
+    if (argument_problem(candidate)) |problem| {
+        try problems.append(arena, problem);
+        repairable = false;
+    }
+    if (candidate.timeout_ms == 0) {
+        try problems.append(arena, "request.timeout_ms must be at least 1; choose the intended deadline.");
+        repairable = false;
+    }
+    if (!supports_tty and (canonical.contains("tty") or canonical.contains("shell") or canonical.contains("chars"))) {
+        try problems.append(arena, "Interactive Shell fields require a saved session.");
+        repairable = false;
+    }
+    if (problems.items.len == 0) {
+        try problems.append(arena, "Submit one Shell action inside request.");
+    }
+    return correction_json(alloc, problems.items, if (repairable) canonical else null);
+}
+
+fn correction_json(
+    alloc: Allocator,
+    problems: []const []const u8,
+    candidate: ?std.json.ObjectMap,
+) Allocator.Error![]u8 {
+    const Retry = struct { request: std.json.Value };
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    errdefer out.deinit();
+    std.json.Stringify.value(.{ .@"error" = .{
+        .code = "invalid_shell_request",
+        .executed = false,
+        .problems = problems,
+        .instruction = if (candidate != null) @as(?[]const u8, "Call shell once using retry_with exactly.") else null,
+        .retry_with = if (candidate) |object| @as(?Retry, .{ .request = .{ .object = object } }) else null,
+    } }, .{ .emit_null_optional_fields = false }, &out.writer) catch return error.OutOfMemory;
+    return try out.toOwnedSlice();
+}
+
+fn argument_problem(input: Input) ?[]const u8 {
+    switch (input.action) {
+        .run => {
+            const command = input.command orelse return "request.command is required.";
+            if (command.len == 0 or command.len > terminal_contracts.max_command_bytes) return "request.command must contain 1-65536 bytes.";
+            if (input.profile != null and input.shell != null) return "Choose either request.profile or request.shell.";
+            if (!input.tty and input.shell != null) return "request.shell requires tty=true; choose the intended execution mode.";
+            if (input.yield_time_ms > managed_contract.max_yield_time_ms) return "request.yield_time_ms must be between 0 and 30000.";
+        },
+        .interact => {
+            if (input.yield_time_ms > managed_contract.max_wait_ceiling_ms) return "request.yield_time_ms must be between 0 and 300000.";
+            if (input.chars) |chars| {
+                if (chars.len > terminal_contracts.max_write_bytes) return "request.chars exceed 65536 bytes.";
+            }
+        },
+        .stop => {},
+    }
+    return null;
 }
 
 fn normalizeCompositeArgument(
@@ -290,17 +471,7 @@ fn validateInteract(
     ctx: tool_dispatch.DispatchContext,
     input: Input,
 ) tool_dispatch.DispatchError!?[]u8 {
-    if (input.yield_time_ms > managed_contract.max_wait_ceiling_ms) {
-        return try ctx.allocator.dupe(
-            u8,
-            "shell interact yield_time_ms must be between 0 and 300000",
-        );
-    }
-    if (input.chars) |chars| {
-        if (chars.len > terminal_contracts.max_write_bytes) {
-            return try ctx.allocator.dupe(u8, "shell interact chars exceed 65536 bytes");
-        }
-    }
+    if (argument_problem(input)) |problem| return try ctx.allocator.dupe(u8, problem);
     return null;
 }
 
@@ -309,20 +480,7 @@ fn validateRun(
     arena: Allocator,
     input: Input,
 ) tool_dispatch.DispatchError!?[]u8 {
-    const command = input.command orelse
-        return try ctx.allocator.dupe(u8, "shell run requires command");
-    if (command.len == 0 or command.len > terminal_contracts.max_command_bytes) {
-        return try ctx.allocator.dupe(u8, "shell run command is invalid");
-    }
-    if (input.profile != null and input.shell != null) {
-        return try ctx.allocator.dupe(u8, "shell run fields profile and shell are mutually exclusive");
-    }
-    if (!input.tty and input.shell != null) {
-        return try ctx.allocator.dupe(u8, "shell run explicit shell requires tty=true");
-    }
-    if (input.yield_time_ms > managed_contract.max_yield_time_ms) {
-        return try ctx.allocator.dupe(u8, "shell yield_time_ms must be between 0 and 30000");
-    }
+    if (argument_problem(input)) |problem| return try ctx.allocator.dupe(u8, problem);
     _ = resolveCwd(arena, ctx, input.cwd) catch |err| {
         return try std.fmt.allocPrint(
             ctx.allocator,
@@ -1621,6 +1779,114 @@ test "shell action fields are closed and command authority covers every run" {
     );
 }
 
+test "shell request correction suggests only unambiguous repairs without executing" {
+    const alloc = std.testing.allocator;
+    const cases = [_]struct { input: []const u8, retry: ?[]const u8 }{
+        .{ .input = "{\"command\":\"sleep 30\",\"timeout_ms\":\"40000\",\"yield_time_ms\":\"30000\"}", .retry = "{\"action\":\"run\",\"command\":\"sleep 30\",\"yield_time_ms\":30000,\"timeout_ms\":40000}" },
+        .{ .input = "{\"request\":{\"command\":\"sleep 30\"},\"yield_time_ms\":\"30000\"}", .retry = "{\"action\":\"run\",\"command\":\"sleep 30\",\"yield_time_ms\":30000}" },
+        .{ .input = "{\"action\":\"run\",\"command\":\"true\",\"background\":null}", .retry = "{\"action\":\"run\",\"command\":\"true\"}" },
+        .{ .input = "{\"request\":\"{\\\"action\\\":\\\"run\\\",\\\"command\\\":\\\"true\\\"}\"}", .retry = "{\"action\":\"run\",\"command\":\"true\"}" },
+        .{ .input = "{\"action\":\"interact\",\"session_id\":\"shell-3\",\"yield_time_ms\":\"1000\",\"unused\":null}", .retry = "{\"action\":\"interact\",\"yield_time_ms\":1000,\"session_id\":\"shell-3\"}" },
+        .{ .input = "{\"command\":\"true\",\"tty\":true}", .retry = null },
+        .{ .input = "{}", .retry = null },
+        .{ .input = "{\"action\":null,\"command\":\"true\"}", .retry = null },
+        .{ .input = "{\"session_id\":\"shell-3\"}", .retry = null },
+        .{ .input = "{\"command\":\"true\",\"session_id\":\"shell-3\"}", .retry = null },
+        .{ .input = "{\"action\":\"run\",\"command\":\"true\",\"background\":true}", .retry = null },
+        .{ .input = "{\"action\":\"run\",\"command\":\"true\",\"profile\":\"clean\",\"shell\":{\"kind\":\"executable\",\"path\":\"/bin/bash\"}}", .retry = null },
+        .{ .input = "{\"action\":\"run\",\"command\":\"true\",\"yield_time_ms\":30001}", .retry = null },
+        .{ .input = "{\"request\":{\"action\":\"run\",\"command\":\"true\",\"yield_time_ms\":\"1000\",\"timeout_ms\":0}}", .retry = null },
+        .{ .input = "{\"action\":\"run\",\"command\":\"true\",\"yield_time_ms\":4294967296}", .retry = null },
+        .{ .input = "{\"action\":\"stop\",\"session_id\":\"shell-3\",\"force\":\"true\"}", .retry = null },
+        .{ .input = "{\"request\":{\"action\":\"run\",\"command\":\"true\"},\"command\":\"false\"}", .retry = null },
+        .{ .input = "{", .retry = null },
+        .{ .input = "[]", .retry = null },
+    };
+    for (cases) |case| {
+        const result = try decode(.{ .allocator = alloc }, case.input);
+        const failure = switch (result) {
+            .failure => |failure| failure,
+            .input => |input| {
+                input.deinit(alloc);
+                return error.TestUnexpectedResult;
+            },
+        };
+        defer alloc.free(failure);
+        var parsed = try std.json.parseFromSlice(std.json.Value, alloc, failure, .{});
+        defer parsed.deinit();
+        const detail = parsed.value.object.get("error").?.object;
+        try std.testing.expectEqualStrings("invalid_shell_request", detail.get("code").?.string);
+        try std.testing.expect(!detail.get("executed").?.bool);
+        try std.testing.expect(detail.get("problems").?.array.items.len > 0);
+        try std.testing.expect((try tool_result_errors.inspectTerminalActionFieldCorrection(alloc, failure)) != null);
+        if (case.retry) |expected| {
+            const request = detail.get("retry_with").?.object.get("request").?;
+            const json = try std.json.Stringify.valueAlloc(alloc, request, .{});
+            defer alloc.free(json);
+            try std.testing.expectEqualStrings(expected, json);
+            const decoded = try decode(.{ .allocator = alloc }, json);
+            switch (decoded) {
+                .input => |input| input.deinit(alloc),
+                .failure => |reason| {
+                    alloc.free(reason);
+                    return error.TestUnexpectedResult;
+                },
+            }
+        } else {
+            try std.testing.expect(detail.get("retry_with") == null);
+        }
+    }
+}
+
+fn check_request_correction_allocations(alloc: Allocator) !void {
+    const result = try decode(.{ .allocator = alloc }, "{\"request\":{\"command\":\"true\"},\"yield_time_ms\":\"30000\"}");
+    switch (result) {
+        .failure => |failure| alloc.free(failure),
+        .input => |input| {
+            input.deinit(alloc);
+            return error.TestUnexpectedResult;
+        },
+    }
+}
+
+test "shell request correction releases partial allocations" {
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, check_request_correction_allocations, .{});
+}
+
+test "shell request correction bounds feedback and preserves input bytes" {
+    const alloc = std.testing.allocator;
+    const command = "printf '\u{1f308}\\n'; echo \"$VALUE\"";
+    const key = "x" ** 63 ++ "\u{1f308}";
+    const source = try std.json.Stringify.valueAlloc(alloc, .{
+        .command = command,
+        .x = null,
+    }, .{});
+    defer alloc.free(source);
+    const correction = try request_correction(alloc, source, true);
+    defer alloc.free(correction);
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, correction, .{});
+    defer parsed.deinit();
+    const request = parsed.value.object.get("error").?.object.get("retry_with").?.object.get("request").?.object;
+    try std.testing.expectEqualStrings(command, request.get("command").?.string);
+
+    const long_key = try std.fmt.allocPrint(alloc, "{{\"command\":\"true\",\"{s}\":null}}", .{key});
+    defer alloc.free(long_key);
+    const bounded = try request_correction(alloc, long_key, true);
+    defer alloc.free(bounded);
+    try std.testing.expect(std.unicode.utf8ValidateSlice(bounded));
+    const too_large = try alloc.alloc(u8, 16 * 1024 + 1);
+    defer alloc.free(too_large);
+    @memset(too_large, ' ');
+    const failure = try request_correction(alloc, too_large, true);
+    defer alloc.free(failure);
+    try std.testing.expect(failure.len < 512);
+    try std.testing.expect(std.mem.find(u8, failure, "retry_with") == null);
+
+    const tty = try request_correction(alloc, "{\"command\":\"true\",\"tty\":true}", true);
+    defer alloc.free(tty);
+    try std.testing.expect(std.mem.find(u8, tty, "retry_with") != null);
+}
+
 test "shell interact classification follows optional input" {
     const alloc = std.testing.allocator;
     const ctx = tool_dispatch.DispatchContext{ .allocator = alloc };
@@ -1739,7 +2005,7 @@ test "shell decoder preserves null omission and rejects cross action fields" {
         },
         .failure => |failure| {
             defer alloc.free(failure);
-            try std.testing.expect(std.mem.find(u8, failure, "invalid_action_fields") != null);
+            try std.testing.expect(std.mem.find(u8, failure, "invalid_shell_request") != null);
         },
     }
 }

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -3383,6 +3383,127 @@ describe("gateway stream lifecycle", () => {
     }
   });
 
+  test("shell request correction repairs one call before its only execution", async () => {
+    const root = createFixtureRoot("shell-request-correction");
+    const tracePath = join(root.root, "trace.log");
+    const marker = join(root.workspace, "executions.txt");
+    const command = "printf 'once\\n' >> executions.txt; printf REPAIRED_SHELL_OK";
+    let step = 0;
+    const gateway = startGateway((body) => {
+      switch (step++) {
+        case 0:
+          return fakeGatewayToolCall("repair_invalid", "shell", {
+            request: { command, profile: "clean" },
+            yield_time_ms: "1000",
+          });
+        case 1: {
+          expect(existsSync(marker)).toBe(false);
+          const correction = JSON.parse(toolResultOutput(body, "repair_invalid")).error;
+          expect(correction.code).toBe("invalid_shell_request");
+          expect(correction.executed).toBe(false);
+          expect(correction.problems).toContain("request.action is required.");
+          expect(correction.retry_with).toEqual({
+            request: { action: "run", command, profile: "clean", yield_time_ms: 1000 },
+          });
+          return fakeGatewayToolCall("repair_valid", "shell", correction.retry_with);
+        }
+        case 2:
+          expect(shellResult(body, "repair_valid")).toMatchObject({
+            state: "completed", exit_code: 0, output_delta: "REPAIRED_SHELL_OK",
+          });
+          return fakeGatewayFinalText("SHELL_REPAIR_COMPLETE");
+        default:
+          return new Response("unexpected request", { status: 500 });
+      }
+    });
+    try {
+      const result = await runFx(["ask", "--json", "--yolo", "Run the marker command once."], {
+        cwd: root.workspace,
+        env: { ...fixtureEnv(root, gateway, tracePath), FX_TRACE_SCOPES: "agent,tool,permission" },
+        timeoutMs: 15_000,
+      });
+      expect(result.code).toBe(0);
+      expect(parseAskJson(result.stdout).output).toContain("SHELL_REPAIR_COMPLETE");
+      expect(readFileSync(marker, "utf8")).toBe("once\n");
+      expect(gateway.requestCount()).toBe(3);
+      expect(gateway.classifierRequests).toHaveLength(0);
+      const trace = readFileSync(tracePath, "utf8");
+      expect(trace).toContain("call_id=repair_invalid");
+      expect(trace.split("\n").filter((line) =>
+        line.includes("call_id=repair_invalid") &&
+        (line.includes("permission_request") || line.includes("execution_start"))
+      )).toHaveLength(0);
+      expect(result.stderr).not.toMatch(/panic|error:|error\./i);
+    } finally {
+      gateway.stop();
+      rmSync(root.root, { recursive: true, force: true });
+    }
+  });
+
+  test("shell request correction stops repeated failures after both batch results", async () => {
+    const root = createFixtureRoot("shell-correction-repeat");
+    const tracePath = join(root.root, "trace.log");
+    const marker = join(root.workspace, "must-not-run.txt");
+    writeFileSync(join(root.workspace, "neighbor.txt"), "NEIGHBOR_OK\n");
+    let step = 0;
+    const gateway = startGateway((body) => {
+      const batch = ++step;
+      if (batch > 2) return new Response("unexpected third request", { status: 500 });
+      if (batch === 2) {
+        expect(JSON.parse(toolResultOutput(body, "invalid_1")).error.code).toBe("invalid_shell_request");
+        expect(toolResultOutput(body, "neighbor_1")).toContain("NEIGHBOR_OK");
+      }
+      return fakeGatewaySse([
+        { type: "tool-call", toolCallId: `invalid_${batch}`, toolName: "shell", input: {
+          request: { command: "printf unexpected > must-not-run.txt", profile: "clean" },
+          yield_time_ms: "1000",
+        } },
+        { type: "tool-call", toolCallId: `neighbor_${batch}`, toolName: "read_file", input: { path: "neighbor.txt" } },
+        { type: "finish", finishReason: { unified: "tool-calls", raw: "tool-calls" } },
+      ]);
+    });
+    try {
+      const result = await runFx(["ask", "--json", "--yolo", "Check the correction and read the neighbor."], {
+        cwd: root.workspace,
+        env: { ...fixtureEnv(root, gateway, tracePath), FX_TRACE_SCOPES: "agent,tool,permission" },
+        timeoutMs: 15_000,
+      });
+      expect(result.code).toBe(0);
+      expect(gateway.requestCount()).toBe(2);
+      expect(existsSync(marker)).toBe(false);
+      const json = parseAskJson(result.stdout);
+      expect(json.tool_calls.filter((call) => call.name === "shell" && call.status === "error")).toHaveLength(2);
+      expect(json.tool_calls.filter((call) => call.name === "read_file" && call.status === "success")).toHaveLength(2);
+      const saved = await runFx(["session", "--id", json.session_id, "--json"], {
+        cwd: root.workspace, env: { HOME: root.home },
+      });
+      expect(saved.code).toBe(0);
+      const history = JSON.parse(saved.stdout).history;
+      const results = history.flatMap((turn: any) =>
+        (turn.execution?.tool_steps ?? []).flatMap((step: any) => step.tool_results));
+      for (const batch of [1, 2]) {
+        const invalid = results.find((item: any) => item.tool_call_id === `invalid_${batch}`);
+        expect(invalid.status).toBe("failure");
+        expect(JSON.parse(invalid.output).error.executed).toBe(false);
+        const neighbor = results.find((item: any) => item.tool_call_id === `neighbor_${batch}`);
+        expect(neighbor.status).toBe("success");
+        expect(neighbor.output).toContain("NEIGHBOR_OK");
+      }
+      const trace = readFileSync(tracePath, "utf8");
+      expect(trace).toContain("terminal_validation_retry");
+      expect(trace).toContain("call_id=invalid_2");
+      expect(trace.split("\n").filter((line) =>
+        /call_id=invalid_[12]\b/.test(line) &&
+        (line.includes("permission_request") || line.includes("execution_start"))
+      )).toHaveLength(0);
+      expect(result.stderr).toContain("Repeated shell validation failures stopped the tool loop.");
+      expect(result.stderr).not.toMatch(/panic|error:|error\./i);
+    } finally {
+      gateway.stop();
+      rmSync(root.root, { recursive: true, force: true });
+    }
+  });
+
   test("no-save shell timeout returns a readable process-scoped replay handle", async () => {
     const root = createFixtureRoot("terminal-timeout-replay");
     const tracePath = join(root.root, "trace.log");
@@ -3401,7 +3522,7 @@ describe("gateway stream lifecycle", () => {
           });
         case 1: {
           const correction = toolResultOutput(body, invalidCallId);
-          expect(correction).toContain("missing_fields");
+          expect(correction).toContain("invalid_shell_request");
           expect(correction).toContain("command");
           expect(existsSync(markerPath)).toBe(false);
           return fakeShellRun(


### PR DESCRIPTION
## Summary

- Explain the specific argument problems in rejected Shell calls before permissions or execution.
- Include a `retry_with` request when the repair is unambiguous, preserving the command and valid supplied fields.
- Withhold suggested calls when requests conflict, deadlines are invalid, or interactive fields are unavailable.
- Keep correction feedback bounded for oversized requests and long field names.
- Stop repeated corrections after completing and retaining every result in the current batch.
