### PR TITLE
Keep update links on their labels

### DIFF
--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -7233,7 +7233,7 @@ test "upgrade notice body identifies stable notes and dev changes" {
                 .previous_revision = "",
                 .revision = "",
             },
-            .expected = "fx has been updated to v9.9.9 \x1b]8;;https://fx.sh/changelog#v9.9.9\x1b\\\x1b[4m(notes)\x1b[24m\x1b]8;;\x1b\\",
+            .expected = "fx has been updated to v9.9.9 (\x1b]8;;https://fx.sh/changelog#v9.9.9\x1b\\\x1b[4mnotes\x1b[24m\x1b]8;;\x1b\\)",
         },
         .{
             .upgrade = .{
@@ -7242,7 +7242,7 @@ test "upgrade notice body identifies stable notes and dev changes" {
                 .previous_revision = "1111111111111111111111111111111111111111",
                 .revision = "abcdef0123456789abcdef0123456789abcdef01",
             },
-            .expected = "fx has been updated to dev abcdef012345 (v9.9.9) \x1b]8;;https://github.com/vercel-labs/fx/compare/1111111111111111111111111111111111111111...abcdef0123456789abcdef0123456789abcdef01\x1b\\\x1b[4m(changes)\x1b[24m\x1b]8;;\x1b\\",
+            .expected = "fx has been updated to dev abcdef012345 (v9.9.9) (\x1b]8;;https://github.com/vercel-labs/fx/compare/1111111111111111111111111111111111111111...abcdef0123456789abcdef0123456789abcdef01\x1b\\\x1b[4mchanges\x1b[24m\x1b]8;;\x1b\\)",
         },
         .{
             .upgrade = .{
@@ -7251,7 +7251,7 @@ test "upgrade notice body identifies stable notes and dev changes" {
                 .previous_revision = "",
                 .revision = "abcdef0123456789abcdef0123456789abcdef01",
             },
-            .expected = "fx has been updated to dev abcdef012345 (v9.9.9) \x1b]8;;https://github.com/vercel-labs/fx/commit/abcdef0123456789abcdef0123456789abcdef01\x1b\\\x1b[4m(changes)\x1b[24m\x1b]8;;\x1b\\",
+            .expected = "fx has been updated to dev abcdef012345 (v9.9.9) (\x1b]8;;https://github.com/vercel-labs/fx/commit/abcdef0123456789abcdef0123456789abcdef01\x1b\\\x1b[4mchanges\x1b[24m\x1b]8;;\x1b\\)",
         },
     };
 
@@ -7786,7 +7786,7 @@ test "upgrade resume restores active session with the installed version notice" 
     try std.testing.expectEqualStrings("run server", context[2].assistant.user.text);
     try std.testing.expectEqual(@as(usize, 2), app.notices.items.len);
     try std.testing.expectEqualStrings(
-        "● fx has been updated to v9.9.9 \x1b]8;;https://fx.sh/changelog#v9.9.9\x1b\\\x1b[4m(notes)\x1b[24m\x1b]8;;\x1b\\",
+        "● fx has been updated to v9.9.9 (\x1b]8;;https://fx.sh/changelog#v9.9.9\x1b\\\x1b[4mnotes\x1b[24m\x1b]8;;\x1b\\)",
         app.notices.items[0],
     );
     try std.testing.expect(std.mem.find(u8, app.notices.items[1], "older context") != null);

--- a/src/core/upgrade/update_notes.zig
+++ b/src/core/upgrade/update_notes.zig
@@ -41,11 +41,12 @@ pub const Destination = struct {
     }
 
     pub fn writeHyperlinkLabel(self: Destination, writer: *std.Io.Writer) !void {
+        try writer.writeByte('(');
         try writer.writeAll("\x1b]8;;");
         try self.writeUrl(writer);
-        try writer.writeAll("\x1b\\\x1b[4m(");
+        try writer.writeAll("\x1b\\\x1b[4m");
         try writeLabel(self.kind, writer);
-        try writer.writeAll(")\x1b[24m\x1b]8;;\x1b\\");
+        try writer.writeAll("\x1b[24m\x1b]8;;\x1b\\)");
     }
 };
 
@@ -144,18 +145,38 @@ test "dev destination treats a short previous revision as the same commit" {
     );
 }
 
-test "destination writes a compact OSC 8 hyperlink label" {
-    var out: std.Io.Writer.Allocating = .init(std.testing.allocator);
-    defer out.deinit();
-
-    const value = destination(.stable, "0.0.8", "", "") orelse
+test "destination links only the label, not its parentheses" {
+    const stable = destination(.stable, "0.0.8", "", "") orelse
         return error.TestExpectedDestination;
-    try value.writeHyperlinkLabel(&out.writer);
-    try std.testing.expectEqualStrings(
-        "\x1b]8;;https://fx.sh/changelog#v0.0.8\x1b\\" ++
-            "\x1b[4m(notes)\x1b[24m\x1b]8;;\x1b\\",
-        out.writer.buffered(),
-    );
+    const dev = destination(
+        .dev,
+        "0.0.8",
+        "1111111111111111111111111111111111111111",
+        "abcdef0123456789abcdef0123456789abcdef01",
+    ) orelse return error.TestExpectedDestination;
+
+    const cases = [_]struct {
+        value: Destination,
+        expected: []const u8,
+    }{
+        .{
+            .value = stable,
+            .expected = "(\x1b]8;;https://fx.sh/changelog#v0.0.8\x1b\\" ++
+                "\x1b[4mnotes\x1b[24m\x1b]8;;\x1b\\)",
+        },
+        .{
+            .value = dev,
+            .expected = "(\x1b]8;;https://github.com/vercel-labs/fx/compare/1111111111111111111111111111111111111111...abcdef0123456789abcdef0123456789abcdef01\x1b\\" ++
+                "\x1b[4mchanges\x1b[24m\x1b]8;;\x1b\\)",
+        },
+    };
+
+    for (cases) |case| {
+        var out: std.Io.Writer.Allocating = .init(std.testing.allocator);
+        defer out.deinit();
+        try case.value.writeHyperlinkLabel(&out.writer);
+        try std.testing.expectEqualStrings(case.expected, out.writer.buffered());
+    }
 }
 
 test "invalid build identity has no destination" {

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -5177,9 +5177,11 @@ test.skipIf(!tmuxAvailable())(
       const resumed = await waitForScrollback(active, "UPGRADE_CTRL_G_INITIAL_DONE");
       expect(resumed).toContain("UPGRADE_CTRL_G_INITIAL_DONE");
       expect(resumed).toContain(updatedNotice);
-      expect(await active.capturePaneEscapes()).toContain(
-        `\x1b[4m\x1b]8;;https://fx.sh/changelog#v${version}\x1b\\(notes)\x1b]8;;\x1b\\`,
+      const noticeEscapes = await active.capturePaneEscapes();
+      expect(noticeEscapes).toContain(
+        `(\x1b[4m\x1b]8;;https://fx.sh/changelog#v${version}\x1b\\notes\x1b[0m`,
       );
+      expect(noticeEscapes).toContain("\x1b]8;;\x1b\\)");
       expect(resumed).not.toContain("● Session resumed:");
       expect(resumed).not.toContain("● Session: resumed:");
 


### PR DESCRIPTION
## Summary

- Keep the parentheses outside the clickable update link in the resume banner.
- Apply the label-only link treatment to stable notes and dev changes.