### PR TITLE
Support slashless exit alias

### DIFF
--- a/src/builtins/commands.zig
+++ b/src/builtins/commands.zig
@@ -454,7 +454,7 @@ pub const slash_specs = [_]SlashSpec{
     .{ .kind = .notifications, .command = "/sound", .help_entry = "/sound [on|off|max]", .completion_description = "toggle sounds and terminal bells", .presentation_category = .appearance, .has_args = true, .accepts_payload = true },
     .{ .kind = .workspace, .command = "/workspace", .help_entry = "/workspace [list|add PATH|remove PATH|clear]", .completion_description = "manage additional workspace directories", .presentation_category = .workspace, .show_in_welcome = true, .has_args = true, .accepts_payload = true },
     .{ .kind = .version, .command = "/version", .help_entry = "/version", .completion_description = "show the fx version", .presentation_category = .general },
-    .{ .kind = .quit, .command = "/quit", .aliases = &.{"/exit"}, .help_entry = "/quit", .completion_description = "exit the interactive shell", .presentation_category = .general, .show_in_welcome = true },
+    .{ .kind = .quit, .command = "/quit", .aliases = &.{ "/exit", "exit" }, .help_entry = "/quit (/exit, exit)", .completion_description = "exit the interactive shell", .presentation_category = .general, .show_in_welcome = true },
 };
 
 pub const slash_registry = SlashRegistry{ .commands = slash_specs[0..] };

--- a/src/core/app/input_submit_runtime.zig
+++ b/src/core/app/input_submit_runtime.zig
@@ -827,10 +827,16 @@ pub fn SubmitRuntime(comptime App: type) type {
         }
 
         fn knownSlashCommand(app: *const App, text: []const u8) ?*const command_specs.SlashSpec {
-            if (text.len == 0 or text[0] != '/') return null;
+            if (text.len == 0) return null;
+            if (text[0] != '/') return bareAliasCommand(app, text);
             var command_end: usize = 1;
             while (command_end < text.len and !std.ascii.isWhitespace(text[command_end])) : (command_end += 1) {}
             return app.slashRegistry().lookup(text[0..command_end]);
+        }
+
+        fn bareAliasCommand(app: *const App, text: []const u8) ?*const command_specs.SlashSpec {
+            const token = bareAliasCandidate(text) orelse return null;
+            return command_specs.lookupBareAlias(app.slashRegistry(), token);
         }
 
         fn shouldRouteUnknownSlashCommand(app: *App, text: []const u8) bool {
@@ -2051,6 +2057,85 @@ pub fn SubmitRuntime(comptime App: type) type {
 pub fn directCommand(expanded: []const u8) ?[]const u8 {
     if (expanded.len == 0 or expanded[0] != '!') return null;
     return expanded[1..];
+}
+
+/// A submission without a leading slash can only name a command when the whole
+/// submission is that command token, so ordinary prose never routes locally.
+pub fn bareCommandSubmission(text: []const u8) []const u8 {
+    return std.mem.trimEnd(u8, text, " \t\r\n");
+}
+
+/// Ordinary prose must stay on the cheapest possible path, so reject it on length
+/// and interior whitespace before any registry comparison happens. Returns the
+/// candidate token only when a slash-less alias could plausibly match.
+pub fn bareAliasCandidate(text: []const u8) ?[]const u8 {
+    if (text.len == 0 or text.len > command_specs.max_bare_alias_len + trailing_whitespace_slack) return null;
+    const token = bareCommandSubmission(text);
+    if (token.len == 0 or token.len > command_specs.max_bare_alias_len) return null;
+    if (std.mem.indexOfAny(u8, token, " \t\r\n") != null) return null;
+    return token;
+}
+
+/// Trailing whitespace tolerated before a submission is treated as prose.
+const trailing_whitespace_slack: usize = 8;
+
+test "bare command submission tolerates trailing whitespace only" {
+    try std.testing.expectEqualStrings("exit", bareCommandSubmission("exit"));
+    try std.testing.expectEqualStrings("exit", bareCommandSubmission("exit \t\r\n"));
+    try std.testing.expectEqualStrings("exit now", bareCommandSubmission("exit now"));
+}
+
+test "bare exit resolves to quit through the default registry" {
+    const registry = @import("../../builtins/commands.zig").slash_registry;
+
+    const bare = command_specs.lookupBareAlias(registry, bareCommandSubmission("exit  ")) orelse
+        return error.TestExpectedEqual;
+    try std.testing.expectEqual(command_specs.SlashKind.quit, bare.kind);
+
+    const slashed = registry.lookup("/exit") orelse return error.TestExpectedEqual;
+    try std.testing.expectEqual(command_specs.SlashKind.quit, slashed.kind);
+
+    try std.testing.expect(command_specs.lookupBareAlias(registry, "exit now") == null);
+    try std.testing.expect(command_specs.lookupBareAlias(registry, "Exit") == null);
+}
+
+test "bare alias lookup never resolves a primary slash token" {
+    const registry = @import("../../builtins/commands.zig").slash_registry;
+
+    try std.testing.expect(command_specs.lookupBareAlias(registry, "/quit") == null);
+    try std.testing.expect(command_specs.lookupBareAlias(registry, "/exit") == null);
+    try std.testing.expect(command_specs.lookupBareAlias(registry, "quit") == null);
+    try std.testing.expect(command_specs.lookupBareAlias(registry, "") == null);
+}
+
+test "bare alias length bound is derived from registry data" {
+    try std.testing.expectEqual(@as(usize, "exit".len), command_specs.max_bare_alias_len);
+}
+
+test "bare exit routes to quit and stays out of slash completions" {
+    const registry = @import("../../builtins/commands.zig").slash_registry;
+    const command_router = @import("../slash_commands/command_router.zig");
+
+    try std.testing.expectEqual(command_router.ParsedCommand.quit, command_router.parse(registry, "exit"));
+    try std.testing.expectEqual(command_router.ParsedCommand.quit, command_router.parse(registry, "exit "));
+    try std.testing.expectEqual(command_router.ParsedCommand.unknown, command_router.parse(registry, "exit now"));
+
+    try std.testing.expectEqual(@as(usize, 0), command_specs.slashCompletionCount(registry, "exit"));
+}
+
+test "prose submissions reject before the registry is consulted" {
+    // Anything with interior whitespace or beyond the longest alias is rejected
+    // without a single token comparison.
+    try std.testing.expect(bareAliasCandidate("") == null);
+    try std.testing.expect(bareAliasCandidate("exit now") == null);
+    try std.testing.expect(bareAliasCandidate("please exit the app") == null);
+    try std.testing.expect(bareAliasCandidate("explain the exit code") == null);
+    try std.testing.expect(bareAliasCandidate("exiting") == null);
+
+    // Only a short single token survives the pre-filter and pays for a scan.
+    try std.testing.expectEqualStrings("exit", bareAliasCandidate("exit").?);
+    try std.testing.expectEqualStrings("exit", bareAliasCandidate("exit  ").?);
+    try std.testing.expectEqualStrings("Exit", bareAliasCandidate("Exit").?);
 }
 
 test "direct terminal route requires the literal first character" {

--- a/src/core/slash_commands/command_specs.zig
+++ b/src/core/slash_commands/command_specs.zig
@@ -275,6 +275,33 @@ pub fn matchesSlashExact(registry: SlashRegistry, cmd: []const u8, kind: SlashKi
     return matched.command.kind == kind;
 }
 
+/// Longest slash-less alias in the built-in registry, used to reject ordinary
+/// prose on length before any comparison work happens.
+pub const max_bare_alias_len: usize = blk: {
+    const builtin_commands = @import("../../builtins/commands.zig");
+    var longest: usize = 0;
+    for (builtin_commands.slash_specs) |spec| {
+        for (spec.aliases) |alias| {
+            if (alias.len == 0 or alias[0] == '/') continue;
+            if (alias.len > longest) longest = alias.len;
+        }
+    }
+    break :blk longest;
+};
+
+/// Resolves a submission that carries no leading slash. Every spec `command` is
+/// slash-prefixed, so only slash-less aliases can match and the primary tokens
+/// are never compared.
+pub fn lookupBareAlias(registry: SlashRegistry, token: []const u8) ?*const SlashSpec {
+    for (registry.commands) |*spec| {
+        for (spec.aliases) |alias| {
+            if (alias.len == 0 or alias[0] == '/') continue;
+            if (std.mem.eql(u8, alias, token)) return spec;
+        }
+    }
+    return null;
+}
+
 pub fn matchedSlashPrefix(registry: SlashRegistry, cmd: []const u8, kind: SlashKind) ?[]const u8 {
     return registry.matchEntryPrefix(cmd, slashSpecPtr(registry, kind));
 }


### PR DESCRIPTION
Allow dummies like me who can't stop typing `exit` to end a session that way.