### PR TITLE
Preserve accepted previews during recovery

### DIFF
--- a/src/core/agent/runtime/assistant_stream.zig
+++ b/src/core/agent/runtime/assistant_stream.zig
@@ -177,7 +177,7 @@ pub const StreamChunkContext = struct {
         const candidate = if (self.raw_text.items.len > 0) self.raw_text.items else fallback;
         if (candidate.len == 0) return self.interrupted_source.items;
         const actual = response_language.evidence(candidate).script orelse return candidate;
-        return if (actual == self.response_language_expected.?) candidate else "";
+        return if (actual == self.response_language_expected.?) candidate else self.interrupted_source.items;
     }
 
     pub fn accept_staged_response_language(self: *StreamChunkContext) !void {
@@ -1183,6 +1183,45 @@ test "recovery starts a fresh response while retaining interrupted evidence" {
     try std.testing.expectEqualStrings("2. A complete replacement.", stream_ctx.interruption_source_or(""));
     try streamAssistantChunk(&stream_ctx, "2. A complete replacement.");
     try std.testing.expectEqualStrings("2. A complete replacement.", stream_ctx.accepted_source());
+}
+
+test "interruption source retains accepted preview until a valid replacement" {
+    const alloc = std.testing.allocator;
+    const prior = "The accepted English preview.";
+    const replacement = "The valid English replacement.";
+    const rejected = "我会先检查锁文件和依赖清单。";
+    const cases = [_]struct {
+        prior: []const u8,
+        candidate: []const u8,
+        interruption: []const u8,
+        accepted: []const u8,
+    }{
+        .{ .prior = prior, .candidate = rejected, .interruption = prior, .accepted = "" },
+        .{ .prior = "", .candidate = rejected, .interruption = "", .accepted = "" },
+        .{ .prior = prior, .candidate = "", .interruption = prior, .accepted = "" },
+        .{ .prior = prior, .candidate = replacement, .interruption = replacement, .accepted = replacement },
+    };
+
+    for (cases) |case| {
+        var capture = StreamCapture{};
+        defer capture.deinit(alloc);
+        var hook_set = capture.hooks();
+        hook_set.render_assistant_text = false;
+        var stream_ctx = StreamChunkContext{
+            .hooks = &hook_set,
+            .turn_id = 1,
+            .alloc = alloc,
+            .response_language_expected = .latin,
+        };
+        defer stream_ctx.deinit();
+        try stream_ctx.restoreRecoverySource(case.prior, true);
+        try stream_ctx.beginRecoveryAttempt();
+        try streamAssistantChunk(&stream_ctx, case.candidate);
+
+        try std.testing.expectEqualStrings(case.interruption, stream_ctx.interruption_source_or(""));
+        try std.testing.expectEqualStrings(case.accepted, stream_ctx.accepted_source());
+        try std.testing.expectEqual(@as(usize, if (case.accepted.len == 0) 0 else 1), capture.source_spans.items.len);
+    }
 }
 
 test "checkpoint recovery restarts Markdown without replaying an unfinished code fence" {

--- a/src/core/agent/runtime/tests/gateway_flow.zig
+++ b/src/core/agent/runtime/tests/gateway_flow.zig
@@ -4759,6 +4759,58 @@ test "processQueuedPrompt masks and terminal-encodes provider diagnostics" {
     );
 }
 
+fn expect_rejected_replacement_retains_preview(cancel_after_replacement: bool) !void {
+    const alloc = std.testing.allocator;
+    const accepted = "The accepted English preview.";
+    const rejected = "我会先检查锁文件和依赖清单。";
+    const completions = [_]FakeCompletion{
+        .{ .chunks = &.{accepted}, .stream_error_after_chunks = error.ReadFailed },
+        .{
+            .chunks = &.{rejected},
+            .content = rejected,
+            .cancel_after_chunks = cancel_after_replacement,
+            .stream_error_after_chunks = if (cancel_after_replacement) null else error.ReadFailed,
+        },
+    };
+    var gateway = FakeGateway.init(alloc, &completions);
+    defer gateway.deinit();
+    var hooks = FakeAgentRuntimeDeps.init(alloc);
+    hooks.enable_recovery_checkpoint = true;
+    defer hooks.deinit();
+    var fixture = PromptFixture{};
+    var config = fixture.config();
+    config.max_provider_attempts = 2;
+    var job = fixture.job();
+    job.prompt = @constCast("Explain the lockfile issue in English.");
+
+    try runFakePrompt(&gateway, &hooks, config, job);
+
+    try std.testing.expectEqual(@as(usize, 2), gateway.request_bodies.items.len);
+    try expectBodyNotContains(&gateway, 1, accepted);
+    try expectBodyNotContains(&gateway, 1, rejected);
+    try std.testing.expectEqual(@as(usize, 1), hooks.assistant_sources.items.len);
+    try std.testing.expectEqualStrings(accepted, hooks.assistant_sources.items[0]);
+    if (cancel_after_replacement) {
+        try std.testing.expectEqual(types.TurnPresentationOutcome.interrupted, hooks.finalized_outcome.?);
+        try std.testing.expectEqual(@as(usize, 1), hooks.interrupted_history_count);
+        try std.testing.expectEqualStrings(accepted, hooks.history_turns.items[0].interrupted.assistant orelse "");
+    } else {
+        try std.testing.expectEqual(types.TurnPresentationOutcome.paused, hooks.finalized_outcome.?);
+        const checkpoint = hooks.recovery_checkpoints.items[hooks.recovery_checkpoints.items.len - 1];
+        try std.testing.expectEqualStrings(accepted, checkpoint.assistant_source);
+        try std.testing.expectEqual(@as(usize, 2), checkpoint.consumed_provider_attempts);
+        try std.testing.expect(!checkpoint.outstanding_reservation);
+    }
+}
+
+test "processQueuedPrompt cancellation retains preview during a rejected replacement" {
+    try expect_rejected_replacement_retains_preview(true);
+}
+
+test "processQueuedPrompt exhaustion retains preview during a rejected replacement" {
+    try expect_rejected_replacement_retains_preview(false);
+}
+
 test "processQueuedPrompt cancellation during provider backoff finishes interrupted" {
     const alloc = std.testing.allocator;
     const completions = [_]FakeCompletion{

--- a/tests/e2e/acp.test.ts
+++ b/tests/e2e/acp.test.ts
@@ -1326,6 +1326,97 @@ describe("acp: model-independent", () => {
   );
 
   test(
+    "ACP cancellation preserves earlier preview while replacement language is rejected",
+    async () => {
+      const root = createIsolatedRoot("fx-acp-rejected-replacement-");
+      const tracePath = join(root.root, "trace.log");
+      const partialText = "The accepted English preview before the connection stopped.";
+      const rejectedText = "我会先检查锁文件和依赖清单。";
+      const laterText = "The later English answer is complete.";
+      const heldReplacement = new Response(new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(
+            `data: ${JSON.stringify({ type: "text-delta", id: "replacement", delta: rejectedText })}\n\n`,
+          ));
+        },
+      }), { headers: { "content-type": "text/event-stream" } });
+      const gateway = startFakeGateway([
+        partialEofResponse(partialText),
+        heldReplacement,
+        finalText(laterText),
+      ]);
+      try {
+        client = await AcpClient.create({
+          cwd: root.workspace,
+          env: {
+            ...fakeGatewayEnv(root, gateway),
+            FX_TRACE_LOG: tracePath,
+            FX_TRACE_SCOPES: "sse",
+          },
+        });
+        const sessionId = await startCodeSession(client);
+        sendPrompt(client, 40, "Explain the repository findings in English without using tools.");
+        await waitForCondition("both response text events", () => {
+          if (!existsSync(tracePath)) return false;
+          return (readFileSync(tracePath, "utf8").match(/event type=text-delta/g) ?? []).length === 2;
+        }, TIMEOUT);
+        expect(client.rawLines.join("\n")).toContain(partialText);
+        expect(client.rawLines.join("\n")).not.toContain(rejectedText);
+        expect(gateway.requests).toHaveLength(2);
+        expect(gateway.requests[1]!.body).not.toContain(partialText);
+
+        client.send({ jsonrpc: "2.0", id: 41, method: "session/cancel", params: {} });
+        const responses = new Map<number, any>();
+        while (responses.size < 2) {
+          const message = await client.readLine() as any;
+          if (message.id === 40 || message.id === 41) responses.set(message.id, message);
+        }
+        expect(responses.get(40)?.result?.stopReason).toBe("cancelled");
+        expect(responses.get(41)?.result).toBeNull();
+        expect(gateway.requests).toHaveLength(2);
+
+        await client.close();
+        client = await AcpClient.create({
+          cwd: root.workspace,
+          env: fakeGatewayEnv(root, gateway),
+        });
+        await client.request("initialize", { protocolVersion: 1 }, 50);
+        client.send({
+          jsonrpc: "2.0",
+          id: 51,
+          method: "session/load",
+          params: { sessionId, mcpServers: [] },
+        });
+        const loaded: any[] = [];
+        while (true) {
+          const message = await client.readLine() as any;
+          if (message.id === 51) {
+            expect(message.error).toBeUndefined();
+            break;
+          }
+          loaded.push(message);
+        }
+        expect(occurrenceCount(JSON.stringify(loaded), partialText)).toBe(1);
+        expect(JSON.stringify(loaded)).not.toContain(rejectedText);
+
+        const later = await runPrompt(client, "Return another English answer.", TIMEOUT);
+        expect(later.promptResult.result.stopReason).toBe("end_turn");
+        expect(JSON.stringify(later.messages)).toContain(laterText);
+        expect(JSON.stringify(later.messages)).not.toContain(partialText);
+        expect(gateway.requests).toHaveLength(3);
+        expect(gateway.requests[2]!.body).toContain(partialText);
+        expect(gateway.requests[2]!.body).not.toContain(rejectedText);
+        expect(client.stderr).toBe("");
+      } finally {
+        await client?.close();
+        gateway.stop();
+        rmSync(root.root, { recursive: true, force: true });
+      }
+    },
+    TIMEOUT,
+  );
+
+  test(
     "ACP sends continuation text normally with the full tool surface",
     async () => {
       const root = createIsolatedRoot("fx-acp-continuation-text-");


### PR DESCRIPTION
## Summary

- Preserve the accepted preview in interrupted history when a wrong-language replacement is cancelled.
- Preserve the accepted preview in recovery checkpoints when retries are exhausted during a wrong-language replacement.
