### PR TITLE
Keep steering previews to two clean lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ cd your_project
 fx
 ```
 
-The current directory becomes the primary workspace. Enter a prompt, or run `/help` to browse interactive commands. While fx is working, Enter steers the active turn at its next safe model boundary. If a tool is running, fx waits for it to finish; press Escape to interrupt the active work and apply the update as soon as the turn settles.
+The current directory becomes the primary workspace. Enter a prompt, or run `/help` to browse interactive commands. While fx is working, Enter steers the active turn at its next safe model boundary. The pending update shows its first two lines, with an ellipsis when more text is hidden. If a tool is running, fx waits for it to finish; press Escape to interrupt the active work and apply the update as soon as the turn settles.
 
 Tool calls are expanded by default. Enable `Collapse tool calls` in `/settings`, or set `"collapse_tool_calls": true` in `~/.fx/settings.json`, to show one summary per tool-call group in the main transcript. Individual calls remain available in the full transcript with Ctrl+O.
 

--- a/src/ui/footer/input_presentation.zig
+++ b/src/ui/footer/input_presentation.zig
@@ -55,99 +55,44 @@ pub const ComposedInputRows = struct {
     }
 };
 
-fn appendSteeringMessageRow(
-    alloc: Allocator,
-    composed: *ComposedInputRows,
-    content: []const u8,
-    width: u16,
-) !void {
-    var row: std.ArrayList(u8) = .empty;
-    errdefer row.deinit(alloc);
-    try row.appendSlice(alloc, ui_render.dim_style);
-    try row_text.appendClipped(alloc, &row, "┋", width);
-    if (width > 1) try row_text.appendClipped(alloc, &row, " ", width - 1);
-    if (width > 2) try row_text.appendClipped(alloc, &row, content, width - 2);
-    try row.appendSlice(alloc, ui_render.reset_style);
-    try composed.rows.append(alloc, row);
-}
-
 pub fn composeSteeringMessageRows(
     alloc: Allocator,
     message: []const u8,
     width: u16,
     row_limit: u16,
+    waits_for_tool: bool,
 ) !ComposedInputRows {
     var composed: ComposedInputRows = .{};
     errdefer composed.deinit(alloc);
-    const max_rows = @min(row_limit, render_input.max_steering_message_rows);
-    if (max_rows == 0) return composed;
-
-    var safe_message = try text_utils.encodeTerminalSafe(
-        alloc,
-        message,
-        std.math.maxInt(usize),
-    );
-    defer safe_message.deinit(alloc);
-
-    const content_width: usize = width -| 2;
-    const visible_width = display_width.visibleWidth(safe_message.bytes);
-    if (content_width == 0 or max_rows == 1 or visible_width <= content_width) {
-        var content: std.ArrayList(u8) = .empty;
-        defer content.deinit(alloc);
-        try row_text.appendSingleLineMiddleEllipsized(
-            alloc,
-            &content,
-            safe_message.bytes,
-            content_width,
-        );
-        try appendSteeringMessageRow(alloc, &composed, content.items, width);
-        return composed;
-    }
-
-    const first = text_utils.prefixTerminalSafeByWidth(safe_message.bytes, content_width);
-    try appendSteeringMessageRow(alloc, &composed, first, width);
-
-    const remaining = safe_message.bytes[first.len..];
-    var second: std.ArrayList(u8) = .empty;
-    defer second.deinit(alloc);
-    if (display_width.visibleWidth(remaining) <= content_width) {
-        try second.appendSlice(alloc, remaining);
-    } else {
-        try second.appendSlice(alloc, "…");
-        if (content_width > 1) {
-            try second.appendSlice(
-                alloc,
-                text_utils.suffixTerminalSafeByWidth(remaining, content_width - 1),
-            );
+    const layout = render_input.steering_message_layout(message, width, waits_for_tool, row_limit);
+    for (layout.rows[0..layout.row_count], 0..) |content, index| {
+        const normalized = try alloc.dupe(u8, content);
+        defer alloc.free(normalized);
+        for (normalized) |*byte| {
+            if (byte.* == '\t') byte.* = ' ';
         }
+        var safe = try text_utils.encodeTerminalSafe(alloc, normalized, std.math.maxInt(usize));
+        defer safe.deinit(alloc);
+
+        var row: std.ArrayList(u8) = .empty;
+        errdefer row.deinit(alloc);
+        try row.appendSlice(alloc, if (waits_for_tool) ui_render.dim_style else ui_render.hint_style);
+        if (waits_for_tool) try row_text.appendClipped(alloc, &row, "┋ ", width);
+        const ellipsis = layout.truncated and index + 1 == layout.row_count and layout.content_width > 0;
+        try row_text.appendClipped(alloc, &row, safe.bytes, layout.content_width - @as(u16, @intFromBool(ellipsis)));
+        if (ellipsis) {
+            try row.appendSlice(alloc, "…");
+        }
+        try row.appendSlice(alloc, ui_render.reset_style);
+        try composed.rows.append(alloc, row);
     }
-    try appendSteeringMessageRow(alloc, &composed, second.items, width);
     return composed;
 }
 
-pub fn composeImmediateSteeringMessageRow(
-    alloc: Allocator,
-    message: []const u8,
-    width: u16,
-) !std.ArrayList(u8) {
-    var row: std.ArrayList(u8) = .empty;
-    errdefer row.deinit(alloc);
-    try row.appendSlice(alloc, ui_render.hint_style);
-    var safe_message = try text_utils.encodeTerminalSafe(
-        alloc,
-        message,
-        std.math.maxInt(usize),
-    );
-    defer safe_message.deinit(alloc);
-    try row_text.appendSingleLineMiddleEllipsized(alloc, &row, safe_message.bytes, width);
-    try row.appendSlice(alloc, ui_render.reset_style);
-    return row;
-}
-
 test "steering rows use the dotted rail without an escape hint" {
-    var first = try composeSteeringMessageRows(std.testing.allocator, "First steer", 80, 2);
+    var first = try composeSteeringMessageRows(std.testing.allocator, "First steer", 80, 2, true);
     defer first.deinit(std.testing.allocator);
-    var second = try composeSteeringMessageRows(std.testing.allocator, "Second steer", 80, 2);
+    var second = try composeSteeringMessageRows(std.testing.allocator, "Second steer", 80, 2, true);
     defer second.deinit(std.testing.allocator);
 
     try std.testing.expectEqual(@as(usize, 1), first.rows.items.len);
@@ -158,32 +103,70 @@ test "steering rows use the dotted rail without an escape hint" {
     try std.testing.expect(std.mem.find(u8, second.rows.items[0].items, "Esc to steer now") == null);
 }
 
-test "narrow steering row preserves distinguishing message ends without the escape hint" {
-    const message = "BEGIN change the implementation direction and retain this unique END";
-    var rows = try composeSteeringMessageRows(std.testing.allocator, message, 48, 2);
+test "steering preview preserves the first two lines and hides the rest" {
+    const alloc = std.testing.allocator;
+    var rows = try composeSteeringMessageRows(alloc, "what is this\r\nLockfile\tfailed\nHIDDEN_TAIL", 40, 2, true);
+    defer rows.deinit(alloc);
+
+    try std.testing.expectEqual(@as(usize, 2), rows.rows.items.len);
+    const first = rows.rows.items[0].items;
+    const second = rows.rows.items[1].items;
+    try std.testing.expectEqualStrings("┋ what is this", first[ui_render.dim_style.len .. first.len - ui_render.reset_style.len]);
+    try std.testing.expectEqualStrings("┋ Lockfile failed…", second[ui_render.dim_style.len .. second.len - ui_render.reset_style.len]);
+}
+
+test "steering preview keeps the beginning of long paragraphs" {
+    const message = "one two three four five six seven eight nine ten HIDDEN_END";
+    var rows = try composeSteeringMessageRows(std.testing.allocator, message, 18, 2, true);
     defer rows.deinit(std.testing.allocator);
 
     try std.testing.expectEqual(@as(usize, 2), rows.rows.items.len);
-    try std.testing.expect(std.mem.find(u8, rows.rows.items[0].items, "┋ BEGIN") != null);
+    try std.testing.expect(std.mem.find(u8, rows.rows.items[0].items, "┋ one two three") != null);
     try std.testing.expect(std.mem.find(u8, rows.rows.items[1].items, "┋ ") != null);
-    try std.testing.expect(std.mem.find(u8, rows.rows.items[1].items, "END") != null);
+    try std.testing.expect(std.mem.find(u8, rows.rows.items[1].items, "┋ four five six…") != null);
     for (rows.rows.items) |row| {
+        try std.testing.expect(std.mem.find(u8, row.items, "HIDDEN_END") == null);
         try std.testing.expect(std.mem.find(u8, row.items, "Esc to steer now") == null);
-        try std.testing.expect(display_width.visibleWidthIgnoringAnsi(row.items) <= 48);
+        try std.testing.expect(display_width.visibleWidthIgnoringAnsi(row.items) <= 18);
     }
 }
 
-test "two steering rows preserve a wide glyph tail when cells do not pack evenly" {
-    var rows = try composeSteeringMessageRows(std.testing.allocator, "界海語", 5, 2);
+test "steering preview layout and painted rows agree at narrow widths" {
+    const alloc = std.testing.allocator;
+    for ([_][]const u8{ "", "first\nsecond\nthird", "alpha\tbeta", "界海語", "é\xff\x1b[2Jtail", "abc\n\ndef", "12\r\n34\r56", "\u{1f469}\u{200d}\u{2764}\u{fe0f}\u{200d}\u{1f48b}\u{200d}\u{1f469}" }) |message| {
+        for ([_]u16{ 0, 1, 2, 3, 5, 12, 31, 33, 80 }) |width| {
+            for ([_]bool{ false, true }) |waiting| {
+                for ([_]u16{ 0, 1, 2 }) |limit| {
+                    const layout = render_input.steering_message_layout(message, width, waiting, limit);
+                    var rows = try composeSteeringMessageRows(alloc, message, width, limit, waiting);
+                    defer rows.deinit(alloc);
+                    try std.testing.expectEqual(@as(usize, layout.row_count), rows.rows.items.len);
+                    try std.testing.expect(rows.rows.items.len <= limit);
+                    for (rows.rows.items) |row| {
+                        try std.testing.expect(display_width.visibleWidthIgnoringAnsi(row.items) <= width);
+                        try std.testing.expect(std.unicode.utf8ValidateSlice(row.items));
+                        try std.testing.expect(std.mem.find(u8, row.items, "\\x0a") == null);
+                        try std.testing.expect(std.mem.find(u8, row.items, "\\x0d") == null);
+                        try std.testing.expect(std.mem.find(u8, row.items, "\\x09") == null);
+                        try std.testing.expect(std.mem.find(u8, row.items, "\x1b[2J") == null);
+                    }
+                }
+            }
+        }
+    }
+}
+
+test "steering preview truncates after the second wide glyph" {
+    var rows = try composeSteeringMessageRows(std.testing.allocator, "界海語", 5, 2, true);
     defer rows.deinit(std.testing.allocator);
 
     try std.testing.expectEqual(@as(usize, 2), rows.rows.items.len);
     try std.testing.expect(std.mem.find(u8, rows.rows.items[0].items, "┋ 界") != null);
-    try std.testing.expect(std.mem.find(u8, rows.rows.items[1].items, "┋ …語") != null);
+    try std.testing.expect(std.mem.find(u8, rows.rows.items[1].items, "┋ 海…") != null);
 }
 
 test "steering rows visibly escape terminal control bytes" {
-    var unsafe = try composeSteeringMessageRows(std.testing.allocator, "before\x1b[2Jafter", 80, 2);
+    var unsafe = try composeSteeringMessageRows(std.testing.allocator, "before\x1b[2Jafter", 80, 2, true);
     defer unsafe.deinit(std.testing.allocator);
     try std.testing.expectEqual(@as(usize, 1), unsafe.rows.items.len);
     try std.testing.expect(std.mem.find(u8, unsafe.rows.items[0].items, "┋ before\\x1b[2Jafter") != null);

--- a/src/ui/footer/paint_plan.zig
+++ b/src/ui/footer/paint_plan.zig
@@ -589,13 +589,12 @@ fn pushSteeringRows(
     var oldest_row_limit: u16 = 0;
     while (visible_start > 0 and remaining_rows > 0) {
         const candidate = visible_start - 1;
-        const candidate_rows = if (ctx.steering_waits_for_tool)
-            render_input.steeringMessageRows(
-                ctx.steering_messages[candidate],
-                width,
-            )
-        else
-            1;
+        const candidate_rows = render_input.steering_message_layout(
+            ctx.steering_messages[candidate],
+            width,
+            ctx.steering_waits_for_tool,
+            render_input.max_steering_message_rows,
+        ).row_count;
         visible_start = candidate;
         oldest_row_limit = @min(candidate_rows, remaining_rows);
         if (candidate_rows >= remaining_rows) break;
@@ -605,41 +604,26 @@ fn pushSteeringRows(
     var painted: u16 = 0;
     for (ctx.steering_messages[visible_start..], visible_start..) |message, index| {
         if (painted >= steering_row_budget) break;
-        if (ctx.steering_waits_for_tool) {
-            const row_limit = if (index == visible_start)
-                oldest_row_limit
-            else
-                render_input.max_steering_message_rows;
-            var rows = try input_presentation.composeSteeringMessageRows(
-                alloc,
-                message,
-                width,
-                row_limit,
-            );
-            defer rows.deinit(alloc);
-            for (rows.rows.items) |*row| {
-                if (painted >= steering_row_budget) break;
-                try pushFooterBandRow(
-                    alloc,
-                    frame,
-                    plan,
-                    plan.footer.banner +| painted,
-                    row,
-                );
-                painted +|= 1;
-            }
-        } else {
-            var row = try input_presentation.composeImmediateSteeringMessageRow(
-                alloc,
-                message,
-                width,
-            );
+        const row_limit = if (index == visible_start)
+            oldest_row_limit
+        else
+            render_input.max_steering_message_rows;
+        var rows = try input_presentation.composeSteeringMessageRows(
+            alloc,
+            message,
+            width,
+            row_limit,
+            ctx.steering_waits_for_tool,
+        );
+        defer rows.deinit(alloc);
+        for (rows.rows.items) |*row| {
+            if (painted >= steering_row_budget) break;
             try pushFooterBandRow(
                 alloc,
                 frame,
                 plan,
                 plan.footer.banner +| painted,
-                &row,
+                row,
             );
             painted +|= 1;
         }
@@ -1449,55 +1433,57 @@ test "footer paints an inline completion suffix without moving the composer curs
     );
 }
 
-test "steering banner wraps one message onto dotted rails above a blank composer gap" {
-    const alloc = std.testing.allocator;
+test "steering banner keeps two clean lines and a composer gap in both delivery modes" {
+    for ([_]bool{ false, true }) |waiting| {
+        const alloc = std.testing.allocator;
 
-    var input = InputRuntime{};
-    defer input.deinit(alloc);
+        var input = InputRuntime{};
+        defer input.deinit(alloc);
 
-    var shell = TranscriptRuntime{
-        .layout = .{
-            .rows = 12,
-            .cols = 48,
-            .content_bottom = 6,
-            .divider_top_row = 7,
-            .input_row = 8,
-            .divider_bottom_row = 9,
-            .hint_row = 10,
-        },
-        .owned_top_row = 1,
-        .viewport_top_row = 1,
-        .cursor_row = 4,
-        .cursor_col = 1,
-    };
-    defer shell.deinit(alloc);
+        var shell = TranscriptRuntime{
+            .layout = .{
+                .rows = 12,
+                .cols = 48,
+                .content_bottom = 6,
+                .divider_top_row = 7,
+                .input_row = 8,
+                .divider_bottom_row = 9,
+                .hint_row = 10,
+            },
+            .owned_top_row = 1,
+            .viewport_top_row = 1,
+            .cursor_row = 4,
+            .cursor_col = 1,
+        };
+        defer shell.deinit(alloc);
 
-    const messages = [_][]const u8{"FOURTH_BEGIN change the implementation direction while keeping this distinguishing FOURTH_END"};
-    var ctx = testContext(&input);
-    ctx.steering_messages = &messages;
-    ctx.steering_waits_for_tool = true;
-    const planner_input: FooterPlannerInput = .{
-        .active_label = null,
-        .ctx = ctx,
-        .place_mid_line_active = false,
-        .input_extra = 0,
-        .input_visible = true,
-        .composer_top_chrome_rows = composerTopChromeRows(),
-        .picker_rows = 0,
-        .footer_extra_rows = 3,
-        .banner_active = true,
-        .banner_rows = 3,
-    };
+        const messages = [_][]const u8{"FIRST_LINE\nSECOND_LINE\nHIDDEN_END"};
+        var ctx = testContext(&input);
+        ctx.steering_messages = &messages;
+        ctx.steering_waits_for_tool = waiting;
+        const planner_input: FooterPlannerInput = .{
+            .active_label = null,
+            .ctx = ctx,
+            .place_mid_line_active = false,
+            .input_extra = 0,
+            .input_visible = true,
+            .composer_top_chrome_rows = composerTopChromeRows(),
+            .picker_rows = 0,
+            .footer_extra_rows = 3,
+            .banner_active = true,
+            .banner_rows = 3,
+        };
 
-    const frame_plan = planFooterPaint(&shell, planner_input);
-    var frame = try composeFooterFrame(alloc, &shell, planner_input, frame_plan.paint);
-    defer frame.deinit(alloc);
+        const frame_plan = planFooterPaint(&shell, planner_input);
+        var frame = try composeFooterFrame(alloc, &shell, planner_input, frame_plan.paint);
+        defer frame.deinit(alloc);
 
-    const banner = frame_plan.paint.footer.banner;
-    try expectFrameRowContains(&frame, banner, shell.layout.cols, "┋ FOURTH_BEGIN");
-    try expectFrameRowContains(&frame, banner + 1, shell.layout.cols, "FOURTH_END");
-    try expectFrameRowTextTrimmed(&frame, banner + 2, shell.layout.cols, "");
-    try expectFrameCellForeground(&frame, banner, shell.layout.cols, 1, .{ .indexed = 245 });
+        const banner = frame_plan.paint.footer.banner;
+        try expectFrameRowContains(&frame, banner, shell.layout.cols, if (waiting) "┋ FIRST_LINE" else "FIRST_LINE");
+        try expectFrameRowContains(&frame, banner + 1, shell.layout.cols, "SECOND_LINE…");
+        try expectFrameRowTextTrimmed(&frame, banner + 2, shell.layout.cols, "");
+        try expectFrameCellForeground(&frame, banner, shell.layout.cols, 1, .{ .indexed = if (waiting) 245 else 255 });
+    }
 }
 
 test "current composer renders a white connected rail across its rows" {

--- a/src/ui/footer/render_input.zig
+++ b/src/ui/footer/render_input.zig
@@ -486,10 +486,90 @@ pub fn activeCompactCommandMenu(ctx: RenderContext) ?CompactCommandMenuProjectio
 pub const steering_composer_gap_rows: u16 = 1;
 pub const max_steering_message_rows: u16 = 2;
 
-pub fn steeringMessageRows(message: []const u8, width: u16) u16 {
-    const content_width = width -| 2;
-    if (content_width == 0) return 1;
-    return if (text_utils.terminalSafeVisibleWidth(message) <= content_width) 1 else max_steering_message_rows;
+const SteeringMessageLayout = struct {
+    rows: [max_steering_message_rows][]const u8 = @splat(""),
+    row_count: u16 = 0,
+    content_width: u16,
+    truncated: bool = false,
+};
+
+fn steering_unit_width(raw: []const u8) usize {
+    var width: usize = 0;
+    var safe_start: usize = 0;
+    var index: usize = 0;
+    while (index < raw.len) {
+        const rune = display_width.decodeNextRune(raw, index);
+        const end = index + rune.len;
+        if (!text_utils.isTerminalSafe(raw[index..end])) {
+            width += display_width.visibleWidth(raw[safe_start..index]);
+            width += text_utils.terminalSafeVisibleWidth(raw[index..end]);
+            safe_start = end;
+        }
+        index = end;
+    }
+    return width + display_width.visibleWidth(raw[safe_start..]);
+}
+
+/// Borrows at most two visible row slices; measurement and painting share this layout.
+pub fn steering_message_layout(
+    message: []const u8,
+    width: u16,
+    waits_for_tool: bool,
+    row_limit: u16,
+) SteeringMessageLayout {
+    var layout: SteeringMessageLayout = .{
+        .content_width = if (waits_for_tool) width -| 2 else width,
+    };
+    const limit = @min(row_limit, max_steering_message_rows);
+    var offset: usize = 0;
+    while (layout.row_count < limit) {
+        const start = offset;
+        var cells: usize = 0;
+        var ellipsis_end = start;
+        var last_space: ?usize = null;
+        while (offset < message.len and message[offset] != '\n' and message[offset] != '\r') {
+            const unit = display_width.displayUnitAt(message, offset);
+            const raw = message[offset .. offset + unit.byte_len];
+            const unit_width = if (message[offset] == '\t')
+                1
+            else if (text_utils.isTerminalSafe(raw))
+                unit.cell_width
+            else
+                steering_unit_width(raw);
+            if (unit_width > layout.content_width - cells) break;
+            if (message[offset] == ' ' or message[offset] == '\t') last_space = offset;
+            cells += unit_width;
+            offset += unit.byte_len;
+            if (cells < layout.content_width) ellipsis_end = offset;
+        }
+        var end = offset;
+        const soft_separator = offset < message.len and (message[offset] == ' ' or message[offset] == '\t');
+        if (soft_separator) {
+            while (offset < message.len and (message[offset] == ' ' or message[offset] == '\t')) offset += 1;
+        }
+        const hard_break = offset < message.len and (message[offset] == '\n' or message[offset] == '\r');
+        if (hard_break) {
+            const cr = message[offset] == '\r';
+            offset += 1;
+            if (cr and offset < message.len and message[offset] == '\n') offset += 1;
+        } else if (!soft_separator and offset < message.len) {
+            if (last_space) |space| {
+                if (space > start) {
+                    end = space;
+                    offset = space + 1;
+                }
+            }
+        }
+        layout.rows[layout.row_count] = message[start..end];
+        layout.row_count += 1;
+        if (offset == message.len) break;
+        if (layout.row_count == limit or (!hard_break and end == start)) {
+            layout.rows[layout.row_count - 1] = message[start..@min(end, ellipsis_end)];
+            layout.truncated = true;
+            break;
+        }
+    }
+    return layout;
 }
 
 pub fn steeringBannerRowsForMessages(
@@ -498,13 +578,9 @@ pub fn steeringBannerRowsForMessages(
     width: u16,
 ) u16 {
     if (messages.len == 0) return 0;
-    if (!waits_for_tool) {
-        return @as(u16, @intCast(@min(messages.len, std.math.maxInt(u16)))) +|
-            steering_composer_gap_rows;
-    }
     var rows: u16 = 0;
     for (messages) |message| {
-        rows +|= steeringMessageRows(message, width);
+        rows +|= steering_message_layout(message, width, waits_for_tool, max_steering_message_rows).row_count;
     }
     return rows +| steering_composer_gap_rows;
 }
@@ -518,6 +594,9 @@ pub fn steeringBannerRows(ctx: RenderContext, width: u16) u16 {
 }
 
 test "steering banner reserves message rows and one composer gap" {
+    for ([_]bool{ false, true }) |waiting| {
+        try std.testing.expectEqual(@as(u16, 3), steeringBannerRowsForMessages(&.{"first\nsecond\nthird"}, waiting, 80));
+    }
     try std.testing.expectEqual(
         @as(u16, 0),
         steeringBannerRowsForMessages(&.{}, true, 80),
@@ -530,6 +609,25 @@ test "steering banner reserves message rows and one composer gap" {
         @as(u16, 5),
         steeringBannerRowsForMessages(&.{ "first steering message", "second steering message" }, true, 12),
     );
+}
+
+test "steering preview layout retains prefix slices at row boundaries" {
+    const cases = [_]struct { text: []const u8, width: u16, first: []const u8, second: []const u8, truncated: bool }{
+        .{ .text = "first\r\nsecond\nthird", .width = 20, .first = "first", .second = "second", .truncated = true },
+        .{ .text = "abcdefghij", .width = 4, .first = "abcd", .second = "efg", .truncated = true },
+        .{ .text = "abcd\nefgh", .width = 4, .first = "abcd", .second = "efgh", .truncated = false },
+        .{ .text = "one two three", .width = 7, .first = "one two", .second = "three", .truncated = false },
+        .{ .text = "abc \ndef", .width = 3, .first = "abc", .second = "def", .truncated = false },
+        .{ .text = "界海語", .width = 3, .first = "界", .second = "海", .truncated = true },
+        .{ .text = "first\n\nthird", .width = 20, .first = "first", .second = "", .truncated = true },
+    };
+    for (cases) |case| {
+        const layout = steering_message_layout(case.text, case.width, false, 2);
+        try std.testing.expectEqual(@as(u16, 2), layout.row_count);
+        try std.testing.expectEqualStrings(case.first, layout.rows[0]);
+        try std.testing.expectEqualStrings(case.second, layout.rows[1]);
+        try std.testing.expectEqual(case.truncated, layout.truncated);
+    }
 }
 
 pub fn transientActivityGapRows(shell: *const TranscriptRuntime, tool_before_activity: bool) u16 {

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -3204,7 +3204,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       const command =
         `while [ ! -f ${JSON.stringify(releasePath)} ]; do sleep 0.05; done; ` +
         "printf COOPERATIVE_TOOL_DONE";
-      const firstSteering = "FIRST_BEGIN use COOPERATIVE_STEERING_SENTINEL in the answer FIRST_END";
+      const firstSteering = "FIRST_BEGIN what is this\nLockfile failed policy check\nHIDDEN_STEERING_TAIL keep the entire message";
       const secondSteering = "SECOND_BEGIN keep the answer concise while preserving its result SECOND_END";
       const thirdSteering = "THIRD_BEGIN mention the completed command before the conclusion THIRD_END";
       const finalText = "COOPERATIVE_STEERING_COMPLETE";
@@ -3245,15 +3245,19 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       await session.waitForComposer(TIMEOUT);
       await session.sendText("Run the cooperative steering fixture.");
       await session.waitForText("Running while", TIMEOUT);
-      await session.sendText(firstSteering);
+      await session.pasteText(firstSteering);
+      await session.sendKeys("Enter");
       await session.sendText(secondSteering);
       await session.sendText(thirdSteering);
       await Bun.sleep(150);
       const pendingPane = await session.capturePane();
-      expect(pendingPane).toContain(`┋ ${firstSteering}`);
+      expect(pendingPane).toContain("┋ FIRST_BEGIN what is this");
+      expect(pendingPane).toContain("┋ Lockfile failed policy check…");
+      expect(pendingPane).not.toContain("HIDDEN_STEERING_TAIL");
+      expect(pendingPane).not.toContain("\\x0a");
       expect(pendingPane).toContain(`┋ ${secondSteering}`);
       expect(pendingPane).toContain(`┋ ${thirdSteering}`);
-      expect(pendingPane.indexOf(firstSteering)).toBeLessThan(
+      expect(pendingPane.indexOf("FIRST_BEGIN")).toBeLessThan(
         pendingPane.indexOf(secondSteering),
       );
       expect(pendingPane.indexOf(secondSteering)).toBeLessThan(
@@ -3276,7 +3280,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       const narrowPane = await session.capturePane();
       for (const marker of [
         "FIRST_BEGIN",
-        "FIRST_END",
+        "Lockfile failed policy check…",
         "SECOND_BEGIN",
         "SECOND_END",
         "THIRD_BEGIN",
@@ -3308,17 +3312,20 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       const continuedBody = steeringGateway.requests[1]!.body;
       const trace = readFileSync(tracePath, "utf8");
       expect(continuedBody.indexOf("COOPERATIVE_TOOL_DONE")).toBeGreaterThanOrEqual(0);
-      expect(continuedBody.indexOf(firstSteering)).toBeGreaterThan(
+      expect(continuedBody.indexOf(JSON.stringify(firstSteering).slice(1, -1))).toBeGreaterThan(
         continuedBody.indexOf("COOPERATIVE_TOOL_DONE"),
       );
       expect(continuedBody.indexOf(secondSteering)).toBeGreaterThan(
-        continuedBody.indexOf(firstSteering),
+        continuedBody.indexOf(JSON.stringify(firstSteering).slice(1, -1)),
       );
       expect(continuedBody.indexOf(thirdSteering)).toBeGreaterThan(
         continuedBody.indexOf(secondSteering),
       );
       expect(continuedBody).toContain("live user update");
       expect(trace).toContain("event=prompt_steering_consumed");
+      const fullScrollback = await session.captureFullScrollback();
+      expect(fullScrollback).toContain("HIDDEN_STEERING_TAIL");
+      expect(fullScrollback).not.toContain("\\x0a");
       expect(readFileSync(stderrPath, "utf8")).toBe("");
       expect(session.isAlive()).toBe(true);
       expect(session.isPaneAlive()).toBe(true);


### PR DESCRIPTION
## Summary

- Show the first two wrapped lines of pending steering messages and truncate at the end.
- Render pasted newlines and tabs as normal whitespace instead of escape markers.
- Keep preview height and composer spacing consistent during tool waits, immediate steering, and terminal resizing.
