### PR TITLE
Preserve auth recovery across prompt and provider changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ fx
 
 If a saved credential cannot be checked, `/login`, `/provider`, and `/setup` still open and identify the unavailable source. Other credentials remain usable. Fix the saved credential and reopen `/provider` to retry. Storage or connection failures do not start another sign-in, and browser authorization reports success only after the new credential is saved.
 
-If credential storage fails when you submit a prompt, fx keeps the prompt and the selected account. Repair the saved credential, then press Enter to retry. A sign-in that cannot save its credential reports a storage failure.
+If credential storage fails when you submit a prompt, fx keeps the prompt and the selected account. Repair the saved credential, then press Enter to retry. A sign-in that cannot save its credential reports a storage failure. Resumed sessions restore their provider's credential and model catalog before the first prompt.
 
 The OpenAI Codex route uses ChatGPT subscription access directly and never sends its OAuth token to Vercel AI Gateway. The session is stored privately at `~/.fx/chatgpt-auth.json` and refreshed when needed. On supported Codex models, `/fast` requests OpenAI's priority service tier and consumes ChatGPT credits at the higher Fast mode rate.
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ fx
 
 If a saved credential cannot be checked, `/login`, `/provider`, and `/setup` still open and identify the unavailable source. Other credentials remain usable. Fix the saved credential and reopen `/provider` to retry. Storage or connection failures do not start another sign-in, and browser authorization reports success only after the new credential is saved.
 
+If credential storage fails when you submit a prompt, fx keeps the prompt and the selected account. Repair the saved credential, then press Enter to retry. A sign-in that cannot save its credential reports a storage failure.
+
 The OpenAI Codex route uses ChatGPT subscription access directly and never sends its OAuth token to Vercel AI Gateway. The session is stored privately at `~/.fx/chatgpt-auth.json` and refreshed when needed. On supported Codex models, `/fast` requests OpenAI's priority service tier and consumes ChatGPT credits at the higher Fast mode rate.
 
 The Grok route uses subscription access directly at xAI and never sends its OAuth token to Vercel AI Gateway or OpenAI. Its session is stored privately at `~/.fx/grok-auth.json`, refreshed when needed, and used only with the authenticated xAI catalog and Responses API.

--- a/src/acp/server.zig
+++ b/src/acp/server.zig
@@ -2176,10 +2176,12 @@ fn handleSetConfigOption(state: *ServerState, alloc: Allocator, msg: *jsonrpc.Me
                     staged_credential.?.gatewayTeam(),
                     staged_credential.?.accountId(),
                 );
+            // Provider selection is independent of earlier prompt cancellation.
+            var catalog_cancel_flag = std.atomic.Value(bool).init(false);
             const fetched = try catalog_provider.fetch(alloc, .{
                 .access = access,
                 .endpoint = state.cfg.gateway_models_path,
-                .cancel_flag = &session.cancel_flag,
+                .cancel_flag = &catalog_cancel_flag,
                 .view = .picker,
             });
             var catalog = switch (fetched) {

--- a/src/builtins/gateway.zig
+++ b/src/builtins/gateway.zig
@@ -21,6 +21,7 @@ const provider_set = @import("../core/gateway/provider_set.zig");
 const provider_catalog = @import("../core/auth/provider_catalog.zig");
 const credential_authority = @import("../core/auth/credential_authority.zig");
 const model_capabilities = @import("../core/config/model_capabilities.zig");
+const model_provider = @import("../core/config/model_provider.zig");
 const vercel_model_policy = @import("../gateway/vercel_model_policy.zig");
 const model_catalog = @import("../core/gateway/model_catalog.zig");
 const output_contracts = @import("../core/output/output_contracts.zig");
@@ -2430,6 +2431,11 @@ fn fetchModelCatalogResponse(
     if (cancel_flag) |flag| {
         if (flag.load(.seq_cst)) return error.Cancelled;
     }
+    if (access == .authenticated and
+        !model_provider.authorizesCredential(.gateway, access.credentialSource()))
+    {
+        return .{ .http_status = .unauthorized };
+    }
 
     const team_path = try modelCatalogTeamPath(alloc, path, access);
     defer if (team_path) |owned| alloc.free(owned);
@@ -2563,6 +2569,82 @@ fn installLoopbackModelsEnv(alloc: std.mem.Allocator, port: u16) !*ModelsUrlTest
     );
     defer alloc.free(models_url);
     return ModelsUrlTestEnv.install(alloc, models_url);
+}
+
+test "Gateway catalog provider rejects subscription credentials before HTTP" {
+    const alloc = std.testing.allocator;
+    for ([_]credentials.Source{ .chatgpt_subscription, .grok_subscription }) |source| {
+        var fixture = try gateway_client.TestModelCatalogFixture.init();
+        defer fixture.deinit();
+        try fixture.start();
+        try std.testing.expect(fixture.waitForAcceptStart(5000));
+        const env = try installLoopbackModelsEnv(alloc, fixture.port());
+        defer env.deinit();
+
+        var result = try model_catalog_provider.fetch(alloc, .{
+            .access = credentials.catalogAccessForCredentialAndAccount(source, "subscription-token", null, "account"),
+            .endpoint = models_path,
+        });
+        defer if (result == .catalog) freeModelCatalog(alloc, &result.catalog);
+        try std.testing.expect(fixture.capturedHeaderValue("authorization") == null);
+        switch (result) {
+            .failure => |failure| {
+                try std.testing.expectEqual(model_catalog.FailureCategory.authentication, failure.category);
+                try std.testing.expectEqual(std.http.Status.unauthorized, failure.http_status.?);
+            },
+            .catalog => return error.TestUnexpectedResult,
+        }
+    }
+}
+
+test "Gateway catalog ID wrappers reject subscription credentials before HTTP" {
+    const alloc = std.testing.allocator;
+    for ([_]credentials.Source{ .chatgpt_subscription, .grok_subscription }) |source| {
+        var fixture = try gateway_client.TestModelCatalogFixture.init();
+        defer fixture.deinit();
+        try fixture.start();
+        try std.testing.expect(fixture.waitForAcceptStart(5000));
+        const env = try installLoopbackModelsEnv(alloc, fixture.port());
+        defer env.deinit();
+
+        var cancel_flag = std.atomic.Value(bool).init(false);
+        var ids = fetchModelIdsCancellable(
+            alloc,
+            credentials.catalogAccessForCredentialAndAccount(source, "subscription-token", null, "account"),
+            models_path,
+            &cancel_flag,
+        ) catch |err| {
+            try std.testing.expectEqual(error.AuthenticationRejected, err);
+            try std.testing.expect(fixture.capturedHeaderValue("authorization") == null);
+            continue;
+        };
+        defer collections.freeStringList(alloc, &ids);
+        try std.testing.expect(fixture.capturedHeaderValue("authorization") == null);
+        return error.TestUnexpectedResult;
+    }
+}
+
+test "Gateway catalog permits public-only and host-managed access without authentication headers" {
+    const alloc = std.testing.allocator;
+    for ([_]credentials.CatalogAccess{
+        .{ .public_only = .no_credential },
+        .{ .public_only = .chatgpt_subscription },
+        .{ .public_only = .grok_subscription },
+        .host_managed,
+    }) |access| {
+        var fixture = try gateway_client.TestModelCatalogFixture.init();
+        defer fixture.deinit();
+        try fixture.start();
+        try std.testing.expect(fixture.waitForAcceptStart(5000));
+        const env = try installLoopbackModelsEnv(alloc, fixture.port());
+        defer env.deinit();
+
+        var ids = try fetchModelIds(alloc, access, models_path);
+        defer collections.freeStringList(alloc, &ids);
+        try std.testing.expect(ids.items.len > 0);
+        try std.testing.expect(fixture.capturedHeaderValue("authorization") == null);
+        if (fixture.failure()) |err| return err;
+    }
 }
 
 test "model catalog GET includes selected team header" {

--- a/src/core/app/app_auth_runtime.zig
+++ b/src/core/app/app_auth_runtime.zig
@@ -98,33 +98,47 @@ pub fn Runtime(comptime App: type) type {
                 @hasDecl(@TypeOf(app.auth), "selectForProvider"))
             {
                 const provider = provider_runtime.provider(app);
-                const required_source: credentials.Source = switch (provider) {
-                    .codex => .chatgpt_subscription,
-                    .grok => .grok_subscription,
-                    .gateway => app.auth.credentialSource() orelse .fx_login,
-                };
-                const route_change = app.auth.selectForProvider(app.alloc, provider) catch |err| switch (err) {
-                    error.OutOfMemory => return err,
-                    else => return recoverCredentialFailure(app, required_source, err),
-                };
-                if (route_change) |changed| {
-                    applyCredentialChange(app, changed);
-                } else if (!model_provider.authorizesCredential(provider, app.auth.credentialSource())) {
-                    try app.writeDomainNotice(.{
-                        .topic = "auth",
-                        .tone = .warning,
-                        .body = if (provider == .grok)
-                            credentials.missing_grok_interactive_credential_message
-                        else if (provider == .codex)
-                            credentials.missing_chatgpt_interactive_credential_message
-                        else
-                            credentials.missing_interactive_credential_message,
-                    }, true);
-                    app.shell.render_requests.request(.footer);
-                    return false;
+                if (!model_provider.authorizesCredential(provider, app.auth.credentialSource())) {
+                    var preferred: ?credentials.Source = null;
+                    if (provider == .gateway and !host_target.is_wasm) {
+                        var settings = config_runtime.loadMergedSettings(app.alloc, app.workspace_root) catch |err| {
+                            if (err == error.OutOfMemory) return err;
+                            debug_trace.logf("auth", "prompt credential preference load failed err={s}", .{@errorName(err)});
+                            try writeAuthNotice(app, .{
+                                .topic = "auth",
+                                .tone = .@"error",
+                                .body = "Could not load authentication settings. Check user settings, then press Enter to retry.",
+                            });
+                            return false;
+                        };
+                        defer settings.deinit(app.alloc);
+                        preferred = settings.credential_source;
+                    }
+                    switch (try app.auth.selectForProvider(app.alloc, provider, preferred)) {
+                        .selected => applyCredentialChange(app, true),
+                        .unchanged => {},
+                        .failed => |failure| return recoverCredentialFailure(app, failure.source, failure.err),
+                        .missing => return missingPromptCredential(app, provider),
+                    }
                 }
             }
             if (app.auth.credentialSource() != null) return true;
+            return missingPromptCredential(app, .gateway);
+        }
+
+        fn missingPromptCredential(app: *App, provider: model_provider.ProviderId) !bool {
+            if (provider != .gateway) {
+                try app.writeDomainNotice(.{
+                    .topic = "auth",
+                    .tone = .warning,
+                    .body = if (provider == .grok)
+                        credentials.missing_grok_interactive_credential_message
+                    else
+                        credentials.missing_chatgpt_interactive_credential_message,
+                }, true);
+                app.shell.render_requests.request(.footer);
+                return false;
+            }
 
             const auth_view = app.auth.view();
             if (auth_view.onboarding_skipped) {
@@ -1494,6 +1508,7 @@ pub fn Runtime(comptime App: type) type {
             if (comptime host_target.is_wasm) {
                 return if (try admitPromptCredential(app)) .current else .rejected;
             }
+            if (!try ensurePromptCredential(app)) return .rejected;
             if (comptime @hasDecl(@TypeOf(app.auth), "credentialFailure")) {
                 if (app.auth.credentialFailure()) |failure| {
                     if (!failure.retryable()) {
@@ -1611,7 +1626,7 @@ pub fn Runtime(comptime App: type) type {
                 ),
                 .invalid_storage => std.fmt.allocPrint(
                     alloc,
-                    "{s} saved sign-in is unreadable.\nCheck credential storage, then press Enter to retry. Your prompt is saved.",
+                    "{s}: Saved credential storage is unavailable.\nCheck credential storage, then press Enter to retry. Your prompt is saved.",
                     .{source_label},
                 ),
                 .persistence_uncertain => std.fmt.allocPrint(

--- a/src/core/app/app_auth_runtime.zig
+++ b/src/core/app/app_auth_runtime.zig
@@ -99,22 +99,17 @@ pub fn Runtime(comptime App: type) type {
             {
                 const provider = provider_runtime.provider(app);
                 if (!model_provider.authorizesCredential(provider, app.auth.credentialSource())) {
-                    var preferred: ?credentials.Source = null;
-                    if (provider == .gateway and !host_target.is_wasm) {
-                        var settings = config_runtime.loadMergedSettings(app.alloc, app.workspace_root) catch |err| {
-                            if (err == error.OutOfMemory) return err;
-                            debug_trace.logf("auth", "prompt credential preference load failed err={s}", .{@errorName(err)});
-                            try writeAuthNotice(app, .{
-                                .topic = "auth",
-                                .tone = .@"error",
-                                .body = "Could not load authentication settings. Check user settings, then press Enter to retry.",
-                            });
-                            return false;
-                        };
-                        defer settings.deinit(app.alloc);
-                        preferred = settings.credential_source;
-                    }
-                    switch (try app.auth.selectForProvider(app.alloc, provider, preferred)) {
+                    const selection = selectProviderCredential(app, provider) catch |err| {
+                        if (err == error.OutOfMemory) return err;
+                        debug_trace.logf("auth", "prompt credential preference load failed err={s}", .{@errorName(err)});
+                        try writeAuthNotice(app, .{
+                            .topic = "auth",
+                            .tone = .@"error",
+                            .body = "Could not load authentication settings. Check user settings, then press Enter to retry.",
+                        });
+                        return false;
+                    };
+                    switch (selection) {
                         .selected => applyCredentialChange(app, true),
                         .unchanged => {},
                         .failed => |failure| return recoverCredentialFailure(app, failure.source, failure.err),
@@ -124,6 +119,65 @@ pub fn Runtime(comptime App: type) type {
             }
             if (app.auth.credentialSource() != null) return true;
             return missingPromptCredential(app, .gateway);
+        }
+
+        fn selectProviderCredential(app: *App, provider: model_provider.ProviderId) !auth_runtime.ProviderCredentialSelection {
+            if (hostManagesAuth(app) or model_provider.authorizesCredential(provider, app.auth.credentialSource())) return .unchanged;
+            var preferred: ?credentials.Source = null;
+            if (provider == .gateway and !host_target.is_wasm) {
+                var settings = try config_runtime.loadMergedSettings(app.alloc, app.workspace_root);
+                defer settings.deinit(app.alloc);
+                preferred = settings.credential_source;
+            }
+            return app.auth.selectForProvider(app.alloc, provider, preferred);
+        }
+
+        pub fn restoreSessionCredential(app: *App, previous_provider: model_provider.ProviderId) !void {
+            // Hydration can run before App.init returns, so it must not start background tasks.
+            const provider = provider_runtime.provider(app);
+            const provider_changed = previous_provider != provider;
+            if (provider_changed) {
+                app.auth.cancelPromptCredentialRefresh();
+                app.model_cache.resetForProviderChange();
+            }
+            if (comptime host_target.is_wasm) return;
+            if (hostManagesAuth(app)) return;
+            const selection = selectProviderCredential(app, provider) catch |err| {
+                if (err == error.OutOfMemory) return err;
+                debug_trace.logf("auth", "resumed credential preference load failed err={s}", .{@errorName(err)});
+                try app.writeDomainNotice(.{
+                    .topic = "auth",
+                    .tone = .@"error",
+                    .body = "Could not load authentication settings for the resumed session. Check user settings and retry.",
+                }, true);
+                app.shell.render_requests.request(.footer);
+                return;
+            };
+            switch (selection) {
+                .selected => app.model_cache.reset(),
+                .unchanged => {},
+                .missing => try app.writeDomainNotice(.{
+                    .topic = "auth",
+                    .tone = .warning,
+                    .body = switch (provider) {
+                        .gateway => credentials.missing_interactive_credential_message,
+                        .codex => credentials.missing_chatgpt_interactive_credential_message,
+                        .grok => credentials.missing_grok_interactive_credential_message,
+                    },
+                }, true),
+                .failed => |failure| {
+                    const classified = auth_runtime.classifyCredentialFailure(failure.source, failure.err);
+                    const message = if (auth_runtime.preparationError(classified)) |err|
+                        auth_runtime.preparationFailureNotice(err).?
+                    else
+                        "Authentication is unavailable. Run /provider to repair this source.";
+                    debug_trace.logf("auth", "resumed credential unavailable source={t} err={s}", .{ failure.source, @errorName(failure.err) });
+                    const body = try std.fmt.allocPrint(app.alloc, "{s}: {s}", .{ credentials.sourceLabel(failure.source), message });
+                    defer app.alloc.free(body);
+                    try app.writeDomainNotice(.{ .topic = "auth", .tone = .@"error", .body = body }, true);
+                },
+            }
+            app.shell.render_requests.request(.footer);
         }
 
         fn missingPromptCredential(app: *App, provider: model_provider.ProviderId) !bool {
@@ -1457,6 +1511,9 @@ pub fn Runtime(comptime App: type) type {
 
         pub fn startPromptCredentialPrewarm(app: *App) void {
             if (comptime !@hasDecl(@TypeOf(app.auth), "beginPromptCredentialRefresh")) return;
+            if (comptime provider_runtime.supported(App)) {
+                if (!model_provider.authorizesCredential(provider_runtime.provider(app), app.auth.credentialSource())) return;
+            }
             const outcome = app.auth.beginPromptCredentialRefresh();
             debug_trace.logf(
                 "auth",
@@ -2006,6 +2063,7 @@ const TestAuth = struct {
     inventory_refresh_action: ?auth_runtime.InventoryRefreshAction = null,
     inventory_refresh_fails: bool = false,
     prompt_refresh_start: auth_runtime.PromptCredentialRefreshStart = .not_needed,
+    prompt_refresh_start_count: usize = 0,
 
     fn credentialSource(self: *const TestAuth) ?credentials.Source {
         return self.active_source;
@@ -2027,6 +2085,7 @@ const TestAuth = struct {
     }
 
     fn beginPromptCredentialRefresh(self: *TestAuth) auth_runtime.PromptCredentialRefreshStart {
+        self.prompt_refresh_start_count += 1;
         return self.prompt_refresh_start;
     }
 
@@ -2727,6 +2786,28 @@ test "team catalog rejection preserves the previous authority before commit" {
     try std.testing.expectEqual(@as(usize, 0), app.preference_write_count);
     try std.testing.expect(std.mem.find(u8, app.transcript.items, "could not be validated") != null);
     try std.testing.expect(std.mem.find(u8, app.transcript.items, "Changed Vercel team") == null);
+}
+
+test "prompt credential prewarm ignores the previous provider credential" {
+    const ProviderApp = struct {
+        selected_model: std.ArrayList(u8) = .empty,
+        selected_provider: model_provider.ProviderId,
+        auth: TestAuth = .{},
+    };
+    const cases = .{
+        .{ model_provider.ProviderId.gateway, credentials.Source.chatgpt_subscription, credentials.Source.fx_login },
+        .{ model_provider.ProviderId.codex, credentials.Source.fx_login, credentials.Source.chatgpt_subscription },
+        .{ model_provider.ProviderId.grok, credentials.Source.fx_login, credentials.Source.grok_subscription },
+    };
+    inline for (cases) |case| {
+        var app = ProviderApp{ .selected_provider = case[0] };
+        app.auth.active_source = case[1];
+        Runtime(ProviderApp).startPromptCredentialPrewarm(&app);
+        try std.testing.expectEqual(@as(usize, 0), app.auth.prompt_refresh_start_count);
+        app.auth.active_source = case[2];
+        Runtime(ProviderApp).startPromptCredentialPrewarm(&app);
+        try std.testing.expectEqual(@as(usize, 1), app.auth.prompt_refresh_start_count);
+    }
 }
 
 test "prompt credential refresh preserves catalog for secret rotation" {

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -1867,12 +1867,14 @@ pub fn Runtime(comptime App: type) type {
         }
 
         pub fn startResumedSessionReconciliation(app: *App) void {
+            if (comptime @hasDecl(App, "startModelCacheWarmup")) app.startModelCacheWarmup();
             if (comptime !@hasField(App, "auth") or !provider_runtime.supported(App)) return;
             if (comptime !@hasDecl(@TypeOf(app.auth), "credentialSource") or
                 !@hasDecl(@TypeOf(app.auth), "accountId") or
                 !@hasDecl(@TypeOf(app.session.usage), "replaceProviderReconciliationCredential")) return;
 
             const source = app.auth.credentialSource() orelse return;
+            if (!model_provider.authorizesCredential(provider_runtime.provider(app), source)) return;
             const credential = app.auth.apiKey() orelse return;
             app.session.usage.replaceProviderReconciliationCredential(
                 app.alloc,
@@ -1956,6 +1958,7 @@ pub fn Runtime(comptime App: type) type {
             display_title: []const u8,
             notice: ResumeNotice,
         ) !void {
+            const previous_provider = provider_runtime.provider(app);
             if (comptime @hasField(App, "next_image_id")) {
                 app.next_image_id = try nextImageIdForResumedHistory(
                     app.alloc,
@@ -2029,6 +2032,9 @@ pub fn Runtime(comptime App: type) type {
                 try writeResumeNotice(app, &sink, display_title, notice);
                 try replayHistoryToSink(app, &sink, state.history);
                 try writeRecoveryCheckpointToSink(app, &sink, state);
+            }
+            if (comptime @hasDecl(App, "restoreSessionCredential")) {
+                try app.restoreSessionCredential(previous_provider);
             }
         }
 
@@ -10163,6 +10169,24 @@ test "resumed sessions install provider-scoped usage reconciliation authority" {
     Runtime(ReconciliationOriginApp).startResumedSessionReconciliation(&gateway);
     try std.testing.expectEqual(model_provider.ProviderId.gateway, gateway.session.usage.replaced_provider.?);
     try std.testing.expectEqual(types.CredentialSource.ai_gateway_api_key, gateway.session.usage.replaced_source.?);
+}
+
+test "resumed usage reconciliation rejects the previous provider credential" {
+    const cases = .{
+        .{ model_provider.ProviderId.gateway, types.CredentialSource.chatgpt_subscription },
+        .{ model_provider.ProviderId.gateway, types.CredentialSource.grok_subscription },
+        .{ model_provider.ProviderId.codex, types.CredentialSource.fx_login },
+        .{ model_provider.ProviderId.grok, types.CredentialSource.fx_login },
+    };
+    inline for (cases) |case| {
+        var app = ReconciliationOriginApp{
+            .auth = .{ .source = case[1] },
+            .selected_provider = case[0],
+        };
+        Runtime(ReconciliationOriginApp).startResumedSessionReconciliation(&app);
+        try std.testing.expect(app.session.usage.replaced_provider == null);
+        try std.testing.expect(app.session.usage.replaced_source == null);
+    }
 }
 
 test "ensureCachedSessionTitle derives from the first prompt and then freezes" {

--- a/src/core/app/model_cache_runtime.zig
+++ b/src/core/app/model_cache_runtime.zig
@@ -471,6 +471,16 @@ pub const Runtime = struct {
         self.cancel_requested.store(false, .seq_cst);
     }
 
+    pub fn resetForProviderChange(self: *Self) void {
+        debug_trace.logf("catalog", "model catalog reset reason=provider_changed", .{});
+        self.reset();
+        self.mutex.lockUncancelable(io_mod.getIo());
+        defer self.mutex.unlock(io_mod.getIo());
+        model_catalog.freeModelCatalog(self.alloc, &self.catalog);
+        self.catalog = .empty;
+        self.outcome = .{};
+    }
+
     /// Installs a catalog that was completely fetched and validated before the
     /// caller's publication boundary. Ownership transfers without allocation.
     pub fn adoptOwnedCatalog(
@@ -1517,6 +1527,31 @@ test "model cache completion hydrates an open menu and reports once" {
     try std.testing.expect(!runtime.menu.active);
     try std.testing.expectEqual(ModelCacheState.idle, runtime.state);
     if (fixture.failure()) |err| return err;
+}
+
+test "provider changes discard public catalog fallback without changing ordinary reset" {
+    const alloc = std.testing.allocator;
+    var runtime = Runtime.init(alloc, "/v1/models");
+    defer runtime.deinit();
+    {
+        const id = try alloc.dupe(u8, "gateway-model");
+        errdefer alloc.free(id);
+        const model_type = try alloc.dupe(u8, "language");
+        errdefer alloc.free(model_type);
+        try runtime.catalog.append(alloc, .{ .id = id, .model_type = model_type });
+    }
+    runtime.outcome = .{ .loaded = .{
+        .access = model_catalog.AccessMetadata.init(.{ .public_only = .no_credential }),
+    } };
+    runtime.state = .ready;
+
+    runtime.reset();
+    try std.testing.expectEqual(@as(usize, 1), runtime.catalog.items.len);
+    try std.testing.expect(runtime.outcome.loaded != null);
+    runtime.resetForProviderChange();
+    try std.testing.expectEqual(@as(usize, 0), runtime.catalog.items.len);
+    try std.testing.expect(runtime.outcome.loaded == null);
+    try std.testing.expectEqual(ModelCacheState.idle, runtime.state);
 }
 
 test "model cache reset replaces ready public catalog with team catalog" {

--- a/src/core/auth/auth_runtime.zig
+++ b/src/core/auth/auth_runtime.zig
@@ -1289,6 +1289,13 @@ pub const GatewayCredential = struct {
     source: credentials.Source,
 };
 
+pub const ProviderCredentialSelection = union(enum) {
+    unchanged,
+    selected,
+    missing,
+    failed: credentials.LoadFailure,
+};
+
 pub const Runtime = struct {
     const Self = @This();
 
@@ -2334,37 +2341,31 @@ pub const Runtime = struct {
         self: *Self,
         alloc: Allocator,
         provider: model_provider.ProviderId,
-    ) !?bool {
-        if (self.auth_mode == .host_managed) return false;
-        return switch (provider) {
-            .codex => if (self.credentialSource() == .chatgpt_subscription)
-                false
-            else
-                self.selectSourceWithLoader(
-                    alloc,
-                    .chatgpt_subscription,
-                    self,
-                    loadRuntimeCredentialSource,
-                ),
-            .grok => if (self.credentialSource() == .grok_subscription)
-                false
-            else
-                self.selectSourceWithLoader(
-                    alloc,
-                    .grok_subscription,
-                    self,
-                    loadRuntimeCredentialSource,
-                ),
-            .gateway => if (self.credentialSource() != .chatgpt_subscription and self.credentialSource() != .grok_subscription)
-                false
-            else
-                @as(?bool, try self.reselectByPrecedenceWithDeps(
-                    alloc,
-                    self,
-                    probeCredentialSource,
-                    loadRuntimeCredentialSource,
-                )),
+        preferred: ?credentials.Source,
+    ) Allocator.Error!ProviderCredentialSelection {
+        if (self.auth_mode == .host_managed or
+            model_provider.authorizesCredential(provider, self.credentialSource())) return .unchanged;
+
+        var resolution = credentials.resolveForProvider(
+            alloc,
+            self.oauth_transport,
+            self.secret_store,
+            .stored,
+            provider,
+            preferred,
+        ) catch |err| {
+            if (err == error.OutOfMemory) return error.OutOfMemory;
+            return .{ .failed = .{
+                .source = requestedSource(provider, preferred) orelse .fx_login,
+                .err = err,
+            } };
         };
+        defer if (resolution.credential) |*credential| credential.deinit(alloc);
+        if (resolution.credential) |*credential| {
+            return if (self.adoptCredential(alloc, credential)) .selected else .unchanged;
+        }
+        if (resolution.failure) |failure| return .{ .failed = failure };
+        return .missing;
     }
 
     pub fn beginPromptCredentialRefresh(self: *Self) PromptCredentialRefreshStart {
@@ -3478,6 +3479,70 @@ test "auth runtime failed selection preserves the active credential" {
     );
     try std.testing.expectEqual(credentials.Source.ai_gateway_api_key, runtime.credentialSource().?);
     try std.testing.expectEqualStrings("active-token", runtime.apiKey().?);
+}
+
+test "provider selection preserves failure provenance and prior authority until recovery" {
+    const FailedAllocation = struct {
+        fn load(_: ?*anyopaque, _: Allocator) host.SecretStoreLoadError!?[]u8 {
+            return error.OutOfMemory;
+        }
+    };
+    const alloc = std.testing.allocator;
+    var fixture: ApiKeySaveFixture = .{ .fail_load = true };
+    var runtime: Runtime = .{ .secret_store = fixture.secretStore() };
+    defer runtime.deinit(alloc);
+    var previous = try makeTestCredential(alloc, "previous-token", .grok_subscription, null, null);
+    defer previous.deinit(alloc);
+    _ = runtime.adoptCredential(alloc, &previous);
+
+    switch (try runtime.selectForProvider(alloc, .gateway, .stored_key)) {
+        .failed => |failure| {
+            try std.testing.expectEqual(credentials.Source.stored_key, failure.source);
+            try std.testing.expectEqual(error.StoredKeyUnreadable, failure.err);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+    try std.testing.expectEqual(credentials.Source.grok_subscription, runtime.credentialSource().?);
+    try std.testing.expectEqualStrings("previous-token", runtime.selected_credential.?.token);
+
+    runtime.secret_store = host.unavailable_secret_store;
+    try std.testing.expectEqual(ProviderCredentialSelection.missing, try runtime.selectForProvider(alloc, .gateway, .stored_key));
+    try std.testing.expectEqual(credentials.Source.grok_subscription, runtime.credentialSource().?);
+    runtime.secret_store.load_fn = FailedAllocation.load;
+    try std.testing.expectError(error.OutOfMemory, runtime.selectForProvider(alloc, .gateway, .stored_key));
+    try std.testing.expectEqualStrings("previous-token", runtime.selected_credential.?.token);
+
+    fixture.fail_load = false;
+    runtime.secret_store = fixture.secretStore();
+    try std.testing.expectEqual(ProviderCredentialSelection.selected, try runtime.selectForProvider(alloc, .gateway, .stored_key));
+    try std.testing.expectEqual(credentials.Source.stored_key, runtime.credentialSource().?);
+    try std.testing.expectEqualStrings("loaded-key", runtime.selected_credential.?.token);
+}
+
+test "provider selection leaves compatible expired credentials for deferred refresh" {
+    const alloc = std.testing.allocator;
+    var fixture: ApiKeySaveFixture = .{ .fail_load = true };
+    var runtime: Runtime = .{ .secret_store = fixture.secretStore() };
+    defer runtime.deinit(alloc);
+    var credential = try makeTestCredential(alloc, "expired-token", .fx_login, "team_1", null);
+    defer credential.deinit(alloc);
+    credential.refresh_after_ms = 0;
+    _ = runtime.adoptCredential(alloc, &credential);
+
+    try std.testing.expectEqual(ProviderCredentialSelection.unchanged, try runtime.selectForProvider(alloc, .gateway, .stored_key));
+    try std.testing.expectEqual(@as(usize, 0), fixture.load_calls);
+    try std.testing.expectEqual(@as(?i64, 0), runtime.selected_credential.?.refresh_after_ms);
+}
+
+test "host-managed provider selection never reads local credentials" {
+    const alloc = std.testing.allocator;
+    var fixture: ApiKeySaveFixture = .{ .fail_load = true };
+    var runtime: Runtime = .{ .auth_mode = .host_managed, .secret_store = fixture.secretStore() };
+    defer runtime.deinit(alloc);
+    for ([_]model_provider.ProviderId{ .gateway, .codex, .grok }) |provider| {
+        try std.testing.expectEqual(ProviderCredentialSelection.unchanged, try runtime.selectForProvider(alloc, provider, .stored_key));
+    }
+    try std.testing.expectEqual(@as(usize, 0), fixture.load_calls);
 }
 
 const LogoutFixture = struct {

--- a/src/core/auth/login_flow.zig
+++ b/src/core/auth/login_flow.zig
@@ -524,7 +524,7 @@ pub const SignInRuntime = struct {
         }
         self.deps.save(self.deps.ctx, alloc, completion) catch |err| {
             debug_trace.logf("auth", "sign-in session save failed err={s}", .{@errorName(err)});
-            self.failure = if (err == error.OutOfMemory) err else error.CredentialPersistenceFailed;
+            self.failure = signInPersistenceError(err);
             self.state = .failed;
             return;
         };
@@ -633,6 +633,10 @@ fn saveSignIn(_: ?*anyopaque, alloc: Allocator, completion: SignInCompletion) !v
     try oauth_session.saveNewSession(alloc, session);
 }
 
+fn signInPersistenceError(err: anyerror) (Allocator.Error || error{CredentialPersistenceFailed}) {
+    return if (err == error.OutOfMemory) error.OutOfMemory else error.CredentialPersistenceFailed;
+}
+
 pub fn runLogin(
     alloc: Allocator,
     transport: oauth_transport.Provider,
@@ -678,7 +682,10 @@ pub fn runLogin(
     );
     defer session.deinit(alloc);
 
-    try oauth_session.saveNewSession(alloc, session);
+    oauth_session.saveNewSession(alloc, session) catch |err| {
+        debug_trace.logf("auth", "sign-in session save failed err={s}", .{@errorName(err)});
+        return signInPersistenceError(err);
+    };
 }
 
 fn take_login_session(

--- a/src/main.zig
+++ b/src/main.zig
@@ -955,6 +955,10 @@ const App = struct {
         return AuthAppRuntime.admitPromptCredential(self);
     }
 
+    pub fn restoreSessionCredential(self: *App, previous_provider: model_provider.ProviderId) !void {
+        try AuthAppRuntime.restoreSessionCredential(self, previous_provider);
+    }
+
     pub fn startPromptCredentialPrewarm(self: *App) void {
         if (comptime !host_target.is_wasm) {
             AuthAppRuntime.startPromptCredentialPrewarm(self);

--- a/tests/e2e/acp.test.ts
+++ b/tests/e2e/acp.test.ts
@@ -6018,6 +6018,18 @@ describe("acp: model-independent", () => {
           message: "Prompt already in progress",
         });
 
+        client.send({
+          jsonrpc: "2.0",
+          id: 98,
+          method: "session/set_config_option",
+          params: { configId: "provider", value: "codex" },
+        });
+        const providerChange = await readResponse(client, 98);
+        expect(providerChange.error).toEqual({
+          code: -32600,
+          message: "Prompt already in progress",
+        });
+
         heldResponse.resolve(finalText("held prompt complete"));
         const prompt = await readResponse(client, 96);
         expect(prompt.error).toBeUndefined();
@@ -8177,6 +8189,78 @@ describe("acp: model catalog authentication", () => {
     },
     TIMEOUT,
   );
+
+  for (const provider of ["codex", "grok"] as const) {
+    for (const transition of ["cancel", "load", "resume"] as const) {
+      test(`provider selection after session/${transition} activates ${provider}`, async () => {
+        const root = createIsolatedRoot("fx-acp-recovery-");
+        const gateway = startFakeGateway([]);
+        const codex = startAcpFakeCodex();
+        const grok = startAcpFakeGrok();
+        writeSeededAcpChatGptLogin(root.home, codex.accessToken);
+        writeSeededAcpGrokLogin(root.home, grok.accessToken);
+        try {
+          client = await AcpClient.create({
+            cwd: root.workspace,
+            env: {
+              ...fakeGatewayEnv(root, gateway),
+              FX_DISABLE_KEYCHAIN: "1",
+              FX_SOUND: "0",
+              FX_E2E_OPENAI_CODEX_RESPONSES_URL: codex.responsesUrl,
+              FX_E2E_OPENAI_CODEX_MODELS_URL: codex.modelsUrl,
+              FX_E2E_CHATGPT_TOKEN_URL: codex.tokenUrl,
+              FX_E2E_XAI_GROK_RESPONSES_URL: grok.responsesUrl,
+              FX_E2E_XAI_GROK_MODELS_URL: grok.modelsUrl,
+              FX_E2E_XAI_GROK_MODALITIES_URL: grok.modalitiesUrl,
+              FX_E2E_GROK_TOKEN_URL: grok.tokenUrl,
+              FX_E2E_GROK_USERINFO_URL: grok.userinfoUrl,
+            },
+          });
+          const initialized = await client.request("initialize", { protocolVersion: 1 }, 1) as any;
+          expect(initialized.error).toBeUndefined();
+          const created = await client.request("session/new", { mcpServers: [] }, 2) as any;
+          expect(created.error).toBeUndefined();
+          const transitioned = await client.request(`session/${transition}`, {
+            sessionId: created.result.sessionId,
+            ...(transition === "cancel" ? {} : { cwd: root.workspace, mcpServers: [] }),
+          }, 3) as any;
+          expect(transitioned.error).toBeUndefined();
+
+          const changed = await client.request("session/set_config_option", {
+            configId: "provider",
+            value: provider,
+          }, 4) as any;
+          expect(changed.error).toBeUndefined();
+          expect(changed.result.configOptions.find((option: any) => option.id === "provider").currentValue)
+            .toBe(provider);
+          const selected = provider === "codex" ? codex : grok;
+          const other = provider === "codex" ? grok : codex;
+          expect(selected.modelRequests.filter((request) => request.path === "/models")).toHaveLength(1);
+          expect(other.modelRequests).toHaveLength(0);
+
+          const prompt = await runPrompt(client, "Answer after changing providers.", TIMEOUT);
+          expect(prompt.promptResult.result.stopReason).toBe("end_turn");
+          expect(JSON.stringify(prompt.messages)).toContain(
+            provider === "codex" ? "ACP_CHATGPT_RESPONSE" : "ACP_GROK_RESPONSE",
+          );
+          expect(selected.requests).toHaveLength(1);
+          expect(selected.requests[0]!.authorization).toBe(`Bearer ${selected.accessToken}`);
+          expect(selected.tokenRequests).toHaveLength(0);
+          expect(other.requests).toHaveLength(0);
+          expect(gateway.requests).toHaveLength(0);
+          client.endStdin();
+          expect(await client.waitForExit()).toBe(0);
+          expect(client.stderr).toBe("");
+        } finally {
+          await client?.close();
+          codex.stop();
+          grok.stop();
+          gateway.stop();
+          rmSync(root.root, { recursive: true, force: true });
+        }
+      }, TIMEOUT);
+    }
+  }
 
   test("an open ACP connection refreshes subscription model options before selection", async () => {
     const root = createIsolatedRoot("fx-acp-catalog-refresh-");

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -1883,13 +1883,11 @@ for (const [provider, previousProvider] of [
           expect(grok.requests.filter((request) => request.path === "/v1/responses")).toHaveLength(0);
           expect(JSON.parse(readFileSync(settingsPath, "utf8"))).toEqual(preferences);
           await session.sendKeys("Escape");
+          await session.waitForPane((pane) => !pane.includes("Esc Close"), TIMEOUT);
+          await session.sendKeys("C-u");
           await session.waitForComposer(TIMEOUT);
           await session.sendText("Continue the restored provider session.");
-          const responseDeadline = Date.now() + 10_000;
-          while (responses().length === 0) {
-            if (Date.now() >= responseDeadline) throw new Error("Restored prompt did not reach its provider");
-            await Bun.sleep(25);
-          }
+          await session.waitForPane(() => responses().length > 0, 10_000);
           expect(responses()).toHaveLength(1);
           expect(responses()[0]!.authorization).toBe(`Bearer ${token}`);
           expect(responses()[0]!.body).toContain("Continue the restored provider session.");

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -325,9 +325,10 @@ async function startFx(
   tracePath?: string,
   envOverrides: Record<string, string | undefined> = {},
   cwd?: string,
+  resumeId?: string,
 ): Promise<TmuxSession> {
   return TmuxSession.create({
-    cmd: FX_BIN,
+    cmd: resumeId ? `${FX_BIN} --resume '${resumeId}'` : FX_BIN,
     cwd,
     env: {
       HOME: testHome,
@@ -1779,6 +1780,146 @@ tmuxTest(
   },
   60_000,
 );
+
+for (const [provider, previousProvider] of [
+  ["codex", "gateway"],
+  ["grok", "gateway"],
+  ["gateway", "codex"],
+  ["gateway", "grok"],
+] as const) {
+  for (const resumeMode of ["startup", "picker"] as const) {
+    tmuxTest(
+      `${provider} ${resumeMode} resume authenticates the model catalog before the first prompt from ${previousProvider}`,
+      async () => {
+        home = mkdtempSync(join(tmpdir(), "fx-auth-resume-"));
+        stderrPath = join(home, "stderr.log");
+        gateway = startFakeGateway(provider === "gateway" ? [
+          fakeGatewayFinalText("GATEWAY_RESUME_SEED"),
+          fakeGatewayFinalText("GATEWAY_RESUME_REPLY"),
+        ] : []);
+        oauth = startFakeOAuth(null);
+        chatgptOauth = startFakeChatGptOAuth();
+        const grok = startFakeGrokOAuth();
+        try {
+          writeSeededFxLogin(home, Date.now() + 60 * 60 * 1000, oauth.issuerUrl, "team_123");
+          writeSeededChatGptLogin(home, chatgptOauth.accessToken);
+          writeSeededGrokLogin(home, grok.initialAccessToken);
+          const models = { gateway: FAKE_GATEWAY_MODEL, codex: "gpt-5.6-sol", grok: "grok-4.20" };
+          const model = models[provider];
+          const otherModel = provider === "codex" ? "gpt-5.4-mini" : provider === "grok" ? "grok-4.6" : model;
+          const settingsPath = join(home, ".fx", "settings.json");
+          writeFileSync(settingsPath, JSON.stringify({ provider, credential_source: "fx_login", models }) + "\n", { mode: 0o600 });
+          const env = {
+            HOME: home,
+            AI_GATEWAY_API_KEY: undefined,
+            VERCEL_OIDC_TOKEN: undefined,
+            FX_MODEL: undefined,
+            FX_DISABLE_KEYCHAIN: "1",
+            FX_AUTO_UPGRADE: "0",
+            FX_GATEWAY_BASE_URL: gateway.baseUrl,
+            FX_GATEWAY_CHAT_URL: gateway.chatUrl,
+            FX_E2E_GATEWAY_MODELS_URL: `${gateway.baseUrl}/coding-agent/v1/models`,
+            FX_E2E_OAUTH_ISSUER_URL: oauth.issuerUrl,
+            ...chatgptOauth.env,
+            ...grok.env,
+          };
+          const seeded = await runFx(["ask", "--json", "--auto", "Save the provider resume fixture."], {
+            env,
+            timeoutMs: TIMEOUT,
+          });
+          expect(seeded.code, `stdout: ${seeded.stdout}\nstderr: ${seeded.stderr}`).toBe(0);
+          const saved = JSON.parse(seeded.stdout) as { session_id: string; output: string };
+          expect(saved.session_id).toMatch(/^[a-zA-Z0-9_-]+$/);
+          expect(saved.output).toContain(provider === "gateway" ? "GATEWAY_RESUME_SEED" : provider === "codex" ? "CHATGPT_DIRECT_RESPONSE" : "GROK_DIRECT_RESPONSE");
+          const preferences = { provider: previousProvider, credential_source: "fx_login", models };
+          writeFileSync(settingsPath, JSON.stringify(preferences) + "\n", { mode: 0o600 });
+          chatgptOauth.requests.length = 0;
+          grok.requests.length = 0;
+          gateway.requests.length = 0;
+          gateway.modelRequests.length = 0;
+
+          session = await startFx(
+            home,
+            stderrPath,
+            gateway,
+            oauth.issuerUrl,
+            undefined,
+            env,
+            undefined,
+            resumeMode === "startup" ? saved.session_id : undefined,
+          );
+          await session.waitForComposer(TIMEOUT);
+          if (resumeMode === "picker") {
+            await session.sendText("/resume");
+            await session.waitForPane((pane) => pane.includes("Sessions") && /\bturns?\b/.test(pane), TIMEOUT);
+            await session.sendKeys("Enter");
+            await session.waitForText("● Session resumed:", TIMEOUT);
+          }
+          await session.sendText("/model");
+          const catalog = await session.waitForPane(
+            (pane) => pane.includes("Models") && pane.includes(model) && pane.includes(otherModel),
+            10_000,
+          );
+          if (provider !== "gateway") expect(catalog).not.toContain(FAKE_GATEWAY_MODEL);
+          const direct = provider === "codex" ? chatgptOauth : grok;
+          const catalogPath = provider === "codex" ? "/chatgpt/models" : "/v1/models";
+          const responsePath = provider === "codex" ? "/chatgpt/responses" : "/v1/responses";
+          const token = provider === "gateway" ? LOGIN_TOKEN : provider === "codex" ? chatgptOauth.accessToken : grok.initialAccessToken;
+          const catalogAuthorizations = provider === "gateway"
+            ? gateway.modelRequests.map((request) => request.headers.get("authorization"))
+            : direct.requests.filter((request) => request.path === catalogPath).map((request) => request.authorization);
+          const responses = () => provider === "gateway"
+            ? gateway!.requests.map((request) => ({ authorization: request.headers.get("authorization"), body: request.body }))
+            : direct.requests.filter((request) => request.path === responsePath);
+          expect(catalogAuthorizations.length).toBeGreaterThan(0);
+          const catalogSources = catalogAuthorizations.map((authorization) =>
+            authorization === `Bearer ${LOGIN_TOKEN}` ? "fx_login"
+              : authorization === `Bearer ${chatgptOauth!.accessToken}` ? "codex"
+                : authorization === `Bearer ${grok.initialAccessToken}` ? "grok"
+                  : authorization === null ? "public" : "other");
+          expect(catalogSources).toEqual(Array(catalogSources.length).fill(provider === "gateway" ? "fx_login" : provider));
+          expect(gateway.requests).toHaveLength(0);
+          expect(chatgptOauth.requests.filter((request) => request.path === "/chatgpt/responses")).toHaveLength(0);
+          expect(grok.requests.filter((request) => request.path === "/v1/responses")).toHaveLength(0);
+          expect(JSON.parse(readFileSync(settingsPath, "utf8"))).toEqual(preferences);
+          await session.sendKeys("Escape");
+          await session.waitForComposer(TIMEOUT);
+          await session.sendText("Continue the restored provider session.");
+          const responseDeadline = Date.now() + 10_000;
+          while (responses().length === 0) {
+            if (Date.now() >= responseDeadline) throw new Error("Restored prompt did not reach its provider");
+            await Bun.sleep(25);
+          }
+          expect(responses()).toHaveLength(1);
+          expect(responses()[0]!.authorization).toBe(`Bearer ${token}`);
+          expect(responses()[0]!.body).toContain("Continue the restored provider session.");
+          if (provider === "gateway") await session.waitForText("GATEWAY_RESUME_REPLY", TIMEOUT);
+          if (provider !== "gateway") expect(gateway.requests).toHaveLength(0);
+          if (provider !== "codex") expect(chatgptOauth.requests.filter((request) => request.path === "/chatgpt/responses")).toHaveLength(0);
+          if (provider !== "grok") expect(grok.requests.filter((request) => request.path === "/v1/responses")).toHaveLength(0);
+          for (const [authorizations, expected] of [
+            [[...gateway.requests, ...gateway.modelRequests].map((request) => request.headers.get("authorization")), LOGIN_TOKEN],
+            [chatgptOauth.requests.map((request) => request.authorization), chatgptOauth.accessToken],
+            [grok.requests.map((request) => request.authorization), grok.initialAccessToken],
+          ] as const) {
+            for (const authorization of authorizations) {
+              if (authorization !== null) expect(authorization).toBe(`Bearer ${expected}`);
+            }
+          }
+          expect(JSON.parse(readFileSync(settingsPath, "utf8"))).toEqual(preferences);
+          const scrollback = await session.captureFullScrollback();
+          expect(scrollback).not.toContain(token);
+          expect(readFileSync(stderrPath, "utf8")).toBe("");
+          await session.sendText("/quit");
+          await session.waitForSessionEnd();
+        } finally {
+          grok.stop();
+        }
+      },
+      60_000,
+    );
+  }
+}
 
 tmuxTest(
   "provider switch before the first prompt discards the previous credential prewarm",

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -1209,6 +1209,153 @@ function startFakeGrokResourceRecovery() {
   };
 }
 
+for (const provider of ["gateway", "codex", "grok"] as const) {
+  tmuxTest(`pending ${provider} prompt retries repaired credential storage without changing accounts`, async () => {
+    home = mkdtempSync(join(tmpdir(), "fx-prompt-storage-retry-"));
+    stderrPath = join(home, "stderr.log");
+    gateway = startFakeGateway([fakeGatewayFinalText("GATEWAY_STORAGE_RECOVERED")]);
+    oauth = startFakeOAuth("unused-token");
+    chatgptOauth = startFakeChatGptOAuth({ unauthorizedResponses: 0 });
+    const grok = startFakeGrokOAuth({ unauthorizedResponses: 0 });
+    try {
+      writeSeededFxLogin(home, Date.now() + 3_600_000, oauth.issuerUrl, "team_fixture");
+      writeSeededChatGptLogin(home);
+      writeSeededGrokLogin(home, grok.initialAccessToken);
+      writeFileSync(join(home, ".fx", "settings.json"), JSON.stringify({
+        provider,
+        credential_source: "fx_login",
+        models: { gateway: FAKE_GATEWAY_MODEL, codex: "gpt-5.6-sol", grok: "grok-4.20" },
+      }));
+      const name = provider === "gateway" ? "auth.json" : provider === "codex" ? "chatgpt-auth.json" : "grok-auth.json";
+      const alias = join(home, "auth.alias");
+      linkSync(join(home, ".fx", name), alias);
+      session = await startFx(home, stderrPath, gateway, oauth.issuerUrl, undefined, {
+        FX_MODEL: undefined,
+        ...chatgptOauth.env,
+        ...grok.env,
+      });
+      await session.waitForComposer(TIMEOUT);
+      const prompt = `STORAGE_RETRY_${provider}`;
+      await session.sendText(prompt);
+      await session.waitForPane((pane) => pane.includes(prompt) && pane.slice(pane.lastIndexOf(prompt) + prompt.length).includes("Auth:"), TIMEOUT);
+      const scrollback = await session.captureFullScrollback();
+      expect(scrollback.slice(scrollback.lastIndexOf(prompt) + prompt.length)).toContain("Saved credential storage is unavailable");
+      expect(gateway.requests).toHaveLength(0);
+      expect(oauth.requests).toHaveLength(0);
+      expect(chatgptOauth.requests).toHaveLength(0);
+      expect(grok.requests).toHaveLength(0);
+
+      unlinkSync(alias);
+      await session.sendKeys("Enter");
+      await session.waitForText(provider === "gateway" ? "GATEWAY_STORAGE_RECOVERED" : provider === "codex" ? "CHATGPT_DIRECT_RESPONSE" : "GROK_DIRECT_RESPONSE", TIMEOUT);
+      const requests = provider === "gateway" ? gateway.requests : provider === "codex"
+        ? chatgptOauth.requests.filter((request) => request.path === "/chatgpt/responses")
+        : grok.requests.filter((request) => request.path === "/v1/responses");
+      expect(requests).toHaveLength(1);
+      expect(JSON.stringify(requests[0]!.body)).toContain(prompt);
+      if (provider === "gateway") {
+        expect(gateway.requests[0]!.headers.get("authorization")).toBe(`Bearer ${LOGIN_TOKEN}`);
+      } else {
+        expect(gateway.requests).toHaveLength(0);
+      }
+      expect(JSON.parse(readFileSync(join(home, ".fx", "settings.json"), "utf8")).provider).toBe(provider);
+      expect(readFileSync(stderrPath, "utf8")).toBe("");
+    } finally {
+      grok.stop();
+    }
+  }, TIMEOUT);
+}
+
+tmuxTest("pending Gateway prompt waits for valid saved preferences and a repaired login", async () => {
+  home = mkdtempSync(join(tmpdir(), "fx-prompt-preference-retry-"));
+  mkdirSync(join(home, ".fx"), { recursive: true, mode: 0o700 });
+  const settingsPath = join(home, ".fx", "settings.json");
+  const settings = JSON.stringify({ provider: "gateway", credential_source: "fx_login", models: { gateway: FAKE_GATEWAY_MODEL } });
+  writeFileSync(settingsPath, settings);
+  stderrPath = join(home, "stderr.log");
+  gateway = startFakeGateway([fakeGatewayFinalText("PREFERENCE_REPAIRED")]);
+  oauth = startFakeOAuth("unused-token");
+  session = await startFx(home, stderrPath, gateway, oauth.issuerUrl, undefined, { FX_MODEL: undefined });
+  await session.waitForComposer(TIMEOUT);
+  writeFileSync(settingsPath, "not-json");
+  await session.sendText("PREFERENCE_RETRY_PROMPT");
+  await session.waitForText("Could not load authentication settings", TIMEOUT);
+  expect(gateway.requests).toHaveLength(0);
+
+  writeFileSync(settingsPath, settings);
+  await session.sendKeys("Enter");
+  await session.waitForPane(
+    (pane) => pane.lastIndexOf("fx needs access to Vercel AI Gateway") > pane.lastIndexOf("Could not load authentication settings"),
+    TIMEOUT,
+  );
+  expect(gateway.requests).toHaveLength(0);
+  writeSeededFxLogin(home, Date.now() + 3_600_000, oauth.issuerUrl, "team_fixture");
+  await session.sendKeys("Enter");
+  await session.waitForText("PREFERENCE_REPAIRED", TIMEOUT);
+  expect(gateway.requests).toHaveLength(1);
+  expect(JSON.stringify(gateway.requests[0]!.body)).toContain("PREFERENCE_RETRY_PROMPT");
+  expect(gateway.requests[0]!.headers.get("authorization")).toBe(`Bearer ${LOGIN_TOKEN}`);
+  expect(oauth.requests).toHaveLength(0);
+  expect(readFileSync(stderrPath, "utf8")).toBe("");
+}, TIMEOUT);
+
+test("Vercel CLI keeps an issuer authorization denial distinct from persistence failure", async () => {
+  home = mkdtempSync(join(tmpdir(), "fx-vercel-authorization-denied-"));
+  oauth = startFakeOAuth("unused-token", undefined, 3600, Number.POSITIVE_INFINITY, {
+    deviceError: "access_denied",
+    rejectAllDeviceClients: true,
+  });
+  const result = await runFx(["login", "vercel"], { env: {
+    HOME: home,
+    AI_GATEWAY_API_KEY: undefined,
+    VERCEL_OIDC_TOKEN: undefined,
+    FX_DISABLE_KEYCHAIN: "1",
+    FX_AUTO_UPGRADE: "0",
+    FX_NO_OPEN_BROWSER: "1",
+    FX_OAUTH_CLIENT_ID: "test-client",
+    FX_E2E_OAUTH_ISSUER_URL: oauth.issuerUrl,
+  }, timeoutMs: TIMEOUT });
+  expect(result.code).toBe(1);
+  expect(result.stderr).toContain("authorization denied");
+  expect(result.stderr).not.toContain("Credential could not be saved");
+  expect(existsSync(join(home, ".fx", "auth.json"))).toBe(false);
+  expect(oauth.requests.filter((request) => request.path === "/oauth/token")).toHaveLength(0);
+}, TIMEOUT);
+
+test("Vercel CLI reports a post-authorization save failure without claiming authorization was denied", async () => {
+  home = mkdtempSync(join(tmpdir(), "fx-vercel-save-failure-"));
+  gateway = startFakeGateway([]);
+  oauth = startFakeOAuth("new-token", undefined, 3600, Number.POSITIVE_INFINITY, {
+    tokenDelayMs: 300,
+    teams: [{ id: "team_fixture", slug: "fixture", name: "Fixture" }],
+  });
+  writeSeededFxLogin(home, Date.now() + 3_600_000, oauth.issuerUrl, "team_fixture");
+  const authPath = join(home, ".fx", "auth.json");
+  const previous = readFileSync(authPath, "utf8");
+  const login = runFx(["login", "vercel"], { env: {
+    HOME: home,
+    AI_GATEWAY_API_KEY: ENV_TOKEN,
+    VERCEL_OIDC_TOKEN: undefined,
+    FX_DISABLE_KEYCHAIN: "1",
+    FX_AUTO_UPGRADE: "0",
+    FX_NO_OPEN_BROWSER: "1",
+    FX_OAUTH_CLIENT_ID: "test-client",
+    FX_E2E_OAUTH_ISSUER_URL: oauth.issuerUrl,
+    FX_E2E_GATEWAY_MODELS_URL: `${gateway.baseUrl}/coding-agent/v1/models`,
+  }, timeoutMs: TIMEOUT });
+  const deadline = Date.now() + 10_000;
+  while (!oauth.requests.some((request) => request.path === "/oauth/token") && Date.now() < deadline) await Bun.sleep(5);
+  expect(oauth.requests.some((request) => request.path === "/oauth/token")).toBe(true);
+  chmodSync(authPath, 0o400);
+  const result = await login;
+  expect(result.code).toBe(1);
+  expect(result.stderr).toContain("Credential could not be saved");
+  expect(result.stderr).not.toContain("authorization denied");
+  expect(result.stdout).not.toContain("Signed in");
+  expect(readFileSync(authPath, "utf8")).toBe(previous);
+  expect(gateway.requests).toHaveLength(0);
+}, TIMEOUT);
+
 tmuxTest(
   "malformed sessions and read-only locks never become missing authentication",
   async () => {


### PR DESCRIPTION
## Summary

- Keep unreadable credentials distinct from missing sign-in without switching accounts.
- Resume saved prompts when Enter retries repaired credentials or authentication settings.
- Report credential save failures separately from authorization denial.
- Allow ACP provider changes after cancellation, session load, and resume while still rejecting changes during an active prompt.
- Restore the matching credential and model catalog when resuming a session on another provider.
- Reject credentials from other providers before fetching Gateway models.
