### PR TITLE
Expose agent context to child commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ fx
 
 The current directory becomes the primary workspace. Enter a prompt, or run `/help` to browse interactive commands. While fx is working, you can submit a multiline update with Enter; it steers the active turn at its next safe model boundary. When no tool is running, your message appears in the transcript immediately. Updates waiting for a running tool show their first two lines with a dotted rail and an ellipsis when more text is hidden. Press Escape to interrupt the active work and apply the update as soon as the turn settles.
 
+Commands run by fx receive `AI_AGENT=fx` in their environment. This lets
+development tools identify fx.
+
 Use `/resume` to choose a saved conversation. The picker shares its catalog across workspace views and reuses unchanged session summaries between launches. The first catalog build, or recovery from missing cache data, scans saved sessions automatically. Changed sessions are checked again, and closing the picker stops obsolete loading work.
 
 Tool calls are expanded by default. Enable `Collapse tool calls` in `/settings`, or set `"collapse_tool_calls": true` in `~/.fx/settings.json`, to show one summary per tool-call group in the main transcript. Individual calls remain available in the full transcript with Ctrl+O. Follow-up activity for captured shell commands shows the original command, such as `Observed zig build`, while tool results keep the same execution handle.

--- a/src/core/execution/command_runner.zig
+++ b/src/core/execution/command_runner.zig
@@ -37,6 +37,13 @@ pub const Config = struct {
     command_artifact_dir: ?[]const u8 = null,
 };
 
+const ai_agent_env = "AI_AGENT";
+const ai_agent_name = "fx";
+
+pub fn applyAgentEnvironment(environment: *std.process.Environ.Map) !void {
+    try environment.put(ai_agent_env, ai_agent_name);
+}
+
 pub const CallbackProjection = enum {
     model_safe,
     raw,
@@ -1078,12 +1085,16 @@ fn executeProcessWithInput(
     isolate_process_group: bool,
 ) !CollectedProcess {
     const started_ms = io_mod.milliTimestamp();
+    var environment = try io_mod.cloneEnvironMap(scratch);
+    defer environment.deinit();
+    try applyAgentEnvironment(&environment);
     var child = try std.process.spawn(io_mod.getIo(), .{
         .argv = argv,
         .stdin = if (closed_input) .pipe else .ignore,
         .stdout = .pipe,
         .stderr = .pipe,
         .cwd = .{ .path = cwd },
+        .environ_map = &environment,
         .pgid = if (isolate_process_group and builtin.os.tag != .windows and builtin.os.tag != .wasi) 0 else null,
     });
     if (child.stdin) |input| {
@@ -1189,12 +1200,16 @@ fn executeProcessWithDetachedSession(
     try helper_argv.appendSlice(scratch, argv);
 
     const started_ms = io_mod.milliTimestamp();
+    var environment = try io_mod.cloneEnvironMap(scratch);
+    defer environment.deinit();
+    try applyAgentEnvironment(&environment);
     var child = try std.process.spawn(io_mod.getIo(), .{
         .argv = helper_argv.items,
         .stdin = .pipe,
         .stdout = .pipe,
         .stderr = .pipe,
         .cwd = .{ .path = cwd },
+        .environ_map = &environment,
     });
 
     var output = OutputCollector.init(scratch, cfg);
@@ -1360,12 +1375,16 @@ fn executeProcessWithScriptUnisolated(
     script: []const u8,
 ) !CollectedProcess {
     const started_ms = io_mod.milliTimestamp();
+    var environment = try io_mod.cloneEnvironMap(scratch);
+    defer environment.deinit();
+    try applyAgentEnvironment(&environment);
     var child = try std.process.spawn(io_mod.getIo(), .{
         .argv = argv,
         .stdin = .pipe,
         .stdout = .pipe,
         .stderr = .pipe,
         .cwd = .{ .path = cwd },
+        .environ_map = &environment,
         .pgid = if (builtin.os.tag != .windows and builtin.os.tag != .wasi) 0 else null,
     });
 
@@ -2901,6 +2920,22 @@ test "raw process execution returns foreground output" {
     try std.testing.expectEqual(@as(usize, 5), command_result.stdout_bytes);
     try std.testing.expectEqual(@as(usize, 0), command_result.stderr_bytes);
     try std.testing.expect(!command_result.truncated);
+}
+
+test "commands receive fx agent environment" {
+    const result = try executeCommand(
+        .{ .max_command_output_bytes = 4096 },
+        std.testing.allocator,
+        "printf '%s' \"$AI_AGENT\"",
+        "/tmp",
+    );
+    defer std.testing.allocator.free(result.output);
+
+    try std.testing.expect(std.mem.find(
+        u8,
+        result.output,
+        "<stdout>\nfx\n</stdout>",
+    ) != null);
 }
 
 test "authorized command executes exactly once" {

--- a/src/core/permissions/direct_command.zig
+++ b/src/core/permissions/direct_command.zig
@@ -216,6 +216,7 @@ fn executeDirectReadOnlyWithLimitAndTestControls(
         const stage = plan.stages[child_count];
         var environment = try environmentForProfile(scratch, stage.environment_profile);
         defer environment.deinit();
+        try command_runner.applyAgentEnvironment(&environment);
 
         const child = std.process.spawn(io_mod.getIo(), .{
             .argv = stage.argv,
@@ -427,6 +428,26 @@ fn environmentForProfile(
         try environment.put("PAGER", "cat");
     }
     return environment;
+}
+
+test "direct commands receive fx agent environment" {
+    if (builtin.os.tag != .macos and builtin.os.tag != .linux) return;
+
+    const stages = [_]command_effect.DirectStage{.{
+        .executable = "/usr/bin/env",
+        .argv = &.{"/usr/bin/env"},
+        .environment_profile = .basic_read_only,
+    }};
+    const result = try executeDirectReadOnly(.{
+        .max_command_output_bytes = 4096,
+    }, std.testing.allocator, .{
+        .command = "env",
+        .cwd = "/tmp",
+        .stages = &stages,
+    });
+    defer std.testing.allocator.free(result.output);
+
+    try std.testing.expect(std.mem.find(u8, result.output, "AI_AGENT=fx") != null);
 }
 
 const DirectTerminationCause = enum {

--- a/src/core/terminal/shell_resolver.zig
+++ b/src/core/terminal/shell_resolver.zig
@@ -246,7 +246,7 @@ pub fn buildBootstrap(
     var output: std.ArrayList(u8) = .empty;
     errdefer output.deinit(alloc);
 
-    try output.appendSlice(alloc, "set +x; ");
+    try output.appendSlice(alloc, "set +x; export AI_AGENT=fx; ");
     if (command_path) |path| {
         try output.appendSlice(alloc, "fx_terminal_command=$(< ");
         try appendShellWord(&output, alloc, path);
@@ -525,7 +525,7 @@ test "bootstrap quotes private paths and separates command completion" {
     );
     defer std.testing.allocator.free(commandless);
     try std.testing.expectEqualStrings(
-        "set +x; '/tmp/fx'\"'\"'bin' '--fx-internal-terminal-control' " ++
+        "set +x; export AI_AGENT=fx; '/tmp/fx'\"'\"'bin' '--fx-internal-terminal-control' " ++
             "'/tmp/control' 'nonce' 'shell-ready' || exit 125\n",
         commandless,
     );

--- a/tests/e2e/tui-command-permissions.test.ts
+++ b/tests/e2e/tui-command-permissions.test.ts
@@ -3098,6 +3098,35 @@ describe("effect-aware command permissions", () => {
   );
 
   test(
+    "fx ask forwards agent identity to captured and TTY commands",
+    async () => {
+      for (const tty of [false, true]) {
+        const root = createIsolatedRoot();
+        const gateway = startFakeGateway([
+          toolCall(`printf 'agent=%s' "$AI_AGENT"`, { tty }),
+          finalText("agent environment complete"),
+        ]);
+        const result = await runFx(
+          ["ask", "--yolo", "--quiet", "--json", "Report the agent environment."],
+          {
+            cwd: root.workspace,
+            env: gatewayEnv(root, gateway),
+            timeoutMs: TIMEOUT,
+          },
+        );
+
+        expect(result.code).toBe(0);
+        expect(result.stderr.toLowerCase()).not.toContain("error");
+        JSON.parse(result.stdout.trim());
+        const toolResult = JSON.parse(toolResultText(gateway.requests[1].body, "command_1"));
+        expect(toolResult).toMatchObject({ state: "completed", exit_code: 0 });
+        expect(toolResult.output_delta).toContain("agent=fx");
+      }
+    },
+    TIMEOUT,
+  );
+
+  test(
     "fx ask yolo executes pwd through the default user profile with process-scoped replay",
     async () => {
       const root = createIsolatedRoot();


### PR DESCRIPTION
Set `AI_AGENT=fx` for commands run by fx so development tools can detect the agent environment.