### PR TITLE
Finish cancelled prompts before host tools settle

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -115,6 +115,9 @@ const agent = await createFxAgent({
 
 The JavaScript host is the authority for tool effects. The same descriptors,
 schemas, cancellation, results, and events are used by N-API and WebAssembly.
+Cancelling a prompt aborts its tools' signals and stops waiting for their
+callbacks. Late results and rejections are ignored. Tools remain responsible
+for stopping their own work when their signal is aborted.
 Instructions are limited to 64 KiB of UTF-8 text, including text assembled by
 the MCP and skills adapters. They are the complete host-owned system context:
 libfx adds no hidden base prompt, and omitting `instructions` sends no system

--- a/sdk/fx-sdk.js
+++ b/sdk/fx-sdk.js
@@ -1221,17 +1221,27 @@ export async function createFxAgent(options = {}) {
     const turn = requestedSessionId === undefined || requestedSessionId === sessionId
       ? activeTurn
       : null;
+    if (turn?.cancelled) return { content: "", isError: false, cancelled: true };
     const controller = new AbortController();
     turn?.toolControllers.add(controller);
-    let content;
+    let onAbort;
+    const aborted = new Promise((resolve) => { onAbort = () => resolve(); });
+    controller.signal.addEventListener("abort", onAbort, { once: true });
+    let content = "";
     let isError = false;
     try {
       if (!execute) throw new Error(`unknown host tool: ${String(name)}`);
-      content = hostToolContent(await execute(input, { signal: controller.signal }));
+      const execution = Promise.resolve().then(() => {
+        if (controller.signal.aborted) return;
+        return execute(input, { signal: controller.signal });
+      });
+      const value = await Promise.race([execution, aborted]);
+      if (!controller.signal.aborted) content = hostToolContent(value);
     } catch (error) {
       isError = true;
       content = error instanceof Error ? error.message : String(error);
     } finally {
+      controller.signal.removeEventListener("abort", onAbort);
       turn?.toolControllers.delete(controller);
     }
     return { content, isError, cancelled: controller.signal.aborted };

--- a/sdk/tests/test-host-tool-cancel.mjs
+++ b/sdk/tests/test-host-tool-cancel.mjs
@@ -9,8 +9,10 @@ import { createFxAgent } from "../node.js";
 const backend = process.argv[2] || "native";
 const scriptDir = fileURLToPath(new URL(".", import.meta.url));
 let modelRequests = 0;
+let requestBodies = [];
 const server = createServer((request, response) => {
-  request.resume();
+  let body = "";
+  request.on("data", (chunk) => { body += chunk; });
   request.on("end", () => {
     if (request.method === "GET") {
       response.writeHead(200, { "content-type": "application/json" });
@@ -18,6 +20,7 @@ const server = createServer((request, response) => {
       return;
     }
     modelRequests += 1;
+    requestBodies.push(body);
     response.writeHead(200, { "content-type": "text/event-stream" });
     if (modelRequests > 1) {
       response.end('data: {"type":"text-delta","delta":"recovered"}\n\ndata: {"type":"finish","finishReason":{"unified":"stop","raw":"stop"}}\n\ndata: [DONE]\n\n');
@@ -28,58 +31,121 @@ const server = createServer((request, response) => {
 });
 await new Promise((resolveListen) => server.listen(0, "127.0.0.1", resolveListen));
 
-let toolStartedResolve;
-const toolStarted = new Promise((resolveStarted) => { toolStartedResolve = resolveStarted; });
-let toolSignalAborted = false;
-const events = [];
-const agent = await createFxAgent({
-  backend,
-  nativeAddon: resolve(scriptDir, "../../zig-out/lib/libfx.node"),
-  ...(backend === "wasm" ? { wasm: await readFile(resolve(scriptDir, "../../zig-out/bin/fx-core.wasm")) } : {}),
-  fetch,
-  traceWasi: process.env.LIBFX_TRACE_WASM === "1",
-  onEvent(event) { events.push(event); },
-  tools: [{
-    name: "wait",
-    description: "Wait until cancelled",
-    inputSchema: { type: "object", properties: {} },
-    execute(_input, { signal }) {
-      toolStartedResolve();
-      return new Promise((_, reject) => signal.addEventListener("abort", () => {
-        toolSignalAborted = true;
-        reject(new DOMException("aborted", "AbortError"));
-      }, { once: true }));
-    },
-  }],
-  apiKey: "cancel-key",
-  gatewayChatUrl: `http://127.0.0.1:${server.address().port}/chat`,
-  model: "cancel/model",
-});
+async function withTimeout(promise, label) {
+  let timer;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`${label} timed out`)), 5000);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function exerciseCancellation(settlement, closeBeforeSettle) {
+  modelRequests = 0;
+  requestBodies = [];
+  let toolStartedResolve;
+  const toolStarted = new Promise((resolveStarted) => { toolStartedResolve = resolveStarted; });
+  let settleTool;
+  let toolCalls = 0;
+  let toolSignalAborted = false;
+  const events = [];
+  const unhandledRejections = [];
+  const recordUnhandled = (error) => unhandledRejections.push(error);
+  process.on("unhandledRejection", recordUnhandled);
+  const controller = new AbortController();
+  let agent;
+  try {
+    agent = await createFxAgent({
+      backend,
+      nativeAddon: resolve(scriptDir, "../../zig-out/lib/libfx.node"),
+      ...(backend === "wasm" ? { wasm: await readFile(resolve(scriptDir, "../../zig-out/bin/fx-core.wasm")) } : {}),
+      fetch,
+      traceWasi: process.env.LIBFX_TRACE_WASM === "1",
+      onEvent(event) {
+        events.push(event);
+        const message = event.message;
+        const beforeTool = backend === "native"
+          ? message?.method === "libfx/tool_call"
+          : message?.method === "session/update" && message.params?.update?.sessionUpdate === "tool_call";
+        if (settlement === "before-start" && event.type === "acp.receive" && beforeTool) {
+          controller.abort();
+          toolStartedResolve();
+        }
+      },
+      tools: [{
+        name: "wait",
+        description: "Wait until cancelled",
+        inputSchema: { type: "object", properties: {} },
+        execute(_input, { signal }) {
+          toolCalls += 1;
+          return new Promise((resolveTool, rejectTool) => {
+            settleTool = () => settlement === "reject"
+              ? rejectTool(new Error("late tool failure"))
+              : resolveTool("late tool result");
+            signal.addEventListener("abort", () => {
+              toolSignalAborted = true;
+              if (settlement === "cooperative") rejectTool(new DOMException("aborted", "AbortError"));
+            }, { once: true });
+            toolStartedResolve();
+          });
+        },
+      }],
+      apiKey: "cancel-key",
+      gatewayChatUrl: `http://127.0.0.1:${server.address().port}/chat`,
+      model: "cancel/model",
+    });
+    const turn = agent.prompt("wait", { signal: controller.signal });
+    const drain = (async () => { for await (const _event of turn) {} })();
+    await withTimeout(toolStarted, "tool start");
+    controller.abort();
+    const [result] = await withTimeout(Promise.all([turn.result, drain]), "cancelled turn and event stream");
+    assert.equal(result.stopReason, "cancelled");
+    assert.equal(toolCalls, settlement === "before-start" ? 0 : 1);
+    assert.equal(toolSignalAborted, settlement !== "before-start");
+    assert.equal(modelRequests, 1);
+
+    const followup = agent.prompt("continue after cancellation");
+    let text = "";
+    await withTimeout((async () => {
+      for await (const event of followup) if (event.type === "text_delta") text += event.delta;
+      assert.equal((await followup.result).stopReason, "end_turn");
+    })(), "follow-up prompt");
+    assert.equal(text, "recovered");
+    assert.equal(modelRequests, 2);
+    assert.ok(requestBodies.every((body) => !body.includes("late tool result") && !body.includes("late tool failure")));
+
+    if (closeBeforeSettle) await withTimeout(agent.close(), "close before tool settlement");
+    const eventsBeforeSettle = events.length;
+    const checkpoint = closeBeforeSettle ? null : await agent.checkpoint();
+    const sendsBeforeSettle = events.filter((event) => event.type === "acp.send").length;
+    settleTool?.();
+    await new Promise((resolveWait) => setTimeout(resolveWait, 25));
+    assert.deepEqual(unhandledRejections, []);
+    assert.equal(events.filter((event) => event.type === "acp.send").length, sendsBeforeSettle);
+    if (closeBeforeSettle) assert.equal(events.length, eventsBeforeSettle);
+    else assert.deepEqual(await agent.checkpoint(), checkpoint);
+    await withTimeout(agent.close(), "close");
+    console.log(`${backend} host tool cancellation passed: ${settlement}, closeBeforeSettle=${closeBeforeSettle}`);
+  } finally {
+    settleTool?.();
+    await withTimeout(agent?.close().catch(() => {}), "cleanup");
+    process.off("unhandledRejection", recordUnhandled);
+  }
+}
 
 try {
-  const controller = new AbortController();
-  const turn = agent.prompt("wait", { signal: controller.signal });
-  await toolStarted;
-  controller.abort();
-  const result = await Promise.race([
-    turn.result,
-    new Promise((_, reject) => setTimeout(() => reject(new Error(
-      `cancel timed out signal=${toolSignalAborted} events=${JSON.stringify(events.slice(-8))}`,
-    )), 5000)),
-  ]);
-  assert.equal(result.stopReason, "cancelled");
-  assert.equal(toolSignalAborted, true);
-  assert.equal(modelRequests, 1);
-  const followup = agent.prompt("continue after cancellation");
-  let text = "";
-  for await (const event of followup) if (event.type === "text_delta") text += event.delta;
-  assert.equal((await followup.result).stopReason, "end_turn");
-  assert.equal(text, "recovered");
-  assert.equal(modelRequests, 2);
-  await agent.close();
-  console.log(`${backend} host tool cancellation passed`);
+  await exerciseCancellation("cooperative", false);
+  await exerciseCancellation("before-start", false);
+  for (const settlement of ["resolve", "reject"]) {
+    await exerciseCancellation(settlement, false);
+    await exerciseCancellation(settlement, true);
+  }
 } finally {
-  await agent.close().catch(() => {});
   server.closeAllConnections();
   await new Promise((resolveClose) => server.close(resolveClose));
 }


### PR DESCRIPTION
## Summary

- Finish cancelled native and WebAssembly Agent prompts without waiting for host callbacks.
- Keep late tool results and failures from affecting later prompts or closed agents.
- Skip host tools when their prompt was cancelled before dispatch.
