### PR TITLE
Stream SDK output with bounded backpressure

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -85,8 +85,10 @@ jobs:
       - name: Package web artifacts
         run: |
           cp sdk/fx-sdk.js fx-sdk.js
+          cp sdk/core-output.js core-output.js
           cp zig-out/bin/fx-term.wasm fx-term.wasm
           sha256sum fx-sdk.js > fx-sdk.js.sha256
+          sha256sum core-output.js > core-output.js.sha256
           sha256sum fx-term.wasm > fx-term.wasm.sha256
 
       - name: Upload artifact
@@ -96,6 +98,8 @@ jobs:
           path: |
             fx-sdk.js
             fx-sdk.js.sha256
+            core-output.js
+            core-output.js.sha256
             fx-term.wasm
             fx-term.wasm.sha256
 
@@ -146,9 +150,10 @@ jobs:
           set -euo pipefail
 
           sha256sum --check fx-sdk.js.sha256
+          sha256sum --check core-output.js.sha256
           sha256sum --check fx-term.wasm.sha256
 
-          for FILE in fx-sdk.js fx-sdk.js.sha256 fx-term.wasm fx-term.wasm.sha256; do
+          for FILE in fx-sdk.js fx-sdk.js.sha256 core-output.js core-output.js.sha256 fx-term.wasm fx-term.wasm.sha256; do
             CONTENT_TYPE="application/octet-stream"
             [[ "$FILE" == *.js ]] && CONTENT_TYPE="text/javascript"
             [[ "$FILE" == *.wasm ]] && CONTENT_TYPE="application/wasm"

--- a/.github/workflows/publish-libfx.yml
+++ b/.github/workflows/publish-libfx.yml
@@ -261,7 +261,7 @@ jobs:
 
           rm -rf sdk/dist/libfx
           mkdir -p sdk/dist/libfx
-          cp sdk/package.json sdk/README.md sdk/browser.js sdk/node.js sdk/fx-sdk.js sdk/mcp.js sdk/skills.js sdk/skills-node.js LICENSE sdk/dist/libfx/
+          cp sdk/package.json sdk/README.md sdk/browser.js sdk/node.js sdk/fx-sdk.js sdk/core-output.js sdk/mcp.js sdk/skills.js sdk/skills-node.js LICENSE sdk/dist/libfx/
           cp wasm-artifacts/fx-core.wasm wasm-artifacts/fx-term.wasm sdk/dist/libfx/
           cp native-addons/*.node sdk/dist/libfx/
           jq --arg version "$LIBFX_VERSION" '.version = $version | del(.files)' \
@@ -282,7 +282,7 @@ jobs:
             const names = new Set(report.files.map(({ path }) => path));
             const required = [
               "package.json", "README.md", "LICENSE", "browser.js", "node.js", "fx-sdk.js",
-              "mcp.js", "skills.js", "skills-node.js",
+              "core-output.js", "mcp.js", "skills.js", "skills-node.js",
               "fx-core.wasm", "fx-term.wasm",
               "libfx.linux-x64.node", "libfx.linux-arm64.node",
               "libfx.darwin-x64.node", "libfx.darwin-arm64.node",

--- a/sdk/NAPI.md
+++ b/sdk/NAPI.md
@@ -112,7 +112,7 @@ The runtime thread never reads or mutates JavaScript values or calls Node-API. I
 
 The addon initializes one process-wide `std.Io.Threaded` instance. Atomic state protects one-time initialization when the addon is loaded in multiple Node worker environments. The same initialization installs inherited process-environment access before any runtime thread starts. It does not configure fx product tracing from ambient `FX_TRACE_*` variables; libfx remains silent unless its JavaScript host explicitly requests SDK observability.
 
-Input and output queues have independent `std.Io.Mutex` protection. The input queue also has a condition variable so the ACP reader sleeps while no input is available. Closing input broadcasts the condition and allows the server thread to terminate.
+Input and output queues have independent `std.Io.Mutex` protection and condition variables. The ACP reader sleeps while input is empty. An output writer fills available byte capacity, then sleeps until JavaScript drains space. The JSON-RPC writer lock preserves record ordering across these partial writes. Closing the core closes both queues and wakes their waiters before joining the native thread.
 
 Readiness has no callback queue or pending flag. A full socket already contains a wake, so a nonblocking `EAGAIN` needs no retry. Other write failures shut down the writer so the reader observes EOF and fails the runtime instead of hanging. Writes suppress `SIGPIPE`, and descriptors are close-on-exec. This avoids depending on a thread-safe-function dispatcher's drain/idle race.
 
@@ -172,6 +172,7 @@ All untrusted values crossing the native boundary are bounded before allocation 
 | Gateway URL | 16 KiB |
 | Input queue | 8 MiB |
 | Output queue | 8 MiB |
+| Encoded output message | 64 MiB |
 | Fetch request record | 8 MiB |
 | Fetch response queue | 8 MiB |
 | Gateway error body | 1 MiB |
@@ -181,9 +182,9 @@ All untrusted values crossing the native boundary are bounded before allocation 
 | ACP history | 100 turns |
 | Agent steps | 64 |
 
-Input overflow fails synchronously with `LIBFX_NATIVE_BACKPRESSURE`. Output overflow causes the ACP runtime to exit with a failure status rather than allowing unbounded native memory growth. Limits must remain checked with overflow-safe subtraction before append operations.
+Input overflow fails synchronously with `LIBFX_NATIVE_BACKPRESSURE`. Output queue pressure blocks the writer until space is available; a single message does not need to fit the queue. Allocation failure or an oversized output message permanently fails the output transport, notifies JavaScript, closes input, and shuts down host fetch. Later writes cannot publish a successful response after that failure.
 
-The JavaScript adapter drains output to quiescence on every readiness callback. Changes that pause notification or consumption must account for the fixed output bound.
+The JavaScript adapter has one ordered output drain. A shared byte-framing parser preserves UTF-8 characters across native drain boundaries, rejects malformed or oversized records, and waits for SDK event admission before consuming another message. Readiness still services fetch cancellation while output is blocked. The unread event queue applies the same limits and cancellation rules on native and WebAssembly backends. Cancelling a turn releases event admission and discards subsequent cancelled-turn updates while transport framing continues, so the next turn starts on a complete record boundary. Destroying the runtime closes output before joining, including worker cleanup without an active JavaScript reader.
 
 ## Argument and handle safety
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -59,6 +59,28 @@ returns an async iterable of normalized events:
 - `tool_start`
 - `tool_end`
 
+Consume the turn while it runs, then await `turn.result`. Output is lossless and
+backpressured: a slow reader pauses production instead of growing an unlimited
+event queue. Awaiting only `turn.result` can wait for an unread stream to drain.
+If you only need the result, explicitly discard events:
+
+```js
+const turn = agent.prompt("Update the index.");
+for await (const _ of turn) {}
+const result = await turn.result;
+```
+
+A turn has one event consumer. Breaking out of its iterator cancels the turn;
+`turn.cancel()` and `agent.close()` also release blocked output. Transport or
+message-decoding failures reject the result instead of returning success with
+missing text.
+
+Native transport buffers at most 8 MiB of output bytes. Unread SDK events apply
+backpressure at 1 MiB of encoded messages or 256 events. One message can exceed
+that threshold when the queue is empty; an individual encoded ACP message is
+limited to 64 MiB on both backends. These are transport bounds, not a total
+answer-size limit or a bound on retained conversation history.
+
 Only one prompt may run at a time. `checkpoint()` is idle-only and returns
 opaque, bounded, versioned bytes. Restore them only when creating a fresh
 agent:

--- a/sdk/core-output.js
+++ b/sdk/core-output.js
@@ -1,0 +1,58 @@
+export const maxCoreMessageBytes = 64 * 1024 * 1024;
+
+// One ordered writer per core; a pending handler holds admission of the next message.
+export class CoreOutput {
+  constructor(handler) {
+    this.handler = handler;
+    this.decoder = new TextDecoder("utf-8", { fatal: true });
+    this.buffer = new Uint8Array(0);
+    this.bytes = 0;
+    this.closed = false;
+  }
+
+  write(chunk) {
+    let offset = 0;
+    const consume = () => {
+      while (offset < chunk.length) {
+        if (this.closed) throw new Error("core output is closed");
+        const newline = chunk.indexOf(10, offset);
+        const end = newline < 0 ? chunk.length : newline;
+        const fragment = chunk.subarray(offset, end);
+        const length = this.bytes + fragment.length;
+        if (length + (newline < 0 ? 0 : 1) > maxCoreMessageBytes) throw new RangeError("core output message exceeds 64 MiB");
+        let data = fragment;
+        if (this.bytes || newline < 0) {
+          if (length > this.buffer.length) {
+            const next = new Uint8Array(Math.min(maxCoreMessageBytes, Math.max(length, this.buffer.length * 2, 4096)));
+            next.set(this.buffer.subarray(0, this.bytes));
+            this.buffer = next;
+          }
+          this.buffer.set(fragment, this.bytes);
+          data = this.buffer.subarray(0, length);
+        }
+        this.bytes = length;
+        offset = newline < 0 ? end : end + 1;
+        if (newline < 0) return;
+        const line = this.decoder.decode(data);
+        const size = length + 1;
+        this.bytes = 0;
+        if (this.buffer.length > 1024 * 1024) this.buffer = new Uint8Array(0);
+        if (line) {
+          const pending = this.handler(JSON.parse(line), size);
+          if (pending) return Promise.resolve(pending).then(consume);
+        }
+      }
+    };
+    return consume();
+  }
+
+  finish() {
+    if (this.bytes) throw new Error("core output ended within a message");
+  }
+
+  close() {
+    this.closed = true;
+    this.buffer = new Uint8Array(0);
+    this.bytes = 0;
+  }
+}

--- a/sdk/fx-sdk.js
+++ b/sdk/fx-sdk.js
@@ -1,3 +1,5 @@
+import { CoreOutput, maxCoreMessageBytes } from "./core-output.js";
+
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 const strictDecoder = new TextDecoder("utf-8", { fatal: true });
@@ -11,6 +13,8 @@ const maxUrlBytes = 16 * 1024;
 const maxModelCatalogBytes = 4 * 1024 * 1024;
 const maxModelCatalogEntries = 10_000;
 const streamReadsPerTaskYield = 32;
+const maxUnreadEventBytes = 1024 * 1024;
+const maxUnreadEvents = 256;
 
 function boundedString(value, name, maxBytes, required) {
   if (value === undefined && !required) return undefined;
@@ -354,7 +358,8 @@ function createRuntime(options) {
   let exitedResolve;
   let exitCode = null;
   let aborted = false;
-  let lineBuffer = "";
+  let coreOutput;
+  let outputError;
   const exited = new Promise((resolve) => { exitedResolve = resolve; });
   const markExited = (code) => {
     if (exitCode !== null) return;
@@ -384,7 +389,7 @@ function createRuntime(options) {
   }
 
   function emitStdout(chunk) {
-    if (options.stdout) options.stdout(chunk);
+    if (options.stdout) return options.stdout(chunk);
   }
 
   function fdWrite(fd, iovs, count, nwritten) {
@@ -394,6 +399,7 @@ function createRuntime(options) {
     for (let index = 0; index < count; index++) {
       total += view.getUint32(iovs + index * 8 + 4, true);
     }
+    if (coreOutput && total > maxCoreMessageBytes) throw new RangeError("core output message exceeds 64 MiB");
     if (fd === 1 || fd === 2) {
       const chunk = new Uint8Array(total);
       let offset = 0;
@@ -403,7 +409,13 @@ function createRuntime(options) {
         chunk.set(bytes(ptr, len), offset);
         offset += len;
       }
-      if (fd === 1) emitStdout(chunk);
+      if (fd === 1) {
+        const pending = emitStdout(chunk);
+        if (coreOutput && pending) return Promise.resolve(pending).then(() => {
+          writeU32(nwritten, total);
+          return 0;
+        });
+      }
       else if (typeof options.stderr === "function") options.stderr(chunk);
       else console.warn(decoder.decode(chunk));
     }
@@ -869,7 +881,7 @@ function createRuntime(options) {
     args_get(ptrs, data) { if (options.traceWasi) console.error("wasi args_get"); writeVector(args, ptrs, data); return 0; },
     environ_sizes_get(count, size) { if (options.traceWasi) console.error("wasi environ_sizes_get"); writeU32(count, env.length); writeU32(size, env.reduce((n, v) => n + encoder.encode(v).length + 1, 0)); return 0; },
     environ_get(ptrs, data) { if (options.traceWasi) console.error("wasi environ_get"); writeVector(env, ptrs, data); return 0; },
-    fd_write: fdWrite,
+    fd_write: options.args?.[0] === "acp" ? new WebAssembly.Suspending(fdWrite) : fdWrite,
     fd_read: new WebAssembly.Suspending(fdRead),
     fd_close() { return 0; },
     fd_fdstat_get(fd, out) {
@@ -949,8 +961,10 @@ function createRuntime(options) {
     wake() { stdin.wake(); },
     closeStdin() { stdin.close(); },
     abortHostEffects,
-    abort() {
+    abort(error) {
       aborted = true;
+      outputError = error;
+      coreOutput?.close();
       abortHostEffects();
       stdin.close();
       markExited(130);
@@ -958,17 +972,12 @@ function createRuntime(options) {
     markExited,
     get aborted() { return aborted; },
     get exitCode() { return exitCode; },
+    get error() { return outputError; },
     setLineHandler(handler) {
-      options.stdout = (chunk) => {
-        lineBuffer += decoder.decode(chunk, { stream: true });
-        for (;;) {
-          const newline = lineBuffer.indexOf("\n");
-          if (newline < 0) break;
-          const line = lineBuffer.slice(0, newline); lineBuffer = lineBuffer.slice(newline + 1);
-          if (line) handler(JSON.parse(line));
-        }
-      };
+      coreOutput = new CoreOutput(handler);
+      options.stdout = (chunk) => coreOutput.write(chunk);
     },
+    finishOutput() { coreOutput?.finish(); },
   };
 }
 
@@ -982,12 +991,16 @@ async function instantiate(options) {
   start().then(
     () => {
       runtime.setInstance(null);
-      runtime.markExited(0);
+      try { runtime.finishOutput(); runtime.markExited(0); }
+      catch (error) { runtime.abort(error); }
     },
     (error) => {
       runtime.setInstance(null);
-      if (!String(error).includes("proc_exit")) console.error(error);
-      runtime.markExited(runtime.aborted ? 130 : 1);
+      if (options.args?.[0] === "acp" && !String(error).includes("proc_exit")) runtime.abort(error);
+      else {
+        if (!String(error).includes("proc_exit")) console.error(error);
+        runtime.markExited(runtime.aborted ? 130 : 1);
+      }
     },
   );
   return runtime;
@@ -1166,6 +1179,7 @@ export async function createFxAgent(options = {}) {
   let sessionId = null;
   let activeTurn = null;
   let closing = false;
+  const isCurrentTurn = (turn) => turn && activeTurn === turn && !turn.cancelled && !closing;
   const emit = (type, detail = {}) => {
     try { options.onEvent?.({ type, timestamp: performance.now(), ...detail }); } catch {}
   };
@@ -1221,8 +1235,9 @@ export async function createFxAgent(options = {}) {
     const turn = requestedSessionId === undefined || requestedSessionId === sessionId
       ? activeTurn
       : null;
+    if (!isCurrentTurn(turn)) return { content: "", isError: true, cancelled: true };
     const controller = new AbortController();
-    turn?.toolControllers.add(controller);
+    turn.toolControllers.add(controller);
     let content;
     let isError = false;
     try {
@@ -1232,9 +1247,9 @@ export async function createFxAgent(options = {}) {
       isError = true;
       content = error instanceof Error ? error.message : String(error);
     } finally {
-      turn?.toolControllers.delete(controller);
+      turn.toolControllers.delete(controller);
     }
-    return { content, isError, cancelled: controller.signal.aborted };
+    return { content, isError, cancelled: controller.signal.aborted || !isCurrentTurn(turn) };
   };
   emit("runtime.start");
   const runtimeOptions = {
@@ -1260,21 +1275,30 @@ export async function createFxAgent(options = {}) {
   });
   runtime.exited.then((code) => {
     emit("runtime.exit", { code });
-    const error = new Error(`fx-core exited with code ${code} before completing the ACP request`);
+    closing = true;
+    const error = runtime.error ?? new Error(`fx-core exited with code ${code} before completing the ACP request`);
     for (const waiter of pending.values()) waiter.reject(error);
     pending.clear();
   });
-  runtime.setLineHandler(async (message) => {
+  runtime.setLineHandler((message, size) => {
     emit("acp.receive", { message });
     if (message.method === "session/update") {
-      if (message.params.sessionId === sessionId) activeTurn?.push(message.params.update);
+      if (message.params.sessionId === sessionId) return activeTurn?.push(message.params.update, size);
       return;
     }
+    void handleControlMessage(message).catch((error) => runtime.abort(error));
+  });
+  async function handleControlMessage(message) {
     if (message.method === "session/request_permission") {
+      const turn = activeTurn;
+      if (!isCurrentTurn(turn)) return;
       emit("permission.request", { request: message.params });
+      if (!isCurrentTurn(turn)) return;
       let optionId = null;
       try { optionId = await options.onPermission?.(message.params); } catch {}
+      if (!isCurrentTurn(turn)) return;
       emit("permission.resolve", { optionId });
+      if (!isCurrentTurn(turn)) return;
       send({ jsonrpc: "2.0", id: message.id, result: optionId ? { outcome: { outcome: "selected", optionId } } : { outcome: { outcome: "cancelled" } } });
       return;
     }
@@ -1290,7 +1314,7 @@ export async function createFxAgent(options = {}) {
     }
     const waiter = pending.get(message.id); if (!waiter) return; pending.delete(message.id);
     if (message.error) waiter.reject(new Error(message.error.message)); else waiter.resolve(message.result);
-  });
+  }
   try {
     await request("initialize", {
       protocolVersion: 1,
@@ -1378,6 +1402,11 @@ export async function createFxAgent(options = {}) {
       }
       return null;
     };
+    const result = rawTurn.result.then((value) => ({
+      stopReason: value.stopReason,
+      usage: normalizeTurnUsage(value.usage),
+    }));
+    void result.catch(() => {});
     return {
       cancel() { rawTurn.cancel(); },
       async *[Symbol.asyncIterator]() {
@@ -1386,10 +1415,7 @@ export async function createFxAgent(options = {}) {
           if (event) yield event;
         }
       },
-      result: rawTurn.result.then((result) => ({
-        stopReason: result.stopReason,
-        usage: normalizeTurnUsage(result.usage),
-      })),
+      result,
     };
   }
 
@@ -1409,22 +1435,62 @@ export async function createFxAgent(options = {}) {
     if (signal !== undefined && (typeof signal?.addEventListener !== "function" || typeof signal?.removeEventListener !== "function")) throw new TypeError("prompt signal must be an AbortSignal");
     const queue = [];
     const waiters = [];
+    let queuedBytes = 0;
+    let resumeOutput;
+    let iteratorTaken = false;
+    let terminalError;
+    let reportedPressure = false;
+    let discardedBytes = 0;
     const toolControllers = new Set();
     let finished = false;
     let cancelled = false;
     const turn = {
-      push(update) { const waiter = waiters.shift(); if (waiter) waiter({ value: update, done: false }); else queue.push(update); },
+      push(update, size = encoder.encode(JSON.stringify(update)).length) {
+        if (cancelled || finished) { discardedBytes += size; return; }
+        if (size > maxCoreMessageBytes) throw new RangeError("core output message exceeds 64 MiB");
+        if (queue.length && (queue.length >= maxUnreadEvents || size > maxUnreadEventBytes - queuedBytes)) {
+          const capacity = new Promise((resolveCapacity) => { resumeOutput = resolveCapacity; });
+          if (!reportedPressure) {
+            reportedPressure = true;
+            emit("output.backpressure", { bufferedBytes: queuedBytes, bufferedEvents: queue.length });
+          }
+          return capacity.then(() => turn.push(update, size));
+        }
+        const waiter = waiters.shift();
+        if (waiter) waiter.resolve({ value: update, done: false });
+        else { queue.push({ update, size }); queuedBytes += size; }
+      },
       toolControllers,
       transportAttempts: 0,
       get cancelled() { return cancelled; },
       cancel() {
         if (finished || cancelled) return;
         cancelled = true;
+        resumeOutput?.();
+        resumeOutput = null;
         send({ jsonrpc: "2.0", method: "session/cancel", params: { sessionId } });
         for (const controller of toolControllers) controller.abort();
         runtime.abortHostEffects();
       },
-      [Symbol.asyncIterator]() { return { next() { if (queue.length) return Promise.resolve({ value: queue.shift(), done: false }); if (finished) return Promise.resolve({ done: true }); return new Promise((resolve) => waiters.push(resolve)); } }; },
+      [Symbol.asyncIterator]() {
+        if (iteratorTaken) throw new Error("a turn has only one event consumer");
+        iteratorTaken = true;
+        return {
+          next() {
+            if (queue.length) {
+              const { update, size } = queue.shift();
+              queuedBytes -= size;
+              resumeOutput?.();
+              resumeOutput = null;
+              return Promise.resolve({ value: update, done: false });
+            }
+            if (terminalError) return Promise.reject(terminalError);
+            if (finished) return Promise.resolve({ done: true });
+            return new Promise((resolve, reject) => waiters.push({ resolve, reject }));
+          },
+          return() { turn.cancel(); return Promise.resolve({ done: true }); },
+        };
+      },
     };
     if (signal?.aborted) {
       finished = true;
@@ -1435,19 +1501,27 @@ export async function createFxAgent(options = {}) {
     const abort = () => turn.cancel();
     signal?.addEventListener("abort", abort, { once: true });
     turn.result = request("session/prompt", { sessionId, prompt })
-      .then((response) => ({ stopReason: response.stopReason, usage: response.usage }))
+      .then((response) => ({ stopReason: cancelled ? "cancelled" : response.stopReason, usage: response.usage }))
       .catch((error) => {
         if (error.message === "Cancelled") return { stopReason: "cancelled" };
+        terminalError = error;
         throw error;
       })
       .finally(() => {
         finished = true;
+        resumeOutput?.();
+        resumeOutput = null;
         signal?.removeEventListener("abort", abort);
         if (activeTurn === turn) activeTurn = null;
         toolControllers.clear();
-        waiters.splice(0).forEach((resolve) => resolve({ done: true }));
+        if (discardedBytes) emit("output.discarded", { reason: "cancelled", bytes: discardedBytes });
+        for (const waiter of waiters.splice(0)) {
+          if (terminalError) waiter.reject(terminalError);
+          else waiter.resolve({ done: true });
+        }
       });
     if (signal?.aborted) turn.cancel();
+    void turn.result.catch(() => {});
     return turn;
   }
 }

--- a/sdk/fx-sdk.js
+++ b/sdk/fx-sdk.js
@@ -1409,11 +1409,19 @@ export async function createFxAgent(options = {}) {
     void result.catch(() => {});
     return {
       cancel() { rawTurn.cancel(); },
-      async *[Symbol.asyncIterator]() {
-        for await (const update of rawTurn) {
-          const event = eventFor(update);
-          if (event) yield event;
-        }
+      [Symbol.asyncIterator]() {
+        const iterator = (async function* () {
+          for await (const update of rawTurn) {
+            const event = eventFor(update);
+            if (event) yield event;
+          }
+        })();
+        return {
+          next(value) { return iterator.next(value); },
+          return(value) { rawTurn.cancel(); return iterator.return(value); },
+          throw(error) { rawTurn.cancel(); return iterator.throw(error); },
+          [Symbol.asyncIterator]() { return this; },
+        };
       },
       result,
     };

--- a/sdk/node.js
+++ b/sdk/node.js
@@ -5,6 +5,7 @@ import { Socket } from "node:net";
 import { homedir } from "node:os";
 import { isAbsolute, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { CoreOutput } from "./core-output.js";
 import {
   createFxAgent as createWasmAgent,
   createFxTerminal as createWasmTerminal,
@@ -147,8 +148,9 @@ function createNativeCoreRuntime(addon, options) {
   const readyClosed = new Promise((resolve) => readySocket.once("close", resolve));
   let exitedResolve;
   let lineHandler = null;
-  let lineBuffer = "";
-  const decoder = new TextDecoder();
+  const output = new CoreOutput((message, size) => lineHandler(message, size));
+  let draining = false;
+  let outputError;
   let settled = false;
   let fetchState = null;
   const exited = new Promise((resolve) => { exitedResolve = resolve; });
@@ -156,9 +158,11 @@ function createNativeCoreRuntime(addon, options) {
     fetchState?.controller.abort();
     try { addon.abortCoreFetch(core); } catch {}
   };
-  const finish = (code) => {
+  const finish = (code, error) => {
     if (settled) return;
     settled = true;
+    outputError = error;
+    output.close();
     abortHostEffects();
     try { addon.destroyCore(core); } catch {}
     readySocket.destroy();
@@ -223,21 +227,33 @@ function createNativeCoreRuntime(addon, options) {
         const fetchRequest = addon.takeCoreFetch(core);
         if (fetchRequest) void pumpFetch(JSON.parse(fetchRequest.toString("utf8")));
       }
-      for (;;) {
+      if (addon.coreExitCode(core) !== 0) {
+        finish(1, new Error("native output delivery failed"));
+        return;
+      }
+      void drainOutput();
+    } catch (error) {
+      finish(1, error);
+    }
+  }
+  async function drainOutput() {
+    if (draining || settled) return;
+    draining = true;
+    try {
+      while (!settled) {
         const chunk = addon.drainCore(core);
         if (!chunk.length) break;
-        lineBuffer += decoder.decode(chunk, { stream: true });
-        for (;;) {
-          const newline = lineBuffer.indexOf("\n");
-          if (newline < 0) break;
-          const line = lineBuffer.slice(0, newline);
-          lineBuffer = lineBuffer.slice(newline + 1);
-          if (line) void Promise.resolve(lineHandler(JSON.parse(line))).catch(() => finish(1));
-        }
+        const pending = output.write(chunk);
+        if (pending) await pending;
       }
-      if (addon.coreExited(core)) finish(addon.coreExitCode(core));
-    } catch {
-      finish(1);
+      if (!settled && addon.coreExited(core)) {
+        output.finish();
+        finish(addon.coreExitCode(core));
+      }
+    } catch (error) {
+      finish(1, error);
+    } finally {
+      draining = false;
     }
   }
 
@@ -252,10 +268,14 @@ function createNativeCoreRuntime(addon, options) {
 
   return {
     exited,
+    get error() { return outputError; },
     write(data) { addon.writeCore(core, Buffer.from(data)); },
     closeStdin() { addon.closeCore(core); },
     abortHostEffects,
-    abort() { abortHostEffects(); addon.closeCore(core); },
+    abort(error) {
+      if (error) finish(1, error);
+      else { abortHostEffects(); addon.closeCore(core); }
+    },
     setLineHandler(handler) { lineHandler = handler; },
   };
 }

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -32,6 +32,7 @@
     "browser.js",
     "node.js",
     "fx-sdk.js",
+    "core-output.js",
     "mcp.js",
     "skills.js",
     "skills-node.js",

--- a/sdk/scripts/package-libfx.mjs
+++ b/sdk/scripts/package-libfx.mjs
@@ -22,6 +22,7 @@ const files = [
   ["sdk/browser.js", "browser.js"],
   ["sdk/node.js", "node.js"],
   ["sdk/fx-sdk.js", "fx-sdk.js"],
+  ["sdk/core-output.js", "core-output.js"],
   ["sdk/mcp.js", "mcp.js"],
   ["sdk/skills.js", "skills.js"],
   ["sdk/skills-node.js", "skills-node.js"],

--- a/sdk/scripts/package-term-demo.mjs
+++ b/sdk/scripts/package-term-demo.mjs
@@ -10,17 +10,22 @@ const outputDir = resolve(process.argv[2] || resolve(repoRoot, "sdk/dist/term-de
 const htmlPath = resolve(repoRoot, "sdk/term-demo.html");
 const browserPath = resolve(repoRoot, "sdk/browser.js");
 const sdkPath = resolve(repoRoot, "sdk/fx-sdk.js");
+const coreOutputPath = resolve(repoRoot, "sdk/core-output.js");
 const wasmPath = resolve(repoRoot, "zig-out/bin/fx-term.wasm");
 
-const [htmlSource, browserBytes, sdkBytes, wasmBytes] = await Promise.all([
+const [htmlSource, browserBytes, sdkSource, coreOutputBytes, wasmBytes] = await Promise.all([
   readFile(htmlPath, "utf8"),
   readFile(browserPath),
   readFile(sdkPath),
+  readFile(coreOutputPath),
   readFile(wasmPath),
 ]);
 
 const digest = (bytes) => createHash("sha256").update(bytes).digest("hex");
 const integrity = (bytes) => `sha256-${createHash("sha256").update(bytes).digest("base64")}`;
+const coreOutputHash = digest(coreOutputBytes);
+const coreOutputName = `core-output.${coreOutputHash}.js`;
+const sdkBytes = Buffer.from(sdkSource.toString().replace('from "./core-output.js";', `from "./${coreOutputName}";`));
 const sdkHash = digest(sdkBytes);
 const wasmHash = digest(wasmBytes);
 const sdkName = `fx-sdk.${sdkHash}.js`;
@@ -66,6 +71,10 @@ const vercelConfig = {
       headers: [{ key: "Cache-Control", value: "public, max-age=31536000, immutable" }],
     },
     {
+      source: `/${coreOutputName}`,
+      headers: [{ key: "Cache-Control", value: "public, max-age=31536000, immutable" }],
+    },
+    {
       source: `/${wasmName}`,
       headers: [{ key: "Cache-Control", value: "public, max-age=31536000, immutable" }],
     },
@@ -79,6 +88,7 @@ await Promise.all([
   writeFile(resolve(outputDir, "index.html"), html),
   writeFile(resolve(outputDir, browserName), packagedBrowser),
   writeFile(resolve(outputDir, sdkName), sdkBytes),
+  writeFile(resolve(outputDir, coreOutputName), coreOutputBytes),
   writeFile(resolve(outputDir, wasmName), wasmBytes),
   writeFile(resolve(outputDir, "vercel.json"), `${JSON.stringify(vercelConfig, null, 2)}\n`),
 ]);
@@ -87,6 +97,7 @@ const manifest = {
   html: "index.html",
   browser: { file: browserName, sha256: digest(packagedBrowser), bytes: packagedBrowser.byteLength },
   sdk: { file: sdkName, sha256: sdkHash, bytes: sdkBytes.byteLength },
+  coreOutput: { file: coreOutputName, sha256: coreOutputHash, bytes: coreOutputBytes.byteLength },
   wasm: { file: wasmName, sha256: wasmHash, integrity: integrity(wasmBytes), bytes: wasmBytes.byteLength },
 };
 await writeFile(resolve(outputDir, "manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`);
@@ -94,4 +105,5 @@ await writeFile(resolve(outputDir, "manifest.json"), `${JSON.stringify(manifest,
 console.log(`packaged ${basename(outputDir)}`);
 console.log(`  ${browserName}`);
 console.log(`  ${sdkName}`);
+console.log(`  ${coreOutputName}`);
 console.log(`  ${wasmName}`);

--- a/sdk/tests/test-core-output-pressure.mjs
+++ b/sdk/tests/test-core-output-pressure.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createFxAgent } from "../node.js";
+
+const backend = process.argv[2] ?? "native";
+const root = fileURLToPath(new URL("../..", import.meta.url));
+const nativeAddon = process.argv[3] ?? resolve(root, "zig-out/lib/libfx.node");
+const wasm = backend === "wasm" ? await readFile(resolve(root, "zig-out/bin/fx-core.wasm")) : undefined;
+const hash = (value) => createHash("sha256").update(value).digest("hex");
+const delta = (text) => `data: ${JSON.stringify({ type: "text-delta", delta: text })}\n\n`;
+const finish = 'data: {"type":"finish","finishReason":{"unified":"stop","raw":"stop"}}\n\ndata: [DONE]\n\n';
+const pause = (ms) => new Promise((resolveWait) => setTimeout(resolveWait, ms));
+const deadline = setTimeout(() => { throw new Error("bounded output did not settle"); }, 25_000);
+let agent;
+
+async function start(fetch, onEvent, options = {}) {
+  agent = await createFxAgent({
+    backend, nativeAddon, wasm, apiKey: "output-pressure-fixture", model: "fixture/output",
+    fetch, onEvent, ...options,
+  });
+  return agent;
+}
+
+async function collect(turn) {
+  const digest = createHash("sha256");
+  let bytes = 0;
+  for await (const event of turn) if (event.type === "text_delta") {
+    bytes += Buffer.byteLength(event.delta);
+    digest.update(event.delta);
+  }
+  assert.equal((await turn.result).stopReason, "end_turn");
+  return { bytes, hash: digest.digest("hex") };
+}
+
+try {
+  // Identical text must survive both one oversized transport write and many writes.
+  const source = "\u{1f600}界".repeat(1_200_000) + " tail\n";
+  for (const fragmented of [false, true]) {
+    console.log(`${backend}: large output fragmented=${fragmented}`);
+    await start(async () => {
+      const parts = fragmented ? source.match(/.{1,4096}/gsu) : [source];
+      return new Response(parts.map(delta).join("") + finish);
+    });
+    assert.deepEqual(await collect(agent.prompt("large text")), {
+      bytes: Buffer.byteLength(source), hash: hash(source),
+    });
+    await agent.close();
+    agent = null;
+  }
+
+  // A fast producer cannot publish the entire response into an unread JS queue.
+  let received = 0;
+  let pressure;
+  console.log(`${backend}: paused consumer`);
+  const part = "x".repeat(16 * 1024);
+  const total = 1024;
+  await start(async () => new Response(delta(part).repeat(total) + finish), (event) => {
+    if (event.type === "output.backpressure") pressure = event;
+    if (event.type === "acp.receive" && event.message?.params?.update?.sessionUpdate === "agent_message_chunk") received++;
+  });
+  const slow = agent.prompt("pause the consumer");
+  let settled = false;
+  void slow.result.then(() => { settled = true; });
+  while (!pressure) await pause(5);
+  assert.ok(pressure.bufferedBytes <= 1024 * 1024);
+  assert.ok(pressure.bufferedEvents <= 256);
+  await pause(100);
+  assert.ok(received < total, "unread SDK events did not backpressure the producer");
+  assert.equal(settled, false, "completion overtook unread output");
+  assert.deepEqual(await collect(slow), { bytes: part.length * total, hash: hash(part.repeat(total)) });
+  await agent.close();
+  agent = null;
+
+  // Cancellation releases an output wait without requiring an iterator to resume.
+  console.log(`${backend}: cancel and reuse`);
+  received = 0;
+  let aborted = false;
+  let requests = 0;
+  await start(async (_url, options) => {
+    requests++;
+    if (requests > 1) return new Response(delta("after cancel") + finish);
+    return new Response(new ReadableStream({
+      start(controller) {
+        options.signal.addEventListener("abort", () => {
+          aborted = true;
+          controller.error(options.signal.reason);
+        }, { once: true });
+        controller.enqueue(new TextEncoder().encode(delta(part).repeat(256)));
+      },
+    }));
+  }, (event) => {
+    if (event.type === "acp.receive" && event.message?.params?.update?.sessionUpdate === "agent_message_chunk") received++;
+  });
+  const cancelled = agent.prompt("cancel with a full queue");
+  while (!received) await pause(5);
+  await pause(50);
+  cancelled.cancel();
+  assert.equal((await cancelled.result).stopReason, "cancelled");
+  assert.equal(aborted, true);
+  assert.deepEqual(await collect(agent.prompt("reuse after cancel")), {
+    bytes: 12, hash: hash("after cancel"),
+  });
+  await agent.close();
+  agent = null;
+  console.log(`${backend}: close while backpressured and independent owner`);
+  pressure = null;
+  await start(async () => new Response(delta(part).repeat(256) + finish), (event) => {
+    if (event.type === "output.backpressure") pressure = event;
+  });
+  const closing = agent.prompt("close while unread");
+  while (!pressure) await pause(5);
+  const independent = await createFxAgent({
+    backend, nativeAddon, wasm, apiKey: "independent-fixture", model: "fixture/output",
+    fetch: async () => new Response(delta("independent") + finish),
+  });
+  try {
+    assert.deepEqual(await collect(independent.prompt("separate owner")), {
+      bytes: 11, hash: hash("independent"),
+    });
+  } finally { await independent.close(); }
+  await agent.close();
+  assert.equal((await closing.result).stopReason, "cancelled");
+  agent = null;
+  console.log(`${backend}: queued tool stays cancelled`);
+  pressure = null;
+  let effects = 0;
+  const toolWire = 'data: {"type":"tool-call","toolCallId":"queued","toolName":"effect","input":{}}\n\n' +
+    'data: {"type":"finish","finishReason":{"unified":"tool-calls","raw":"tool-calls"}}\n\ndata: [DONE]\n\n';
+  await start(async () => new Response(delta(part).repeat(128) + toolWire), (event) => {
+    if (event.type === "output.backpressure") pressure = event;
+  }, { tools: [{
+    name: "effect", description: "Record one effect", inputSchema: { type: "object", properties: {} },
+    execute() { effects++; return "effect"; },
+  }] });
+  const queuedTool = agent.prompt("cancel queued tool");
+  while (!pressure) await pause(5);
+  await pause(100);
+  queuedTool.cancel();
+  assert.equal((await queuedTool.result).stopReason, "cancelled");
+  assert.equal(effects, 0, "a tool queued behind output executed after cancellation");
+  await agent.close();
+  agent = null;
+  console.log(`${backend}: cancel from pressure notification`);
+  let callbackTurn;
+  await start(async () => new Response(delta(part).repeat(128) + finish), (event) => {
+    if (event.type === "output.backpressure") callbackTurn.cancel();
+  });
+  callbackTurn = agent.prompt("cancel in the callback");
+  assert.equal((await callbackTurn.result).stopReason, "cancelled");
+  await agent.close();
+  agent = null;
+  if (backend === "native") {
+    const addon = createRequire(import.meta.url)(nativeAddon);
+    let corrupt = false;
+    await start(async () => new Response(delta("valid provider text") + finish), undefined, {
+      nativeAddon: {
+        ...addon,
+        drainCore(core) {
+          const chunk = addon.drainCore(core);
+          if (corrupt && chunk.length) { corrupt = false; return Buffer.from("not-json\n"); }
+          return chunk;
+        },
+      },
+    });
+    corrupt = true;
+    const broken = agent.prompt("transport corruption");
+    const next = broken[Symbol.asyncIterator]().next();
+    await Promise.all([assert.rejects(broken.result, SyntaxError), assert.rejects(next, SyntaxError)]);
+    await agent.close();
+    agent = null;
+  }
+  console.log(`${backend} bounded output passed: large frames, slow consumer, cancellation and reuse`);
+} finally {
+  await agent?.close();
+  clearTimeout(deadline);
+}

--- a/sdk/tests/test-core-output-pressure.mjs
+++ b/sdk/tests/test-core-output-pressure.mjs
@@ -154,6 +154,39 @@ try {
   assert.equal((await callbackTurn.result).stopReason, "cancelled");
   await agent.close();
   agent = null;
+  console.log(`${backend}: iterator close interrupts a pending read`);
+  for (const operation of ["return", "throw"]) {
+    let fetchStarted = false;
+    aborted = false;
+    await start(async (_url, options) => {
+      fetchStarted = true;
+      return new Promise((_, reject) => options.signal.addEventListener("abort", () => {
+        aborted = true;
+        reject(options.signal.reason);
+      }, { once: true }));
+    });
+    const unread = agent.prompt("close the pending iterator");
+    const iterator = unread[Symbol.asyncIterator]();
+    const next = iterator.next();
+    while (!fetchStarted) await pause(5);
+    const reason = new Error("stop consuming");
+    const stopped = iterator[operation](reason);
+    assert.equal(aborted, true, "iterator close did not abort the active fetch immediately");
+    const closingResult = operation === "throw" ? assert.rejects(stopped, (error) => error === reason) : stopped;
+    assert.equal((await unread.result).stopReason, "cancelled");
+    assert.equal((await next).done, true);
+    await closingResult;
+    await agent.close();
+    agent = null;
+  }
+  let earlyFetches = 0;
+  await start(async () => { earlyFetches++; return new Response(delta("unexpected") + finish); });
+  const neverRead = agent.prompt("close before the first read");
+  await neverRead[Symbol.asyncIterator]().return();
+  assert.equal((await neverRead.result).stopReason, "cancelled");
+  assert.equal(earlyFetches, 0);
+  await agent.close();
+  agent = null;
   if (backend === "native") {
     const addon = createRequire(import.meta.url)(nativeAddon);
     let corrupt = false;

--- a/sdk/tests/test-core-output.mjs
+++ b/sdk/tests/test-core-output.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { CoreOutput } from "../core-output.js";
+import { createFxAgent } from "../fx-sdk.js";
+
+const encoder = new TextEncoder();
+const message = { text: "¢€\u{1f600}界\nsecond line", escaped: '"\\' };
+const wire = encoder.encode(JSON.stringify(message) + "\n");
+for (let split = 1; split < wire.length; split++) {
+  const messages = [];
+  const output = new CoreOutput((value) => { messages.push(value); });
+  output.write(wire.subarray(0, split));
+  assert.equal(messages.length, 0);
+  output.write(wire.subarray(split));
+  output.finish();
+  assert.deepEqual(messages, [message]);
+}
+
+const a = [], b = [];
+const first = new CoreOutput((value) => { a.push(value); });
+const second = new CoreOutput((value) => { b.push(value); });
+for (const byte of wire) {
+  first.write(Uint8Array.of(byte));
+  second.write(Uint8Array.of(byte));
+}
+assert.deepEqual(a, [message]);
+assert.deepEqual(b, [message]);
+
+let release;
+const received = [];
+const gated = new CoreOutput((value) => {
+  received.push(value.id);
+  if (value.id === 1) return new Promise((resolve) => { release = resolve; });
+});
+const pending = gated.write(encoder.encode('{"id":1}\n{"id":2}\n'));
+assert.deepEqual(received, [1]);
+release();
+await pending;
+assert.deepEqual(received, [1, 2]);
+
+for (const invalid of [Uint8Array.of(0xff, 10), encoder.encode("not json\n")]) {
+  const output = new CoreOutput(() => assert.fail("invalid output was published"));
+  assert.throws(() => output.write(invalid));
+}
+const truncated = new CoreOutput(() => assert.fail("partial output was published"));
+truncated.write(encoder.encode('{"id":1}'));
+assert.throws(() => truncated.finish(), /within a message/);
+truncated.close();
+assert.throws(() => truncated.write(wire), /closed/);
+
+const limited = new CoreOutput(() => assert.fail("oversized output was published"));
+const fragment = new Uint8Array(1024 * 1024).fill(32);
+for (let index = 0; index < 64; index++) limited.write(fragment);
+assert.throws(() => limited.write(Uint8Array.of(10)), /exceeds 64 MiB/);
+limited.close();
+
+const exactMessages = [];
+const exact = new CoreOutput((value) => { exactMessages.push(value); });
+exact.write(encoder.encode("{}"));
+for (let index = 0; index < 63; index++) exact.write(fragment);
+exact.write(fragment.subarray(0, fragment.length - 3));
+exact.write(Uint8Array.of(10));
+exact.finish();
+assert.deepEqual(exactMessages, [{}]);
+
+const failure = new Error("consumer failed");
+const rejected = new CoreOutput(() => Promise.reject(failure));
+await assert.rejects(rejected.write(wire), (error) => error === failure);
+
+for (const cancelAt of ["permission.request", "permission.resolve"]) {
+  let handler, exit, promptId, turn;
+  let permissionCalls = 0;
+  const approvals = [];
+  const runtime = {
+    exited: new Promise((resolve) => { exit = resolve; }),
+    setLineHandler(value) { handler = value; },
+    write(data) {
+      const message = JSON.parse(data);
+      const deliver = (value) => queueMicrotask(() => handler(value));
+      if (message.method === "initialize") deliver({ id: message.id, result: {} });
+      if (message.method === "libfx/new") deliver({ id: message.id, result: { sessionId: "session" } });
+      if (message.method === "session/prompt") {
+        promptId = message.id;
+        deliver({ id: 100, method: "session/request_permission", params: { sessionId: "session", options: [] } });
+      }
+      if (message.method === "session/cancel") deliver({ id: promptId, result: { stopReason: "cancelled" } });
+      if (message.id === 100) approvals.push(message);
+    },
+    abortHostEffects() {},
+    closeStdin() { exit(0); },
+  };
+  const agent = await createFxAgent({
+    apiKey: "callback-fixture", runtimeFactory: () => runtime,
+    onEvent(event) { if (event.type === cancelAt) turn.cancel(); },
+    onPermission() { permissionCalls++; return "allow-once"; },
+  });
+  turn = agent.prompt("permission callback");
+  assert.equal((await turn.result).stopReason, "cancelled");
+  assert.equal(permissionCalls, cancelAt === "permission.request" ? 0 : 1);
+  assert.deepEqual(approvals, [], "approval escaped after callback cancellation");
+  await agent.close();
+}
+console.log("core output framing passed: fragmented UTF-8, isolation, ordering, invalid and bounded records");

--- a/sdk/tests/test-native-core-config-isolation.mjs
+++ b/sdk/tests/test-native-core-config-isolation.mjs
@@ -70,6 +70,7 @@ try {
     "native addon host must not start workspace MCP",
   );
   const turn = agent.prompt("read the explicit workspace context");
+  for await (const _ of turn) {}
   await turn.result;
   assert.match(requestBody, new RegExp(marker), "native startup omitted explicit host instructions");
   assert.doesNotMatch(requestBody, new RegExp(workspaceMarker), "minimal kernel scanned workspace context");

--- a/sdk/tests/test-native-core-exit-code.mjs
+++ b/sdk/tests/test-native-core-exit-code.mjs
@@ -16,9 +16,34 @@ try {
   while (!addon.coreExited(core) && Date.now() < deadline) {
     await new Promise((resolveWait) => setTimeout(resolveWait, 5));
   }
-  assert.equal(addon.coreExited(core), true, "output backpressure did not stop the native runtime");
-  assert.notEqual(addon.coreExitCode(core), 0, "native output failure must not report a graceful exit");
-  console.log("native exit code passed: output backpressure reports a nonzero runtime status");
+  assert.equal(addon.coreExited(core), false, "queue pressure must pause output rather than stop the runtime");
+  let count = 0;
+  let buffered = "";
+  const drainDeadline = Date.now() + 5000;
+  while (count < 180_000 && Date.now() < drainDeadline) {
+    const chunk = addon.drainCore(core);
+    if (!chunk.length) { await new Promise((resolveWait) => setTimeout(resolveWait, 1)); continue; }
+    buffered += chunk.toString("utf8");
+    const lines = buffered.split("\n");
+    buffered = lines.pop();
+    for (const line of lines) {
+      assert.equal(JSON.parse(line).error.code, -32600);
+      count++;
+    }
+  }
+  assert.equal(count, 180_000, "backpressured output lost replies");
+  addon.closeCore(core);
+  while (!addon.coreExited(core) && Date.now() < drainDeadline) {
+    await new Promise((resolveWait) => setTimeout(resolveWait, 1));
+  }
+  assert.equal(addon.coreExited(core), true);
+  assert.equal(addon.coreExitCode(core), 0);
 } finally {
   addon.destroyCore(core);
 }
+
+const blocked = addon.createCore({ apiKey: "blocked-close-key", home: "/tmp", workspaceRoot: "/tmp" });
+addon.writeCore(blocked, Buffer.from("{}\n".repeat(180_000)));
+await new Promise((resolveWait) => setTimeout(resolveWait, 50));
+addon.destroyCore(blocked);
+console.log("native output passed: lossless backpressure, graceful drain and blocked destruction");

--- a/sdk/tests/test-node-napi.mjs
+++ b/sdk/tests/test-node-napi.mjs
@@ -4,6 +4,8 @@ import { fileURLToPath } from "node:url";
 
 const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
 const scripts = [
+  "test-core-output.mjs",
+  "test-core-output-pressure.mjs",
   "test-native-core-ready.mjs",
   "test-native-core-misuse.mjs",
   "test-native-core-workers.mjs",

--- a/sdk/tests/test-node-wasm.mjs
+++ b/sdk/tests/test-node-wasm.mjs
@@ -14,6 +14,8 @@ const termScripts = [
   "test-term-workspace.mjs",
 ];
 const commands = [
+  [process.execPath, [fileURLToPath(new URL("test-core-output.mjs", import.meta.url))]],
+  [process.execPath, ["--experimental-wasm-jspi", fileURLToPath(new URL("test-core-output-pressure.mjs", import.meta.url)), "wasm"]],
   [process.execPath, [fileURLToPath(new URL("test-wasm-memory.mjs", import.meta.url))]],
   [process.execPath, ["--experimental-wasm-jspi", fileURLToPath(new URL("test-agent-bootstrap.mjs", import.meta.url)), "wasm"]],
   [process.execPath, ["--experimental-wasm-jspi", fileURLToPath(new URL("test-instruction-limits.mjs", import.meta.url)), "wasm"]],

--- a/sdk/tests/test-term.mjs
+++ b/sdk/tests/test-term.mjs
@@ -43,6 +43,7 @@ const terminal = {
     if (steeringSubmittedAt !== undefined) postSubmitText += decoded;
     if (draftVisibleAt === undefined && streamedText.includes(liveDraft)) draftVisibleAt = performance.now();
     process.stdout.write(chunk);
+    return true;
   },
   async drain() {
     drainCalls += 1;

--- a/src/napi_core_main.zig
+++ b/src/napi_core_main.zig
@@ -22,6 +22,7 @@ const Allocator = std.mem.Allocator;
 const max_drain_bytes = 1024 * 1024;
 const max_input_bytes = 8 * 1024 * 1024;
 const max_output_bytes = 8 * 1024 * 1024;
+const max_output_message_bytes = 64 * 1024 * 1024;
 const max_fetch_request_bytes = 8 * 1024 * 1024;
 const max_fetch_response_bytes = 8 * 1024 * 1024;
 const max_api_key_bytes = 64 * 1024;
@@ -145,23 +146,47 @@ const InputQueue = struct {
 
 const OutputQueue = struct {
     mutex: std.Io.Mutex = .init,
+    wake: std.Io.Condition = .init,
     bytes: std.ArrayList(u8) = .empty,
     offset: usize = 0,
     ready: ?*ReadyNotifier = null,
+    closed: bool = false,
+    failed: bool = false,
 
     fn write(self: *OutputQueue, alloc: Allocator, data: []const u8) !void {
         const io = io_mod.getIo();
         self.mutex.lockUncancelable(io);
         defer self.mutex.unlock(io);
-        const queued = self.bytes.items.len - self.offset;
-        if (data.len > max_output_bytes or queued > max_output_bytes - data.len) return error.OutputQueueFull;
-        if (self.offset > 0) {
-            std.mem.copyForwards(u8, self.bytes.items[0..queued], self.bytes.items[self.offset..]);
-            self.bytes.items.len = queued;
-            self.offset = 0;
+        errdefer |err| if (err != error.OutputClosed) {
+            self.failed = true;
+            self.wake.broadcast(io);
+            self.ready.?.notify();
+        };
+        if (data.len > max_output_message_bytes) return error.OutputMessageTooLarge;
+        var written: usize = 0;
+        while (written < data.len) {
+            if (self.failed) return error.OutputFailed;
+            if (self.closed) return error.OutputClosed;
+            const queued = self.bytes.items.len - self.offset;
+            if (queued == max_output_bytes) {
+                self.wake.waitUncancelable(io, &self.mutex);
+                continue;
+            }
+            if (self.offset > 0) {
+                std.mem.copyForwards(u8, self.bytes.items[0..queued], self.bytes.items[self.offset..]);
+                self.bytes.items.len = queued;
+                self.offset = 0;
+            }
+            const len = @min(data.len - written, max_output_bytes - queued);
+            const needed = queued + len;
+            if (needed > self.bytes.capacity) {
+                const capacity = @min(max_output_bytes, @max(needed, self.bytes.capacity + self.bytes.capacity / 2 + 8));
+                try self.bytes.ensureTotalCapacityPrecise(alloc, capacity);
+            }
+            self.bytes.appendSliceAssumeCapacity(data[written..][0..len]);
+            written += len;
+            if (queued == 0) self.ready.?.notify();
         }
-        try self.bytes.appendSlice(alloc, data);
-        if (queued == 0) self.ready.?.notify();
     }
 
     fn drain(self: *OutputQueue, destination: []u8) usize {
@@ -177,14 +202,24 @@ const OutputQueue = struct {
             self.bytes.clearRetainingCapacity();
             self.offset = 0;
         }
+        self.wake.broadcast(io);
         return len;
     }
 
-    fn available(self: *OutputQueue) usize {
+    fn available(self: *OutputQueue) !usize {
         const io = io_mod.getIo();
         self.mutex.lockUncancelable(io);
         defer self.mutex.unlock(io);
+        if (self.failed) return error.OutputFailed;
         return self.bytes.items.len - self.offset;
+    }
+
+    fn close(self: *OutputQueue) void {
+        const io = io_mod.getIo();
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
+        self.closed = true;
+        self.wake.broadcast(io);
     }
 
     fn deinit(self: *OutputQueue, alloc: Allocator) void {
@@ -446,7 +481,12 @@ const Runtime = struct {
     fn writeOutput(context: ?*anyopaque, bytes: []const u8) !void {
         const self: *Runtime = @ptrCast(@alignCast(context.?));
         self.output.write(self.alloc, bytes) catch |err| {
-            self.exit_code.store(1, .seq_cst);
+            if (err != error.OutputClosed) {
+                self.exit_code.store(1, .seq_cst);
+                self.input.close();
+                self.fetch.shutdown();
+                self.ready.notify();
+            }
             return err;
         };
     }
@@ -502,6 +542,7 @@ const Runtime = struct {
     }
 
     fn closeInput(self: *Runtime) void {
+        self.output.close();
         self.input.close();
     }
 
@@ -889,7 +930,9 @@ fn drainCore(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.napi_va
     const handle = runtimeHandleArg(env, info, &argv) orelse return null;
     const runtime = lockRuntime(env, handle) orelse return null;
     defer unlockRuntime(handle);
-    const len = @min(runtime.output.available(), max_drain_bytes);
+    const available = runtime.output.available() catch
+        return throw(env, "LIBFX_NATIVE_IO", "native output delivery failed");
+    const len = @min(available, max_drain_bytes);
     var value: c.napi_value = undefined;
     var data: ?*anyopaque = null;
     if (!statusOk(env, c.napi_create_buffer(env, len, &data, &value), "could not allocate output Buffer")) return null;


### PR DESCRIPTION
## Summary

- Deliver large native SDK responses through a bounded output queue without dropping text.
- Pause native and WebAssembly output when unread SDK events reach capacity; callers explicitly drain streams before awaiting completion.
- Reject malformed or oversized output messages and surface delivery failures to both the turn result and event iterator.
- Release blocked output on cancellation, close, and native worker shutdown.
- Prevent queued tools and permission approvals from running after cancellation, including cancellation from event callbacks.
- Cancel a turn when its event iterator closes early.
