### PR TITLE
Show the running fx version in terminal tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ fx session resume last
 fx session resume --id <id>
 ```
 
-Each interactive session names its terminal tab. The title prefers the session name, falls back to the workspace name, and keeps the active model as secondary context. Renaming or resuming a session updates the tab, and exiting clears the fx-owned title. Noninteractive commands do not emit terminal-title controls.
+Interactive terminal tabs show `fx v<version>` using the running binary's version. The title stays the same when you rename or resume a session or switch models. Exiting clears the fx-owned title. Noninteractive commands do not emit terminal-title controls.
 
 Run `/feedback` to open the feedback form at `fx.sh/feedback`. It does not create a diagnostic or change the clipboard.
 

--- a/src/core/app/app_bootstrap_runtime.zig
+++ b/src/core/app/app_bootstrap_runtime.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const build_options = @import("build_options");
 const app_lifecycle = @import("app_lifecycle.zig");
 const provider_runtime = @import("provider_runtime.zig");
 const app_input_runtime = @import("app_input_runtime.zig");
@@ -942,7 +943,7 @@ test "app_bootstrap_runtime transfers startup state and starts a fresh session" 
     try std.testing.expectEqualStrings("title", events[5]);
     try std.testing.expectEqual(@as(usize, 1), capture.begin_calls);
     try std.testing.expectEqual(@as(usize, 1), capture.enable_calls);
-    try std.testing.expectEqualStrings("workspace · model-x", capture.titleText());
+    try std.testing.expectEqualStrings("v" ++ build_options.app_version, capture.titleText());
 
     try std.testing.expectEqualStrings("/workspace", app.workspace_root);
     try std.testing.expectEqualStrings("api-key", app.auth.apiKey().?);

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const builtin = @import("builtin");
+const build_options = @import("build_options");
 const question_answer = @import("../agent/question_answer.zig");
 const config_runtime = @import("../config/config_runtime.zig");
 const model_capabilities = @import("../config/model_capabilities.zig");
@@ -2874,8 +2875,7 @@ pub fn Runtime(comptime App: type) type {
             return null;
         }
 
-        /// Replaces the cached footer title. App owns the copy. Keeps the
-        /// terminal title in step because both surfaces read this cache.
+        /// Replaces the cached footer title. App owns the copy.
         pub fn setCachedSessionTitle(app: *App, title: []const u8) !void {
             if (comptime !@hasField(App, "session_title")) return;
             app.session_title.clearRetainingCapacity();
@@ -2889,12 +2889,9 @@ pub fn Runtime(comptime App: type) type {
             syncTerminalTitle(app);
         }
 
-        /// Drops C0 and DEL bytes. The cached title feeds the statusline and
-        /// the OSC 2 terminal title, where a stray BEL or ESC would close the
-        /// escape sequence early and hand the remaining bytes to the terminal
-        /// as commands. Derived titles come from prompt text and from the
-        /// display sidecar, so neither source is trusted here; `/rename` input
-        /// is already rejected by `validateSessionTitle`.
+        /// Drops C0 and DEL bytes before the cached title reaches the statusline.
+        /// Derived titles come from untrusted prompt text and display sidecars;
+        /// `/rename` input is already rejected by `validateSessionTitle`.
         fn appendTitleWithoutControlBytes(app: *App, title: []const u8) !void {
             var start: usize = 0;
             for (title, 0..) |byte, index| {
@@ -2913,65 +2910,18 @@ pub fn Runtime(comptime App: type) type {
             @compileError("interactive session runtime requires a terminal title host capability");
         }
 
-        const terminal_title_primary_max_bytes: usize = 64;
-        const terminal_title_model_max_bytes: usize = 48;
-        const terminal_title_separator = " · ";
-        const terminal_title_label_max_bytes = terminal_title_primary_max_bytes +
-            terminal_title_separator.len + terminal_title_model_max_bytes;
-
-        fn workspaceTerminalTitle(app: *App) []const u8 {
-            if (comptime !@hasField(App, "workspace_root")) return "workspace";
-            const basename = std.fs.path.basename(app.workspace_root);
-            return if (basename.len == 0) "workspace" else basename;
-        }
-
-        fn writeBoundedTerminalTitleComponent(
-            writer: *std.Io.Writer,
-            value: []const u8,
-            max_bytes: usize,
-        ) !void {
-            if (value.len <= max_bytes) return writer.writeAll(value);
-            const marker = "...";
-            const prefix_budget = max_bytes - marker.len;
-            const prefix = if (std.unicode.utf8ValidateSlice(value))
-                text_utils.utf8PrefixByBytes(value, prefix_budget)
-            else
-                value[0..prefix_budget];
-            try writer.writeAll(prefix);
-            try writer.writeAll(marker);
-        }
-
-        /// Terminal tabs prefer the session name and otherwise use the
-        /// workspace basename. The active model remains visible as secondary
-        /// context, including after a model switch.
+        /// Terminal tabs identify the running build independently of the session.
         pub fn syncTerminalTitle(app: *App) void {
             if (comptime !provider_runtime.supported(App)) return;
             syncTerminalTitleWith(app, terminalTitle(app));
         }
 
         pub fn syncTerminalTitleWith(
-            app: *App,
+            _: *App,
             provider: host_capability.TerminalTitle,
         ) void {
             if (comptime !provider_runtime.supported(App)) return;
-            var label_buffer: [terminal_title_label_max_bytes]u8 = undefined;
-            var writer: std.Io.Writer = .fixed(&label_buffer);
-            const primary = cachedSessionTitle(app) orelse workspaceTerminalTitle(app);
-            writeBoundedTerminalTitleComponent(
-                &writer,
-                primary,
-                terminal_title_primary_max_bytes,
-            ) catch return;
-            const selected_model = provider_runtime.model(app);
-            if (selected_model.len > 0) {
-                writer.writeAll(terminal_title_separator) catch return;
-                writeBoundedTerminalTitleComponent(
-                    &writer,
-                    selected_model,
-                    terminal_title_model_max_bytes,
-                ) catch return;
-            }
-            provider.set(writer.buffered());
+            provider.set("v" ++ build_options.app_version);
         }
 
         pub fn cachedSessionTitle(app: *App) ?[]const u8 {
@@ -10105,8 +10055,7 @@ test "renameActiveSession persists the title to the sidecar and session index" {
         Runtime(TestApp).cachedSessionTitle(&app).?,
     );
 
-    // And carried to the terminal tab.
-    try std.testing.expectEqualStrings("deploy pipeline fix", app.terminalTitleLabelText());
+    try std.testing.expectEqualStrings("v" ++ build_options.app_version, app.terminalTitleLabelText());
 
     // Durable in the sidecar.
     const loaded = &app.session_persistence.writable.?;
@@ -10242,7 +10191,7 @@ test "ensureCachedSessionTitle derives from the first prompt and then freezes" {
     try std.testing.expect(Runtime(TestApp).cachedSessionTitle(&app) == null);
 }
 
-test "terminal title combines session or workspace with the active model" {
+test "terminal title initializes to the build version and ignores session and model changes" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -10255,11 +10204,13 @@ test "terminal title combines session or workspace with the active model" {
     var app = try TestApp.init(alloc, paths.workspace);
     defer app.deinit();
 
-    try app.selected_model.appendSlice(alloc, "zai/glm-5.2");
-
-    // Before the first turn names the session, tabs show workspace and model.
+    try std.testing.expectEqualStrings("", app.terminalTitleLabelText());
     Runtime(TestApp).syncTerminalTitle(&app);
-    try std.testing.expectEqualStrings("workspace · zai/glm-5.2", app.terminalTitleLabelText());
+    try std.testing.expectEqualStrings("v" ++ build_options.app_version, app.terminalTitleLabelText());
+
+    try app.selected_model.appendSlice(alloc, "zai/glm-5.2");
+    Runtime(TestApp).syncTerminalTitle(&app);
+    try std.testing.expectEqualStrings("v" ++ build_options.app_version, app.terminalTitleLabelText());
 
     try app.session.appendHistoryEntry(alloc, .{ .assistant = .{
         .user = .{ .text = @constCast("wire the release notes generator") },
@@ -10268,26 +10219,19 @@ test "terminal title combines session or workspace with the active model" {
     } });
     try Runtime(TestApp).ensureCachedSessionTitle(&app);
     try std.testing.expectEqualStrings(
-        "wire the release notes generator · zai/glm-5.2",
-        app.terminalTitleLabelText(),
+        "wire the release notes generator",
+        Runtime(TestApp).cachedSessionTitle(&app).?,
     );
+    try std.testing.expectEqualStrings("v" ++ build_options.app_version, app.terminalTitleLabelText());
 
-    // A model switch preserves the session discriminator and updates the
-    // secondary model context.
     app.selected_model.clearRetainingCapacity();
     try app.selected_model.appendSlice(alloc, "anthropic/claude-opus-5");
     Runtime(TestApp).syncTerminalTitle(&app);
-    try std.testing.expectEqualStrings(
-        "wire the release notes generator · anthropic/claude-opus-5",
-        app.terminalTitleLabelText(),
-    );
+    try std.testing.expectEqualStrings("v" ++ build_options.app_version, app.terminalTitleLabelText());
 
-    // Starting over hands the primary discriminator back to the workspace.
     Runtime(TestApp).clearCachedSessionTitle(&app);
-    try std.testing.expectEqualStrings(
-        "workspace · anthropic/claude-opus-5",
-        app.terminalTitleLabelText(),
-    );
+    try std.testing.expect(Runtime(TestApp).cachedSessionTitle(&app) == null);
+    try std.testing.expectEqualStrings("v" ++ build_options.app_version, app.terminalTitleLabelText());
 }
 
 test "cached session title drops control bytes before they reach the terminal" {
@@ -10303,18 +10247,16 @@ test "cached session title drops control bytes before they reach the terminal" {
     var app = try TestApp.init(alloc, paths.workspace);
     defer app.deinit();
 
-    // Derived titles come from prompt text and from the display sidecar, so a
-    // BEL could otherwise close the OSC 2 sequence and hand the rest of the
-    // title to the terminal as commands.
+    try app.selected_model.appendSlice(alloc, "provider/\x07\x1b]2;owned\x7fmodel");
     try Runtime(TestApp).setCachedSessionTitle(&app, "safe\x07\x1b]2;owned\x7ftail");
     try std.testing.expectEqualStrings(
         "safe]2;ownedtail",
         Runtime(TestApp).cachedSessionTitle(&app).?,
     );
-    try std.testing.expectEqualStrings("safe]2;ownedtail", app.terminalTitleLabelText());
+    try std.testing.expectEqualStrings("v" ++ build_options.app_version, app.terminalTitleLabelText());
 }
 
-test "terminal title bounds session and model context" {
+test "terminal title ignores long session and model context" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -10330,8 +10272,5 @@ test "terminal title bounds session and model context" {
     try app.selected_model.appendSlice(alloc, "provider/" ++ ("model" ** 20));
     try Runtime(TestApp).setCachedSessionTitle(&app, "session-" ++ ("title" ** 20));
 
-    const label = app.terminalTitleLabelText();
-    try std.testing.expect(label.len <= Runtime(TestApp).terminal_title_label_max_bytes);
-    try std.testing.expect(std.mem.find(u8, label, "...") != null);
-    try std.testing.expect(std.mem.find(u8, label, " · provider/") != null);
+    try std.testing.expectEqualStrings("v" ++ build_options.app_version, app.terminalTitleLabelText());
 }

--- a/src/core/session/session_commands.zig
+++ b/src/core/session/session_commands.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const build_options = @import("build_options");
 const app_permission_runtime = @import("../app/app_permission_runtime.zig");
 const app_session_runtime = @import("../app/app_session_runtime.zig");
 const auth_runtime = @import("../auth/auth_runtime.zig");
@@ -1124,8 +1125,6 @@ pub fn Commands(comptime App: type) type {
             const selected = provider_runtime.model(app);
             try app.worker.syncQueuedPromptModel(std.heap.c_allocator, selected);
             if (comptime @hasDecl(App, "persistAcceptedModel")) try app.persistAcceptedModel(selected);
-            // Keep the session or workspace discriminator while updating the
-            // model shown as secondary terminal-tab context.
             app_session_runtime.Runtime(App).syncTerminalTitle(app);
 
             if (announce) {
@@ -2197,7 +2196,7 @@ test "session_commands handleModel resolves fuzzy cached model and syncs queued 
     try std.testing.expectEqualStrings("anthropic/claude-sonnet-4-20250514", app.worker.synced_model.?);
     try std.testing.expectEqual(model_provider.ProviderId.codex, app.last_preference_provider.?);
     try std.testing.expectEqualStrings(
-        "workspace · anthropic/claude-sonnet-4-20250514",
+        "v" ++ build_options.app_version,
         app.terminalTitleLabelText(),
     );
     try expectTranscriptContains(&app, "● Switched to anthropic/claude-sonnet-4-20250514");
@@ -2214,7 +2213,7 @@ test "session_commands handleModel falls back to raw query when model fetch fail
     try std.testing.expectEqualStrings("custom/provider-model", app.selected_model.items);
     try std.testing.expectEqualStrings("custom/provider-model", app.worker.synced_model.?);
     try std.testing.expectEqualStrings(
-        "workspace · custom/provider-model",
+        "v" ++ build_options.app_version,
         app.terminalTitleLabelText(),
     );
 }
@@ -2750,7 +2749,7 @@ test "session_commands model picker accepts the current selected model slice" {
     try std.testing.expectEqualStrings("anthropic/claude-opus-4.6", app.worker.synced_model.?);
     try std.testing.expectEqualStrings("anthropic/claude-opus-4.6", app.last_preference_model.items);
     try std.testing.expectEqualStrings(
-        "workspace · anthropic/claude-opus-4.6",
+        "v" ++ build_options.app_version,
         app.terminalTitleLabelText(),
     );
     try std.testing.expectEqual(types.ReasoningEffort.literal("high"), app.effort);

--- a/src/ui/render.zig
+++ b/src/ui/render.zig
@@ -669,7 +669,7 @@ fn titleOutput(raw: ?*anyopaque) std.Io.File {
 }
 
 const terminal_title_osc_prefix = "\x1b]2;";
-const terminal_title_display_prefix = "fx · ";
+const terminal_title_display_prefix = "fx ";
 const terminal_title_max_content_bytes: usize = 128;
 const terminal_title_max_label_bytes = terminal_title_max_content_bytes - terminal_title_display_prefix.len;
 
@@ -729,13 +729,13 @@ test "terminal title writes the label to the caller's output file" {
 
     // A host that redirects its output keeps the escape sequence off the
     // real stdout, which the Zig test runner owns as its protocol channel.
-    terminalTitleFor(&sink).set("release notes");
+    terminalTitleFor(&sink).set("v" ++ main.version);
 
     var written_file = try tmp.dir.openFile(io_mod.getIo(), "terminal-title.log", .{});
     defer written_file.close(io_mod.getIo());
     const written = try io_mod.readFileToEnd(alloc, &written_file, 128);
     defer alloc.free(written);
-    try std.testing.expectEqualStrings("\x1b]2;fx · release notes\x07", written);
+    try std.testing.expectEqualStrings("\x1b]2;fx v" ++ main.version ++ "\x07", written);
 }
 
 test "terminal title sanitizes and bounds untrusted labels" {
@@ -752,7 +752,7 @@ test "terminal title sanitizes and bounds untrusted labels" {
     const written = try io_mod.readFileToEnd(alloc, &written_file, 512);
     defer alloc.free(written);
     try std.testing.expect(written.len <= terminal_title_osc_prefix.len + terminal_title_max_content_bytes + 1);
-    try std.testing.expect(std.mem.startsWith(u8, written, "\x1b]2;fx · safe]2;owned"));
+    try std.testing.expect(std.mem.startsWith(u8, written, "\x1b]2;fx safe]2;owned"));
     try std.testing.expect(std.mem.endsWith(u8, written, "...\x07"));
     try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, written, "\x07"));
     try std.testing.expect(std.mem.find(u8, written[terminal_title_osc_prefix.len..], "\x1b") == null);

--- a/tests/e2e/tui-composer-edit-contracts.test.ts
+++ b/tests/e2e/tui-composer-edit-contracts.test.ts
@@ -16,6 +16,7 @@ import {
   composerContains,
   FAKE_GATEWAY_MODEL,
   fakeGatewayFinalText,
+  hasEmptyComposer,
   startFakeGateway,
   TmuxSession,
   tmuxAvailable,
@@ -92,7 +93,7 @@ async function startFx(
     gateway = startFakeGateway(
       Array.from(
         { length: responseCount },
-        () => fakeGatewayFinalText("edit contract complete"),
+        (_, index) => fakeGatewayFinalText(`edit contract complete ${index + 1}`),
       ),
       {
         models: [{
@@ -149,6 +150,17 @@ function historyImageSnapshotPath(): string {
 
 async function waitForGatewayRequest(count = 1): Promise<void> {
   await waitForGatewayRequestWithin(TIMEOUT, count);
+}
+
+async function waitForCompletedTurn(active: TmuxSession, count: number): Promise<void> {
+  await active.waitForPane(
+    (pane) =>
+      pane.includes(`edit contract complete ${count}`) &&
+      hasEmptyComposer(pane) &&
+      !pane.includes("esc interrupt") &&
+      !pane.includes("Thinking"),
+    TIMEOUT,
+  );
 }
 
 async function waitForGatewayRequestWithin(
@@ -267,7 +279,7 @@ tmuxTest(
     await waitForGatewayRequest(1);
     expect(finalUserText(0)).toBe("Xabc");
 
-    await active.waitForComposer(TIMEOUT);
+    await waitForCompletedTurn(active, 1);
     await active.sendLiteralText("/");
     await active.sendHexBytes(["1b", "15", ...textHex("after")]);
     await active.sendKeys("Enter");
@@ -568,7 +580,7 @@ tmuxTest(
 
     expect(finalUserText(0)).toBe("FIRST\nHOME_SECOND_END\nTHIRD");
 
-    await active.waitForComposer(TIMEOUT);
+    await waitForCompletedTurn(active, 1);
     await pasteExact(active, "ONE\nTWO\nTHREE");
     await active.sendKeys("Up");
     await active.sendHexBytes(["01"]);
@@ -964,7 +976,7 @@ tmuxTest(
     await waitForGatewayRequest(1);
     expect(finalUserText(0)).toBe("$review @target.txt ");
 
-    await active.waitForComposer(TIMEOUT);
+    await waitForCompletedTurn(active, 1);
     await selectReviewSkill(active);
     await active.sendLiteralText("hello");
     await active.sendHexBytes(["1b", "62", "1b", "62"]);
@@ -973,7 +985,7 @@ tmuxTest(
     await waitForGatewayRequest(2);
     expect(finalUserText(1)).toBe("X$review hello");
 
-    await active.waitForComposer(TIMEOUT);
+    await waitForCompletedTurn(active, 2);
     await selectReviewSkill(active);
     await active.sendHexBytes(["1b", "7f"]);
     await active.sendLiteralText("ALT_BACKSPACE_OK");
@@ -981,7 +993,7 @@ tmuxTest(
     await waitForGatewayRequest(3);
     expect(finalUserText(2)).toBe("ALT_BACKSPACE_OK");
 
-    await active.waitForComposer(TIMEOUT);
+    await waitForCompletedTurn(active, 3);
     await selectReviewSkill(active);
     await active.sendKeys("Home");
     await active.sendHexBytes(["04"]);

--- a/tests/e2e/tui-slash-menu.test.ts
+++ b/tests/e2e/tui-slash-menu.test.ts
@@ -243,7 +243,12 @@ async function waitForWorkspaceMenu(session: TmuxSession): Promise<string[]> {
   while (Date.now() < deadline) {
     latest = await session.capturePaneGrid();
     const pane = latest.join("\n");
-    if (pane.includes("Workspace") && pane.includes("Enter Use")) return latest;
+    if (
+      pane.includes("Workspace") &&
+      pane.includes("Additional directories") &&
+      pane.includes("Add directory…") &&
+      pane.includes("Enter Use")
+    ) return latest;
     await Bun.sleep(100);
   }
   throw new Error(`Timed out waiting for workspace menu.\nPane:\n${latest.join("\n")}`);
@@ -1813,7 +1818,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       await session.sendKeys("Right");
       grid = await waitForStatuslineMenu(session, "off  on");
       pane = grid.join("\n");
-      expect(JSON.parse(readFileSync(settingsPath, "utf8")).statusLine.context).toBe(true);
+      await waitForStatuslineValue(settingsPath, "context", true);
 
       await session.sendKeys("Down");
       await session.sendKeys("Right");
@@ -1821,7 +1826,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       pane = grid.join("\n");
       expect(pane).not.toContain("saved to user settings");
       expect(pane).not.toContain("● Statusline:");
-      expect(JSON.parse(readFileSync(settingsPath, "utf8")).statusLine.session).toBe(true);
+      await waitForStatuslineValue(settingsPath, "session", true);
 
       await session.sendKeys("Down");
       await session.sendKeys("Right");

--- a/tests/e2e/tui-slash-menu.test.ts
+++ b/tests/e2e/tui-slash-menu.test.ts
@@ -84,6 +84,22 @@ function captureViewportEscapes(session: TmuxSession): string {
   });
 }
 
+function runningBinaryTitle(): string {
+  const version = execFileSync(FX_BIN, ["--version"], { encoding: "utf8" }).trim();
+  expect(version).toMatch(/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/);
+  return `fx v${version}`;
+}
+
+async function expectCleanTitleTranscript(session: TmuxSession, title: string): Promise<void> {
+  const transcript = await session.captureFullScrollback();
+  expect(transcript.trim().length).toBeGreaterThan(0);
+  expect(transcript).not.toContain(title);
+  expect(transcript).not.toContain("]0;");
+  expect(transcript).not.toContain("]2;");
+  expect(transcript).not.toContain("\x1b");
+  expect(transcript).not.toContain("\x07");
+}
+
 async function waitForPaneTitle(
   session: TmuxSession,
   expected: string,
@@ -796,8 +812,9 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
   );
 
   test(
-    "terminal tab title follows the session name across rename and resume",
+    "terminal tab title stays at the running binary version across rename, resume, and new session",
     async () => {
+      const title = runningBinaryTitle();
       const workDir = mkdtempSync(join(tmpdir(), "fx-title-rename-e2e-"));
       workDirs.push(workDir);
       const home = join(workDir, "home");
@@ -833,27 +850,34 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
         width: 120,
         height: 32,
         isolated: true,
+        remainOnExit: true,
       });
       await session.waitForComposer(10_000);
+      await waitForPaneTitle(session, title, 5_000);
+      await expectCleanTitleTranscript(session, title);
 
-      // Before the first turn names the session, the workspace distinguishes
-      // parallel tabs while the model remains visible.
-      expect(await session.paneTitle()).toBe(`fx · workspace · ${model}`);
-
-      // The first prompt names the session, and the tab follows it.
+      // Naming the session must not add session or model context to the title.
       await session.sendText("generate the release notes");
       await session.waitForText("TITLE_RENAME_COMPLETE", 30_000);
-      await waitForPaneTitle(session, `fx · generate the release notes · ${model}`, 5_000);
+      await session.waitForStableComposer();
+      await waitForPaneTitle(session, title, 5_000);
+      await expectCleanTitleTranscript(session, title);
 
       await session.sendText("/rename deploy pipeline fix");
       await session.waitForText("renamed: deploy pipeline fix", 10_000);
-      await waitForPaneTitle(session, `fx · deploy pipeline fix · ${model}`, 5_000);
+      await session.waitForStableComposer();
+      await waitForPaneTitle(session, title, 5_000);
+      await expectCleanTitleTranscript(session, title);
 
       await session.sendText("/quit");
-      expect(await session.waitForSessionEnd(10_000)).toBe(true);
+      await session.waitForPane(() => session!.paneStatus().dead, 10_000);
+      expect(session.paneStatus()).toEqual({ dead: true, status: 0 });
+      expect(session.isAlive()).toBe(true);
+      expect(await session.paneTitle()).toBe("");
+      await expectCleanTitleTranscript(session, title);
+      expect(readFileSync(stderrPath, "utf8")).toBe("");
       await session.kill();
       session = null;
-      expect(readFileSync(stderrPath, "utf8")).toBe("");
 
       const sessionIds = readdirSync(join(home, ".fx", "sessions"), {
         withFileTypes: true,
@@ -862,7 +886,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
         .map((entry) => entry.name);
       expect(sessionIds).toHaveLength(1);
 
-      // Resuming restores both the chosen name and active model context.
+      // Restoring a named session must keep the same version-only title.
       gateway.stop();
       gateway = startFakeGateway([]);
       session = await TmuxSession.create({
@@ -877,15 +901,27 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
         width: 120,
         height: 32,
         isolated: true,
+        remainOnExit: true,
       });
       await session.waitForComposer(10_000);
-      await waitForPaneTitle(session, `fx · deploy pipeline fix · ${model}`, 5_000);
+      await waitForPaneTitle(session, title, 5_000);
+      expect(await session.captureFullScrollback()).toContain("TITLE_RENAME_COMPLETE");
+      await expectCleanTitleTranscript(session, title);
+
+      await session.sendText("/new");
+      await session.waitForStableComposer();
+      await waitForPaneTitle(session, title, 5_000);
+      await expectCleanTitleTranscript(session, title);
 
       await session.sendText("/quit");
-      expect(await session.waitForSessionEnd(10_000)).toBe(true);
+      await session.waitForPane(() => session!.paneStatus().dead, 10_000);
+      expect(session.paneStatus()).toEqual({ dead: true, status: 0 });
+      expect(session.isAlive()).toBe(true);
+      expect(await session.paneTitle()).toBe("");
+      await expectCleanTitleTranscript(session, title);
+      expect(readFileSync(resumedStderrPath, "utf8")).toBe("");
       await session.kill();
       session = null;
-      expect(readFileSync(resumedStderrPath, "utf8")).toBe("");
     },
     TEST_TIMEOUT,
   );
@@ -2791,7 +2827,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
         height: 32,
       });
       await session.waitForComposer(10_000);
-      expect(await session.paneTitle()).toBe(`fx · workspace · ${currentModel}`);
+      expect(await session.paneTitle()).toBe(runningBinaryTitle());
 
       const alternateCount = (sequence: string) =>
         countOccurrences(readFileSync(fixture.tapePath).toString("latin1"), sequence);
@@ -2906,7 +2942,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
 
       const settings = JSON.parse(readFileSync(fixture.settingsPath, "utf8")) as { models?: { gateway?: string } };
       expect(settings.models?.gateway).toBe(selectedModel);
-      expect(await session.paneTitle()).toBe(`fx · workspace · ${selectedModel}`);
+      expect(await session.paneTitle()).toBe(runningBinaryTitle());
       expect(session.isAlive()).toBe(true);
 
       await session.sendText("/quit");
@@ -3020,7 +3056,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       expect(pane).not.toContain("Reasoning effort");
       expect(pane).not.toContain("default");
       expect(JSON.parse(readFileSync(fixture.settingsPath, "utf8")).models.gateway).toBe(selectedModel);
-      expect(await session.paneTitle()).toBe(`fx · workspace · ${selectedModel}`);
+      expect(await session.paneTitle()).toBe(runningBinaryTitle());
       expect(session.isAlive()).toBe(true);
       expect(readFileSync(fixture.stderrPath, "utf8")).toBe("");
 


### PR DESCRIPTION
## Summary

- Show `fx v<version>` in terminal tabs using the running binary's version instead of the session, workspace, and model.
- Keep the version title unchanged across session renames, resumes, new sessions, and model switches.
