### PR TITLE
Keep rejected tool inputs safe to replay

### DIFF
--- a/src/core/agent/runtime/lifecycle.zig
+++ b/src/core/agent/runtime/lifecycle.zig
@@ -105,6 +105,97 @@ test "PreparedToolCall exposes only consuming blocked output access" {
     try std.testing.expect(!@hasDecl(PreparedToolCall, "blockedOutput"));
 }
 
+test "non-object function arguments are blocked before hooks with safe replay input" {
+    const alloc = std.testing.allocator;
+    const Capture = struct {
+        calls: usize = 0,
+        fn run(raw: *anyopaque, _: hooks.PreToolUseInput) hooks.HandlerError!hooks.PreToolUseAction {
+            const self: *@This() = @ptrCast(@alignCast(raw));
+            self.calls += 1;
+            return .continue_;
+        }
+    };
+    var capture = Capture{};
+    var runtime = hooks.Runtime.init(alloc);
+    defer runtime.deinit();
+    try runtime.registerPreToolUse(.{ .name = "observe", .ctx = &capture, .run = Capture.run });
+    const context = LifecycleContext{
+        .view = runtime.freeze(),
+        .scope = .{ .kind = .ask, .workspace_root = "/fixture" },
+        .outcome_allocator = alloc,
+    };
+    for ([_][]const u8{ "[]", "[1]", "42", "null", "true", "\"text\"" }) |arguments| {
+        const call = ToolCall{ .id = "rejected", .name = "read_file", .arguments_json = arguments };
+        var prepared = try prepareToolCallForLifecycle(alloc, context, null, 1, 0, call);
+        defer prepared.deinit(alloc);
+        try std.testing.expect(prepared == .blocked);
+        try std.testing.expectEqual(@as(usize, 0), capture.calls);
+        try std.testing.expectEqualStrings("{}", prepared.call().arguments_json);
+        try std.testing.expectEqualStrings("rejected", prepared.call().id);
+        try std.testing.expectEqualStrings("read_file", prepared.call().name);
+        try std.testing.expect(prepared.call().argument_integrity != .valid);
+        try std.testing.expect(std.mem.find(u8, prepared.blocked.model_output.?, "object") != null);
+        try std.testing.expectEqualStrings(arguments, call.arguments_json);
+    }
+
+    const arguments = " {\"items\":[1,{\"nested\":true}]} ";
+    var valid = try prepareToolCallForLifecycle(alloc, context, null, 1, 0, .{
+        .id = "valid",
+        .name = "read_file",
+        .arguments_json = arguments,
+    });
+    defer valid.deinit(alloc);
+    try std.testing.expect(valid == .ready);
+    try std.testing.expectEqualStrings(arguments, valid.call().arguments_json);
+    try std.testing.expectEqual(@as(usize, 1), capture.calls);
+}
+
+test "non-object calls blocked by policy retain the policy result and safe replay input" {
+    const alloc = std.testing.allocator;
+    const call = ToolCall{ .id = "held", .name = "read_file", .arguments_json = "[]" };
+    var prepared = try makePreparedBlocked(alloc, call, .lifecycle_block, "policy held this call");
+    defer prepared.deinit(alloc);
+    try std.testing.expectEqualStrings("{}", prepared.call().arguments_json);
+    try std.testing.expect(prepared.call().argument_integrity != .valid);
+    try std.testing.expect(std.mem.find(u8, prepared.blocked.model_output.?, "policy held this call") != null);
+    try std.testing.expectEqualStrings("[]", call.arguments_json);
+}
+
+test "non-object provider-executed input remains provider owned" {
+    const alloc = std.testing.allocator;
+    const context = LifecycleContext{
+        .view = hooks.RuntimeView.empty(),
+        .scope = .{ .kind = .ask, .workspace_root = "/fixture" },
+        .outcome_allocator = alloc,
+    };
+    var prepared = try prepareToolCallForLifecycle(alloc, context, null, 1, 0, .{
+        .id = "native",
+        .name = "native_tool",
+        .arguments_json = "[]",
+        .provenance = .provider_executed,
+        .provider_result = "recorded result",
+    });
+    defer prepared.deinit(alloc);
+    try std.testing.expect(prepared == .provider_executed);
+    try std.testing.expectEqualStrings("[]", prepared.call().arguments_json);
+    try std.testing.expectEqualStrings("recorded result", prepared.call().provider_result.?);
+}
+
+fn checkNonObjectPreparationAllocationFailures(alloc: Allocator) !void {
+    var prepared = try prepareToolCallForLifecycle(alloc, .{
+        .view = hooks.RuntimeView.empty(),
+        .scope = .{ .kind = .ask, .workspace_root = "/fixture" },
+        .outcome_allocator = alloc,
+    }, null, 1, 0, .{ .id = "call", .name = "read_file", .arguments_json = "[1]" });
+    defer prepared.deinit(alloc);
+    try std.testing.expect(prepared == .blocked);
+    try std.testing.expectEqualStrings("{}", prepared.call().arguments_json);
+}
+
+test "non-object preparation cleans every failed allocation" {
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, checkNonObjectPreparationAllocationFailures, .{});
+}
+
 pub noinline fn prepareToolCallForLifecycle(
     result_allocator: Allocator,
     lifecycle: LifecycleContext,
@@ -135,10 +226,16 @@ fn prepareToolCallFromCheckpoint(
     if (call.provenance == .provider_executed) {
         return .{ .provider_executed = try types.dupeToolCall(result_allocator, call) };
     }
-    if (call.argument_integrity == .malformed_json) {
+    const integrity = if (call.argument_integrity == .valid)
+        try types.ToolArgumentIntegrity.classifyFunctionInput(result_allocator, call.arguments_json)
+    else
+        call.argument_integrity;
+    if (integrity != .valid) {
+        var rejected = call;
+        rejected.argument_integrity = integrity;
         return makePreparedBlocked(
             result_allocator,
-            call,
+            rejected,
             .malformed_arguments,
             null,
         );
@@ -275,19 +372,32 @@ fn preparedCallFromPreToolUseOutcome(
     };
 }
 
+/// Returns an owned copy for an already-blocked call, never for execution.
+pub fn dupeBlockedToolCall(alloc: Allocator, call: ToolCall) !ToolCall {
+    var replay = call;
+    if (call.provenance != .provider_executed) {
+        replay.argument_integrity = if (call.argument_integrity == .valid)
+            try types.ToolArgumentIntegrity.classifyFunctionInput(alloc, call.arguments_json)
+        else
+            call.argument_integrity;
+        if (replay.argument_integrity != .valid) replay.arguments_json = "{}";
+    }
+    return types.dupeToolCall(alloc, replay);
+}
+
 fn makePreparedBlocked(
     alloc: Allocator,
     call: ToolCall,
     kind: PreparedToolBlockKind,
     reason: ?[]const u8,
 ) !PreparedToolCall {
-    const owned_call = try types.dupeToolCall(alloc, call);
+    const owned_call = try dupeBlockedToolCall(alloc, call);
     errdefer types.freeToolCall(alloc, owned_call);
     const model_output = switch (kind) {
-        .malformed_arguments => try tool_result_errors.malformedToolArgumentsJson(
-            alloc,
-            call.name,
-        ),
+        .malformed_arguments => if (call.argument_integrity == .non_object_json)
+            try tool_result_errors.nonObjectToolArgumentsJson(alloc, call.name)
+        else
+            try tool_result_errors.malformedToolArgumentsJson(alloc, call.name),
         .lifecycle_block => try tool_result_errors.preToolUseBlockedJson(
             alloc,
             call.name,

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -762,7 +762,7 @@ fn project_subagent_request_messages(
         if (message.role != .assistant) continue;
         for (message.tool_calls) |call| {
             if (!std.mem.eql(u8, call.name, "subagent")) continue;
-            if (call.argument_integrity != .valid) {
+            if (call.argument_integrity == .malformed_json) {
                 try calls.append(alloc, .{
                     .id = call.id,
                     .action = "malformed",
@@ -892,6 +892,42 @@ fn project_subagent_request_messages(
         }
     }
     return projected;
+}
+
+test "non-object subagent rejection keeps its call and result during projection" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const alloc = arena_state.allocator();
+    const tool = tool_dispatch.Tool{
+        .name = "subagent",
+        .description = "subagent",
+        .model_schema = .{ .name = "subagent", .description = "subagent" },
+        .executor_kind = .subagent,
+        .decode = undefined,
+        .call = undefined,
+        .reads_only_fn = undefined,
+        .irreversible_fn = undefined,
+    };
+    var calls = [_]ToolCall{
+        .{ .id = "rejected", .name = "subagent", .arguments_json = "{}", .argument_integrity = .non_object_json },
+        .{ .id = "valid", .name = "read_file", .arguments_json = "{\"path\":\"file\"}" },
+    };
+    const messages = [_]ChatMessage{
+        .{ .role = .assistant, .tool_calls = &calls },
+        .{ .role = .tool, .tool_call_id = "rejected", .tool_name = "subagent", .content = "not executed", .tool_result_status = .failure },
+        .{ .role = .tool, .tool_call_id = "valid", .tool_name = "read_file", .content = "contents", .tool_result_status = .success },
+    };
+    for (0..2) |_| {
+        const projected = try project_subagent_request_messages(alloc, .{ .tools = &.{tool} }, true, &messages);
+        try std.testing.expectEqual(@as(usize, 2), projected[0].tool_calls.len);
+        try std.testing.expectEqualStrings("rejected", projected[0].tool_calls[0].id);
+        try std.testing.expectEqualStrings("{}", projected[0].tool_calls[0].arguments_json);
+        try std.testing.expectEqual(types.ChatRole.tool, projected[1].role);
+        try std.testing.expectEqualStrings("rejected", projected[1].tool_call_id.?);
+        try std.testing.expectEqualStrings("not executed", projected[1].content.?);
+        try std.testing.expectEqual(types.PersistedToolStatus.failure, projected[1].tool_result_status.?);
+        calls[0].argument_integrity = .valid;
+    }
 }
 
 test "subagent history makes every removed manager action inert" {
@@ -7248,7 +7284,7 @@ fn processQueuedPromptLoop(
             if (successful_vision_mode == .required and
                 !std.mem.eql(u8, tool_call.name, "vision"))
             {
-                const owned_call = try types.dupeToolCall(arena, tool_call);
+                const owned_call = try runtime_lifecycle.dupeBlockedToolCall(arena, tool_call);
                 errdefer types.freeToolCall(arena, owned_call);
                 prepared_tool_calls[tool_call_index] = .{ .blocked = .{
                     .call = owned_call,
@@ -7267,7 +7303,7 @@ fn processQueuedPromptLoop(
             if (std.mem.eql(u8, tool_call.name, "vision") and
                 successful_vision_mode == .unavailable)
             {
-                const owned_call = try types.dupeToolCall(arena, tool_call);
+                const owned_call = try runtime_lifecycle.dupeBlockedToolCall(arena, tool_call);
                 errdefer types.freeToolCall(arena, owned_call);
                 prepared_tool_calls[tool_call_index] = .{ .blocked = .{
                     .call = owned_call,
@@ -8002,7 +8038,7 @@ fn processQueuedPromptLoop(
                     admitted_precomputed_results,
                 ) |parallel_call, precomputed| {
                     const execution = precomputed orelse continue;
-                    if (parallel_call.argument_integrity == .malformed_json) continue;
+                    if (parallel_call.argument_integrity != .valid) continue;
                     try runtime_tool_admission.recordRejectedToolCall(
                         deps,
                         arena,
@@ -8071,8 +8107,8 @@ fn processQueuedPromptLoop(
                             "tool",
                             "argument_integrity_rejected",
                             step_ctx,
-                            "call_id={s} name={s} failure=malformed_json provenance=fx_local",
-                            .{ tool_call.id, tool_call.name },
+                            "call_id={s} name={s} failure={s} provenance=fx_local",
+                            .{ tool_call.id, tool_call.name, @tagName(tool_call.argument_integrity) },
                         );
                     } else if (blocked.kind == .route_unavailable) {
                         debug_trace.eventf(
@@ -8139,12 +8175,13 @@ fn processQueuedPromptLoop(
                         "tool",
                         "execution_result",
                         step_ctx,
-                        "call_id={s} name={s} result_kind={s} model_output_bytes={d}",
+                        "call_id={s} name={s} result_kind={s} model_output_bytes={d} argument_integrity={s}",
                         .{
                             tool_call.id,
                             tool_call.name,
                             @tagName(blocked.kind),
                             prepared.model_output.len,
+                            @tagName(tool_call.argument_integrity),
                         },
                     );
                     try runtime_tool_batch.appendToolResultContent(
@@ -8161,7 +8198,7 @@ fn processQueuedPromptLoop(
                 },
                 .provider_executed, .ready => {},
             }
-            if (tool_call.argument_integrity == .malformed_json) {
+            if (tool_call.argument_integrity != .valid) {
                 unreachable;
             }
             if (config.cancel_flag.load(.seq_cst)) {

--- a/src/core/agent/runtime/tool_admission.zig
+++ b/src/core/agent/runtime/tool_admission.zig
@@ -294,7 +294,7 @@ pub const MalformedArgumentsRetryState = struct {
 
     pub fn observe(self: *MalformedArgumentsRetryState, call: ToolCall) void {
         self.current_call_count += 1;
-        if (call.argument_integrity != .malformed_json) return;
+        if (call.argument_integrity == .valid) return;
         self.current_malformed_count += 1;
     }
 
@@ -311,6 +311,19 @@ pub const MalformedArgumentsRetryState = struct {
         return self.consecutive_malformed_batches == max_consecutive_malformed_argument_batches;
     }
 };
+
+test "non-object arguments use the existing bounded invalid-argument retry budget" {
+    var state = MalformedArgumentsRetryState{};
+    const call: ToolCall = .{ .id = "bad", .name = "read_file", .arguments_json = "{}", .argument_integrity = .non_object_json };
+    for (0..3) |index| {
+        state.beginBatch();
+        state.observe(call);
+        try std.testing.expectEqual(index == 2, state.finishBatch());
+    }
+    state.beginBatch();
+    state.observe(.{ .id = "good", .name = "read_file", .arguments_json = "{}" });
+    try std.testing.expect(!state.finishBatch());
+}
 
 test "malformed arguments retry state stops consecutive all-malformed batches" {
     const malformed_read: ToolCall = .{

--- a/src/core/agent/runtime/tool_batch.zig
+++ b/src/core/agent/runtime/tool_batch.zig
@@ -207,7 +207,7 @@ pub fn assembleParallelToolResults(
                     );
                 };
             }
-        } else if (original_call.argument_integrity == .malformed_json) {
+        } else if (original_call.argument_integrity != .valid) {
             try provisional_statuses.finishMalformedToolArguments(
                 hooks,
                 arena,
@@ -218,8 +218,8 @@ pub fn assembleParallelToolResults(
                 "tool",
                 "argument_integrity_rejected",
                 step_ctx,
-                "call_id={s} name={s} failure=malformed_json provenance=fx_local",
-                .{ original_call.id, original_call.name },
+                "call_id={s} name={s} failure={s} provenance=fx_local",
+                .{ original_call.id, original_call.name, @tagName(original_call.argument_integrity) },
             );
             try runtime_tool_admission.recordRejectedToolCall(
                 hooks,

--- a/src/core/agent/runtime/tool_presentation.zig
+++ b/src/core/agent/runtime/tool_presentation.zig
@@ -165,8 +165,8 @@ pub const ProvisionalToolStatuses = struct {
         const call_id = self.visibleId(call) orelse return;
         const summary = try std.fmt.allocPrint(
             arena,
-            "{s} failed: invalid JSON arguments",
-            .{fallbackToolDisplay(hooks.tool_registry, call.name)},
+            "{s} failed: {s}",
+            .{ fallbackToolDisplay(hooks.tool_registry, call.name), if (call.argument_integrity == .non_object_json) "non-object arguments" else "invalid JSON arguments" },
         );
         try hooks.push_tool_lifecycle(hooks.ctx, .{
             .terminal = .{
@@ -1320,11 +1320,11 @@ fn commandArtifactHandle(
 pub fn malformedToolArgumentsResult(arena: Allocator, call: ToolCall) !ToolExecutionResult {
     return .{
         .status = .failure,
-        .model_output = try tool_result_errors.malformedToolArgumentsJson(
-            arena,
-            call.name,
-        ),
-        .status_detail = "invalid JSON arguments",
+        .model_output = if (call.argument_integrity == .non_object_json)
+            try tool_result_errors.nonObjectToolArgumentsJson(arena, call.name)
+        else
+            try tool_result_errors.malformedToolArgumentsJson(arena, call.name),
+        .status_detail = if (call.argument_integrity == .non_object_json) "non-object arguments" else "invalid JSON arguments",
     };
 }
 

--- a/src/core/agent/tool_preparation.zig
+++ b/src/core/agent/tool_preparation.zig
@@ -156,7 +156,7 @@ pub const ReadyCallBatch = struct {
 /// Classifies one effective `.ready` lifecycle call without permission,
 /// presentation, execution, or product-state mutation.
 pub fn prepareReadyCall(alloc: Allocator, call: ToolCall, config: Config) !Result {
-    if (call.provenance == .provider_executed or call.argument_integrity == .malformed_json) {
+    if (call.provenance == .provider_executed or call.argument_integrity != .valid) {
         return error.NotLifecycleReady;
     }
     try checkCancellation(config.cancel_flag);

--- a/src/core/session/session.zig
+++ b/src/core/session/session.zig
@@ -1465,14 +1465,29 @@ pub fn repairPersistedToolArguments(
     source: PersistedToolArgumentsSource,
 ) !void {
     for (calls) |call| {
-        if (call.argument_integrity == .malformed_json) {
+        if (call.argument_integrity != .valid) {
             _ = try persistedResultForMalformedCall(calls, results, call);
         }
     }
 
     for (calls) |*call| {
-        if (call.argument_integrity != .malformed_json) continue;
+        if (call.argument_integrity == .valid) continue;
         const result = try persistedResultForMalformedCall(calls, results, call.*);
+        const integrity = call.argument_integrity;
+        if (integrity == .non_object_json) {
+            // Repair replay input without changing what the stored result says happened.
+            if (call.provider_result != null or result.provider_native) {
+                call.provenance = .provider_executed;
+                call.argument_integrity = .valid;
+                continue;
+            }
+            const safe_arguments = try alloc.dupe(u8, "{}");
+            alloc.free(call.arguments_json);
+            call.arguments_json = safe_arguments;
+            call.argument_integrity = .valid;
+            tracePersistedToolArgumentsRepair(call.*, source, true, integrity);
+            continue;
+        }
         const failure_output = try tool_result_errors.malformedToolArgumentsJson(alloc, call.name);
 
         alloc.free(result.output);
@@ -1487,17 +1502,29 @@ pub fn repairPersistedToolArguments(
         result.truncated = false;
         result.provider_native = false;
         call.argument_integrity = .valid;
-        tracePersistedToolArgumentsRepair(call.*, source, true);
+        tracePersistedToolArgumentsRepair(call.*, source, true, integrity);
     }
 }
 
 pub fn repairPersistedInterruptedToolArguments(
+    alloc: Allocator,
     call: *ToolCall,
     source: PersistedToolArgumentsSource,
-) void {
-    if (call.argument_integrity != .malformed_json) return;
+) Allocator.Error!void {
+    if (call.argument_integrity == .valid) return;
+    const integrity = call.argument_integrity;
+    if (integrity == .non_object_json) {
+        if (call.provider_result != null) {
+            call.provenance = .provider_executed;
+            call.argument_integrity = .valid;
+            return;
+        }
+        const safe_arguments = try alloc.dupe(u8, "{}");
+        alloc.free(call.arguments_json);
+        call.arguments_json = safe_arguments;
+    }
     call.argument_integrity = .valid;
-    tracePersistedToolArgumentsRepair(call.*, source, false);
+    tracePersistedToolArgumentsRepair(call.*, source, false, integrity);
 }
 
 fn persistedResultForMalformedCall(
@@ -1527,13 +1554,14 @@ fn tracePersistedToolArgumentsRepair(
     call: ToolCall,
     source: PersistedToolArgumentsSource,
     paired_result: bool,
+    integrity: core_types.ToolArgumentIntegrity,
 ) void {
     debug_trace.eventf(
         "session",
         "persisted_tool_arguments_repaired",
         .{},
-        "source={s} call_id={s} tool={s} failure=malformed_json paired_result={s}",
-        .{ @tagName(source), call.id, call.name, if (paired_result) "true" else "false" },
+        "source={s} call_id={s} tool={s} failure={s} paired_result={s}",
+        .{ @tagName(source), call.id, call.name, @tagName(integrity), if (paired_result) "true" else "false" },
     );
 }
 

--- a/src/core/session/session_codec.zig
+++ b/src/core/session/session_codec.zig
@@ -1693,7 +1693,7 @@ fn parseToolCall(alloc: Allocator, value: std.json.Value) !session.ToolCall {
     errdefer alloc.free(name);
     var arguments_json = try parseRequiredDurableBytes(alloc, object, "arguments_json");
     errdefer alloc.free(arguments_json);
-    const argument_integrity = try types.ToolArgumentIntegrity.classifySerialized(alloc, arguments_json);
+    const argument_integrity = try types.ToolArgumentIntegrity.classifyFunctionInput(alloc, arguments_json);
     if (argument_integrity == .malformed_json) {
         const safe_arguments = try alloc.dupe(u8, "{}");
         alloc.free(arguments_json);
@@ -1717,7 +1717,8 @@ fn parseOptionalToolCall(alloc: Allocator, value: std.json.Value) !?session.Tool
         .null => null,
         .object => blk: {
             var call = try parseToolCall(alloc, value);
-            session.repairPersistedInterruptedToolArguments(&call, .schema_v3);
+            errdefer session.freeToolCall(alloc, call);
+            try session.repairPersistedInterruptedToolArguments(alloc, &call, .schema_v3);
             break :blk call;
         },
         else => error.InvalidSessionFormat,
@@ -2791,6 +2792,83 @@ test "durable state repairs duplicate-key execution and interrupted tool argumen
     const interrupted = decoded.history[1].interrupted.tool_call.?;
     try std.testing.expectEqualStrings("{}", interrupted.arguments_json);
     try std.testing.expectEqual(types.ToolArgumentIntegrity.valid, interrupted.argument_integrity);
+}
+
+test "non-object saved function inputs are repaired without changing recorded outcomes" {
+    const alloc = std.testing.allocator;
+    for ([_][]const u8{ "[]", "42", "null", "true", "\"text\"" }) |arguments| {
+        for ([_]session.PersistedToolStatus{ .success, .failure }) |status| {
+            for (0..3) |native_kind| {
+                var calls = [_]session.ToolCall{.{ .id = "call", .name = "read_file", .arguments_json = arguments }};
+                calls[0].provider_result = if (native_kind == 1) "provider result" else null;
+                var results = [_]session.PersistedToolResult{persistedResultForTest("call", "read_file")};
+                results[0].status = status;
+                results[0].provider_native = native_kind == 2;
+                results[0].output_handle = @constCast("retained-handle");
+                results[0].preview = @constCast("retained-preview");
+                var steps = [_]session.ToolExecutionStep{.{ .tool_calls = &calls, .tool_results = &results }};
+                const turn: session.HistoryTurn = .{ .assistant = .{
+                    .user = .{ .text = @constCast("read") },
+                    .assistant = @constCast("done"),
+                    .execution = .{ .tool_steps = &steps },
+                } };
+                var encoded: std.Io.Writer.Allocating = .init(alloc);
+                defer encoded.deinit();
+                try writeHistoryTurn(&encoded.writer, turn);
+                var parsed = try std.json.parseFromSlice(std.json.Value, alloc, encoded.written(), .{});
+                defer parsed.deinit();
+                const decoded = try parseHistoryTurn(alloc, parsed.value);
+                defer session.freeHistoryTurn(alloc, decoded);
+                const step = decoded.assistant.execution.tool_steps[0];
+                try std.testing.expectEqualStrings(if (native_kind == 0) "{}" else arguments, step.tool_calls[0].arguments_json);
+                try std.testing.expectEqual(if (native_kind == 0) types.ToolExecutionProvenance.fx_local else .provider_executed, step.tool_calls[0].provenance);
+                try std.testing.expectEqual(types.ToolArgumentIntegrity.valid, step.tool_calls[0].argument_integrity);
+                try std.testing.expectEqual(status, step.tool_results[0].status);
+                try std.testing.expectEqualStrings("stale", step.tool_results[0].output);
+                try std.testing.expectEqualStrings("retained-handle", step.tool_results[0].output_handle.?);
+                try std.testing.expectEqualStrings("retained-preview", step.tool_results[0].preview.?);
+                try std.testing.expectEqualStrings(arguments, calls[0].arguments_json);
+                try session.repairPersistedToolArguments(alloc, step.tool_calls, step.tool_results, .schema_v3);
+                try std.testing.expectEqualStrings(if (native_kind == 0) "{}" else arguments, step.tool_calls[0].arguments_json);
+                if (native_kind == 0 and status == .failure and std.mem.eql(u8, arguments, "[]")) {
+                    try std.testing.checkAllAllocationFailures(alloc, checkNonObjectHistoryAllocationFailures, .{parsed.value});
+                }
+            }
+        }
+    }
+}
+
+fn checkNonObjectHistoryAllocationFailures(alloc: Allocator, value: std.json.Value) !void {
+    const decoded = try parseHistoryTurn(alloc, value);
+    defer session.freeHistoryTurn(alloc, decoded);
+    try std.testing.expectEqualStrings("{}", decoded.assistant.execution.tool_steps[0].tool_calls[0].arguments_json);
+    try std.testing.expectEqual(session.PersistedToolStatus.failure, decoded.assistant.execution.tool_steps[0].tool_results[0].status);
+}
+
+test "non-object interrupted inputs repair locally and preserve provider-owned records" {
+    const alloc = std.testing.allocator;
+    for ([_]bool{ false, true }) |native| {
+        var out: std.Io.Writer.Allocating = .init(alloc);
+        defer out.deinit();
+        try writeToolCall(&out.writer, .{
+            .id = "interrupted",
+            .name = "read_file",
+            .arguments_json = "[]",
+            .provider_result = if (native) "provider result" else null,
+        });
+        var parsed = try std.json.parseFromSlice(std.json.Value, alloc, out.written(), .{});
+        defer parsed.deinit();
+        const repaired = (try parseOptionalToolCall(alloc, parsed.value)).?;
+        defer session.freeToolCall(alloc, repaired);
+        try std.testing.expectEqualStrings(if (native) "[]" else "{}", repaired.arguments_json);
+        if (!native) try std.testing.checkAllAllocationFailures(alloc, checkNonObjectInterruptedAllocationFailures, .{parsed.value});
+    }
+}
+
+fn checkNonObjectInterruptedAllocationFailures(alloc: Allocator, value: std.json.Value) !void {
+    const call = (try parseOptionalToolCall(alloc, value)).?;
+    defer session.freeToolCall(alloc, call);
+    try std.testing.expectEqualStrings("{}", call.arguments_json);
 }
 
 test "current history decode rejects ambiguous malformed tool result pairings" {

--- a/src/core/session/session_json.zig
+++ b/src/core/session/session_json.zig
@@ -735,8 +735,9 @@ fn parseOptionalToolCall(alloc: Allocator, maybe_value: ?std.json.Value) !?sessi
         .object => try parseToolCall(alloc, value),
         else => return error.InvalidSessionFormat,
     };
+    errdefer if (call) |owned| session.freeToolCall(alloc, owned);
     if (call) |*parsed| {
-        session.repairPersistedInterruptedToolArguments(parsed, .legacy);
+        try session.repairPersistedInterruptedToolArguments(alloc, parsed, .legacy);
     }
     return call;
 }
@@ -748,8 +749,8 @@ fn parseToolCall(alloc: Allocator, value: std.json.Value) !session.ToolCall {
     const name = try alloc.dupe(u8, try requireString(object, "name"));
     errdefer alloc.free(name);
     const raw_arguments_json = try requireString(object, "arguments_json");
-    const argument_integrity = try types.ToolArgumentIntegrity.classifySerialized(alloc, raw_arguments_json);
-    const arguments_json = try alloc.dupe(u8, if (argument_integrity == .valid) raw_arguments_json else "{}");
+    const argument_integrity = try types.ToolArgumentIntegrity.classifyFunctionInput(alloc, raw_arguments_json);
+    const arguments_json = try alloc.dupe(u8, if (argument_integrity == .malformed_json) "{}" else raw_arguments_json);
     errdefer alloc.free(arguments_json);
     const provider_result = try optionalStringDup(alloc, object.get("provider_result"));
     errdefer if (provider_result) |result| alloc.free(result);
@@ -1737,6 +1738,57 @@ test "session JSON persists malformed argument recovery as a safe failed pair" {
     try std.testing.expectEqual(.valid, execution.tool_steps[0].tool_calls[0].argument_integrity);
     try std.testing.expectEqual(session.PersistedToolStatus.failure, execution.tool_steps[0].tool_results[0].status);
     try std.testing.expectEqualStrings(failure_output, execution.tool_steps[0].tool_results[0].output);
+}
+
+test "non-object legacy function inputs are repaired without changing recorded outcomes" {
+    const alloc = std.testing.allocator;
+    for ([_]session.PersistedToolStatus{ .success, .failure }) |status| {
+        for (0..3) |native_kind| {
+            var calls = [_]session.ToolCall{.{ .id = "call", .name = "read_file", .arguments_json = "[]" }};
+            calls[0].provider_result = if (native_kind == 1) "provider result" else null;
+            var results = [_]session.PersistedToolResult{.{
+                .tool_call_id = @constCast("call"),
+                .tool_name = @constCast("read_file"),
+                .status = status,
+                .output = @constCast("recorded"),
+                .output_bytes = 8,
+                .stored_output_bytes = 8,
+                .truncated = false,
+                .provider_native = native_kind == 2,
+                .created_at_ms = 1,
+            }};
+            var steps = [_]session.ToolExecutionStep{.{ .tool_calls = &calls, .tool_results = &results }};
+            var encoded: std.Io.Writer.Allocating = .init(alloc);
+            defer encoded.deinit();
+            try writeExecutionMemoryJson(&encoded.writer, .{ .tool_steps = &steps });
+            var parsed = try std.json.parseFromSlice(std.json.Value, alloc, encoded.written(), .{});
+            defer parsed.deinit();
+            const decoded = try parseOptionalExecutionMemory(alloc, parsed.value);
+            defer session.freeExecutionMemory(alloc, decoded);
+            const step = decoded.tool_steps[0];
+            try std.testing.expectEqualStrings(if (native_kind == 0) "{}" else "[]", step.tool_calls[0].arguments_json);
+            try std.testing.expectEqual(if (native_kind == 0) types.ToolExecutionProvenance.fx_local else .provider_executed, step.tool_calls[0].provenance);
+            try std.testing.expectEqual(types.ToolArgumentIntegrity.valid, step.tool_calls[0].argument_integrity);
+            try std.testing.expectEqual(status, step.tool_results[0].status);
+            try std.testing.expectEqualStrings("recorded", step.tool_results[0].output);
+            try std.testing.expectEqual(@as(usize, 8), step.tool_results[0].stored_output_bytes);
+        }
+    }
+}
+
+fn checkNonObjectLegacyInterruptedAllocationFailures(alloc: Allocator, value: std.json.Value) !void {
+    const call = (try parseOptionalToolCall(alloc, value)).?;
+    defer session.freeToolCall(alloc, call);
+    try std.testing.expectEqualStrings("{}", call.arguments_json);
+}
+
+test "non-object legacy interrupted repair cleans every allocation failure" {
+    const alloc = std.testing.allocator;
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc,
+        \\{"id":"pending","name":"read_file","arguments_json":"[]","provider_result":null}
+    , .{});
+    defer parsed.deinit();
+    try std.testing.checkAllAllocationFailures(alloc, checkNonObjectLegacyInterruptedAllocationFailures, .{parsed.value});
 }
 
 test "old assistant session JSON without execution parses as empty memory" {

--- a/src/core/shared/types.zig
+++ b/src/core/shared/types.zig
@@ -692,6 +692,7 @@ pub const ProviderResultIdentityFailure = enum {
 pub const ToolArgumentIntegrity = enum {
     valid,
     malformed_json,
+    non_object_json,
 
     pub fn classifySerialized(
         alloc: std.mem.Allocator,
@@ -703,6 +704,16 @@ pub const ToolArgumentIntegrity = enum {
         };
         defer parsed.deinit();
         return .valid;
+    }
+
+    pub fn classifyFunctionInput(
+        alloc: std.mem.Allocator,
+        serialized: []const u8,
+    ) std.mem.Allocator.Error!ToolArgumentIntegrity {
+        const integrity = try classifySerialized(alloc, serialized);
+        if (integrity != .valid) return integrity;
+        // A complete JSON root is nonempty; only an object can start with '{'.
+        return if (std.mem.trimStart(u8, serialized, " \t\r\n")[0] == '{') .valid else .non_object_json;
     }
 };
 
@@ -2510,6 +2521,30 @@ test "dupeToolCall preserves argument integrity" {
     defer freeToolCall(std.testing.allocator, copy);
 
     try std.testing.expectEqual(ToolArgumentIntegrity.malformed_json, copy.argument_integrity);
+}
+
+test "function input classification distinguishes syntax from object shape" {
+    const cases = [_]struct { input: []const u8, expected: ToolArgumentIntegrity }{
+        .{ .input = "{}", .expected = .valid },
+        .{ .input = " \n{\"nested\":[1,null,{}]}\t", .expected = .valid },
+        .{ .input = "[]", .expected = .non_object_json },
+        .{ .input = "42", .expected = .non_object_json },
+        .{ .input = "null", .expected = .non_object_json },
+        .{ .input = "true", .expected = .non_object_json },
+        .{ .input = "\"text\"", .expected = .non_object_json },
+        .{ .input = "", .expected = .malformed_json },
+        .{ .input = "{} trailing", .expected = .malformed_json },
+        .{ .input = "{\"a\":1,\"a\":2}", .expected = .malformed_json },
+    };
+    for (cases) |case| {
+        try std.testing.expectEqual(case.expected, try ToolArgumentIntegrity.classifyFunctionInput(std.testing.allocator, case.input));
+        try std.testing.expectEqual(case.expected, try ToolArgumentIntegrity.classifyFunctionInput(std.testing.allocator, case.input));
+        if (case.expected == .non_object_json) {
+            try std.testing.expectEqual(ToolArgumentIntegrity.valid, try ToolArgumentIntegrity.classifySerialized(std.testing.allocator, case.input));
+        }
+    }
+    var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = 0 });
+    try std.testing.expectError(error.OutOfMemory, ToolArgumentIntegrity.classifyFunctionInput(failing.allocator(), "{\"path\":\"file\"}"));
 }
 
 test "ToolArgumentIntegrity accepts complete serialized JSON roots" {

--- a/src/core/tooling/tool_result_errors.zig
+++ b/src/core/tooling/tool_result_errors.zig
@@ -365,6 +365,14 @@ pub fn malformedToolArgumentsJson(alloc: Allocator, tool_name: []const u8) Alloc
     });
 }
 
+pub fn nonObjectToolArgumentsJson(alloc: Allocator, tool_name: []const u8) Allocator.Error![]u8 {
+    return toolExecutionFailureJson(alloc, .{
+        .tool_name = tool_name,
+        .message = "Tool arguments must be a JSON object. The call was not executed.",
+        .suggestion = "Reissue the tool call with a JSON object matching the tool schema.",
+    });
+}
+
 pub fn preToolUseBlockedJson(
     alloc: Allocator,
     tool_name: []const u8,

--- a/src/gateway/responses_protocol.zig
+++ b/src/gateway/responses_protocol.zig
@@ -45,7 +45,7 @@ pub fn writeInput(
                 try writer.writeAll("]}");
             },
             .assistant => {
-                try validateReplayMessage(message, limits);
+                try validateReplayMessage(alloc, message, limits);
                 if (message.provider_state_json) |state_json| {
                     var state = std.json.parseFromSlice(std.json.Value, alloc, state_json, .{}) catch
                         return error.InvalidProviderState;
@@ -86,7 +86,31 @@ pub fn writeInput(
     }
 }
 
-fn validateReplayMessage(message: types.ChatMessage, limits: ReplayLimits) !void {
+test "non-object provider-owned arguments retain their Responses representation" {
+    const calls = [_]types.ToolCall{.{ .id = "native", .name = "native_tool", .arguments_json = "[]", .provenance = .provider_executed, .provider_result = "native result" }};
+    const messages = [_]types.ChatMessage{.{ .role = .assistant, .tool_calls = &calls }};
+    var out: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer out.deinit();
+    try writeInput(&out.writer, std.testing.allocator, &messages, null, .{ .tool_calls = 128, .tool_identity_bytes = 256, .tool_arguments_bytes = 4096, .provider_state_bytes = 4096 });
+    try std.testing.expect(std.mem.find(u8, out.written(), "\"arguments\":\"[]\"") != null);
+}
+
+test "non-object function arguments cannot enter a Responses request" {
+    for ([_][]const u8{ "[]", "42", "null", "true", "\"text\"", "{]" }) |arguments| {
+        const calls = [_]types.ToolCall{.{ .id = "call", .name = "read_file", .arguments_json = arguments }};
+        const messages = [_]types.ChatMessage{.{ .role = .assistant, .tool_calls = &calls }};
+        var out: std.Io.Writer.Allocating = .init(std.testing.allocator);
+        defer out.deinit();
+        try std.testing.expectError(error.InvalidToolArguments, writeInput(&out.writer, std.testing.allocator, &messages, null, .{
+            .tool_calls = 128,
+            .tool_identity_bytes = 256,
+            .tool_arguments_bytes = 4096,
+            .provider_state_bytes = 4096,
+        }));
+    }
+}
+
+fn validateReplayMessage(alloc: std.mem.Allocator, message: types.ChatMessage, limits: ReplayLimits) !void {
     if (message.provider_state_json) |state_json| {
         if (state_json.len > limits.provider_state_bytes) return error.ProviderStateTooLarge;
     }
@@ -99,6 +123,11 @@ fn validateReplayMessage(message: types.ChatMessage, limits: ReplayLimits) !void
         }
         if (call.arguments_json.len > limits.tool_arguments_bytes) {
             return error.ToolArgumentsTooLarge;
+        }
+        if (call.provenance != .provider_executed and
+            try types.ToolArgumentIntegrity.classifyFunctionInput(alloc, call.arguments_json) != .valid)
+        {
+            return error.InvalidToolArguments;
         }
     }
 }

--- a/src/gateway/vercel_protocol.zig
+++ b/src/gateway/vercel_protocol.zig
@@ -537,13 +537,45 @@ fn validateAssistantToolResultBlock(
 fn validateAssistantToolCalls(alloc: std.mem.Allocator, calls: []const ToolCall) !void {
     for (calls, 0..) |call, i| {
         if (call.id.len == 0 or call.name.len == 0 or call.arguments_json.len == 0) return error.InvalidGatewayHistory;
-        if (try types.ToolArgumentIntegrity.classifySerialized(alloc, call.arguments_json) == .malformed_json) {
+        const integrity = if (call.provenance == .provider_executed)
+            try types.ToolArgumentIntegrity.classifySerialized(alloc, call.arguments_json)
+        else
+            try types.ToolArgumentIntegrity.classifyFunctionInput(alloc, call.arguments_json);
+        if (integrity != .valid) {
             return error.InvalidGatewayHistory;
         }
         var j = i + 1;
         while (j < calls.len) : (j += 1) {
             if (std.mem.eql(u8, call.id, calls[j].id)) return error.InvalidGatewayHistory;
         }
+    }
+}
+
+test "non-object provider-owned arguments retain their Gateway representation" {
+    const calls = [_]ToolCall{.{ .id = "native", .name = "native_tool", .arguments_json = "[]", .provenance = .provider_executed, .provider_result = "native result" }};
+    const messages = [_]ChatMessage{
+        .{ .role = .assistant, .tool_calls = &calls },
+        .{ .role = .tool, .tool_call_id = "native", .tool_name = "native_tool", .content = "native result" },
+    };
+    const body = try buildGatewayRequestBody(std.testing.allocator, "[]", &messages);
+    defer std.testing.allocator.free(body);
+    try std.testing.expect(std.mem.find(u8, body, "\"input\":[]") != null);
+}
+
+test "non-object function arguments cannot enter a Gateway request" {
+    for ([_][]const u8{ "[]", "42", "null", "true", "\"text\"" }) |arguments| {
+        const calls = [_]ToolCall{.{ .id = "call", .name = "read_file", .arguments_json = arguments }};
+        const messages = [_]ChatMessage{
+            .{ .role = .user, .content = "read" },
+            .{ .role = .assistant, .tool_calls = &calls },
+            .{ .role = .tool, .tool_call_id = "call", .tool_name = "read_file", .content = "not executed", .tool_result_status = .failure },
+        };
+        const body = buildGatewayRequestBody(std.testing.allocator, "[]", &messages) catch |err| {
+            try std.testing.expectEqual(error.InvalidGatewayHistory, err);
+            continue;
+        };
+        defer std.testing.allocator.free(body);
+        return error.TestExpectedError;
     }
 }
 

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -2295,6 +2295,73 @@ describe("gateway stream lifecycle", () => {
     }
   });
 
+  test("non-object tool inputs remain failed and replay-safe across a mixed batch and model switch", async () => {
+    const root = createFixtureRoot("non-object-inputs");
+    const tracePath = join(root.root, "trace.log");
+    const inputs: unknown[] = [[], "[]", "[1]", "42", "null", "true", '"text"'];
+    const badCalls = inputs.map((input, index) => ({
+      type: "tool-call", toolCallId: `invalid_${index}`, toolName: "read_file", input,
+    }));
+    const invalidSubagent = { type: "tool-call", toolCallId: "invalid_subagent", toolName: "subagent", input: "[]" };
+    const responses = [
+      fakeGatewaySse([
+        ...badCalls,
+        invalidSubagent,
+        { type: "tool-call", toolCallId: "valid_write", toolName: "write_file", input: { path: "valid.txt", content: "written once\n" } },
+        { type: "finish", finishReason: { unified: "tool-calls", raw: "tool-calls" } },
+      ]),
+      fakeGatewayFinalText("Rejected invalid calls and completed the valid write."),
+      fakeGatewayFinalText("Resumed safely with another model."),
+    ];
+    const gateway = startDynamicFakeGateway(
+      () => responses.shift() ?? new Response("unexpected request", { status: 500 }),
+      { classifierDecision: "clear", models: [MODEL, DEFAULT_MODEL].map((id) => ({ id, type: "language", tags: ["tool-use"] })) },
+    );
+    try {
+      const first = await runFx(["ask", "--json", "--auto", "Run the fixture batch."], {
+        cwd: root.workspace,
+        env: { ...fixtureEnv(root, gateway, tracePath), FX_TRACE_SCOPES: "agent,core,gateway,stream,tool" },
+        timeoutMs: 20_000,
+      });
+      expect(first.code).toBe(0);
+      const firstJson = parseAskJson(first.stdout);
+      expect(firstJson.tool_calls.filter((call) => call.name === "read_file")).toEqual(
+        badCalls.map(() => ({ name: "read_file", status: "error" })),
+      );
+      expect(firstJson.tool_calls.filter((call) => call.name === "write_file")).toEqual([{ name: "write_file", status: "success" }]);
+      expect(firstJson.tool_calls.filter((call) => call.name === "subagent")).toEqual([{ name: "subagent", status: "error" }]);
+      expect(readFileSync(join(root.workspace, "valid.txt"), "utf8")).toBe("written once\n");
+      expect(readFileSync(tracePath, "utf8")).toContain("failure=non_object_json");
+      expect(first.stderr).not.toContain("Reading");
+      expect(gateway.requests).toHaveLength(2);
+
+      const resumed = await runFx(["ask", "--json", "--auto", "--resume-id", firstJson.session_id, "Continue."], {
+        cwd: root.workspace,
+        env: { ...fixtureEnv(root, gateway, join(root.root, "resume.log")), FX_MODEL: DEFAULT_MODEL },
+        timeoutMs: 20_000,
+      });
+      expect(resumed.code).toBe(0);
+      expect(resumed.stderr).toBe("");
+      expect(JSON.parse(resumed.stdout).model).toBe(DEFAULT_MODEL);
+      expect(parseAskJson(resumed.stdout).tool_calls).toEqual([]);
+      expect(gateway.requests).toHaveLength(3);
+      for (const request of gateway.requests.slice(1)) {
+        const prompt = parseGatewayRequest(request.body).prompt;
+        const parts = prompt.flatMap((message) => Array.isArray(message.content) ? message.content : []);
+        for (const call of [...badCalls, invalidSubagent]) {
+          expect(parts).toContainEqual({ type: "tool-call", toolCallId: call.toolCallId, toolName: call.toolName, input: {} });
+          expect(parts).toContainEqual(expect.objectContaining({
+            type: "tool-result", toolCallId: call.toolCallId, toolName: call.toolName,
+            output: expect.objectContaining({ type: "error-text", value: expect.stringContaining("not executed") }),
+          }));
+        }
+      }
+    } finally {
+      gateway.stop();
+      rmSync(root.root, { recursive: true, force: true });
+    }
+  });
+
   test("default ask stops a consecutive malformed argument loop", async () => {
     const root = createFixtureRoot("repeated-malformed-arguments");
     const tracePath = join(root.root, "trace.log");

--- a/tests/e2e/vision-route-fake-gateway.test.ts
+++ b/tests/e2e/vision-route-fake-gateway.test.ts
@@ -981,6 +981,7 @@ describe("Vision route fake Gateway", () => {
       writeFileSync(forbiddenPath, forbiddenContents);
       const gateway = startImageGateway([
         sseToolCall("read_file", { path: forbiddenPath }, "read_before_vision"),
+        sseToolCall("read_file", [], "non_object_before_vision"),
         sseToolCall("vision", { image_ids: [1], focus: "inspect" }, "vision_after_rejection"),
         sseText(VISION_RESULT),
         sseText("Recovered after required Vision rejection"),
@@ -1008,7 +1009,7 @@ describe("Vision route fake Gateway", () => {
         expect(json.output).toContain("Recovered after required Vision rejection");
         expect(json.tool_calls).toContainEqual({ name: "read_file", status: "error" });
         expect(json.tool_calls).toContainEqual({ name: "vision", status: "success" });
-        expect(gateway.chatRequests).toHaveLength(4);
+        expect(gateway.chatRequests).toHaveLength(5);
         expect(gateway.chatRequests[0].body).toContain('"toolChoice":{"type":"required"}');
         expect(gateway.chatRequests[1].body).toContain('"toolChoice":{"type":"required"}');
         expect(gateway.chatRequests[1].body).toContain("read_before_vision");
@@ -1016,10 +1017,14 @@ describe("Vision route fake Gateway", () => {
           "Only Vision can be called while attached images are pending.",
         );
         expect(gateway.chatRequests[1].body).not.toContain(forbiddenContents);
-        expect(gateway.chatRequests[2].headers.get("ai-language-model-id")).toBe(GEMINI_MODEL);
-        expect(filePartCount(gateway.chatRequests[2].body)).toBe(1);
-        expect(gateway.chatRequests[3].body).toContain("FX LOGO");
-        expect(gateway.chatRequests[3].body).not.toContain(forbiddenContents);
+        const rejectedCall = JSON.parse(gateway.chatRequests[2].body).prompt
+          .flatMap((message: { content: unknown }) => Array.isArray(message.content) ? message.content : [])
+          .find((part: { toolCallId?: string; type?: string }) => part.type === "tool-call" && part.toolCallId === "non_object_before_vision");
+        expect(rejectedCall.input).toEqual({});
+        expect(gateway.chatRequests[3].headers.get("ai-language-model-id")).toBe(GEMINI_MODEL);
+        expect(filePartCount(gateway.chatRequests[3].body)).toBe(1);
+        expect(gateway.chatRequests[4].body).toContain("FX LOGO");
+        expect(gateway.chatRequests[4].body).not.toContain(forbiddenContents);
       } finally {
         gateway.stop();
         rmSync(root.root, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- Reject non-object local tool arguments before hooks or execution and retain a failed call/result pair that providers can replay.
- Resume existing sessions with non-object tool arguments without re-executing tools or changing recorded outcomes.
- Preserve provider-executed input bytes during replay.
- Keep rejected subagent calls paired with their results during replay.
- Reject remaining invalid local function inputs before sending a provider request.
