### PR TITLE
Omit blank assistant text from summary continuations

### DIFF
--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -7127,8 +7127,17 @@ fn processQueuedPromptLoop(
             if (needs_continuation) {
                 continuation_injected = true;
                 const continuation_prompt = "Summarize what you just did.";
-                debug_trace.logf("agent", "injecting continuation after {d} silent tool steps", .{silent_tool_steps});
-                try within_turn_suffix.append(arena, .{ .role = .assistant, .content = completion.content });
+                debug_trace.logf("agent", "injecting continuation after {d} silent tool steps omitted_assistant_bytes={d} preserved_provider_state={s}", .{
+                    silent_tool_steps,
+                    if (completion.content) |content| content.len else 0,
+                    if (completion.provider_state_json != null) "true" else "false",
+                });
+                if (completion.provider_state_json) |state| {
+                    try within_turn_suffix.append(arena, .{
+                        .role = .assistant,
+                        .provider_state_json = state,
+                    });
+                }
                 try within_turn_suffix.append(arena, .{ .role = .user, .content = continuation_prompt });
                 continue;
             }

--- a/src/core/agent/runtime/tests/gateway_flow.zig
+++ b/src/core/agent/runtime/tests/gateway_flow.zig
@@ -6424,18 +6424,81 @@ test "processQueuedPrompt uses configured tool choice only for first call" {
     try expectBodyContains(&gateway, 1, "\"toolChoice\":{\"type\":\"auto\"}");
 }
 
-test "processQueuedPrompt injects silent-tool continuation without synthetic assistant text" {
+test "processQueuedPrompt omits blank assistant messages from silent-tool continuation" {
+    const alloc = std.testing.allocator;
+    const call_one = [_]ToolCall{toolCall("call_1", "read_file", "{\"path\":\"a\"}")};
+    const call_two = [_]ToolCall{toolCall("call_2", "read_file", "{\"path\":\"b\"}")};
+    for ([_]?[]const u8{ null, "", " ", "\t\r\n" }) |blank| {
+        const completions = [_]FakeCompletion{
+            .{ .tool_calls = &call_one },
+            .{ .tool_calls = &call_two },
+            .{ .content = blank },
+            .{ .content = "Summary" },
+        };
+        var gateway = FakeGateway.init(alloc, &completions);
+        defer gateway.deinit();
+        var hooks = FakeAgentRuntimeDeps.init(alloc);
+        defer hooks.deinit();
+        var fixture = PromptFixture{};
+
+        try runFakePrompt(&gateway, &hooks, fixture.config(), fixture.job());
+
+        try std.testing.expectEqual(@as(usize, 4), gateway.request_bodies.items.len);
+        try expectGatewayPromptFinalUserText(&gateway, 3, "Summarize what you just did.");
+        try expectBodyNotContains(&gateway, 3, "Done.");
+        const parsed = try std.json.parseFromSlice(std.json.Value, alloc, gateway.request_bodies.items[3], .{});
+        defer parsed.deinit();
+        var assistant_count: usize = 0;
+        for (parsed.value.object.get("prompt").?.array.items) |message| {
+            if (!std.mem.eql(u8, message.object.get("role").?.string, "assistant")) continue;
+            assistant_count += 1;
+            const content = message.object.get("content").?.array.items;
+            try std.testing.expectEqual(@as(usize, 1), content.len);
+            try std.testing.expectEqualStrings("tool-call", content[0].object.get("type").?.string);
+        }
+        try std.testing.expectEqual(@as(usize, 2), assistant_count);
+        try std.testing.expectEqual(@as(usize, 2), hooks.executed_names.items.len);
+        try std.testing.expectEqual(@as(usize, 1), hooks.finalization_count);
+        try std.testing.expectEqualStrings("Summary", hooks.finish_assistant_text.?);
+    }
+}
+
+test "processQueuedPrompt preserves provider state during silent-tool continuation" {
+    const StateObserver = struct {
+        const state = "[{\"type\":\"reasoning\",\"id\":\"state_1\",\"encrypted_content\":\"opaque\",\"summary\":[]}]";
+
+        fn observe(request: agent_stream_provider.ModelRequest) !void {
+            const last = request.messages[request.messages.len - 1];
+            if (!std.mem.eql(u8, last.content orelse "", "Summarize what you just did.")) return;
+            const previous = request.messages[request.messages.len - 2];
+            try std.testing.expectEqual(types.ChatRole.assistant, previous.role);
+            try std.testing.expectEqual(@as(?[]const u8, null), previous.content);
+            try std.testing.expectEqualStrings(state, previous.provider_state_json orelse "");
+            try std.testing.expectEqual(@as(usize, 0), previous.tool_calls.len);
+            var wire: std.Io.Writer.Allocating = .init(std.testing.allocator);
+            defer wire.deinit();
+            try @import("../../../../gateway/responses_protocol.zig").writeInput(
+                &wire.writer,
+                std.testing.allocator,
+                &.{previous},
+                null,
+                .{ .tool_calls = 128, .tool_identity_bytes = 256, .tool_arguments_bytes = 4096, .provider_state_bytes = 4096 },
+            );
+            try std.testing.expectEqualStrings(state[1 .. state.len - 1], wire.written());
+        }
+    };
     const alloc = std.testing.allocator;
     const call_one = [_]ToolCall{toolCall("call_1", "read_file", "{\"path\":\"a\"}")};
     const call_two = [_]ToolCall{toolCall("call_2", "read_file", "{\"path\":\"b\"}")};
     const completions = [_]FakeCompletion{
         .{ .tool_calls = &call_one },
         .{ .tool_calls = &call_two },
-        .{},
+        .{ .content = " \n", .provider_state_json = StateObserver.state },
         .{ .content = "Summary" },
     };
     var gateway = FakeGateway.init(alloc, &completions);
     defer gateway.deinit();
+    gateway.observe_request = StateObserver.observe;
     var hooks = FakeAgentRuntimeDeps.init(alloc);
     defer hooks.deinit();
     var fixture = PromptFixture{};
@@ -6443,8 +6506,8 @@ test "processQueuedPrompt injects silent-tool continuation without synthetic ass
     try runFakePrompt(&gateway, &hooks, fixture.config(), fixture.job());
 
     try std.testing.expectEqual(@as(usize, 4), gateway.request_bodies.items.len);
-    try expectBodyContains(&gateway, 3, "Summarize what you just did.");
-    try expectBodyNotContains(&gateway, 3, "Done.");
+    try expectGatewayPromptFinalUserText(&gateway, 3, "Summarize what you just did.");
+    try std.testing.expectEqualStrings("Summary", hooks.finish_assistant_text.?);
 }
 
 test "tool presentation groups span silent steps and split on visible assistant prose" {

--- a/src/core/agent/runtime/tests/support.zig
+++ b/src/core/agent/runtime/tests/support.zig
@@ -199,6 +199,7 @@ pub const FakeCompletion = struct {
     chunks: []const []const u8 = &.{},
     reasoning_chunks: []const []const u8 = &.{},
     content: ?[]const u8 = null,
+    provider_state_json: ?[]const u8 = null,
     tool_calls: []const ToolCall = &.{},
     streamed_tool_starts: []const ToolCall = &.{},
     provider_result_identity_failure: ?types.ProviderResultIdentityFailure = null,
@@ -227,6 +228,7 @@ pub const FakeGateway = struct {
     request_session_ids: std.ArrayList(?[]u8) = .empty,
     admitted_requests: usize = 0,
     recovery_pause_flag: ?*std.atomic.Value(bool) = null,
+    observe_request: ?*const fn (agent_stream_provider.ModelRequest) anyerror!void = null,
 
     pub fn init(alloc: Allocator, completions: []const FakeCompletion) FakeGateway {
         return .{ .alloc = alloc, .completions = completions };
@@ -257,6 +259,7 @@ pub const FakeGateway = struct {
         alloc: Allocator,
         request: agent_stream_provider.ModelRequest,
     ) !agent_stream_provider.Result {
+        if (self.observe_request) |observe| try observe(request);
         const payload = request.prepared_request_body orelse
             try builtin_gateway.buildAgentRequest(alloc, request.data());
         defer if (request.prepared_request_body == null) alloc.free(payload);
@@ -335,6 +338,7 @@ pub const FakeGateway = struct {
         return .{ .completed = .{
             .completion = .{
                 .content = completion.content,
+                .provider_state_json = completion.provider_state_json,
                 .tool_calls = completion.tool_calls,
                 .provider_result_identity_failure = completion.provider_result_identity_failure,
                 .provider_failure_cause = completion.provider_failure_cause,

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -7018,6 +7018,66 @@ printf '%s' ${JSON.stringify(trailingMarker)} > ${JSON.stringify(effectPath)}
     }
   });
 
+  test("silent-tool continuation omits blank assistant text and keeps settled results", async () => {
+    const root = createFixtureRoot("blank-continuation");
+    const tracePath = join(root.root, "trace.log");
+    writeFileSync(join(root.workspace, "fixture.txt"), "settled evidence\n");
+    const responses = [
+      fakeGatewayToolCall("read_1", "read_file", { path: "fixture.txt" }),
+      fakeGatewayToolCall("read_2", "read_file", { path: "fixture.txt" }),
+      fakeGatewayFinalText(" \t\r\n"),
+      fakeGatewayFinalText("Finished reading the fixture."),
+    ];
+    const gateway = startGateway(() =>
+      responses.shift() ?? new Response("unexpected request", { status: 400 })
+    );
+    try {
+      const result = await runFx(
+        ["ask", "--json", "--auto", "Read fixture.txt twice, then summarize it."],
+        { cwd: root.workspace, env: fixtureEnv(root, gateway, tracePath), timeoutMs: 15_000 },
+      );
+      expect(result.code).toBe(0);
+      expect(result.signal).toBeNull();
+      expect(result.stderr).toBe("Reading fixture.txt\nReading fixture.txt\n");
+      const json = parseAskJson(result.stdout);
+      expect(json.output).toContain("Finished reading the fixture.");
+      expect(json.tool_calls).toEqual([
+        { name: "read_file", status: "success" },
+        { name: "read_file", status: "success" },
+      ]);
+      expect(gateway.requests).toHaveLength(4);
+      const request = JSON.parse(gateway.requests[3]!.body);
+      const assistants = request.prompt.filter((message: { role: string }) => message.role === "assistant");
+      expect(assistants).toHaveLength(2);
+      expect(assistants.map((message: { content: Array<{ type: string; toolCallId: string }> }) => message.content.map((part) => [part.type, part.toolCallId])))
+        .toEqual([[["tool-call", "read_1"]], [["tool-call", "read_2"]]]);
+      expect(request.prompt.at(-1)).toEqual({
+        role: "user",
+        content: [{ type: "text", text: "Summarize what you just did." }],
+      });
+      for (const id of ["read_1", "read_2"]) {
+        expect(toolResultOutput(gateway.requests[3]!.body, id)).toContain("settled evidence");
+      }
+      responses.push(fakeGatewayFinalText("Resume complete."));
+      const resumed = await runFx(
+        ["ask", "--json", "--auto", "--resume-id", json.session_id, "What did you just read?"],
+        { cwd: root.workspace, env: fixtureEnv(root, gateway, tracePath), timeoutMs: 15_000 },
+      );
+      expect(resumed.code).toBe(0);
+      expect(resumed.stderr).toBe("");
+      expect(parseAskJson(resumed.stdout).tool_calls).toEqual([]);
+      expect(gateway.requests).toHaveLength(5);
+      expect(gateway.requests[4]!.body).toContain("Finished reading the fixture.");
+      for (const id of ["read_1", "read_2"]) {
+        expect(toolResultOutput(gateway.requests[4]!.body, id)).toContain("settled evidence");
+      }
+      expect(readFileSync(tracePath, "utf8")).toContain("injecting continuation after 2 silent tool steps");
+    } finally {
+      gateway.stop();
+      rmSync(root.root, { recursive: true, force: true });
+    }
+  });
+
   test("accepted tool-only replacement discards only the obsolete JSON preview", async () => {
     const root = createFixtureRoot("tool-only-replacement");
     const tracePath = join(root.root, "trace.log");


### PR DESCRIPTION
## Summary

- Avoid blank-message API errors when requesting a summary after silent tool steps.
- Preserve available provider state during those summary continuations.
