### PR TITLE
Keep tool call IDs portable across model switches

### DIFF
--- a/src/core/shared/types.zig
+++ b/src/core/shared/types.zig
@@ -1491,7 +1491,7 @@ pub fn authoritativeToolAdmission(completion: ModelCompletion) AuthoritativeTool
     }
 
     for (completion.tool_calls) |call| {
-        const final_identity = if (call.final_identity == .valid and call.id.len == 0)
+        const final_identity = if (call.final_identity == .valid and std.mem.trim(u8, call.id, " \t\r\n").len == 0)
             FinalToolIdentity.empty
         else
             call.final_identity;
@@ -1529,6 +1529,16 @@ pub fn authoritativeToolAdmission(completion: ModelCompletion) AuthoritativeTool
     }
 
     return .admitted;
+}
+
+test "authoritative tool admission rejects blank current call ids" {
+    for ([_][]const u8{ "", " ", "\t\r\n" }) |id| {
+        const calls = [_]ToolCall{.{ .id = id, .name = "read_file", .arguments_json = "{}" }};
+        try std.testing.expectEqualDeep(
+            AuthoritativeToolAdmission{ .reject_malformed_identity = .empty },
+            authoritativeToolAdmission(.{ .tool_calls = &calls }),
+        );
+    }
 }
 
 test "authoritative tool admission rejects duplicate final ids across provenance" {

--- a/src/gateway/responses_protocol.zig
+++ b/src/gateway/responses_protocol.zig
@@ -4,6 +4,7 @@ const model_provider = @import("../core/config/model_provider.zig");
 const model_tool_schema = @import("../core/tooling/model_tool_schema.zig");
 const types = @import("../core/shared/types.zig");
 const image_attachments = @import("../core/images/image_attachments.zig");
+const tool_call_ids = @import("tool_call_ids.zig");
 
 pub const ReplayLimits = struct {
     tool_calls: usize,
@@ -19,6 +20,11 @@ pub fn writeInput(
     verified_images: ?[]const image_attachments.VerifiedSnapshot,
     limits: ReplayLimits,
 ) !void {
+    for (messages) |message| {
+        if (message.role == .assistant) try validateReplayMessage(alloc, message, limits);
+    }
+    var ids = try tool_call_ids.Projection.init(alloc, messages);
+    defer ids.deinit(alloc);
     var first = true;
     for (messages, 0..) |message, message_index| {
         switch (message.role) {
@@ -45,7 +51,6 @@ pub fn writeInput(
                 try writer.writeAll("]}");
             },
             .assistant => {
-                try validateReplayMessage(alloc, message, limits);
                 if (message.provider_state_json) |state_json| {
                     var state = std.json.parseFromSlice(std.json.Value, alloc, state_json, .{}) catch
                         return error.InvalidProviderState;
@@ -66,7 +71,7 @@ pub fn writeInput(
                 for (message.tool_calls) |call| {
                     try writeComma(writer, &first);
                     try writer.writeAll("{\"type\":\"function_call\",\"call_id\":");
-                    try std.json.Stringify.value(call.id, .{}, writer);
+                    try std.json.Stringify.value(ids.resolve(call.id), .{}, writer);
                     try writer.writeAll(",\"name\":");
                     try std.json.Stringify.value(call.name, .{}, writer);
                     try writer.writeAll(",\"arguments\":");
@@ -77,13 +82,56 @@ pub fn writeInput(
             .tool => {
                 try writeComma(writer, &first);
                 try writer.writeAll("{\"type\":\"function_call_output\",\"call_id\":");
-                try std.json.Stringify.value(message.tool_call_id orelse "", .{}, writer);
+                try std.json.Stringify.value(ids.resolve(message.tool_call_id orelse ""), .{}, writer);
                 try writer.writeAll(",\"output\":");
                 try std.json.Stringify.value(message.content orelse "", .{}, writer);
                 try writer.writeByte('}');
             },
         }
     }
+}
+
+test "Responses request projects long call ids with matching outputs" {
+    const source_id = "c" ** 65;
+    const calls = [_]types.ToolCall{.{ .id = source_id, .name = "read_file", .arguments_json = "{}" }};
+    const messages = [_]types.ChatMessage{
+        .{ .role = .assistant, .tool_calls = &calls },
+        .{ .role = .tool, .tool_call_id = source_id, .tool_name = "read_file", .content = "result" },
+    };
+    var out: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer out.deinit();
+    try out.writer.writeByte('[');
+    try writeInput(&out.writer, std.testing.allocator, &messages, null, .{ .tool_calls = 128, .tool_identity_bytes = 256, .tool_arguments_bytes = 4096, .provider_state_bytes = 4096 });
+    try out.writer.writeByte(']');
+    const parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, out.written(), .{});
+    defer parsed.deinit();
+    const items = parsed.value.array.items;
+    const call_id = items[0].object.get("call_id").?.string;
+    try std.testing.expect(call_id.len <= 64);
+    try std.testing.expectEqualStrings(call_id, items[1].object.get("call_id").?.string);
+    try std.testing.expectEqualStrings(source_id, calls[0].id);
+    try std.testing.expectEqualStrings("result", items[1].object.get("output").?.string);
+}
+
+test "Responses request preserves opaque tool-call identity" {
+    const state = "[{\"type\":\"reasoning\",\"id\":\"rs_1\",\"encrypted_content\":\"opaque\",\"summary\":[]}]";
+    const calls = [_]types.ToolCall{.{ .id = "signed:0", .name = "read_file", .arguments_json = "{}" }};
+    const messages = [_]types.ChatMessage{
+        .{ .role = .assistant, .tool_calls = &calls, .provider_state_json = state },
+        .{ .role = .tool, .tool_call_id = "signed:0", .tool_name = "read_file", .content = "result" },
+    };
+    var out: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer out.deinit();
+    try out.writer.writeByte('[');
+    try writeInput(&out.writer, std.testing.allocator, &messages, null, .{ .tool_calls = 128, .tool_identity_bytes = 256, .tool_arguments_bytes = 4096, .provider_state_bytes = 4096 });
+    try out.writer.writeByte(']');
+    const parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, out.written(), .{});
+    defer parsed.deinit();
+    const items = parsed.value.array.items;
+    try std.testing.expectEqualStrings("opaque", items[0].object.get("encrypted_content").?.string);
+    try std.testing.expectEqualStrings("signed:0", items[1].object.get("call_id").?.string);
+    try std.testing.expectEqualStrings("signed:0", items[2].object.get("call_id").?.string);
+    try std.testing.expectEqualStrings(state, messages[0].provider_state_json.?);
 }
 
 test "non-object provider-owned arguments retain their Responses representation" {

--- a/src/gateway/tool_call_ids.zig
+++ b/src/gateway/tool_call_ids.zig
@@ -1,0 +1,225 @@
+const std = @import("std");
+const types = @import("../core/shared/types.zig");
+
+const max_id_bytes = 64;
+
+/// Request-local wire IDs. Source IDs remain borrowed and unchanged; generated
+/// IDs are owned until deinit. Portable requests allocate nothing.
+pub const Projection = struct {
+    const Entry = struct { wire: []const u8, protected: bool };
+
+    ids: std.StringHashMapUnmanaged(Entry) = .empty,
+    owned: std.ArrayList([]u8) = .empty,
+
+    pub fn init(alloc: std.mem.Allocator, messages: []const types.ChatMessage) !Projection {
+        var needed = false;
+        var opaque_history = false;
+        for (messages) |message| {
+            if (message.role == .tool) {
+                const id = message.tool_call_id orelse return error.InvalidToolCallId;
+                if (id.len == 0) return error.InvalidToolCallId;
+                needed = needed or !portable(id);
+            }
+            if (message.role != .assistant) continue;
+            opaque_history = opaque_history or message.provider_state_json != null;
+            for (message.tool_calls) |call| {
+                if (call.id.len == 0) return error.InvalidToolCallId;
+                if (portable(call.id)) continue;
+                needed = true;
+            }
+        }
+        if (!needed) return .{};
+
+        var self: Projection = .{};
+        errdefer self.deinit(alloc);
+        for (messages) |message| {
+            if (message.role == .assistant) {
+                for (message.tool_calls) |call| {
+                    const entry = try self.ids.getOrPut(alloc, call.id);
+                    const protected = call.provenance == .provider_executed or message.provider_state_json != null;
+                    if (!entry.found_existing) entry.value_ptr.* = .{ .wire = call.id, .protected = false };
+                    entry.value_ptr.protected = entry.value_ptr.protected or protected;
+                }
+            }
+            if (message.role == .tool) {
+                const id = message.tool_call_id.?;
+                const entry = try self.ids.getOrPut(alloc, id);
+                if (!entry.found_existing) entry.value_ptr.* = .{ .wire = id, .protected = false };
+            }
+        }
+        for (messages) |message| {
+            if (message.role != .assistant) continue;
+            for (message.tool_calls) |call| {
+                if (portable(self.resolve(call.id))) continue;
+                if (call.provenance == .provider_executed or message.provider_state_json != null) continue;
+                if (self.ids.get(call.id).?.protected) return error.ProtectedToolCallId;
+                var digest: [32]u8 = undefined;
+                std.crypto.hash.sha2.Sha256.hash(call.id, &digest, .{});
+                const hex = std.fmt.bytesToHex(digest[0..20].*, .lower);
+                const attempts = try std.math.add(usize, self.ids.count(), 1);
+                for (0..attempts) |attempt| {
+                    var buffer: [max_id_bytes]u8 = undefined;
+                    const candidate = try std.fmt.bufPrint(&buffer, "fx_{s}_{d}", .{ &hex, attempt });
+                    if (self.ids.contains(candidate)) {
+                        // Opaque state may refer to an alias from an earlier request.
+                        if (opaque_history) return error.ProtectedToolCallId;
+                        continue;
+                    }
+                    const alias = try alloc.dupe(u8, candidate);
+                    errdefer alloc.free(alias);
+                    try self.ids.ensureUnusedCapacity(alloc, 1);
+                    try self.owned.ensureUnusedCapacity(alloc, 1);
+                    self.ids.putAssumeCapacity(alias, .{ .wire = alias, .protected = false });
+                    self.ids.getPtr(call.id).?.wire = alias;
+                    self.owned.appendAssumeCapacity(alias);
+                    break;
+                } else return error.ToolCallIdMappingExhausted;
+            }
+        }
+        for (messages) |message| {
+            if (message.role == .tool) {
+                const entry = self.ids.get(message.tool_call_id.?).?;
+                if (!entry.protected and !portable(entry.wire)) return error.InvalidToolCallId;
+            }
+        }
+        return self;
+    }
+
+    pub fn deinit(self: *Projection, alloc: std.mem.Allocator) void {
+        self.ids.deinit(alloc);
+        for (self.owned.items) |id| alloc.free(id);
+        self.owned.deinit(alloc);
+    }
+
+    /// The result borrows either source or this projection's storage.
+    pub fn resolve(self: *const Projection, source: []const u8) []const u8 {
+        return if (self.ids.get(source)) |entry| entry.wire else source;
+    }
+};
+
+fn portable(id: []const u8) bool {
+    if (id.len == 0 or id.len > max_id_bytes) return false;
+    for (id) |byte| {
+        if (!std.ascii.isAlphanumeric(byte) and byte != '_' and byte != '-') return false;
+    }
+    return true;
+}
+
+test "portable tool call ids use an allocation-free identity projection" {
+    var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = 0 });
+    const calls = [_]types.ToolCall{
+        .{ .id = "call_ABC-123", .name = "read", .arguments_json = "{}" },
+        .{ .id = "x" ** 64, .name = "read", .arguments_json = "{}" },
+    };
+    var projection = try Projection.init(failing.allocator(), &.{.{ .role = .assistant, .tool_calls = &calls }});
+    defer projection.deinit(failing.allocator());
+    for (calls) |call| try std.testing.expect(projection.resolve(call.id).ptr == call.id.ptr);
+}
+
+test "tool call id projection ignores fields not serialized for a role" {
+    var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = 0 });
+    const calls = [_]types.ToolCall{.{ .id = "", .name = "ignored", .arguments_json = "{}" }};
+    var projection = try Projection.init(failing.allocator(), &.{.{
+        .role = .user,
+        .content = "question",
+        .tool_calls = &calls,
+        .tool_call_id = "ignored:0",
+        .provider_state_json = "ignored",
+    }});
+    defer projection.deinit(failing.allocator());
+    try std.testing.expectEqual(@as(usize, 0), projection.owned.items.len);
+}
+
+test "tool call id projection is deterministic and preserves source IDs" {
+    const alloc = std.testing.allocator;
+    const sources = [_][]const u8{ "functions.read:0", "functions/read:0", " ", "\t\n", "é", "x" ** 65, "x" ** 256 };
+    var calls: [sources.len]types.ToolCall = undefined;
+    for (sources, 0..) |source, i| calls[i] = .{ .id = source, .name = "read", .arguments_json = "{}" };
+    const messages = [_]types.ChatMessage{.{ .role = .assistant, .tool_calls = &calls }};
+    var first = try Projection.init(alloc, &messages);
+    defer first.deinit(alloc);
+    var second = try Projection.init(alloc, &messages);
+    defer second.deinit(alloc);
+    for (sources, 0..) |source, i| {
+        const id = first.resolve(source);
+        try std.testing.expect(portable(id));
+        try std.testing.expectEqualStrings(id, second.resolve(source));
+        try std.testing.expectEqualStrings(source, calls[i].id);
+        for (sources[0..i]) |prior| try std.testing.expect(!std.mem.eql(u8, id, first.resolve(prior)));
+    }
+}
+
+test "tool call id projection avoids aliases reserved by portable calls" {
+    const alloc = std.testing.allocator;
+    const source = "functions.read:0";
+    var calls = [_]types.ToolCall{.{ .id = source, .name = "read", .arguments_json = "{}" }};
+    var first = try Projection.init(alloc, &.{.{ .role = .assistant, .tool_calls = &calls }});
+    defer first.deinit(alloc);
+    const original_alias = first.resolve(source);
+    const colliding_calls = [_]types.ToolCall{
+        calls[0],
+        .{ .id = original_alias, .name = "read", .arguments_json = "{}" },
+    };
+    var second = try Projection.init(alloc, &.{.{ .role = .assistant, .tool_calls = &colliding_calls }});
+    defer second.deinit(alloc);
+    try std.testing.expectEqualStrings(original_alias, second.resolve(original_alias));
+    try std.testing.expect(!std.mem.eql(u8, original_alias, second.resolve(source)));
+    try std.testing.expect(portable(second.resolve(source)));
+    try std.testing.expectError(error.ProtectedToolCallId, Projection.init(alloc, &.{
+        .{ .role = .assistant, .tool_calls = &calls },
+        .{ .role = .assistant, .tool_calls = colliding_calls[1..], .provider_state_json = "opaque" },
+    }));
+}
+
+test "tool call id projection never rewrites protected identities" {
+    const alloc = std.testing.allocator;
+    var call = types.ToolCall{ .id = "native:0", .name = "native", .arguments_json = "{}", .provenance = .provider_executed };
+    var native = try Projection.init(alloc, &.{.{ .role = .assistant, .tool_calls = &.{call} }});
+    defer native.deinit(alloc);
+    try std.testing.expectEqualStrings(call.id, native.resolve(call.id));
+    call.provenance = .fx_local;
+    var projection = try Projection.init(alloc, &.{.{ .role = .assistant, .tool_calls = &.{call}, .provider_state_json = "opaque" }});
+    defer projection.deinit(alloc);
+    try std.testing.expectEqualStrings(call.id, projection.resolve(call.id));
+    const native_call = types.ToolCall{ .id = call.id, .name = "native", .arguments_json = "{}", .provenance = .provider_executed };
+    try std.testing.expectError(error.ProtectedToolCallId, Projection.init(alloc, &.{
+        .{ .role = .assistant, .tool_calls = &.{call} },
+        .{ .role = .assistant, .tool_calls = &.{native_call} },
+    }));
+}
+
+test "tool call id projection reuses aliases across settled steps" {
+    const alloc = std.testing.allocator;
+    const call = types.ToolCall{ .id = "call:0", .name = "read", .arguments_json = "{}" };
+    const messages = [_]types.ChatMessage{
+        .{ .role = .assistant, .tool_calls = &.{call} },
+        .{ .role = .tool, .tool_call_id = call.id, .content = "one" },
+        .{ .role = .assistant, .tool_calls = &.{call} },
+        .{ .role = .tool, .tool_call_id = call.id, .content = "two" },
+    };
+    var projection = try Projection.init(alloc, &messages);
+    defer projection.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 1), projection.owned.items.len);
+    for (messages) |message| {
+        const id = message.tool_call_id orelse message.tool_calls[0].id;
+        try std.testing.expectEqualStrings(projection.owned.items[0], projection.resolve(id));
+    }
+}
+
+test "tool call id projection rejects unpaired nonportable result ids" {
+    try std.testing.expectError(error.InvalidToolCallId, Projection.init(std.testing.allocator, &.{.{ .role = .tool, .tool_call_id = "missing:0" }}));
+}
+
+fn allocation_failure_case(alloc: std.mem.Allocator) !void {
+    const calls = [_]types.ToolCall{
+        .{ .id = "functions.read:0", .name = "read", .arguments_json = "{}" },
+        .{ .id = "x" ** 65, .name = "read", .arguments_json = "{}" },
+    };
+    var projection = try Projection.init(alloc, &.{.{ .role = .assistant, .tool_calls = &calls }});
+    defer projection.deinit(alloc);
+    for (calls) |call| try std.testing.expect(portable(projection.resolve(call.id)));
+}
+
+test "tool call id projection cleans up allocation failures" {
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, allocation_failure_case, .{});
+}

--- a/src/gateway/vercel_protocol.zig
+++ b/src/gateway/vercel_protocol.zig
@@ -5,6 +5,7 @@ const io_mod = @import("../core/shared/io.zig");
 const model_capabilities = @import("../core/config/model_capabilities.zig");
 const tool_result_errors = @import("../core/tooling/tool_result_errors.zig");
 const types = @import("../core/shared/types.zig");
+const tool_call_ids = @import("tool_call_ids.zig");
 
 pub const ChatRole = types.ChatRole;
 pub const ChatMessage = types.ChatMessage;
@@ -28,20 +29,20 @@ pub fn roleName(role: ChatRole) []const u8 {
     };
 }
 
-pub fn writeChatMessageJson(
+fn writeChatMessageJson(
     scratch_alloc: std.mem.Allocator,
     writer: *std.Io.Writer,
     message: ChatMessage,
 ) !void {
-    writeChatMessageJsonInner(scratch_alloc, writer, message, false, null, null) catch |err| return err;
+    writeChatMessageJsonInner(scratch_alloc, writer, message, false, null, null, &.{}) catch |err| return err;
 }
 
-pub fn writeChatMessageJsonCached(
+fn writeChatMessageJsonCached(
     scratch_alloc: std.mem.Allocator,
     writer: *std.Io.Writer,
     message: ChatMessage,
 ) !void {
-    writeChatMessageJsonInner(scratch_alloc, writer, message, true, null, null) catch |err| return err;
+    writeChatMessageJsonInner(scratch_alloc, writer, message, true, null, null, &.{}) catch |err| return err;
 }
 
 pub fn buildGatewayRequestBody(
@@ -342,6 +343,8 @@ fn buildGatewayRequestBodyValidated(
         }
     }
 
+    var ids = try tool_call_ids.Projection.init(alloc, messages);
+    defer ids.deinit(alloc);
     var out: std.Io.Writer.Allocating = .init(alloc);
     defer out.deinit();
 
@@ -356,7 +359,7 @@ fn buildGatewayRequestBodyValidated(
         if (i > 0) try out.writer.writeByte(',');
         if (message.role == .tool) {
             const results = tool_result_prefix(messages[i..]);
-            try write_tool_result_group(&out.writer, results, budget);
+            try write_tool_result_group(&out.writer, results, budget, &ids);
             for (results) |result| {
                 if (result.cache_policy == .no_cache) prefix_cacheable = false;
             }
@@ -369,20 +372,15 @@ fn buildGatewayRequestBodyValidated(
             if (override.message_index == i) override.images else null
         else
             null;
-        if (budget) |active| {
-            try writeChatMessageJsonInner(
-                std.heap.c_allocator,
-                &out.writer,
-                message,
-                use_cache,
-                active,
-                verified_images,
-            );
-        } else if (use_cache) {
-            try writeChatMessageJsonCached(std.heap.c_allocator, &out.writer, message);
-        } else {
-            try writeChatMessageJson(std.heap.c_allocator, &out.writer, message);
-        }
+        try writeChatMessageJsonInner(
+            std.heap.c_allocator,
+            &out.writer,
+            message,
+            use_cache,
+            budget,
+            verified_images,
+            &ids,
+        );
         if (message.cache_policy == .no_cache) prefix_cacheable = false;
         if (budget) |active| try active.check();
         i += 1;
@@ -551,6 +549,49 @@ fn validateAssistantToolCalls(alloc: std.mem.Allocator, calls: []const ToolCall)
     }
 }
 
+test "Gateway request projects nonportable call ids without changing source history" {
+    const source_id = "functions.read_file:0";
+    const second_id = "functions/read_file:0";
+    const calls = [_]ToolCall{
+        .{ .id = source_id, .name = "read_file", .arguments_json = "{}" },
+        .{ .id = second_id, .name = "read_file", .arguments_json = "{}" },
+    };
+    const messages = [_]ChatMessage{
+        .{ .role = .assistant, .tool_calls = &calls },
+        .{ .role = .tool, .tool_call_id = second_id, .tool_name = "read_file", .content = "second" },
+        .{ .role = .tool, .tool_call_id = source_id, .tool_name = "read_file", .content = "result" },
+    };
+    const body = try buildGatewayRequestBody(std.testing.allocator, "[]", &messages);
+    defer std.testing.allocator.free(body);
+    const parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, body, .{});
+    defer parsed.deinit();
+    const prompt = parsed.value.object.get("prompt").?.array.items;
+    const call_id = prompt[0].object.get("content").?.array.items[0].object.get("toolCallId").?.string;
+    const results = prompt[1].object.get("content").?.array.items;
+    try std.testing.expectEqual(@as(usize, 2), results.len);
+    const result_id = results[1].object.get("toolCallId").?.string;
+    try std.testing.expect(!std.mem.eql(u8, source_id, call_id));
+    try std.testing.expect(call_id.len <= 64);
+    for (call_id) |byte| try std.testing.expect(std.ascii.isAlphanumeric(byte) or byte == '_' or byte == '-');
+    try std.testing.expectEqualStrings(call_id, result_id);
+    const second_call_id = prompt[0].object.get("content").?.array.items[1].object.get("toolCallId").?.string;
+    try std.testing.expect(!std.mem.eql(u8, call_id, second_call_id));
+    try std.testing.expectEqualStrings(second_call_id, results[0].object.get("toolCallId").?.string);
+    try std.testing.expectEqualStrings(source_id, calls[0].id);
+    try std.testing.expectEqualStrings(source_id, messages[2].tool_call_id.?);
+}
+
+test "Gateway request preserves provider-owned call ids" {
+    const calls = [_]ToolCall{.{ .id = "native:0", .name = "native", .arguments_json = "{}", .provenance = .provider_executed, .provider_result = "result" }};
+    const messages = [_]ChatMessage{
+        .{ .role = .assistant, .tool_calls = &calls },
+        .{ .role = .tool, .tool_call_id = "native:0", .tool_name = "native", .content = "result" },
+    };
+    const body = try buildGatewayRequestBody(std.testing.allocator, "[]", &messages);
+    defer std.testing.allocator.free(body);
+    try std.testing.expect(std.mem.find(u8, body, "\"toolCallId\":\"native:0\"") != null);
+}
+
 test "non-object provider-owned arguments retain their Gateway representation" {
     const calls = [_]ToolCall{.{ .id = "native", .name = "native_tool", .arguments_json = "[]", .provenance = .provider_executed, .provider_result = "native result" }};
     const messages = [_]ChatMessage{
@@ -605,19 +646,20 @@ fn write_tool_result_group(
     writer: *std.Io.Writer,
     results: []const ChatMessage,
     budget: ?BuildBudget,
+    ids: *const tool_call_ids.Projection,
 ) !void {
     try writer.writeAll("{\"role\":\"tool\",\"content\":[");
     for (results, 0..) |result, index| {
         if (budget) |active| try active.check();
         if (index > 0) try writer.writeByte(',');
-        try write_tool_result_part(writer, result);
+        try write_tool_result_part(writer, result, ids);
     }
     try writer.writeAll("]}");
 }
 
-fn write_tool_result_part(writer: *std.Io.Writer, message: ChatMessage) !void {
+fn write_tool_result_part(writer: *std.Io.Writer, message: ChatMessage, ids: *const tool_call_ids.Projection) !void {
     try writer.writeAll("{\"type\":\"tool-result\",\"toolCallId\":");
-    try std.json.Stringify.value(message.tool_call_id orelse "", .{}, writer);
+    try std.json.Stringify.value(ids.resolve(message.tool_call_id orelse ""), .{}, writer);
     try writer.writeAll(",\"toolName\":");
     try std.json.Stringify.value(message.tool_name orelse "unknown", .{}, writer);
     const content = message.content orelse "";
@@ -644,6 +686,7 @@ fn writeChatMessageJsonInner(
     cached: bool,
     budget: ?BuildBudget,
     verified_images: ?[]const image_attachments.VerifiedSnapshot,
+    ids: *const tool_call_ids.Projection,
 ) !void {
     try writer.writeAll("{\"role\":");
     try std.json.Stringify.value(roleName(message.role), .{}, writer);
@@ -716,7 +759,7 @@ fn writeChatMessageJsonInner(
             for (message.tool_calls) |tool_call| {
                 if (wrote_part) try writer.writeByte(',');
                 try writer.writeAll("{\"type\":\"tool-call\",\"toolCallId\":");
-                try std.json.Stringify.value(tool_call.id, .{}, writer);
+                try std.json.Stringify.value(ids.resolve(tool_call.id), .{}, writer);
                 try writer.writeAll(",\"toolName\":");
                 try std.json.Stringify.value(tool_call.name, .{}, writer);
                 try writer.writeAll(",\"input\":");
@@ -728,7 +771,7 @@ fn writeChatMessageJsonInner(
         },
         .tool => {
             try writer.writeAll(",\"content\":[");
-            try write_tool_result_part(writer, message);
+            try write_tool_result_part(writer, message, ids);
             try writer.writeByte(']');
         },
     }

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -7022,6 +7022,89 @@ printf '%s' ${JSON.stringify(trailingMarker)} > ${JSON.stringify(effectPath)}
     }
   });
 
+  test("tool call ids remain canonical in storage and portable on model switch", async () => {
+    const root = createFixtureRoot("portable-call-ids");
+    const tracePath = join(root.root, "trace.log");
+    const ids = ["functions.read_file:0", "c".repeat(256), "call_keep"];
+    writeFileSync(join(root.workspace, "fixture.txt"), "id projection fixture\n");
+    const responses = [
+      fakeGatewaySse([
+        ...ids.map((id) => ({ type: "tool-call", toolCallId: id, toolName: "read_file", input: { path: "fixture.txt" } })),
+        { type: "finish", finishReason: { unified: "tool-calls", raw: "tool-calls" } },
+      ]),
+      fakeGatewayFinalText("Read the fixture."),
+    ];
+    const gateway = startDynamicFakeGateway(() =>
+      responses.shift() ?? new Response("unexpected request", { status: 400 }),
+      { classifierDecision: "clear", models: [MODEL, DEFAULT_MODEL].map((id) => ({ id, type: "language", tags: ["tool-use"] })) },
+    );
+    try {
+      const result = await runFx(["ask", "--json", "--auto", "Read fixture.txt."], {
+        cwd: root.workspace, env: fixtureEnv(root, gateway, tracePath), timeoutMs: 15_000,
+      });
+      expect(result.code).toBe(0);
+      expect(result.signal).toBeNull();
+      const json = parseAskJson(result.stdout);
+      expect(json.tool_calls).toEqual(ids.map(() => ({ name: "read_file", status: "success" })));
+      expect(gateway.requests).toHaveLength(2);
+      const firstParts = JSON.parse(gateway.requests[1]!.body).prompt.flatMap((message: { content: unknown }) => Array.isArray(message.content) ? message.content : []);
+      const wireIds = firstParts.filter((part: { type: string }) => part.type === "tool-call").map((part: { toolCallId: string }) => part.toolCallId);
+      expect(wireIds).toHaveLength(3);
+      expect(new Set(wireIds).size).toBe(3);
+      for (const id of wireIds) {
+        expect(id).toMatch(/^[a-zA-Z0-9_-]{1,64}$/);
+        expect(toolResultOutput(gateway.requests[1]!.body, id)).toContain("id projection fixture");
+      }
+      expect(wireIds[0]).not.toBe(ids[0]);
+      expect(wireIds[1]).not.toBe(ids[1]);
+      expect(wireIds[2]).toBe(ids[2]);
+      const detail = await runFx(["session", "--id", json.session_id, "--json"], {
+        cwd: root.workspace, env: { HOME: root.home },
+      });
+      expect(detail.code).toBe(0);
+      const step = JSON.parse(detail.stdout).history[0].execution.tool_steps[0];
+      expect(step.tool_calls.map((call: { id: string }) => call.id)).toEqual(ids);
+      expect(step.tool_results.map((result: { tool_call_id: string }) => result.tool_call_id)).toEqual(ids);
+
+      responses.push(fakeGatewayFinalText("Resumed without more tools."));
+      const resumed = await runFx(["ask", "--json", "--auto", "--resume-id", json.session_id, "What did you read?"], {
+        cwd: root.workspace,
+        env: { ...fixtureEnv(root, gateway, tracePath), FX_MODEL: DEFAULT_MODEL },
+        timeoutMs: 15_000,
+      });
+      expect(resumed.code).toBe(0);
+      expect(resumed.stderr).toBe("");
+      expect(JSON.parse(resumed.stdout).model).toBe(DEFAULT_MODEL);
+      expect(parseAskJson(resumed.stdout).tool_calls).toEqual([]);
+      expect(gateway.requests).toHaveLength(3);
+      for (const id of wireIds) expect(toolResultOutput(gateway.requests[2]!.body, id)).toContain("id projection fixture");
+    } finally {
+      gateway.stop();
+      rmSync(root.root, { recursive: true, force: true });
+    }
+  });
+
+  test("blank current tool id is rejected before file execution", async () => {
+    const root = createFixtureRoot("blank-call-id");
+    const tracePath = join(root.root, "trace.log");
+    const gateway = startGateway(() => fakeGatewayToolCall(" \t", "write_file", {
+      path: "must-not-exist.txt", content: "unexpected effect",
+    }));
+    try {
+      const result = await runFx(["ask", "--json", "--auto", "--no-save", "Write the fixture file."], {
+        cwd: root.workspace, env: fixtureEnv(root, gateway, tracePath), timeoutMs: 15_000,
+      });
+      expect(result.code).toBe(1);
+      expect(result.stdout).toContain("MalformedAuthoritativeToolIdentity");
+      expect(parseAskJson(result.stdout).tool_calls).toEqual([]);
+      expect(gateway.requests).toHaveLength(1);
+      expect(existsSync(join(root.workspace, "must-not-exist.txt"))).toBe(false);
+    } finally {
+      gateway.stop();
+      rmSync(root.root, { recursive: true, force: true });
+    }
+  });
+
   test("silent-tool continuation omits blank assistant text and keeps settled results", async () => {
     const root = createFixtureRoot("blank-continuation");
     const tracePath = join(root.root, "trace.log");


### PR DESCRIPTION
## Summary

- Use compatible local tool-call IDs in provider requests while keeping the original IDs in saved sessions.
- Keep calls paired with their results and avoid collisions when replaying history.
- Reject blank tool-call IDs before local execution.
- Preserve provider-owned IDs and state, and stop locally when a shared identity or alias collision makes projection unsafe.
