### PR TITLE
Reject invalid tool identities before execution

### DIFF
--- a/src/builtins/gateway.zig
+++ b/src/builtins/gateway.zig
@@ -1245,6 +1245,16 @@ fn normalizeGatewayCompletion(
             ) });
             break :blk false;
         },
+        .reject_unstorable_identity => |failure| blk: {
+            const detail = try std.fmt.allocPrint(
+                alloc,
+                "provider search tool identity cannot be stored ({s}: {s})",
+                .{ @tagName(failure.field), @tagName(failure.reason) },
+            );
+            errdefer alloc.free(detail);
+            try content.append(alloc, .{ .error_text = detail });
+            break :blk false;
+        },
         .reject_malformed_provider_result => |failure| blk: {
             try content.append(alloc, .{ .error_text = try std.fmt.allocPrint(
                 alloc,
@@ -1321,9 +1331,11 @@ fn normalizeGatewayCompletion(
         } });
     }
 
+    const stop_reason = if (completion.finish_reason) |reason| try alloc.dupe(u8, reason.label()) else null;
+    errdefer if (stop_reason) |value| alloc.free(value);
     return .{
         .content = try content.toOwnedSlice(alloc),
-        .stop_reason = if (completion.finish_reason) |reason| try alloc.dupe(u8, reason.label()) else null,
+        .stop_reason = stop_reason,
         .usage = .{
             .input_tokens = completion.usage.input_tokens orelse 0,
             .output_tokens = completion.usage.output_tokens orelse 0,
@@ -1706,6 +1718,33 @@ test "gateway worker returns one bounded error for malformed provider result ide
         try std.testing.expectEqualStrings(expected, response.content[0].error_text);
         try std.testing.expectEqual(@as(u32, 0), response.usage.?.web_search_requests);
     }
+}
+
+test "gateway worker rejects unstorable provider identities without returning search results" {
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, expectUnstorableProviderIdentity, .{});
+}
+
+fn expectUnstorableProviderIdentity(alloc: Allocator) !void {
+    const oversized = [_]u8{'i'} ** 257;
+    var cancel_flag = std.atomic.Value(bool).init(false);
+    var response = try normalizeGatewayCompletion(alloc, .{
+        .backend = perplexity_search_backend_id,
+        .query = "Zig documentation",
+        .cancel_flag = &cancel_flag,
+    }, .{
+        .tool_calls = &.{.{
+            .id = &oversized,
+            .name = "perplexity_search",
+            .arguments_json = "{}",
+            .provider_result = "{\"results\":[]}",
+            .provenance = .provider_executed,
+        }},
+        .finish_reason = .stop,
+    }, null, null);
+    defer response.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 1), response.content.len);
+    try std.testing.expect(response.content[0] == .error_text);
+    try std.testing.expect(std.mem.find(u8, response.content[0].error_text, "id: too_long") != null);
 }
 
 test "gateway worker rejects malformed provider arguments before accepting search results" {

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -7226,6 +7226,12 @@ fn processQueuedPromptLoop(
                     finish_trace.finish("malformed_tool_identity");
                     return error.MalformedAuthoritativeToolIdentity;
                 },
+                .reject_unstorable_identity => |failure| {
+                    try stream_ctx.provisional_statuses.finishRejectedCompletions(deps, arena, turn_id, completion.tool_calls, advertised_dynamic_tool_names);
+                    debug_trace.eventf("agent", "authoritative_tool_admission_rejected", step_ctx, "field={s} failure={s}", .{ @tagName(failure.field), @tagName(failure.reason) });
+                    finish_trace.finish("unstorable_tool_identity");
+                    return error.MalformedAuthoritativeToolIdentity;
+                },
                 .reject_malformed_provider_result => |failure| {
                     try stream_ctx.provisional_statuses.finishRejectedCompletions(deps, arena, turn_id, completion.tool_calls, advertised_dynamic_tool_names);
                     debug_trace.eventf("agent", "authoritative_tool_admission_rejected", step_ctx, "failure={s} provenance=provider_executed", .{@tagName(failure)});

--- a/src/core/agent/runtime/tests/tool_flow.zig
+++ b/src/core/agent/runtime/tests/tool_flow.zig
@@ -1722,6 +1722,22 @@ fn expectRejectedPrompt(completion: FakeCompletion, expected_error: anyerror) !v
     try std.testing.expect(logContains(&hooks, "event:turn_finished"));
 }
 
+test "processQueuedPrompt rejects unstorable tool batches before permissions or execution" {
+    const oversized = [_]u8{'i'} ** 257;
+    const invalid = [_]ToolCall{
+        .{ .id = "bad", .name = "", .arguments_json = "{}" },
+        .{ .id = &oversized, .name = "read_file", .arguments_json = "{}" },
+        .{ .id = "bad", .name = "read_file", .provisional_id = &oversized, .arguments_json = "{}" },
+    };
+    const valid = toolCall("good", "write_file", "{\"path\":\"a.txt\",\"content\":\"x\"}");
+    for (invalid) |bad| {
+        for ([_]bool{ false, true }) |bad_first| {
+            const calls = if (bad_first) [_]ToolCall{ bad, valid } else [_]ToolCall{ valid, bad };
+            try expectRejectedPrompt(.{ .tool_calls = &calls }, error.MalformedAuthoritativeToolIdentity);
+        }
+    }
+}
+
 fn lifecycleCallId(event: types.ToolLifecycleEvent) ?[]const u8 {
     return switch (event) {
         .provisional => |value| value.id.call_id,

--- a/src/core/session/session_event.zig
+++ b/src/core/session/session_event.zig
@@ -17,7 +17,7 @@ pub const Digest = [Sha256.digest_length]u8;
 
 pub const conversation_schema_version: u8 = 1;
 pub const max_conversation_text_bytes: usize = event_frame_max_bytes;
-pub const max_conversation_identity_bytes: usize = 256;
+pub const max_conversation_identity_bytes: usize = types.ConversationIdentity.max_bytes;
 pub const max_conversation_arguments_bytes: usize = event_frame_max_bytes;
 pub const max_conversation_preview_bytes: usize = 4 * 1024;
 
@@ -308,10 +308,7 @@ fn validateOptionalConversationText(text: []const u8) ConversationTransitionErro
 }
 
 fn validateConversationIdentity(value: []const u8) ConversationTransitionError!void {
-    if (value.len == 0 or
-        value.len > max_conversation_identity_bytes or
-        !std.unicode.utf8ValidateSlice(value))
-    {
+    if (types.ConversationIdentity.invalidReason(value) != null) {
         return error.InvalidConversationEvent;
     }
 }

--- a/src/core/shared/types.zig
+++ b/src/core/shared/types.zig
@@ -1477,9 +1477,25 @@ test "ProviderFinishReason accepts only the canonical provider domain" {
     try std.testing.expectEqual(ProviderFinishReason.content_filter, ProviderFinishReason.parse_legacy("content_filter").?);
 }
 
+pub const ConversationIdentity = struct {
+    pub const max_bytes: usize = 256;
+    pub const Failure = enum { empty, too_long, invalid_utf8 };
+
+    pub fn invalidReason(value: []const u8) ?Failure {
+        if (value.len == 0) return .empty;
+        if (value.len > max_bytes) return .too_long;
+        if (!std.unicode.utf8ValidateSlice(value)) return .invalid_utf8;
+        return null;
+    }
+};
+
 pub const AuthoritativeToolAdmission = union(enum) {
     admitted,
     reject_malformed_identity: FinalToolIdentity,
+    reject_unstorable_identity: struct {
+        field: enum { id, name, provisional_id },
+        reason: ConversationIdentity.Failure,
+    },
     reject_malformed_provider_result: ProviderResultIdentityFailure,
     reject_malformed_provider_arguments,
     reject_duplicate_identity,
@@ -1515,6 +1531,20 @@ pub fn authoritativeToolAdmission(completion: ModelCompletion) AuthoritativeTool
     }
 
     for (completion.tool_calls) |call| {
+        if (ConversationIdentity.invalidReason(call.id)) |reason| {
+            return .{ .reject_unstorable_identity = .{ .field = .id, .reason = reason } };
+        }
+        if (ConversationIdentity.invalidReason(call.name)) |reason| {
+            return .{ .reject_unstorable_identity = .{ .field = .name, .reason = reason } };
+        }
+        if (call.provisional_id) |id| {
+            if (ConversationIdentity.invalidReason(id)) |reason| {
+                return .{ .reject_unstorable_identity = .{ .field = .provisional_id, .reason = reason } };
+            }
+        }
+    }
+
+    for (completion.tool_calls) |call| {
         if (call.provenance == .provider_executed and
             call.argument_integrity == .malformed_json)
         {
@@ -1538,6 +1568,62 @@ test "authoritative tool admission rejects blank current call ids" {
             AuthoritativeToolAdmission{ .reject_malformed_identity = .empty },
             authoritativeToolAdmission(.{ .tool_calls = &calls }),
         );
+    }
+}
+
+test "authoritative tool admission rejects unstorable names" {
+    const oversized = [_]u8{'n'} ** 257;
+    const cases = [_]struct { value: []const u8, reason: ConversationIdentity.Failure }{
+        .{ .value = "", .reason = .empty },
+        .{ .value = &oversized, .reason = .too_long },
+        .{ .value = "\xff", .reason = .invalid_utf8 },
+    };
+    for ([_]ToolExecutionProvenance{ .fx_local, .provider_executed }) |provenance| {
+        for (cases) |case| {
+            const calls = [_]ToolCall{.{ .id = "call", .name = case.value, .arguments_json = "{}", .provenance = provenance, .provider_result = "result" }};
+            try std.testing.expectEqualDeep(
+                AuthoritativeToolAdmission{ .reject_unstorable_identity = .{ .field = .name, .reason = case.reason } },
+                authoritativeToolAdmission(.{ .tool_calls = &calls }),
+            );
+        }
+    }
+}
+
+test "authoritative tool admission rejects unstorable correlation identities" {
+    const oversized = [_]u8{'i'} ** 257;
+    const cases = [_]struct { value: []const u8, reason: ConversationIdentity.Failure }{
+        .{ .value = &oversized, .reason = .too_long },
+        .{ .value = "\xff", .reason = .invalid_utf8 },
+    };
+    for (cases) |case| {
+        const calls = [_]ToolCall{.{ .id = case.value, .name = "read_file", .arguments_json = "{}" }};
+        try std.testing.expectEqualDeep(
+            AuthoritativeToolAdmission{ .reject_unstorable_identity = .{ .field = .id, .reason = case.reason } },
+            authoritativeToolAdmission(.{ .tool_calls = &calls }),
+        );
+        const provisional = [_]ToolCall{.{ .id = "call", .name = "read_file", .arguments_json = "{}", .provisional_id = case.value }};
+        try std.testing.expectEqualDeep(
+            AuthoritativeToolAdmission{ .reject_unstorable_identity = .{ .field = .provisional_id, .reason = case.reason } },
+            authoritativeToolAdmission(.{ .tool_calls = &provisional }),
+        );
+    }
+    const empty_provisional = [_]ToolCall{.{ .id = "call", .name = "read_file", .arguments_json = "{}", .provisional_id = "" }};
+    try std.testing.expectEqualDeep(
+        AuthoritativeToolAdmission{ .reject_unstorable_identity = .{ .field = .provisional_id, .reason = .empty } },
+        authoritativeToolAdmission(.{ .tool_calls = &empty_provisional }),
+    );
+}
+
+test "authoritative tool admission preserves bounded canonical identity formats" {
+    const boundary = [_]u8{'i'} ** 256;
+    const unicode_boundary = "é" ** 128;
+    for ([_][]const u8{ &boundary, unicode_boundary, "functions.read_file:0", "unknown/tool" }) |identity| {
+        for ([_]ToolExecutionProvenance{ .fx_local, .provider_executed }) |provenance| {
+            const calls = [_]ToolCall{.{ .id = identity, .name = identity, .provisional_id = identity, .arguments_json = "{}", .provenance = provenance, .provider_result = "result" }};
+            try std.testing.expectEqual(AuthoritativeToolAdmission.admitted, authoritativeToolAdmission(.{ .tool_calls = &calls }));
+            try std.testing.expectEqualStrings(identity, calls[0].id);
+            try std.testing.expectEqualStrings(identity, calls[0].name);
+        }
     }
 }
 

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -7089,6 +7089,72 @@ printf '%s' ${JSON.stringify(trailingMarker)} > ${JSON.stringify(effectPath)}
     }
   });
 
+  test("unstorable tool identities reject the batch and preserve earlier saved work", async () => {
+    for (const kind of ["empty-name", "missing-name", "null-name", "long-name", "long-id", "long-provisional"]) {
+      const root = createFixtureRoot(`identity-${kind}`);
+      const tracePath = join(root.root, "trace.log");
+      const invalid: Record<string, unknown> = {
+        type: "tool-call", toolCallId: kind === "long-id" ? "i".repeat(257) : "bad",
+        toolName: "unknown_tool", input: {},
+      };
+      if (kind === "empty-name") invalid.toolName = "";
+      if (kind === "missing-name") delete invalid.toolName;
+      if (kind === "null-name") invalid.toolName = null;
+      if (kind === "long-name") invalid.toolName = "n".repeat(257);
+      const streamed = kind === "long-provisional" ? [
+        { type: "tool-input-start", id: "p".repeat(257), toolName: "unknown_tool" },
+        { type: "tool-input-delta", id: "p".repeat(257), delta: "{}" },
+        { type: "tool-input-end", id: "p".repeat(257) },
+      ] : [];
+      const responses = [
+        fakeGatewayToolCall("prior", "write_file", { path: "prior.txt", content: "settled" }),
+        fakeGatewaySse([
+          ...streamed,
+          { type: "tool-call", toolCallId: "sibling", toolName: "write_file", input: { path: "must-not-exist.txt", content: "unexpected effect" } },
+          invalid,
+          { type: "finish", finishReason: { unified: "tool-calls", raw: "tool_calls" } },
+        ]),
+      ];
+      const gateway = startGateway(() => responses.shift() ?? new Response("unexpected request", { status: 400 }));
+      try {
+        const env = fixtureEnv(root, gateway, tracePath);
+        const result = await runFx(["ask", "--json", "--auto", "Create prior.txt, then must-not-exist.txt."], {
+          cwd: root.workspace, env, timeoutMs: 15_000,
+        });
+        expect(result.code, kind).toBe(1);
+        expect(result.signal).toBeNull();
+        expect(result.stdout).toContain("MalformedAuthoritativeToolIdentity");
+        expect(readFileSync(join(root.workspace, "prior.txt"), "utf8")).toBe("settled");
+        expect(existsSync(join(root.workspace, "must-not-exist.txt"))).toBe(false);
+        expect(gateway.requests).toHaveLength(2);
+        const json = parseAskJson(result.stdout);
+        expect(json.tool_calls).toEqual([{ name: "write_file", status: "success" }]);
+        const detail = await runFx(["session", "--id", json.session_id, "--json"], { cwd: root.workspace, env });
+        expect(detail.code).toBe(0);
+        const history = JSON.parse(detail.stdout).history;
+        expect(history).toHaveLength(1);
+        expect(history[0].execution.tool_steps).toHaveLength(1);
+        expect(history[0].execution.tool_steps[0].tool_calls.map((call: { id: string }) => call.id)).toEqual(["prior"]);
+        const field = kind === "long-id" ? "id" : kind === "long-provisional" ? "provisional_id" : "name";
+        expect(readFileSync(tracePath, "utf8")).toContain(`field=${field} failure=${kind.startsWith("long-") ? "too_long" : "empty"}`);
+
+        responses.push(fakeGatewayFinalText("The prior write is retained."));
+        const resumed = await runFx(["ask", "--json", "--auto", "--resume-id", json.session_id, "What was completed?"], {
+          cwd: root.workspace, env, timeoutMs: 15_000,
+        });
+        expect(resumed.code).toBe(0);
+        expect(parseAskJson(resumed.stdout).tool_calls).toEqual([]);
+        expect(gateway.requests).toHaveLength(3);
+        expect(toolResultOutput(gateway.requests[2]!.body, "prior")).toContain("wrote prior.txt");
+        const parts = JSON.parse(gateway.requests[2]!.body).prompt.flatMap((message: { content: unknown }) => Array.isArray(message.content) ? message.content : []);
+        expect(parts.filter((part: { type: string }) => part.type === "tool-call").map((part: { toolCallId: string }) => part.toolCallId)).toEqual(["prior"]);
+      } finally {
+        gateway.stop();
+        rmSync(root.root, { recursive: true, force: true });
+      }
+    }
+  });
+
   test("blank current tool id is rejected before file execution", async () => {
     const root = createFixtureRoot("blank-call-id");
     const tracePath = join(root.root, "trace.log");

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -895,6 +895,7 @@ async function runCodexLoginWithBrowser(
 }
 
 function startFakeCodexToolLoop(options: {
+  toolCallId?: string;
   toolName?: string;
   toolArguments?: object;
   finalText?: string;
@@ -922,7 +923,7 @@ function startFakeCodexToolLoop(options: {
         return new Response(
           'data: {"type":"response.output_item.added","output_index":0,"item":{"type":"reasoning"}}\n\n' +
             'data: {"type":"response.output_item.done","output_index":0,"item":{"id":"rs_tool","type":"reasoning","summary":[],"encrypted_content":"opaque-tool-loop"}}\n\n' +
-            `data: ${JSON.stringify({ type: "response.output_item.added", output_index: 1, item: { type: "function_call", call_id: "call_tool", name: toolName } })}\n\n` +
+            `data: ${JSON.stringify({ type: "response.output_item.added", output_index: 1, item: { type: "function_call", call_id: options.toolCallId ?? "call_tool", name: toolName } })}\n\n` +
             `data: ${JSON.stringify({ type: "response.function_call_arguments.done", output_index: 1, arguments: JSON.stringify(toolArguments) })}\n\n` +
             'data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":5,"output_tokens":2}}}\n\n',
           { headers: { "content-type": "text/event-stream" } },
@@ -985,6 +986,7 @@ function startFakeCodexCapacityLoop() {
 }
 
 function startFakeGrokToolLoop(options: {
+  toolCallId?: string;
   toolName?: string;
   toolArguments?: object;
   finalText?: string;
@@ -1010,7 +1012,7 @@ function startFakeGrokToolLoop(options: {
         return new Response(
           'data: {"type":"response.output_item.added","output_index":0,"item":{"type":"reasoning"}}\n\n' +
             'data: {"type":"response.output_item.done","output_index":0,"item":{"id":"rs_tool","type":"reasoning","summary":[],"encrypted_content":"opaque-grok-tool-loop"}}\n\n' +
-            `data: ${JSON.stringify({ type: "response.output_item.added", output_index: 1, item: { type: "function_call", call_id: "call_tool", name: toolName } })}\n\n` +
+            `data: ${JSON.stringify({ type: "response.output_item.added", output_index: 1, item: { type: "function_call", call_id: options.toolCallId ?? "call_tool", name: toolName } })}\n\n` +
             `data: ${JSON.stringify({ type: "response.function_call_arguments.done", output_index: 1, arguments: JSON.stringify(toolArguments) })}\n\n` +
             'data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":5,"output_tokens":2}}}\n\n',
           { headers: { "content-type": "text/event-stream" } },
@@ -4337,6 +4339,53 @@ tmuxTest(
   },
   60_000,
 );
+
+test("direct provider tool identities obey the session boundary before execution", async () => {
+  for (const provider of ["codex", "grok"] as const) {
+    for (const bytes of [256, 257]) {
+      const profile = mkdtempSync(join(tmpdir(), `fx-${provider}-identity-`));
+      const testGateway = startFakeGateway([]);
+      const options = { toolCallId: "i".repeat(bytes), toolName: "write_file", toolArguments: { path: "result.txt", content: "saved" } };
+      const direct = provider === "codex" ? startFakeCodexToolLoop(options) : startFakeGrokToolLoop(options);
+      try {
+        if (provider === "codex") writeSeededChatGptLogin(profile, direct.accessToken);
+        else writeSeededGrokLogin(profile, direct.accessToken);
+        const catalog = await (await fetch(direct.modelsUrl)).json();
+        const model = provider === "codex" ? catalog.models[0].slug : catalog.data[0].id;
+        writeFileSync(join(profile, ".fx", "settings.json"), JSON.stringify({ provider, [`${provider}_model`]: model }), { mode: 0o600 });
+        const env = {
+          HOME: profile, AI_GATEWAY_API_KEY: "fixture", VERCEL_OIDC_TOKEN: undefined, FX_MODEL: undefined,
+          FX_DISABLE_KEYCHAIN: "1", FX_AUTO_UPGRADE: "0", FX_SOUND: "0",
+          FX_GATEWAY_BASE_URL: testGateway.baseUrl,
+          FX_E2E_GATEWAY_MODELS_URL: `${testGateway.baseUrl}/coding-agent/v1/models`,
+          FX_E2E_OPENAI_CODEX_RESPONSES_URL: direct.responsesUrl,
+          FX_E2E_OPENAI_CODEX_MODELS_URL: direct.modelsUrl,
+          FX_E2E_XAI_GROK_RESPONSES_URL: direct.responsesUrl,
+          FX_E2E_XAI_GROK_MODELS_URL: direct.modelsUrl,
+          FX_E2E_XAI_GROK_MODALITIES_URL: "modalitiesUrl" in direct ? direct.modalitiesUrl : undefined,
+        };
+        const result = await runFx(["ask", "--json", "--auto", "Create result.txt containing saved."], { cwd: profile, env, timeoutMs: TIMEOUT });
+        const accepted = bytes === 256;
+        expect(result.code, `${provider}/${bytes}: ${result.stdout}\n${result.stderr}`).toBe(accepted ? 0 : 1);
+        expect(result.signal).toBeNull();
+        expect(existsSync(join(profile, "result.txt"))).toBe(accepted);
+        expect(direct.bodies).toHaveLength(accepted ? 2 : 1);
+        expect(testGateway.requests).toHaveLength(0);
+        const json = JSON.parse(result.stdout);
+        expect(json.tool_calls).toEqual(accepted ? [{ name: "write_file", status: "success" }] : []);
+        if (!accepted) expect(json.error).toBe("MalformedAuthoritativeToolIdentity");
+        const detail = await runFx(["session", "--json", "--id", json.session_id], { cwd: profile, env });
+        expect(detail.code).toBe(0);
+        const history = JSON.parse(detail.stdout).history;
+        expect(history).toHaveLength(accepted ? 1 : 0);
+        if (accepted) expect(history[0].execution.tool_steps[0].tool_calls[0].id).toBe(options.toolCallId);
+      } finally {
+        direct.stop(); testGateway.stop();
+        rmSync(profile, { recursive: true, force: true });
+      }
+    }
+  }
+}, 60_000);
 
 test(
   "ChatGPT tool loops round-trip encrypted reasoning without Gateway leakage",


### PR DESCRIPTION
## Summary

- Reject tool batches with call IDs, names, or provisional IDs that cannot be stored before any local tool executes.
- Preserve completed tool steps in saved history when a later batch is rejected.
- Record the failing identity field and reason in rejection diagnostics.
