### PR TITLE
Enable automatic Gateway caching for agent conversations

### DIFF
--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -1482,7 +1482,7 @@ test "shell request projection wraps eligible flat objects without changing sour
     calls[cases.len + 2] = .{ .id = "other-executor", .name = "browser_terminal", .arguments_json = "{}" };
     const messages = [_]ChatMessage{
         .{ .role = .user, .content = "keep user message", .tool_calls = calls[0..1] },
-        .{ .role = .assistant, .content = "assistant", .tool_calls = &calls, .provider_state_json = "[]", .cache_policy = .no_cache },
+        .{ .role = .assistant, .content = "assistant", .tool_calls = &calls, .provider_state_json = "[]" },
         .{ .role = .tool, .content = "keep result", .tool_call_id = "valid-action", .tool_name = "shell" },
     };
 
@@ -1492,7 +1492,6 @@ test "shell request projection wraps eligible flat objects without changing sour
     try std.testing.expect(messages[0].tool_calls.ptr != projected[0].tool_calls.ptr);
     try std.testing.expectEqualStrings("assistant", projected[1].content.?);
     try std.testing.expectEqualStrings("[]", projected[1].provider_state_json.?);
-    try std.testing.expectEqual(.no_cache, projected[1].cache_policy);
     try std.testing.expectEqualStrings("keep result", projected[2].content.?);
     for (cases, 0..) |case, index| {
         try std.testing.expectEqualStrings(case.expected, projected[1].tool_calls[index].arguments_json);
@@ -2830,7 +2829,6 @@ fn appendRecoveryConversationContext(
     try messages.append(alloc, .{
         .role = .user,
         .content = prompt,
-        .cache_policy = .no_cache,
     });
 }
 
@@ -2853,7 +2851,6 @@ test "recovery conversation context is chronological and system free" {
         try std.testing.expectEqual(@as(usize, 2), messages.items.len);
         try std.testing.expectEqual(types.ChatRole.user, messages.items[1].role);
         try std.testing.expectEqualStrings(continue_response_recovery_prompt, messages.items[1].content.?);
-        try std.testing.expectEqual(types.ChatCachePolicy.no_cache, messages.items[1].cache_policy);
     }
 
     const prompted = [_]model_response_recovery.Strategy{
@@ -2868,7 +2865,6 @@ test "recovery conversation context is chronological and system free" {
         try appendRecoveryConversationContext(alloc, &messages, strategy);
         try std.testing.expectEqual(@as(usize, 2), messages.items.len);
         try std.testing.expectEqual(types.ChatRole.user, messages.items[1].role);
-        try std.testing.expectEqual(types.ChatCachePolicy.no_cache, messages.items[1].cache_policy);
     }
 
     for ([_]model_response_recovery.Strategy{ .pause, .stop }) |strategy| {
@@ -2906,7 +2902,6 @@ fn build_provider_prompt_with_response_language_control(
         projected[ephemeral_overlay.len] = .{
             .role = .system,
             .content = response_language_control,
-            .cache_policy = .no_cache,
         };
         break :blk projected;
     } else ephemeral_overlay;
@@ -2926,7 +2921,6 @@ fn build_provider_prompt_with_response_language_control(
         try prompt.messages.append(alloc, .{
             .role = .user,
             .content = response_language_correction_control,
-            .cache_policy = .no_cache,
         });
     }
     return .{
@@ -4583,7 +4577,6 @@ fn buildProviderPromptForCompactionWindow(
     try compacted_history.append(alloc, .{
         .role = .user,
         .content = handoff.?,
-        .cache_policy = .no_cache,
     });
     try compacted_history.appendSlice(alloc, retained_history_tail);
     return runtime_prompt_context.buildProviderPrompt(
@@ -4762,7 +4755,7 @@ pub fn prepareManualCompactionContinuation(
         stable_prefix.items,
         overlay.items,
         &.{},
-        .{ .role = .user, .content = "", .cache_policy = .no_cache },
+        .{ .role = .user, .content = "" },
         &.{},
         config.origin,
         config.enforce_response_language,
@@ -4771,6 +4764,8 @@ pub fn prepareManualCompactionContinuation(
         &.{},
         0,
     );
+    var provider_options = model_capabilities.resolveProviderOptionsForCapabilities(capabilities, config.effort, config.fast_mode);
+    provider_options.prompt_caching = true;
     return .{
         .request = .{
             .model = model,
@@ -4782,7 +4777,7 @@ pub fn prepareManualCompactionContinuation(
                 .advertised_functions = config.advertised_functions,
             },
             .tool_choice = config.first_call_tool_choice,
-            .provider_options = model_capabilities.resolveProviderOptionsForCapabilities(capabilities, config.effort, config.fast_mode),
+            .provider_options = provider_options,
             .max_output_tokens = request_max_output_tokens(capabilities),
             .budget = .{ .cancel_flag = config.cancel_flag },
         },
@@ -5482,7 +5477,8 @@ fn processQueuedPromptLoop(
                 subagent_request_messages,
             );
             last_gateway_message_count = gateway_instructions.items.len + request_messages.len;
-            const provider_opts = model_capabilities.resolveProviderOptionsForCapabilities(request_capabilities, config.effort, route_fast_mode);
+            var provider_opts = model_capabilities.resolveProviderOptionsForCapabilities(request_capabilities, config.effort, route_fast_mode);
+            provider_opts.prompt_caching = true;
             runtime_telemetry.traceGatewayProviderOptions(step_ctx, gateway_model, route_fast_mode, config.effort, provider_opts);
             const tool_choice: types.ToolChoice = if (recovery_strategy == .reconcile_tool)
                 .none
@@ -6392,7 +6388,6 @@ fn processQueuedPromptLoop(
                 try within_turn_suffix.append(arena, .{
                     .role = .user,
                     .content = assistant_prefill_recovery_prompt,
-                    .cache_policy = .no_cache,
                 });
                 debug_trace.eventf(
                     "gateway",
@@ -9933,7 +9928,6 @@ fn processQueuedPromptLoop(
                 try within_turn_suffix.append(arena, .{
                     .role = .user,
                     .content = notice,
-                    .cache_policy = .no_cache,
                 });
             }
             if (execution.interactive_notice) |notice| {

--- a/src/core/agent/runtime/prompt_context.zig
+++ b/src/core/agent/runtime/prompt_context.zig
@@ -354,7 +354,7 @@ pub fn buildProviderPrompt(
     errdefer messages.deinit(alloc);
 
     try instructions.appendSlice(alloc, stable_prefix);
-    try appendEphemeralOverlayMessages(alloc, &instructions, ephemeral_overlay);
+    try instructions.appendSlice(alloc, ephemeral_overlay);
     try messages.appendSlice(alloc, durable_history);
     try messages.append(alloc, current_user_message);
     try messages.appendSlice(alloc, within_turn_suffix);
@@ -362,14 +362,6 @@ pub fn buildProviderPrompt(
         .instructions = instructions,
         .messages = messages,
     };
-}
-
-fn appendEphemeralOverlayMessages(alloc: Allocator, messages: *std.ArrayList(ChatMessage), ephemeral_overlay: []const ChatMessage) !void {
-    for (ephemeral_overlay) |overlay_message| {
-        var copy = overlay_message;
-        copy.cache_policy = .no_cache;
-        try messages.append(alloc, copy);
-    }
 }
 
 test "buildProviderPrompt separates instructions from chronological messages" {
@@ -402,7 +394,6 @@ test "buildProviderPrompt separates instructions from chronological messages" {
     try std.testing.expectEqualStrings("history assistant answer", prompt.messages.items[1].content.?);
     try std.testing.expectEqualStrings("current user prompt", prompt.messages.items[2].content.?);
     try std.testing.expectEqualStrings("within turn assistant", prompt.messages.items[3].content.?);
-    try std.testing.expectEqual(types.ChatCachePolicy.no_cache, prompt.instructions.items[2].cache_policy);
 }
 
 test "buildProviderPrompt keeps compacted session context out of instructions" {

--- a/src/core/agent/runtime/tests/gateway_flow.zig
+++ b/src/core/agent/runtime/tests/gateway_flow.zig
@@ -609,29 +609,6 @@ fn runScriptedVision(
     });
 }
 
-fn expectGatewayPromptEntryCacheControl(gateway: *const FakeGateway, index: usize, needle: []const u8, expected: bool) !void {
-    const alloc = std.testing.allocator;
-    try std.testing.expect(index < gateway.request_bodies.items.len);
-
-    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, gateway.request_bodies.items[index], .{});
-    defer parsed.deinit();
-
-    const prompt = parsed.value.object.get("prompt").?.array.items;
-    for (prompt) |entry| {
-        if (countPromptEntryText(entry, needle) == 0) continue;
-        try std.testing.expectEqual(expected, entry.object.get("providerOptions") != null);
-        return;
-    }
-    return error.TestExpectedPromptMessageMissing;
-}
-
-fn expectNoPromptCacheControlAfter(gateway: *const FakeGateway, index: usize, needle: []const u8) !void {
-    try std.testing.expect(index < gateway.request_bodies.items.len);
-    const body = gateway.request_bodies.items[index];
-    const start = std.mem.indexOf(u8, body, needle) orelse return error.TestExpectedBodyNeedleMissing;
-    try std.testing.expect(std.mem.find(u8, body[start..], "cacheControl") == null);
-}
-
 test "processQueuedPrompt gates text-only images through the real Vision runtime" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
@@ -2768,7 +2745,7 @@ test "processQueuedPrompt omits Fast without catalog support" {
     try std.testing.expectEqual(@as(usize, 1), gateway.request_bodies.items.len);
     try expectBodyContains(&gateway, 0, "\"reasoning\":\"high\"");
     try expectRootFieldAbsent(&gateway, 0, "fast");
-    try expectRootFieldAbsent(&gateway, 0, "providerOptions");
+    try expectBodyContains(&gateway, 0, "\"providerOptions\":{\"gateway\":{\"caching\":\"auto\"}}");
     try expectBodyNotContains(&gateway, 0, "\"maxOutputTokens\"");
 }
 
@@ -3603,7 +3580,7 @@ test "processQueuedPrompt resolves catalog capabilities for opaque effort" {
     try std.testing.expectEqual(@as(usize, 1), hooks.capability_queries.items.len);
     try std.testing.expectEqualStrings("provider/new-reasoning-model", hooks.capability_queries.items[0]);
     try expectBodyContains(&gateway, 0, "\"reasoning\":\"future-tier\"");
-    try expectBodyNotContains(&gateway, 0, "\"providerOptions\"");
+    try expectBodyContains(&gateway, 0, "\"providerOptions\":{\"gateway\":{\"caching\":\"auto\"}}");
 
     const trace = try readTraceFile(alloc, trace_path, 65536);
     defer alloc.free(trace);
@@ -3640,7 +3617,7 @@ test "processQueuedPrompt traces why stale controls are omitted" {
 
     try expectBodyNotContains(&gateway, 0, "\"reasoning\"");
     try expectRootFieldAbsent(&gateway, 0, "fast");
-    try expectRootFieldAbsent(&gateway, 0, "providerOptions");
+    try expectBodyContains(&gateway, 0, "\"providerOptions\":{\"gateway\":{\"caching\":\"auto\"}}");
     const trace = try readTraceFile(alloc, trace_path, 65536);
     defer alloc.free(trace);
     try std.testing.expect(std.mem.find(u8, trace, "reasoning=unsupported_or_missing") != null);
@@ -3725,7 +3702,7 @@ test "processQueuedPrompt keeps exact model identity and emits Gateway Fast" {
     try std.testing.expectEqualStrings("zai/glm-5.2", gateway.request_models.items[0]);
     try std.testing.expectEqual(@as(usize, 1), hooks.capability_queries.items.len);
     try expectRootFieldAbsent(&gateway, 0, "fast");
-    try expectBodyContains(&gateway, 0, "\"providerOptions\":{\"gateway\":{\"speed\":\"fast\"}}");
+    try expectBodyContains(&gateway, 0, "\"providerOptions\":{\"gateway\":{\"speed\":\"fast\",\"caching\":\"auto\"}}");
 }
 
 test "processQueuedPrompt keeps directly selected fast model identity for portable lookup" {
@@ -3785,7 +3762,7 @@ test "processQueuedPrompt filters stale controls against each queued model" {
 
         try expectBodyContains(&gateway, 0, "\"reasoning\":\"xhigh\"");
         try expectRootFieldAbsent(&gateway, 0, "fast");
-        try expectBodyContains(&gateway, 0, "\"providerOptions\":{\"gateway\":{\"speed\":\"fast\"}}");
+        try expectBodyContains(&gateway, 0, "\"providerOptions\":{\"gateway\":{\"speed\":\"fast\",\"caching\":\"auto\"}}");
     }
 
     {
@@ -3804,7 +3781,7 @@ test "processQueuedPrompt filters stale controls against each queued model" {
 
         try expectBodyNotContains(&gateway, 0, "\"reasoning\"");
         try expectRootFieldAbsent(&gateway, 0, "fast");
-        try expectRootFieldAbsent(&gateway, 0, "providerOptions");
+        try expectBodyContains(&gateway, 0, "\"providerOptions\":{\"gateway\":{\"caching\":\"auto\"}}");
     }
 }
 
@@ -3828,7 +3805,7 @@ test "processQueuedPrompt filters captured Fast by model capability" {
 
         try std.testing.expectEqual(@as(usize, 1), gateway.request_bodies.items.len);
         try expectRootFieldAbsent(&gateway, 0, "fast");
-        try expectRootFieldAbsent(&gateway, 0, "providerOptions");
+        try expectBodyContains(&gateway, 0, "\"providerOptions\":{\"gateway\":{\"caching\":\"auto\"}}");
     }
 
     {
@@ -3847,7 +3824,7 @@ test "processQueuedPrompt filters captured Fast by model capability" {
 
         try std.testing.expectEqual(@as(usize, 1), gateway.request_bodies.items.len);
         try expectRootFieldAbsent(&gateway, 0, "fast");
-        try expectBodyContains(&gateway, 0, "\"providerOptions\":{\"gateway\":{\"speed\":\"fast\"}}");
+        try expectBodyContains(&gateway, 0, "\"providerOptions\":{\"gateway\":{\"speed\":\"fast\",\"caching\":\"auto\"}}");
     }
 }
 
@@ -3881,7 +3858,7 @@ test "processQueuedPrompt provider payload follows queued model sync boundaries"
 
         try std.testing.expectEqual(@as(usize, 1), gateway.request_bodies.items.len);
         try expectRootFieldAbsent(&gateway, 0, "fast");
-        try expectRootFieldAbsent(&gateway, 0, "providerOptions");
+        try expectBodyContains(&gateway, 0, "\"providerOptions\":{\"gateway\":{\"caching\":\"auto\"}}");
     }
     worker.finishProcessing();
 
@@ -3915,7 +3892,7 @@ test "processQueuedPrompt provider payload follows queued model sync boundaries"
         try std.testing.expectEqual(@as(usize, 1), gateway.request_bodies.items.len);
         try expectBodyContains(&gateway, 0, "\"reasoning\":\"high\"");
         try expectRootFieldAbsent(&gateway, 0, "fast");
-        try expectBodyContains(&gateway, 0, "\"providerOptions\":{\"gateway\":{\"speed\":\"fast\"}}");
+        try expectBodyContains(&gateway, 0, "\"providerOptions\":{\"gateway\":{\"speed\":\"fast\",\"caching\":\"auto\"}}");
     }
 }
 
@@ -4090,6 +4067,45 @@ test "processQueuedPrompt final summary counts submitted input once across Gatew
     try std.testing.expect(summary.turn_duration_ms >= summary.thinking_duration_ms);
 }
 
+test "processQueuedPrompt enables Gateway automatic caching across model families and tool steps" {
+    const alloc = std.testing.allocator;
+    const models = [_][]const u8{
+        "anthropic/claude-sonnet-4.6",
+        "openai/gpt-5.6-luna",
+        "zai/glm-5.2",
+        "moonshotai/kimi-k3",
+        "google/gemini-3-flash",
+        "xai/grok-4.5",
+        "provider/new-model",
+    };
+    for (models) |model| {
+        const calls = [_]ToolCall{toolCall("read", "read_file", "{\"path\":\"a\"}")};
+        const completions = [_]FakeCompletion{
+            .{ .tool_calls = &calls },
+            .{ .content = "Done" },
+        };
+        var gateway = FakeGateway.init(alloc, &completions);
+        defer gateway.deinit();
+        var hooks = FakeAgentRuntimeDeps.init(alloc);
+        defer hooks.deinit();
+        hooks.runtime_context_text = "runtime context remains visible";
+        var fixture = PromptFixture{};
+        var job = fixture.job();
+        job.model = @constCast(model);
+        try runFakePrompt(&gateway, &hooks, fixture.config(), job);
+        try std.testing.expectEqual(@as(usize, 2), gateway.request_bodies.items.len);
+        for (gateway.request_bodies.items) |body| {
+            var parsed = try std.json.parseFromSlice(std.json.Value, alloc, body, .{});
+            defer parsed.deinit();
+            const options = parsed.value.object.get("providerOptions").?.object;
+            try std.testing.expectEqualStrings("auto", options.get("gateway").?.object.get("caching").?.string);
+            try std.testing.expect(std.mem.find(u8, body, "cacheControl") == null);
+            try std.testing.expect(std.mem.find(u8, body, "runtime context remains visible") != null);
+        }
+        try std.testing.expectEqual(@as(usize, 1), hooks.executed_names.items.len);
+    }
+}
+
 test "processQueuedPrompt places transient overlay before history and current prompt" {
     const alloc = std.testing.allocator;
     const completions = [_]FakeCompletion{.{ .content = "No" }};
@@ -4122,10 +4138,6 @@ test "processQueuedPrompt places transient overlay before history and current pr
     try std.testing.expect(static_idx < runtime_idx);
     try std.testing.expect(runtime_idx < history_idx);
     try std.testing.expect(history_idx < current_idx);
-    try expectGatewayPromptEntryCacheControl(&gateway, 0, "system", true);
-    try expectGatewayPromptEntryCacheControl(&gateway, 0, "static project context unique", true);
-    try expectGatewayPromptEntryCacheControl(&gateway, 0, "runtime tail context unique", false);
-    try expectNoPromptCacheControlAfter(&gateway, 0, "runtime tail context unique");
     try expectGatewayPromptFinalUserText(&gateway, 0, "is it still running");
     try std.testing.expectEqual(@as(usize, 0), hooks.executed_names.items.len);
 }
@@ -5229,9 +5241,9 @@ test "processQueuedPrompt disables provider option fast after a replay safe SSE 
     try runFakePrompt(&gateway, &hooks, config, fixture.job());
 
     try std.testing.expectEqual(@as(usize, 2), gateway.request_models.items.len);
-    try expectBodyContains(&gateway, 0, "\"providerOptions\":{\"gateway\":{\"speed\":\"fast\"}}");
+    try expectBodyContains(&gateway, 0, "\"providerOptions\":{\"gateway\":{\"speed\":\"fast\",\"caching\":\"auto\"}}");
     try expectRootFieldAbsent(&gateway, 0, "fast");
-    try expectRootFieldAbsent(&gateway, 1, "providerOptions");
+    try expectBodyContains(&gateway, 1, "\"providerOptions\":{\"gateway\":{\"caching\":\"auto\"}}");
 }
 
 test "processQueuedPrompt disables provider option fast after a replay safe HTTP failure" {
@@ -5257,9 +5269,9 @@ test "processQueuedPrompt disables provider option fast after a replay safe HTTP
     try runFakePrompt(&gateway, &hooks, config, fixture.job());
 
     try std.testing.expectEqual(@as(usize, 2), gateway.request_models.items.len);
-    try expectBodyContains(&gateway, 0, "\"providerOptions\":{\"gateway\":{\"speed\":\"fast\"}}");
+    try expectBodyContains(&gateway, 0, "\"providerOptions\":{\"gateway\":{\"speed\":\"fast\",\"caching\":\"auto\"}}");
     try expectRootFieldAbsent(&gateway, 0, "fast");
-    try expectRootFieldAbsent(&gateway, 1, "providerOptions");
+    try expectBodyContains(&gateway, 1, "\"providerOptions\":{\"gateway\":{\"caching\":\"auto\"}}");
 }
 
 test "processQueuedPrompt retries directly selected intrinsic fast model without rewriting its ID" {
@@ -6655,9 +6667,9 @@ test "processQueuedPrompt disable Fast recovery retries the same exact model" {
     try std.testing.expectEqual(@as(usize, 2), gateway.request_models.items.len);
     try std.testing.expectEqualStrings("zai/glm-5.2", gateway.request_models.items[0]);
     try std.testing.expectEqualStrings("zai/glm-5.2", gateway.request_models.items[1]);
-    try expectBodyContains(&gateway, 0, "\"providerOptions\":{\"gateway\":{\"speed\":\"fast\"}}");
+    try expectBodyContains(&gateway, 0, "\"providerOptions\":{\"gateway\":{\"speed\":\"fast\",\"caching\":\"auto\"}}");
     try expectRootFieldAbsent(&gateway, 0, "fast");
-    try expectRootFieldAbsent(&gateway, 1, "providerOptions");
+    try expectBodyContains(&gateway, 1, "\"providerOptions\":{\"gateway\":{\"caching\":\"auto\"}}");
     try std.testing.expectEqual(@as(usize, 1), hooks.capability_queries.items.len);
     try std.testing.expectEqualStrings("zai/glm-5.2", hooks.capability_queries.items[0]);
     try std.testing.expectEqual(@as(usize, 0), hooks.route_recovery_count);

--- a/src/core/agent/runtime/tests/support.zig
+++ b/src/core/agent/runtime/tests/support.zig
@@ -644,7 +644,6 @@ pub const FakeAgentRuntimeDeps = struct {
     last_route_recovery_unsafe_reason: ?types.RouteRecoveryUnsafeReason = null,
     default_model_capabilities: model_capabilities.Capabilities = .{
         .image_input_support = .non_native,
-        .prompt_caching = true,
         .context_window = 1_000_000,
     },
     capability_overrides: []const ModelCapabilityOverride = &.{},

--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -3349,7 +3349,6 @@ const CoordinatorTestApp = struct {
 
     pub fn resolvedModelCapabilities(self: *CoordinatorTestApp, model: []const u8) model_capabilities.Capabilities {
         var fallback = model_capabilities.Capabilities{
-            .prompt_caching = true,
             .context_window = 1_000_000,
         };
         if (self.intrinsic_fast_model) |intrinsic_model| {

--- a/src/core/config/model_capabilities.zig
+++ b/src/core/config/model_capabilities.zig
@@ -56,7 +56,6 @@ pub const Capabilities = struct {
     supports_web_search: bool = false,
     supports_explicit_caching: bool = false,
     supports_implicit_caching: bool = false,
-    prompt_caching: bool = false,
     parallel_tool_calls: ?bool = null,
     context_window: ?u32 = null,
     max_output_tokens: ?u32 = null,
@@ -154,7 +153,6 @@ pub fn resolveProviderOptionsForCapabilities(
 ) ResolvedProviderOptions {
     var resolved: ResolvedProviderOptions = .{
         .parallel_tool_calls = capabilities.parallel_tool_calls,
-        .prompt_caching = capabilities.prompt_caching,
     };
     if (!effort.isDefault() and reasoningEffortSupported(capabilities, effort)) {
         resolved.reasoning = effort;
@@ -196,7 +194,7 @@ test "mergeCapabilities preserves provider controls and supplied fallback policy
         types.ReasoningEffort.literal("future-tier"),
         types.ReasoningEffort.literal("high"),
     };
-    const capabilities = mergeCapabilities(.{ .intrinsic_fast = true, .prompt_caching = true }, .{
+    const capabilities = mergeCapabilities(.{ .intrinsic_fast = true }, .{
         .reasoning_efforts = .fromSlice(&efforts),
         .supports_fast_mode = true,
         .supports_tool_use = true,
@@ -220,7 +218,6 @@ test "mergeCapabilities preserves provider controls and supplied fallback policy
     try std.testing.expect(capabilities.supports_web_search);
     try std.testing.expect(capabilities.supports_explicit_caching);
     try std.testing.expect(capabilities.supports_implicit_caching);
-    try std.testing.expect(capabilities.prompt_caching);
     try std.testing.expectEqual(@as(?u32, 300_000), capabilities.context_window);
     try std.testing.expectEqual(@as(?u32, 32_000), capabilities.max_output_tokens);
 }
@@ -321,6 +318,5 @@ test "request controls remain safe across repeated state transitions" {
 
 test "generic fallback capabilities contain no vendor policy" {
     const fallback = capabilitiesForModel("anthropic/claude-any");
-    try std.testing.expect(!fallback.prompt_caching);
     try std.testing.expect(fallback.context_window == null);
 }

--- a/src/core/shared/types.zig
+++ b/src/core/shared/types.zig
@@ -1055,11 +1055,6 @@ pub const UserTurn = struct {
     work_id: ?[]u8 = null,
 };
 
-pub const ChatCachePolicy = enum {
-    default,
-    no_cache,
-};
-
 pub const ChatMessage = struct {
     role: ChatRole,
     content: ?[]const u8 = null,
@@ -1073,7 +1068,6 @@ pub const ChatMessage = struct {
     tool_result_status: ?PersistedToolStatus = null,
     tool_result_memory: ?ToolResultMemory = null,
     permission_feedback: bool = false,
-    cache_policy: ChatCachePolicy = .default,
 };
 
 pub const Usage = struct {

--- a/src/gateway/vercel_model_policy.zig
+++ b/src/gateway/vercel_model_policy.zig
@@ -3,9 +3,7 @@ const model_capabilities = @import("../core/config/model_capabilities.zig");
 
 pub fn capabilitiesForModel(model: []const u8) model_capabilities.Capabilities {
     var capabilities = model_capabilities.capabilitiesForModel(model);
-    if (std.mem.startsWith(u8, model, "anthropic/")) {
-        capabilities.prompt_caching = true;
-    } else if (std.mem.startsWith(u8, model, "xai/")) {
+    if (std.mem.startsWith(u8, model, "xai/")) {
         capabilities.parallel_tool_calls = true;
     }
     capabilities.context_window = contextWindowSize(model);
@@ -60,6 +58,5 @@ test "Vercel fallback policy owns vendor model heuristics" {
     try std.testing.expect(capabilitiesForModel("anthropic/claude-opus-4.8-fast").intrinsic_fast);
     try std.testing.expect(!capabilitiesForModel("moonshotai/kimi-k3-fast").supports_fast_mode);
     try std.testing.expectEqual(@as(?u32, 1_000_000), contextWindowSize("anthropic/claude-opus-4.8"));
-    try std.testing.expect(capabilitiesForModel("anthropic/claude-opus-4.8").prompt_caching);
     try std.testing.expectEqual(@as(?bool, true), capabilitiesForModel("xai/grok-4").parallel_tool_calls);
 }

--- a/src/gateway/vercel_protocol.zig
+++ b/src/gateway/vercel_protocol.zig
@@ -34,15 +34,7 @@ fn writeChatMessageJson(
     writer: *std.Io.Writer,
     message: ChatMessage,
 ) !void {
-    writeChatMessageJsonInner(scratch_alloc, writer, message, false, null, null, &.{}) catch |err| return err;
-}
-
-fn writeChatMessageJsonCached(
-    scratch_alloc: std.mem.Allocator,
-    writer: *std.Io.Writer,
-    message: ChatMessage,
-) !void {
-    writeChatMessageJsonInner(scratch_alloc, writer, message, true, null, null, &.{}) catch |err| return err;
+    writeChatMessageJsonInner(scratch_alloc, writer, message, null, null, &.{}) catch |err| return err;
 }
 
 pub fn buildGatewayRequestBody(
@@ -348,9 +340,6 @@ fn buildGatewayRequestBodyValidated(
     var out: std.Io.Writer.Allocating = .init(alloc);
     defer out.deinit();
 
-    const cache_breakpoint_idx = if (options.prompt_caching) findCacheBreakpoint(messages) else null;
-    var prefix_cacheable = true;
-
     try out.writer.writeAll("{\"prompt\":[");
     var i: usize = 0;
     while (i < messages.len) {
@@ -360,14 +349,10 @@ fn buildGatewayRequestBodyValidated(
         if (message.role == .tool) {
             const results = tool_result_prefix(messages[i..]);
             try write_tool_result_group(&out.writer, results, budget, &ids);
-            for (results) |result| {
-                if (result.cache_policy == .no_cache) prefix_cacheable = false;
-            }
             i += results.len;
             if (budget) |active| try active.check();
             continue;
         }
-        const use_cache = prefix_cacheable and shouldCacheMessage(message, i, cache_breakpoint_idx, options.prompt_caching);
         const verified_images = if (verified_image_override) |override|
             if (override.message_index == i) override.images else null
         else
@@ -376,12 +361,10 @@ fn buildGatewayRequestBodyValidated(
             std.heap.c_allocator,
             &out.writer,
             message,
-            use_cache,
             budget,
             verified_images,
             &ids,
         );
-        if (message.cache_policy == .no_cache) prefix_cacheable = false;
         if (budget) |active| try active.check();
         i += 1;
     }
@@ -474,12 +457,21 @@ fn validatePendingToolReviewMessages(
 }
 
 pub fn writeProviderOptions(writer: *std.Io.Writer, options: model_capabilities.ResolvedProviderOptions) !void {
-    if (!options.fast and options.parallel_tool_calls == null) return;
+    const gateway_options = options.fast or options.prompt_caching;
+    if (!gateway_options and options.parallel_tool_calls == null) return;
 
     try writer.writeAll(",\"providerOptions\":{");
-    if (options.fast) try writer.writeAll("\"gateway\":{\"speed\":\"fast\"}");
+    if (gateway_options) {
+        try writer.writeAll("\"gateway\":{");
+        if (options.fast) try writer.writeAll("\"speed\":\"fast\"");
+        if (options.prompt_caching) {
+            if (options.fast) try writer.writeByte(',');
+            try writer.writeAll("\"caching\":\"auto\"");
+        }
+        try writer.writeByte('}');
+    }
     if (options.parallel_tool_calls) |parallel_tool_calls| {
-        if (options.fast) try writer.writeByte(',');
+        if (gateway_options) try writer.writeByte(',');
         try writer.writeAll("\"xai\":{\"parallelToolCalls\":");
         try writer.writeAll(if (parallel_tool_calls) "true" else "false");
         try writer.writeByte('}');
@@ -627,13 +619,6 @@ fn findToolCallIndex(calls: []const ToolCall, id: []const u8) ?usize {
     return null;
 }
 
-pub fn shouldCacheMessage(message: ChatMessage, index: usize, cache_breakpoint_idx: ?usize, prompt_caching: bool) bool {
-    if (!prompt_caching) return false;
-    if (message.cache_policy == .no_cache) return false;
-    return message.role == .system or (cache_breakpoint_idx != null and index == cache_breakpoint_idx.?);
-}
-
-const anthropic_cache_meta = ",\"providerOptions\":{\"anthropic\":{\"cacheControl\":{\"type\":\"ephemeral\"}}}";
 const max_prompt_shape_entries: usize = 12;
 
 fn tool_result_prefix(messages: []const ChatMessage) []const ChatMessage {
@@ -683,7 +668,6 @@ fn writeChatMessageJsonInner(
     scratch_alloc: std.mem.Allocator,
     writer: *std.Io.Writer,
     message: ChatMessage,
-    cached: bool,
     budget: ?BuildBudget,
     verified_images: ?[]const image_attachments.VerifiedSnapshot,
     ids: *const tool_call_ids.Projection,
@@ -776,7 +760,6 @@ fn writeChatMessageJsonInner(
         },
     }
 
-    if (cached) try writer.writeAll(anthropic_cache_meta);
     try writer.writeAll("}");
 }
 
@@ -895,16 +878,6 @@ fn jsonKindName(value: std.json.Value) []const u8 {
         .array => "array",
         .object => "object",
     };
-}
-
-fn findCacheBreakpoint(messages: []const ChatMessage) ?usize {
-    if (messages.len < 3) return null;
-    var i = messages.len - 2;
-    while (i > 0) : (i -= 1) {
-        const role = messages[i].role;
-        if (role == .user or role == .assistant) return i;
-    }
-    return null;
 }
 
 pub fn parseGatewayCompletion(alloc: std.mem.Allocator, body: []const u8) !GatewayCompletion {
@@ -1214,60 +1187,50 @@ test "writeChatMessageJson maps tool result status to the Vercel output variant"
     }
 }
 
-test "writeChatMessageJsonCached adds provider options and non-cached omits them" {
+test "Gateway automatic caching preserves transient context and grouped tool results" {
     const alloc = std.testing.allocator;
-    var cached_out: std.Io.Writer.Allocating = .init(alloc);
-    defer cached_out.deinit();
-    var uncached_out: std.Io.Writer.Allocating = .init(alloc);
-    defer uncached_out.deinit();
-
-    const message: ChatMessage = .{ .role = .system, .content = "rules" };
-    try writeChatMessageJsonCached(alloc, &cached_out.writer, message);
-    try writeChatMessageJson(alloc, &uncached_out.writer, message);
-
-    try std.testing.expect(std.mem.find(u8, cached_out.written(), "\"providerOptions\"") != null);
-    try std.testing.expect(std.mem.find(u8, cached_out.written(), "\"cacheControl\":{\"type\":\"ephemeral\"}") != null);
-    try std.testing.expect(std.mem.find(u8, uncached_out.written(), "providerOptions") == null);
-}
-
-fn promptStringEntryHasCacheControl(body: []const u8, needle: []const u8) !bool {
-    const alloc = std.testing.allocator;
+    const calls = [_]ToolCall{
+        .{ .id = "first", .name = "read_file", .arguments_json = "{}" },
+        .{ .id = "second", .name = "read_file", .arguments_json = "{}" },
+    };
+    const messages = [_]ChatMessage{
+        .{ .role = .system, .content = "stable instructions" },
+        .{ .role = .system, .content = "runtime context" },
+        .{ .role = .user, .content = "read both" },
+        .{ .role = .assistant, .tool_calls = &calls },
+        .{ .role = .tool, .tool_call_id = "first", .tool_name = "read_file", .content = "A" },
+        .{ .role = .tool, .tool_call_id = "second", .tool_name = "read_file", .content = "B" },
+    };
+    const body = try buildGatewayRequestBodyWithOptions(alloc, "[]", &messages, .{
+        .prompt_caching = true,
+        .fast = true,
+        .parallel_tool_calls = false,
+    }, .auto);
+    defer alloc.free(body);
     var parsed = try std.json.parseFromSlice(std.json.Value, alloc, body, .{});
     defer parsed.deinit();
+    const options = parsed.value.object.get("providerOptions").?.object;
+    const gateway = options.get("gateway").?.object;
+    const caching = gateway.get("caching") orelse return error.TestExpectedAutomaticCaching;
+    try std.testing.expectEqualStrings("auto", caching.string);
+    try std.testing.expectEqualStrings("fast", gateway.get("speed").?.string);
+    try std.testing.expect(!options.get("xai").?.object.get("parallelToolCalls").?.bool);
+    try std.testing.expect(std.mem.find(u8, body, "cacheControl") == null);
+    const prompt = parsed.value.object.get("prompt").?.array.items;
+    try std.testing.expectEqualStrings("runtime context", prompt[1].object.get("content").?.string);
+    const results = prompt[4].object.get("content").?.array.items;
+    try std.testing.expectEqual(@as(usize, 2), results.len);
+    try std.testing.expectEqualStrings("A", results[0].object.get("output").?.object.get("value").?.string);
+    try std.testing.expectEqualStrings("B", results[1].object.get("output").?.object.get("value").?.string);
 
-    const prompt = parsed.value.object.get("prompt") orelse return error.TestExpectedPromptMissing;
-    if (prompt != .array) return error.TestExpectedPromptMissing;
-    for (prompt.array.items) |entry| {
-        if (entry != .object) continue;
-        const content = entry.object.get("content") orelse continue;
-        if (content != .string) continue;
-        if (std.mem.find(u8, content.string, needle) == null) continue;
-        return entry.object.get("providerOptions") != null;
-    }
-    return error.TestExpectedPromptMessageMissing;
-}
-
-test "buildGatewayRequestBodyWithOptions leaves transient system messages uncached" {
-    const alloc = std.testing.allocator;
-    const msgs = [_]ChatMessage{
-        .{ .role = .system, .content = "stable system prompt" },
-        .{ .role = .system, .content = "static project context" },
-        .{ .role = .system, .content = "volatile runtime overlay", .cache_policy = .no_cache },
-        .{ .role = .user, .content = "first question" },
-        .{ .role = .assistant, .content = "answer" },
-        .{ .role = .user, .content = "follow up" },
-    };
-    const body = try buildGatewayRequestBodyWithOptions(alloc, "[]", &msgs, .{ .prompt_caching = true }, .auto);
-    defer alloc.free(body);
-
-    const cache_marker = "\"cacheControl\":{\"type\":\"ephemeral\"}";
-    try std.testing.expectEqual(@as(usize, 2), std.mem.count(u8, body, cache_marker));
-    try std.testing.expect(try promptStringEntryHasCacheControl(body, "stable system prompt"));
-    try std.testing.expect(try promptStringEntryHasCacheControl(body, "static project context"));
-    try std.testing.expect(!try promptStringEntryHasCacheControl(body, "volatile runtime overlay"));
-
-    const overlay_idx = std.mem.indexOf(u8, body, "volatile runtime overlay") orelse return error.TestExpectedPromptMessageMissing;
-    try std.testing.expect(std.mem.find(u8, body[overlay_idx..], "cacheControl") == null);
+    const default_body = try buildGatewayRequestBodyWithOptions(alloc, "[]", &messages, .{
+        .fast = true,
+        .parallel_tool_calls = false,
+    }, .auto);
+    defer alloc.free(default_body);
+    const without_cache_option = try std.mem.replaceOwned(u8, alloc, body, ",\"caching\":\"auto\"", "");
+    defer alloc.free(without_cache_option);
+    try std.testing.expectEqualStrings(default_body, without_cache_option);
 }
 
 test "buildGatewayRequestBodyWithOptions keeps Anthropic default silent and named effort provider neutral" {
@@ -1562,58 +1525,7 @@ test "formatGatewayRequestShapeSummary reports content kinds without request con
     try std.testing.expect(std.mem.find(u8, mutated_summary, "SECRET_MUTATED_SYSTEM") == null);
 }
 
-test "findCacheBreakpoint returns null for short conversations" {
-    const messages = [_]ChatMessage{
-        .{ .role = .system, .content = "sys" },
-        .{ .role = .user, .content = "hi" },
-    };
-    try std.testing.expect(findCacheBreakpoint(&messages) == null);
-}
-
-test "findCacheBreakpoint returns last user/assistant before final message" {
-    const messages = [_]ChatMessage{
-        .{ .role = .system, .content = "sys" },
-        .{ .role = .user, .content = "first" },
-        .{ .role = .assistant, .content = "reply" },
-        .{ .role = .user, .content = "second" },
-    };
-    try std.testing.expectEqual(@as(?usize, 2), findCacheBreakpoint(&messages));
-}
-
-test "findCacheBreakpoint skips tool messages" {
-    const messages = [_]ChatMessage{
-        .{ .role = .system, .content = "sys" },
-        .{ .role = .user, .content = "do it" },
-        .{ .role = .assistant, .content = "ok" },
-        .{ .role = .tool, .content = "result", .tool_call_id = "t1", .tool_name = "read_file" },
-        .{ .role = .user, .content = "next" },
-    };
-    try std.testing.expectEqual(@as(?usize, 2), findCacheBreakpoint(&messages));
-}
-
-test "buildGatewayRequestBodyWithOptions includes cache markers for anthropic" {
-    const alloc = std.testing.allocator;
-    const messages = [_]ChatMessage{
-        .{ .role = .system, .content = "system prompt" },
-        .{ .role = .user, .content = "first question" },
-        .{ .role = .assistant, .content = "answer" },
-        .{ .role = .user, .content = "follow up" },
-    };
-    const body = try buildGatewayRequestBodyWithOptions(alloc, "[]", &messages, .{ .prompt_caching = true }, .auto);
-    defer alloc.free(body);
-
-    const cache_marker = "\"providerOptions\":{\"anthropic\":{\"cacheControl\":{\"type\":\"ephemeral\"}}}";
-
-    var count: usize = 0;
-    var pos: usize = 0;
-    while (std.mem.find(u8, body[pos..], cache_marker)) |idx| {
-        count += 1;
-        pos += idx + cache_marker.len;
-    }
-    try std.testing.expectEqual(@as(usize, 2), count);
-}
-
-test "buildGatewayRequestBodyWithOptions omits cache markers when disabled" {
+test "buildGatewayRequestBodyWithOptions leaves one-shot caching to the provider" {
     const alloc = std.testing.allocator;
     const messages = [_]ChatMessage{
         .{ .role = .system, .content = "system prompt" },
@@ -1623,6 +1535,7 @@ test "buildGatewayRequestBodyWithOptions omits cache markers when disabled" {
     defer alloc.free(body);
 
     try std.testing.expect(std.mem.find(u8, body, "cacheControl") == null);
+    try std.testing.expect(std.mem.find(u8, body, "providerOptions") == null);
 }
 
 test "tool result grouping borrows only the leading contiguous results" {
@@ -1693,13 +1606,13 @@ test "gateway request serialization keeps each tool result group together" {
     try std.testing.expectEqualStrings(denial, messages[4].content.?);
 }
 
-test "grouped tool results preserve cache fences and request budgets" {
+test "grouped tool results preserve request budgets with automatic caching" {
     const alloc = std.testing.allocator;
     const calls = [_]ToolCall{
         .{ .id = "a", .name = "read_file", .arguments_json = "{}" },
         .{ .id = "b", .name = "read_file", .arguments_json = "{}" },
     };
-    var messages = [_]ChatMessage{
+    const messages = [_]ChatMessage{
         .{ .role = .system, .content = "rules" },
         .{ .role = .user, .content = "read" },
         .{ .role = .assistant, .tool_calls = &calls },
@@ -1708,24 +1621,18 @@ test "grouped tool results preserve cache fences and request budgets" {
         .{ .role = .assistant, .content = "summary" },
         .{ .role = .user, .content = "continue" },
     };
-    for ([_]?usize{ null, 3, 4 }) |fence| {
-        messages[3].cache_policy = .default;
-        messages[4].cache_policy = .default;
-        if (fence) |index| messages[index].cache_policy = .no_cache;
-        const body = try buildGatewayRequestBodyWithOptionsAndBudget(alloc, "[]", &messages, .{ .prompt_caching = true }, .auto, null, .{});
-        defer alloc.free(body);
-        var parsed = try std.json.parseFromSlice(std.json.Value, alloc, body, .{});
-        defer parsed.deinit();
-        const prompt = parsed.value.object.get("prompt").?.array.items;
-        try std.testing.expectEqual(@as(usize, 6), prompt.len);
-        try std.testing.expect(prompt[0].object.contains("providerOptions"));
-        try std.testing.expectEqual(fence == null, prompt[4].object.contains("providerOptions"));
-        try std.testing.expectEqual(@as(usize, 2), prompt[3].object.get("content").?.array.items.len);
-    }
+    const body = try buildGatewayRequestBodyWithOptionsAndBudget(alloc, "[]", &messages, .{ .prompt_caching = true }, .auto, null, .{});
+    defer alloc.free(body);
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, body, .{});
+    defer parsed.deinit();
+    const prompt = parsed.value.object.get("prompt").?.array.items;
+    try std.testing.expectEqual(@as(usize, 6), prompt.len);
+    try std.testing.expectEqual(@as(usize, 2), prompt[3].object.get("content").?.array.items.len);
+    try std.testing.expectEqualStrings("auto", parsed.value.object.get("providerOptions").?.object.get("gateway").?.object.get("caching").?.string);
     var cancel = std.atomic.Value(bool).init(true);
-    try std.testing.expectError(error.Cancelled, buildGatewayRequestBodyWithOptionsAndBudget(alloc, "[]", &messages, .{}, .auto, null, .{ .cancel_flag = &cancel }));
+    try std.testing.expectError(error.Cancelled, buildGatewayRequestBodyWithOptionsAndBudget(alloc, "[]", &messages, .{ .prompt_caching = true }, .auto, null, .{ .cancel_flag = &cancel }));
     const expired = std.Io.Clock.Timestamp.fromNow(io_mod.getIo(), .{ .clock = .awake, .raw = .fromMilliseconds(-1) });
-    try std.testing.expectError(error.TimedOut, buildGatewayRequestBodyWithOptionsAndBudget(alloc, "[]", &messages, .{}, .auto, null, .{ .deadline = expired }));
+    try std.testing.expectError(error.TimedOut, buildGatewayRequestBodyWithOptionsAndBudget(alloc, "[]", &messages, .{ .prompt_caching = true }, .auto, null, .{ .deadline = expired }));
 }
 
 fn check_grouped_request_allocations(alloc: std.mem.Allocator) !void {
@@ -1738,7 +1645,7 @@ fn check_grouped_request_allocations(alloc: std.mem.Allocator) !void {
         .{ .role = .tool, .tool_call_id = "a", .tool_name = "read_file", .content = "first" },
         .{ .role = .tool, .tool_call_id = "b", .tool_name = "read_file", .content = "second" },
     };
-    const body = buildGatewayRequestBodyWithOptions(alloc, "[]", &messages, .{}, .auto) catch |err| switch (err) {
+    const body = buildGatewayRequestBodyWithOptions(alloc, "[]", &messages, .{ .prompt_caching = true }, .auto) catch |err| switch (err) {
         // The allocation checker expects OOM; this writer has no other failure source.
         error.WriteFailed => return error.OutOfMemory,
         else => return err,

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -4030,7 +4030,7 @@ describe("cli: ask success", () => {
           maxOutputTokens: 64_000,
         });
         expect(gateway.modelRequests).toHaveLength(1);
-        expect(request).not.toHaveProperty("providerOptions");
+        expect(request.providerOptions).toEqual({ gateway: { caching: "auto" } });
         expect(
           gateway.requests[0]!.headers.get(
             "ai-language-model-specification-version",

--- a/tests/e2e/config-persistence.test.ts
+++ b/tests/e2e/config-persistence.test.ts
@@ -1377,9 +1377,9 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
         expect(JSON.parse(gateway.requests[1]!.body)).toMatchObject({
           reasoning: "future-tier",
         });
-        expect(JSON.parse(gateway.requests[1]!.body)).not.toHaveProperty(
-          "providerOptions",
-        );
+        expect(JSON.parse(gateway.requests[1]!.body).providerOptions).toEqual({
+          gateway: { caching: "auto" },
+        });
 
         await session.sendText("/quit");
         await session.waitForSessionEnd(TIMEOUT);

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -923,6 +923,8 @@ describe("gateway stream lifecycle", () => {
         expect(gateway.requests).toHaveLength(2);
         for (const request of gateway.requests) {
           expectPermissionModeContext(request.body, mode);
+          expect(JSON.parse(request.body).providerOptions.gateway.caching).toBe("auto");
+          expect(request.body).not.toContain("cacheControl");
           const captured = parseGatewayRequest(request.body);
           expect(findUnavailableCapabilityReferences(captured)).toEqual([]);
           expect(customProviderGuidanceState(captured).guidanceMessageIndices).toEqual([1]);

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -2238,7 +2238,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       for (const request of queuedGateway.requests.slice(1)) {
         const retryRequest = JSON.parse(request.body);
         expect(retryRequest).not.toHaveProperty("fast");
-        expect(retryRequest.providerOptions?.gateway).toBeUndefined();
+        expect(retryRequest.providerOptions?.gateway).toEqual({ caching: "auto" });
       }
       expect(readFileSync(stderrPath, "utf8")).toBe("");
     },
@@ -2426,10 +2426,10 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       });
       const secondRequest = JSON.parse(queuedGateway.requests[1]!.body);
       expect(secondRequest).not.toHaveProperty("fast");
-      expect(secondRequest.providerOptions?.gateway).toBeUndefined();
+      expect(secondRequest.providerOptions?.gateway).toEqual({ caching: "auto" });
       const finalRequest = JSON.parse(queuedGateway.requests[3]!.body);
       expect(finalRequest).not.toHaveProperty("fast");
-      expect(finalRequest.providerOptions?.gateway).toBeUndefined();
+      expect(finalRequest.providerOptions?.gateway).toEqual({ caching: "auto" });
       expect(scrollback).toContain(finalText);
       expect(scrollback).toMatch(TURN_SUMMARY_WITH_TOKENS);
       expect(scrollback).not.toContain("✓ recovered");

--- a/tests/e2e/web-search-fake-gateway.test.ts
+++ b/tests/e2e/web-search-fake-gateway.test.ts
@@ -880,7 +880,7 @@ describe("web_search Gateway fixture", () => {
           const request = JSON.parse(gateway.requests[0].body);
           expect(request).not.toHaveProperty("reasoning");
           expect(request).not.toHaveProperty("fast");
-          expect(request.providerOptions?.gateway).toBeUndefined();
+          expect(request.providerOptions?.gateway).toEqual({ caching: "auto" });
           expect(gateway.requests[0].body).not.toContain('"thinking"');
 
           const stored = JSON.parse(


### PR DESCRIPTION
## Summary

- Enable Gateway automatic caching across model families during agent turns.
- Allow conversation and tool-result prefixes after runtime context to participate in caching.
- Leave standalone helper requests on provider defaults without explicit cache-write markers.
