### PR TITLE
Show the project folder in terminal tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ fx session resume last
 fx session resume --id <id>
 ```
 
-Interactive terminal tabs show `fx v<version>` using the running binary's version. The title stays the same when you rename or resume a session or switch models. Exiting clears the fx-owned title. Noninteractive commands do not emit terminal-title controls.
+Interactive terminal tabs show `fx v<version> | <folder>` using the running binary's version and current workspace folder name, for example `fx v0.0.7 | fx`. Renaming a session or switching models leaves the title unchanged. Resuming from another folder uses that folder's name. Exiting clears the fx-owned title. Noninteractive commands do not emit terminal-title controls.
 
 Run `/feedback` to open the feedback form at `fx.sh/feedback`. It does not create a diagnostic or change the clipboard.
 

--- a/src/core/app/app_bootstrap_runtime.zig
+++ b/src/core/app/app_bootstrap_runtime.zig
@@ -909,7 +909,7 @@ test "app_bootstrap_runtime transfers startup state and starts a fresh session" 
     try std.testing.expectEqualStrings("title", events[5]);
     try std.testing.expectEqual(@as(usize, 1), capture.begin_calls);
     try std.testing.expectEqual(@as(usize, 1), capture.enable_calls);
-    try std.testing.expectEqualStrings("v" ++ build_options.app_version, capture.titleText());
+    try std.testing.expectEqualStrings("v" ++ build_options.app_version ++ " | workspace", capture.titleText());
 
     try std.testing.expectEqualStrings("/workspace", app.workspace_root);
     try std.testing.expectEqualStrings("api-key", app.auth.apiKey().?);

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -2610,18 +2610,30 @@ pub fn Runtime(comptime App: type) type {
             @compileError("interactive session runtime requires a terminal title host capability");
         }
 
-        /// Terminal tabs identify the running build independently of the session.
+        /// Terminal tabs identify the running build and workspace, not the session.
         pub fn syncTerminalTitle(app: *App) void {
             if (comptime !provider_runtime.supported(App)) return;
             syncTerminalTitleWith(app, terminalTitle(app));
         }
 
         pub fn syncTerminalTitleWith(
-            _: *App,
+            app: *App,
             provider: host_capability.TerminalTitle,
         ) void {
             if (comptime !provider_runtime.supported(App)) return;
-            provider.set("v" ++ build_options.app_version);
+            const basename = if (comptime @hasField(App, "workspace_root"))
+                std.fs.path.basename(app.workspace_root)
+            else
+                "";
+            const folder = if (basename.len == 0) "workspace" else basename;
+            const prefix = "v" ++ build_options.app_version ++ " | ";
+            var label_buffer: [prefix.len + std.fs.max_path_bytes]u8 = undefined;
+            const label = std.fmt.bufPrint(&label_buffer, "{s}{s}", .{ prefix, folder }) catch |err| {
+                debug_trace.logf("session", "terminal title workspace omitted err={s}", .{@errorName(err)});
+                provider.set("v" ++ build_options.app_version);
+                return;
+            };
+            provider.set(label);
         }
 
         pub fn cachedSessionTitle(app: *App) ?[]const u8 {
@@ -9194,7 +9206,7 @@ test "renameActiveSession persists the title only in session metadata" {
         Runtime(TestApp).cachedSessionTitle(&app).?,
     );
 
-    try std.testing.expectEqualStrings("v" ++ build_options.app_version, app.terminalTitleLabelText());
+    try std.testing.expectEqualStrings("v" ++ build_options.app_version ++ " | workspace", app.terminalTitleLabelText());
 
     const loaded = &app.session_persistence.writable.?;
     _ = try loaded.appendEvent(
@@ -9357,7 +9369,7 @@ test "ensureCachedSessionTitle derives from the first prompt and then freezes" {
     try std.testing.expect(Runtime(TestApp).cachedSessionTitle(&app) == null);
 }
 
-test "terminal title initializes to the build version and ignores session and model changes" {
+test "terminal title combines the build version and workspace but ignores session and model changes" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -9372,11 +9384,11 @@ test "terminal title initializes to the build version and ignores session and mo
 
     try std.testing.expectEqualStrings("", app.terminalTitleLabelText());
     Runtime(TestApp).syncTerminalTitle(&app);
-    try std.testing.expectEqualStrings("v" ++ build_options.app_version, app.terminalTitleLabelText());
+    try std.testing.expectEqualStrings("v" ++ build_options.app_version ++ " | workspace", app.terminalTitleLabelText());
 
     try app.selected_model.appendSlice(alloc, "zai/glm-5.2");
     Runtime(TestApp).syncTerminalTitle(&app);
-    try std.testing.expectEqualStrings("v" ++ build_options.app_version, app.terminalTitleLabelText());
+    try std.testing.expectEqualStrings("v" ++ build_options.app_version ++ " | workspace", app.terminalTitleLabelText());
 
     try app.session.appendHistoryEntry(alloc, .{ .assistant = .{
         .user = .{ .text = @constCast("wire the release notes generator") },
@@ -9388,16 +9400,16 @@ test "terminal title initializes to the build version and ignores session and mo
         "wire the release notes generator",
         Runtime(TestApp).cachedSessionTitle(&app).?,
     );
-    try std.testing.expectEqualStrings("v" ++ build_options.app_version, app.terminalTitleLabelText());
+    try std.testing.expectEqualStrings("v" ++ build_options.app_version ++ " | workspace", app.terminalTitleLabelText());
 
     app.selected_model.clearRetainingCapacity();
     try app.selected_model.appendSlice(alloc, "anthropic/claude-opus-5");
     Runtime(TestApp).syncTerminalTitle(&app);
-    try std.testing.expectEqualStrings("v" ++ build_options.app_version, app.terminalTitleLabelText());
+    try std.testing.expectEqualStrings("v" ++ build_options.app_version ++ " | workspace", app.terminalTitleLabelText());
 
     Runtime(TestApp).clearCachedSessionTitle(&app);
     try std.testing.expect(Runtime(TestApp).cachedSessionTitle(&app) == null);
-    try std.testing.expectEqualStrings("v" ++ build_options.app_version, app.terminalTitleLabelText());
+    try std.testing.expectEqualStrings("v" ++ build_options.app_version ++ " | workspace", app.terminalTitleLabelText());
 }
 
 test "cached session title drops control bytes before they reach the terminal" {
@@ -9419,7 +9431,25 @@ test "cached session title drops control bytes before they reach the terminal" {
         "safe]2;ownedtail",
         Runtime(TestApp).cachedSessionTitle(&app).?,
     );
-    try std.testing.expectEqualStrings("v" ++ build_options.app_version, app.terminalTitleLabelText());
+    try std.testing.expectEqualStrings("v" ++ build_options.app_version ++ " | workspace", app.terminalTitleLabelText());
+}
+
+test "terminal title uses the workspace basename and handles unnamed roots" {
+    const cases = [_]struct { path: []const u8, folder: []const u8 }{
+        .{ .path = "/projects/fx", .folder = "fx" },
+        .{ .path = "/projects/fx/", .folder = "fx" },
+        .{ .path = "/projects/my project é", .folder = "my project é" },
+        .{ .path = "/", .folder = "workspace" },
+        .{ .path = "", .folder = "workspace" },
+    };
+    for (cases) |case| {
+        var app = try TestApp.init(std.testing.allocator, case.path);
+        defer app.deinit();
+        Runtime(TestApp).syncTerminalTitle(&app);
+        var expected_buffer: [128]u8 = undefined;
+        const expected = try std.fmt.bufPrint(&expected_buffer, "v{s} | {s}", .{ build_options.app_version, case.folder });
+        try std.testing.expectEqualStrings(expected, app.terminalTitleLabelText());
+    }
 }
 
 test "terminal title ignores long session and model context" {
@@ -9438,5 +9468,5 @@ test "terminal title ignores long session and model context" {
     try app.selected_model.appendSlice(alloc, "provider/" ++ ("model" ** 20));
     try Runtime(TestApp).setCachedSessionTitle(&app, "session-" ++ ("title" ** 20));
 
-    try std.testing.expectEqualStrings("v" ++ build_options.app_version, app.terminalTitleLabelText());
+    try std.testing.expectEqualStrings("v" ++ build_options.app_version ++ " | workspace", app.terminalTitleLabelText());
 }

--- a/src/core/session/session_commands.zig
+++ b/src/core/session/session_commands.zig
@@ -2196,7 +2196,7 @@ test "session_commands handleModel resolves fuzzy cached model and syncs queued 
     try std.testing.expectEqualStrings("anthropic/claude-sonnet-4-20250514", app.worker.synced_model.?);
     try std.testing.expectEqual(model_provider.ProviderId.codex, app.last_preference_provider.?);
     try std.testing.expectEqualStrings(
-        "v" ++ build_options.app_version,
+        "v" ++ build_options.app_version ++ " | workspace",
         app.terminalTitleLabelText(),
     );
     try expectTranscriptContains(&app, "● Switched to anthropic/claude-sonnet-4-20250514");
@@ -2213,7 +2213,7 @@ test "session_commands handleModel falls back to raw query when model fetch fail
     try std.testing.expectEqualStrings("custom/provider-model", app.selected_model.items);
     try std.testing.expectEqualStrings("custom/provider-model", app.worker.synced_model.?);
     try std.testing.expectEqualStrings(
-        "v" ++ build_options.app_version,
+        "v" ++ build_options.app_version ++ " | workspace",
         app.terminalTitleLabelText(),
     );
 }
@@ -2749,7 +2749,7 @@ test "session_commands model picker accepts the current selected model slice" {
     try std.testing.expectEqualStrings("anthropic/claude-opus-4.6", app.worker.synced_model.?);
     try std.testing.expectEqualStrings("anthropic/claude-opus-4.6", app.last_preference_model.items);
     try std.testing.expectEqualStrings(
-        "v" ++ build_options.app_version,
+        "v" ++ build_options.app_version ++ " | workspace",
         app.terminalTitleLabelText(),
     );
     try std.testing.expectEqual(types.ReasoningEffort.literal("high"), app.effort);

--- a/src/ui/render.zig
+++ b/src/ui/render.zig
@@ -729,13 +729,13 @@ test "terminal title writes the label to the caller's output file" {
 
     // A host that redirects its output keeps the escape sequence off the
     // real stdout, which the Zig test runner owns as its protocol channel.
-    terminalTitleFor(&sink).set("v" ++ main.version);
+    terminalTitleFor(&sink).set("v" ++ main.version ++ " | fx");
 
     var written_file = try tmp.dir.openFile(io_mod.getIo(), "terminal-title.log", .{});
     defer written_file.close(io_mod.getIo());
     const written = try io_mod.readFileToEnd(alloc, &written_file, 128);
     defer alloc.free(written);
-    try std.testing.expectEqualStrings("\x1b]2;fx v" ++ main.version ++ "\x07", written);
+    try std.testing.expectEqualStrings("\x1b]2;fx v" ++ main.version ++ " | fx\x07", written);
 }
 
 test "terminal title sanitizes and bounds untrusted labels" {

--- a/tests/e2e/tui-slash-menu.test.ts
+++ b/tests/e2e/tui-slash-menu.test.ts
@@ -13,7 +13,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { FX_BIN } from "../evals/eval-helpers";
 import {
   composerContains,
@@ -84,10 +84,10 @@ function captureViewportEscapes(session: TmuxSession): string {
   });
 }
 
-function runningBinaryTitle(): string {
+function runningBinaryTitle(workspace: string): string {
   const version = execFileSync(FX_BIN, ["--version"], { encoding: "utf8" }).trim();
   expect(version).toMatch(/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/);
-  return `fx v${version}`;
+  return `fx v${version} | ${basename(workspace)}`;
 }
 
 async function expectCleanTitleTranscript(session: TmuxSession, title: string): Promise<void> {
@@ -817,15 +817,17 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
   );
 
   test(
-    "terminal tab title stays at the running binary version across rename, resume, and new session",
+    "terminal tab title shows the version and current folder across rename, resume, and new session",
     async () => {
-      const title = runningBinaryTitle();
       const workDir = mkdtempSync(join(tmpdir(), "fx-title-rename-e2e-"));
       workDirs.push(workDir);
       const home = join(workDir, "home");
-      const workspace = join(workDir, "workspace");
+      const workspace = join(workDir, "fx");
+      const resumedWorkspace = join(workDir, "another project é");
+      let title = runningBinaryTitle(workspace);
       mkdirSync(join(home, ".fx"), { recursive: true });
       mkdirSync(workspace, { recursive: true });
+      mkdirSync(resumedWorkspace, { recursive: true });
       writeFileSync(
         join(home, ".fx", "settings.json"),
         JSON.stringify({ sandbox: "none", permission: {} }),
@@ -861,7 +863,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       await waitForPaneTitle(session, title, 5_000);
       await expectCleanTitleTranscript(session, title);
 
-      // Naming the session must not add session or model context to the title.
+      // Session names must not replace the workspace in the title.
       await session.sendText("generate the release notes");
       await session.waitForText("TITLE_RENAME_COMPLETE", 30_000);
       await session.waitForStableComposer();
@@ -891,12 +893,13 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
         .map((entry) => entry.name);
       expect(sessionIds).toHaveLength(1);
 
-      // Restoring a named session must keep the same version-only title.
+      // A resumed session uses its current folder, not its original workspace.
+      title = runningBinaryTitle(resumedWorkspace);
       gateway.stop();
       gateway = startFakeGateway([]);
       session = await TmuxSession.create({
         cmd: `${FX_BIN} resume ${sessionIds[0]}`,
-        cwd: workspace,
+        cwd: resumedWorkspace,
         env: {
           ...env,
           FX_GATEWAY_BASE_URL: gateway.baseUrl,
@@ -2832,7 +2835,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
         height: 32,
       });
       await session.waitForComposer(10_000);
-      expect(await session.paneTitle()).toBe(runningBinaryTitle());
+      expect(await session.paneTitle()).toBe(runningBinaryTitle(fixture.workspace));
 
       const alternateCount = (sequence: string) =>
         countOccurrences(readFileSync(fixture.tapePath).toString("latin1"), sequence);
@@ -2947,7 +2950,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
 
       const settings = JSON.parse(readFileSync(fixture.settingsPath, "utf8")) as { models?: { gateway?: string } };
       expect(settings.models?.gateway).toBe(selectedModel);
-      expect(await session.paneTitle()).toBe(runningBinaryTitle());
+      expect(await session.paneTitle()).toBe(runningBinaryTitle(fixture.workspace));
       expect(session.isAlive()).toBe(true);
 
       await session.sendText("/quit");
@@ -3061,7 +3064,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       expect(pane).not.toContain("Reasoning effort");
       expect(pane).not.toContain("default");
       expect(JSON.parse(readFileSync(fixture.settingsPath, "utf8")).models.gateway).toBe(selectedModel);
-      expect(await session.paneTitle()).toBe(runningBinaryTitle());
+      expect(await session.paneTitle()).toBe(runningBinaryTitle(fixture.workspace));
       expect(session.isAlive()).toBe(true);
       expect(readFileSync(fixture.stderrPath, "utf8")).toBe("");
 


### PR DESCRIPTION
## Summary

- Show `fx v<version> | <folder>` in interactive terminal tabs, for example `fx v0.0.7 | fx`.
- Use the current workspace folder when resuming a session from another directory.