### PR TITLE
Preserve oversized result reads through compaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ fx automatically summarizes a long session into a fresh context window when the 
 
 Compaction handoffs remain internal context for the model. Resuming a session and opening its full transcript show the conversation and tool activity, not internal summaries or operation ledgers.
 
+In saved sessions, oversized `read_tool_result` responses keep a complete terminal-safe backing copy even when the inline response is clipped. Compaction and later retrieval preserve that copy without masking the explicitly requested text again.
+
 Use `fx ask` for a single request:
 
 ```bash

--- a/src/core/agent/runtime/execution_memory.zig
+++ b/src/core/agent/runtime/execution_memory.zig
@@ -411,6 +411,7 @@ pub fn prepareCapturedToolModelOutput(
             raw_output,
             config.max_tool_result_bytes,
         );
+        errdefer arena.free(prepared.model_output);
         var memory: types.ToolResultMemory = .{
             .output_bytes = raw_output.len,
             .stored_output_bytes = prepared.model_output.len,
@@ -420,6 +421,7 @@ pub fn prepareCapturedToolModelOutput(
             (config.session_child_capability != null or config.tool_result_dir != null))
         {
             const complete_output = try text_utils.sanitizeModelText(arena, raw_output);
+            defer if (complete_output.ptr != raw_output.ptr) arena.free(complete_output);
             memory.output_handle = if (config.session_child_capability) |capability|
                 try result_store.storeLargeResultManaged(arena, capability, tool_call.id, tool_call.name, complete_output)
             else
@@ -1240,10 +1242,8 @@ test "retrieved output storage failure does not publish an unbacked result" {
     defer writable.deinit();
     var readonly = try session_child_store.SessionChildCapability.initLegacyRoute(alloc, dir, .tool_results, .read_only);
     defer readonly.deinit();
-    var arena_state = std.heap.ArenaAllocator.init(alloc);
-    defer arena_state.deinit();
     var cancel = std.atomic.Value(bool).init(false);
-    try std.testing.expectError(error.SessionChildReadOnly, prepareToolModelOutput(arena_state.allocator(), .{
+    try std.testing.expectError(error.SessionChildReadOnly, prepareToolModelOutput(alloc, .{
         .system_prompt = "",
         .gateway_retry_count = 0,
         .gateway_chat_url = "",

--- a/src/core/agent/runtime/execution_memory.zig
+++ b/src/core/agent/runtime/execution_memory.zig
@@ -10,6 +10,7 @@ const io_mod = @import("../../shared/io.zig");
 const file_mutation = @import("../../tooling/file_mutation.zig");
 const tool_result_errors = @import("../../tooling/tool_result_errors.zig");
 const tool_result_limits = @import("../../tooling/tool_result_limits.zig");
+const text_utils = @import("../../shared/text_utils.zig");
 
 const runtime_config = @import("config.zig");
 const runtime_tool_contracts = @import("tool_contracts.zig");
@@ -410,13 +411,24 @@ pub fn prepareCapturedToolModelOutput(
             raw_output,
             config.max_tool_result_bytes,
         );
+        var memory: types.ToolResultMemory = .{
+            .output_bytes = raw_output.len,
+            .stored_output_bytes = prepared.model_output.len,
+            .truncated = prepared.truncated,
+        };
+        if (prepared.truncated and
+            (config.session_child_capability != null or config.tool_result_dir != null))
+        {
+            const complete_output = try text_utils.sanitizeModelText(arena, raw_output);
+            memory.output_handle = if (config.session_child_capability) |capability|
+                try result_store.storeLargeResultManaged(arena, capability, tool_call.id, tool_call.name, complete_output)
+            else
+                try result_store.storeLargeResult(arena, config.tool_result_dir.?, tool_call.id, tool_call.name, complete_output);
+            memory.stored_output_bytes = complete_output.len;
+        }
         return .{
             .model_output = prepared.model_output,
-            .memory = .{
-                .output_bytes = raw_output.len,
-                .stored_output_bytes = prepared.model_output.len,
-                .truncated = prepared.truncated,
-            },
+            .memory = memory,
         };
     }
     const required_command_replay = if (capture) |candidate|
@@ -1156,6 +1168,124 @@ test "saved read_tool_result preparation preserves exact secret-like output" {
     try std.testing.expect(std.mem.find(u8, prepared.model_output, "[redacted]") == null);
     try std.testing.expect(!prepared.memory.truncated);
     try std.testing.expect(prepared.memory.output_handle == null);
+}
+
+test "retrieved output remains backed across the inline cap" {
+    const compaction = @import("context_compaction.zig");
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(dir);
+    var capability = try session_child_store.SessionChildCapability.initLegacyRoute(alloc, dir, .tool_results, .writable);
+    defer capability.deinit();
+    var cancel = std.atomic.Value(bool).init(false);
+    const stores = [_]enum { legacy, managed, unavailable }{ .legacy, .managed, .unavailable };
+    const cases = [_]struct { cap: usize, bytes: usize }{
+        .{ .cap = 65536, .bytes = 65536 },
+        .{ .cap = 65536, .bytes = 65537 },
+        .{ .cap = 65536, .bytes = 65689 },
+        .{ .cap = 1024, .bytes = 1025 },
+    };
+    for (stores) |storage| for (cases) |case| {
+        var arena_state = std.heap.ArenaAllocator.init(alloc);
+        defer arena_state.deinit();
+        const arena = arena_state.allocator();
+        const raw = try arena.alloc(u8, case.bytes);
+        @memset(raw, 'x');
+        const head = "PROBE_TOKEN=0123456789abcdef\n";
+        const tail = "\nRETRIEVAL_COMPLETE_TAIL";
+        @memcpy(raw[0..head.len], head);
+        @memcpy(raw[raw.len - tail.len ..], tail);
+        const prepared = try prepareToolModelOutput(arena, .{
+            .system_prompt = "",
+            .gateway_retry_count = 0,
+            .gateway_chat_url = "",
+            .agent_step_limit = 1,
+            .cancel_flag = &cancel,
+            .max_tool_result_bytes = case.cap,
+            .tool_result_dir = if (storage == .legacy) dir else null,
+            .session_child_capability = if (storage == .managed) &capability else null,
+        }, toolCall("retrieval-cap", "read_tool_result", "{}"), raw);
+        try std.testing.expectEqual(case.bytes > case.cap, prepared.memory.truncated);
+        try std.testing.expectEqual(@min(case.bytes, case.cap), prepared.model_output.len);
+        try std.testing.expect(std.mem.startsWith(u8, prepared.model_output, head));
+        try std.testing.expect(std.mem.find(u8, prepared.model_output, "[redacted]") == null);
+        var messages = [_]ChatMessage{.{ .role = .tool, .tool_call_id = "retrieval-cap", .tool_name = "read_tool_result", .content = prepared.model_output, .tool_result_memory = prepared.memory }};
+        if (case.bytes > case.cap and storage != .unavailable) {
+            const handle = prepared.memory.output_handle orelse return error.TestExpectedStoredRetrieval;
+            try std.testing.expectEqual(case.bytes, prepared.memory.stored_output_bytes);
+            const stored = try result_store.readForReplayManaged(arena, &capability, handle, case.bytes);
+            try std.testing.expectEqualStrings(raw, stored);
+            try compaction.promoteMessageResults(arena, &messages, .{ .managed = &capability }, 0);
+            try std.testing.expectEqualStrings(handle, messages[0].tool_result_memory.?.output_handle.?);
+        } else {
+            try std.testing.expect(prepared.memory.output_handle == null);
+            if (case.bytes > case.cap) {
+                try std.testing.expectError(error.IncompleteCompactionResult, compaction.promoteMessageResults(arena, &messages, .unavailable, 0));
+            } else {
+                try std.testing.expectEqualStrings(raw, prepared.model_output);
+            }
+        }
+    };
+}
+
+test "retrieved output storage failure does not publish an unbacked result" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(dir);
+    var writable = try session_child_store.SessionChildCapability.initLegacyRoute(alloc, dir, .tool_results, .writable);
+    defer writable.deinit();
+    var readonly = try session_child_store.SessionChildCapability.initLegacyRoute(alloc, dir, .tool_results, .read_only);
+    defer readonly.deinit();
+    var arena_state = std.heap.ArenaAllocator.init(alloc);
+    defer arena_state.deinit();
+    var cancel = std.atomic.Value(bool).init(false);
+    try std.testing.expectError(error.SessionChildReadOnly, prepareToolModelOutput(arena_state.allocator(), .{
+        .system_prompt = "",
+        .gateway_retry_count = 0,
+        .gateway_chat_url = "",
+        .agent_step_limit = 1,
+        .cancel_flag = &cancel,
+        .max_tool_result_bytes = 1024,
+        .session_child_capability = &readonly,
+    }, toolCall("retrieval-store-error", "read_tool_result", "{}"), "x" ** 1025));
+}
+
+test "saved tool output preparation keeps builtins and dynamic tools compactable" {
+    const builtins = @import("../../../builtins/tools.zig");
+    const compaction = @import("context_compaction.zig");
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(dir);
+    var cancel = std.atomic.Value(bool).init(false);
+    for (0..builtins.all.len + 1) |index| {
+        const name = if (index < builtins.all.len) builtins.all[index].name else "mcp_fixture_lookup";
+        var arena_state = std.heap.ArenaAllocator.init(alloc);
+        defer arena_state.deinit();
+        const arena = arena_state.allocator();
+        const raw = "COMPLETE_TOOL_BODY\n" ++ "x" ** 8192;
+        const prepared = try prepareToolModelOutput(arena, .{
+            .system_prompt = "",
+            .gateway_retry_count = 0,
+            .gateway_chat_url = "",
+            .agent_step_limit = 1,
+            .cancel_flag = &cancel,
+            .max_tool_result_bytes = 1024,
+            .tool_result_dir = dir,
+        }, toolCall("tool-preparation", name, "{}"), raw);
+        const handle = prepared.memory.output_handle orelse return error.TestExpectedStoredOutput;
+        try std.testing.expectEqual(raw.len, prepared.memory.stored_output_bytes);
+        var messages = [_]ChatMessage{.{ .role = .tool, .tool_call_id = "tool-preparation", .tool_name = name, .content = prepared.model_output, .tool_result_memory = prepared.memory }};
+        try compaction.promoteMessageResults(arena, &messages, .{ .legacy_dir = dir }, 0);
+        try std.testing.expectEqualStrings(handle, messages[0].tool_result_memory.?.output_handle.?);
+        const stored = try result_store.readByRange(arena, dir, handle, 1, 16384);
+        try std.testing.expect(std.mem.find(u8, stored, raw) != null);
+    }
 }
 
 test "saved preparation externalizes complete redacted output without cap loss" {

--- a/src/core/session/result_store.zig
+++ b/src/core/session/result_store.zig
@@ -24,7 +24,7 @@ const StorageTarget = union(enum) {
     managed: *session_child_store.SessionChildCapability,
 };
 
-/// Read-only, validated access to a persisted redacted tool result. The
+/// Read-only, validated access to persisted tool-result text. The
 /// caller chooses bounded raw pages and owns each returned allocation.
 pub const ResultReader = struct {
     file: session_child_store.ManagedFile,

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -4848,6 +4848,116 @@ printf '%s' ${JSON.stringify(trailingMarker)} > ${JSON.stringify(effectPath)}
     60_000,
   );
 
+  for (const trigger of ["automatic", "manual"] as const) {
+    test.skipIf(!tmuxAvailable())(
+      `oversized result retrieval survives ${trigger} compaction and restart`,
+      async () => {
+        const root = createFixtureRoot(`retrieval-compaction-${trigger}`);
+        const tracePath = join(root.root, "trace.log");
+        const stderrPath = join(root.root, "stderr.log");
+        const token = "PROBE_TOKEN=0123456789abcdef01234567";
+        const prefix = `RETRIEVAL_MATCH ${token} `;
+        const tail = "RETRIEVAL_EDGE_SENTINEL";
+        writeFileSync(join(root.workspace, "source.txt"), prefix + "x".repeat(65480 - prefix.length) + tail + "x".repeat(1024) + "\n");
+        writeFileSync(join(root.workspace, "small.txt"), "small follow-up\n");
+        let step = 0;
+        let compactions = 0;
+        let snapshotHandle = "";
+        const gateway = startDynamicFakeGateway((body) => {
+          const request = JSON.parse(body);
+          if (request.tools.length === 0) {
+            compactions++;
+            snapshotHandle = body.match(/result-read_tool_result-[a-f0-9-]+\.txt/)?.[0] ?? "";
+            expect(snapshotHandle).not.toBe("");
+            return fakeGatewayFinalText(`The command ran once. Read ${snapshotHandle} at byte 65300 to recover the clipped tail. Do not repeat the command.`);
+          }
+          switch (step++) {
+            case 0:
+              return fakeGatewayToolCall("retrieval-source", "shell", {
+                request: { action: "run", command: "printf 'once\\n' >> effects.txt; cat source.txt", profile: "clean", yield_time_ms: 30000 },
+              });
+            case 1: {
+              const source = JSON.parse(toolResultOutput(body, "retrieval-source"));
+              expect(source.exit_code).toBe(0);
+              expect(source.full_output_handle).toBeString();
+              return fakeGatewayToolCall("retrieval-page", "read_tool_result", {
+                request: { handle: source.full_output_handle, query: "RETRIEVAL_MATCH" },
+              });
+            }
+            case 2: {
+              const page = toolResultOutput(body, "retrieval-page");
+              expect(page).toContain(token);
+              expect(page).toContain("tool result truncated");
+              expect(page).not.toContain(tail);
+              return fakeGatewaySse([
+                { type: "tool-call", toolCallId: "retrieval-follow-up", toolName: "read_file", input: { path: "small.txt" } },
+                { type: "finish", finishReason: { unified: "tool-calls", raw: "tool-calls" }, ...(trigger === "automatic" ? { usage: { inputTokens: { total: 120000 }, outputTokens: { total: 10 } } } : {}) },
+              ]);
+            }
+            case 3:
+              if (trigger === "automatic") {
+                expect(compactions).toBe(1);
+                expect(body).toContain("context_handoff");
+              }
+              return fakeGatewayFinalText("RETRIEVAL_TURN_COMPLETE");
+            case 4:
+              expect(body).toContain(snapshotHandle);
+              return fakeGatewayToolCall("retrieval-tail", "read_tool_result", {
+                request: { handle: snapshotHandle, start_byte: 65300, byte_count: 1024 },
+              });
+            case 5:
+              expect(toolResultOutput(body, "retrieval-tail")).toContain(tail);
+              return fakeGatewayFinalText("RETRIEVAL_RESTART_COMPLETE");
+            default:
+              return new Response("unexpected request", { status: 500 });
+          }
+        }, { models: [{ id: MODEL, type: "language", tags: ["tool-use"], context_window: 128000 }] });
+        let tui: TmuxSession | null = null;
+        try {
+          const env = { ...fixtureEnv(root, gateway, tracePath), FX_AUTO_UPGRADE: "0", FX_TRACE_SCOPES: "agent,tool,session,context_compaction" };
+          tui = await TmuxSession.create({ cwd: root.workspace, env, stderrPath });
+          await tui.waitForComposer(15000);
+          await tui.sendText("Run and retrieve the fixture output, then read the small follow-up file.");
+          const pane = await tui.waitForPane((text) => hasEmptyComposer(text) && (text.includes("RETRIEVAL_TURN_COMPLETE") || text.includes("request failed:")), 30000);
+          expect(pane).not.toContain("request failed:");
+          expect(pane).toContain("RETRIEVAL_TURN_COMPLETE");
+          if (trigger === "manual") {
+            await tui.sendText("/compact");
+            const compacted = await tui.waitForPane((text) => hasEmptyComposer(text) && (text.includes("Context compacted.") || text.includes("request failed:")), 20000);
+            expect(compacted).not.toContain("request failed:");
+            expect(compacted).toContain("Context compacted.");
+          }
+          expect(compactions).toBe(1);
+          await tui.sendText("/quit");
+          expect(await tui.waitForSessionEnd(15000)).toBe(true);
+          tui = null;
+          expect(readFileSync(stderrPath, "utf8")).toBe("");
+          const latest = await runFx(["session", "last", "--json"], { cwd: root.workspace, env });
+          expect(latest.code).toBe(0);
+          const sessionId = JSON.parse(latest.stdout).id;
+          const sessionDir = join(root.home, ".fx", "sessions", sessionId);
+          const snapshot = readFileSync(join(sessionDir, "tool-results", snapshotHandle), "utf8");
+          expect(Buffer.byteLength(snapshot)).toBeGreaterThan(65536);
+          expect(snapshot).toContain(token);
+          expect(snapshot).toContain(tail);
+          expect(readFileSync(join(sessionDir, "events.jsonl"), "utf8")).toContain(snapshotHandle);
+          const resumed = await runFx(["ask", "--json", "--resume-id", sessionId, "Recover the clipped tail from the saved retrieval without rerunning the command."], { cwd: root.workspace, env, timeoutMs: 30000 });
+          expect(resumed.code).toBe(0);
+          expect(resumed.stderr).toBe("Reading tool result\n");
+          expect(JSON.parse(resumed.stdout).final_output).toBe("RETRIEVAL_RESTART_COMPLETE");
+          expect(gateway.requests).toHaveLength(7);
+          expect(readFileSync(join(root.workspace, "effects.txt"), "utf8")).toBe("once\n");
+          expect(readFileSync(tracePath, "utf8")).not.toContain("IncompleteCompactionResult");
+        } finally {
+          await tui?.kill();
+          gateway.stop();
+          rmSync(root.root, { recursive: true, force: true });
+        }
+      },
+      120000,
+    );
+  }
+
   test.skipIf(!tmuxAvailable())(
     "manual context compaction survives restart without changing canonical history",
     async () => {


### PR DESCRIPTION
## Summary

- Keep automatic compaction running after oversized `read_tool_result` responses.
- Preserve complete retrieval responses for manual compaction and session restart without masking explicitly requested text again.
- Keep the requested page inline and retain the existing output limits.
