### PR TITLE
Preserve full transcript results and show recovery progress

### DIFF
--- a/src/core/app/app_worker_runtime.zig
+++ b/src/core/app/app_worker_runtime.zig
@@ -437,6 +437,16 @@ pub fn Runtime(comptime App: type) type {
             try pushOwnedEvent(app, .{ .diff_block = payload });
         }
 
+        /// Activate an admitted continuation without presenting another user turn.
+        pub fn beginRecoveryPresentation(app: *App) void {
+            app.stream = .{
+                .active = true,
+                .turn_started_ms = io_mod.milliTimestamp(),
+            };
+            _ = app.shell.worker_status_state().clear();
+            app.shell.render_requests.request(.footer);
+        }
+
         pub fn syncState(
             app: *App,
             presenter: activity_runtime.LifecyclePresenter,
@@ -2538,6 +2548,31 @@ test "core.app_worker_runtime syncState does not start activity for idle queued 
 
     try std.testing.expect(!app.stream.active);
     try std.testing.expect(!app.shell.render_requests.hasReason(.footer));
+}
+
+test "core.app_worker_runtime admitted recovery activates progress without resetting command display" {
+    var app = FakeApp.init(std.testing.allocator);
+    defer app.deinit();
+    try app.worker.pushEvent(std.heap.c_allocator, .{ .route_recovery_status = .{
+        .kind = .terminal_provider_error,
+        .failed_attempt = 1,
+        .attempt_limit = 10,
+        .action = .paused,
+    } });
+    try tickNoop(&app);
+    app.shell.command_output_display.touched = true;
+    app.worker.queued_count = 1;
+
+    Runtime(FakeApp).beginRecoveryPresentation(&app);
+    Runtime(FakeApp).syncState(&app, NoopBridge.lifecyclePresenter(&app));
+
+    try std.testing.expect(app.stream.active);
+    try std.testing.expectEqual(types.TurnPhase.thinking, app.stream.phase);
+    try std.testing.expect(app.stream.turn_started_ms > 0);
+    try std.testing.expect(app.shell.activityProjection() == .none);
+    try std.testing.expect(app.shell.command_output_display.touched);
+    try std.testing.expect(app.shell.render_requests.hasReason(.footer));
+    try std.testing.expectEqual(@as(usize, 0), app.worker.events.items.len);
 }
 
 test "core.app_worker_runtime syncState does not start activity for idle processing snapshot" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -1327,6 +1327,7 @@ const App = struct {
             checkpoint.turn_id,
             false,
         )) return false;
+        WorkerAppRuntime.beginRecoveryPresentation(self);
         WorkerAppRuntime.syncState(
             self,
             app_callbacks.Bindings(App).worker_tool_lifecycle_presenter(self),

--- a/src/ui/transcript/full_transcript_worker.zig
+++ b/src/ui/transcript/full_transcript_worker.zig
@@ -154,9 +154,13 @@ pub const Source = struct {
 pub const InstalledSource = struct {
     request: full_transcript_page.Request,
     range: full_transcript_page.SourceRange,
+    // Stored projection segments borrow the snapshot's result and handle bytes.
+    details: std.ArrayList(transcript_blocks.ToolDetailRecord) = .empty,
     capability: ?session_child_store.SessionChildCapability = null,
 
-    pub fn deinit(self: *InstalledSource) void {
+    pub fn deinit(self: *InstalledSource, alloc: Allocator) void {
+        for (self.details.items) |*detail| detail.deinit(alloc);
+        self.details.deinit(alloc);
         if (self.capability) |*capability| capability.deinit();
         self.* = undefined;
     }
@@ -202,11 +206,14 @@ pub const Task = struct {
     }
 
     pub fn takeInstalledSource(self: *Task) InstalledSource {
+        const details = self.source.details;
+        self.source.details = .empty;
         const capability = self.source.capability;
         self.source.capability = null;
         return .{
             .request = self.source.request,
             .range = self.source.range,
+            .details = details,
             .capability = capability,
         };
     }
@@ -345,6 +352,103 @@ pub fn cloneCommandBlockForPageSnapshot(
     }
     try clone.pruned_ranges.appendSlice(alloc, source.pruned_ranges.items);
     return clone;
+}
+
+test "installed projection retains saved output and fallback after source disposal" {
+    const alloc = std.testing.allocator;
+    const io_mod = @import("../../core/shared/io.zig");
+    const result_store = @import("../../core/session/result_store.zig");
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(path);
+
+    var task = Task{ .source = .{
+        .request = .{ .content_revision = 1, .cols = 80, .anchor = .tail },
+        .range = .{ .start = 0, .end = 1 },
+        .styles = .{},
+        .capability = try session_child_store.SessionChildCapability.initLegacyRoute(
+            alloc,
+            path,
+            .tool_results,
+            .writable,
+        ),
+    } };
+    var source_owned = true;
+    defer if (source_owned) task.source.deinit(alloc);
+    try task.source.details.ensureTotalCapacity(alloc, 1);
+    task.source.details.appendAssumeCapacity(.{
+        .entry_id = 1,
+        .tool_name = try alloc.dupe(u8, "read_file"),
+    });
+    const detail = &task.source.details.items[0];
+    detail.result = try alloc.dupe(u8, "retained preview");
+    detail.result_handle = try result_store.storeLargeResultManaged(
+        alloc,
+        &task.source.capability.?,
+        "installed-result",
+        "read_file",
+        "SAVED_HEAD\nSAVED_TAIL\n",
+    );
+    const entries = [_]transcript_blocks.TranscriptEntry{.{ .raw_bytes = .{
+        .id = 1,
+        .created_at_ms = 0,
+        .bytes = @constCast("Read fixture.txt\n"),
+        .class = .tool_status,
+    } }};
+    var projection = try full_transcript_screen.buildProjection(
+        alloc,
+        &entries,
+        task.source.details.items,
+        &.{},
+        .{},
+        80,
+        null,
+    );
+    var installed = task.takeInstalledSource();
+    defer installed.deinit(alloc);
+    defer projection.deinit(alloc);
+    task.source.deinit(alloc);
+    source_owned = false;
+
+    const rendered = try full_transcript_screen.renderProjectionViewportSourceInterruptible(
+        alloc,
+        &projection,
+        &installed.capability.?,
+        80,
+        20,
+        0,
+        null,
+    );
+    defer alloc.free(rendered);
+    try std.testing.expect(std.mem.find(u8, rendered, "SAVED_HEAD") != null);
+    try std.testing.expect(std.mem.find(u8, rendered, "SAVED_TAIL") != null);
+    try std.testing.expect(std.mem.find(u8, rendered, "Full saved result unavailable.") == null);
+
+    // A newly built view must still have a readable preview if the file disappears.
+    try result_store.deleteManaged(&installed.capability.?, installed.details.items[0].result_handle.?);
+    var missing = try full_transcript_screen.buildProjection(
+        alloc,
+        &entries,
+        installed.details.items,
+        &.{},
+        .{},
+        80,
+        null,
+    );
+    defer missing.deinit(alloc);
+    const fallback = try full_transcript_screen.renderProjectionViewportSourceInterruptible(
+        alloc,
+        &missing,
+        &installed.capability.?,
+        80,
+        20,
+        0,
+        null,
+    );
+    defer alloc.free(fallback);
+    try std.testing.expect(std.mem.find(u8, fallback, "retained preview") != null);
+    try std.testing.expect(std.mem.find(u8, fallback, "Full saved result unavailable.") != null);
 }
 
 pub const Load = struct {

--- a/src/ui/transcript/runtime.zig
+++ b/src/ui/transcript/runtime.zig
@@ -4009,7 +4009,7 @@ const InstalledFullTranscriptPage = struct {
             std.heap.c_allocator.free(self.measured_item_rows);
         }
         self.projection.deinit(std.heap.c_allocator);
-        self.source.deinit();
+        self.source.deinit(std.heap.c_allocator);
         self.* = undefined;
     }
 };
@@ -9743,8 +9743,8 @@ pub const TranscriptRuntime = struct {
         } else if (!task.cancel_requested.load(.acquire) and
             full_transcript_page.sameSurface(desired, request))
         {
-            if (task.takeProjection()) |projection| {
-                const prepared_window = task.takePreparedWindow() orelse
+            if (task.projection) |projection| {
+                const prepared_window = task.prepared_window orelse
                     return error.MissingPreparedFullTranscriptSource;
                 const measured_item_rows = try std.heap.c_allocator.dupe(
                     transcript_presentation.ItemRow,
@@ -9758,8 +9758,8 @@ pub const TranscriptRuntime = struct {
                 if (self.full_transcript_installed_page) |*page| page.deinit();
                 self.full_transcript_installed_page = .{
                     .source = source,
-                    .projection = projection,
-                    .prepared_window = prepared_window,
+                    .projection = task.takeProjection().?,
+                    .prepared_window = task.takePreparedWindow().?,
                     .measured_total_rows = projection.measured_total_rows,
                     .measured_anchor_row = projection.measured_anchor_row,
                     .measured_item_rows = measured_item_rows,

--- a/tests/e2e/tui-full-transcript-brutal.test.ts
+++ b/tests/e2e/tui-full-transcript-brutal.test.ts
@@ -19,6 +19,7 @@ import {
   composerContains,
   FAKE_GATEWAY_MODEL,
   fakeGatewayFinalText,
+  fakeGatewayToolCall,
   fakeGatewaySse,
   fakeShellRun,
   startFakeGateway,
@@ -1202,6 +1203,70 @@ async function runStress(config: StressConfig): Promise<StressRoot> {
     }
   }
 }
+
+test.skipIf(!tmuxAvailable())(
+  "Ctrl-O keeps saved tool output intact across window replacement",
+  async () => {
+    const paths = makeRoot("saved-result-lifetime");
+    mkdirSync(join(paths.home, ".fx"), { recursive: true });
+    mkdirSync(paths.workspace);
+    const lines = Array.from({ length: 300 }, (_, i) =>
+      `SAVED_ROW_${String(i + 1).padStart(4, "0")} original tool output`,
+    );
+    writeFileSync(join(paths.workspace, "saved.txt"), lines.join("\n") + "\n");
+    const savedGateway = startFakeGateway([
+      fakeGatewayToolCall("saved-read", "read_file", { path: "saved.txt", line_count: 300 }),
+      fakeGatewayFinalText("Saved read complete."),
+    ]);
+    let active: TmuxSession | null = null;
+    try {
+      active = await TmuxSession.create({
+        cmd: FX_BIN,
+        cwd: paths.workspace,
+        env: { ...gatewayEnv(paths.home, savedGateway), FX_RECORD: paths.tapePath },
+        stderrPath: paths.stderrPath,
+        width: 100,
+        height: 32,
+      });
+      await active.waitForComposer(TIMEOUT);
+      await active.sendText("Read saved.txt completely.");
+      await active.waitForText("Saved read complete.", TIMEOUT);
+      for (const width of [100, 80]) {
+        await active.resizeWindow(width, 32);
+        await active.sendHexBytes(CTRL_O);
+        await active.waitForText(FULL_FOOTER, TIMEOUT);
+        let previous = await active.waitForText("SAVED_ROW_0300", TIMEOUT);
+        // Each accepted page must show earlier original rows, including cache misses.
+        for (let page = 0; page < 6; page++) {
+          const first = Number(previous.match(/SAVED_ROW_(\d+)/)?.[1]);
+          expect(first).toBeGreaterThan(1);
+          await active.sendHexBytes(PAGE_UP);
+          previous = await active.waitForPane((pane) => {
+            const current = Number(pane.match(/SAVED_ROW_(\d+)/)?.[1]);
+            return current > 0 && current < first;
+          }, TIMEOUT);
+          expect(previous).not.toContain("Full saved result unavailable.");
+          for (const marker of previous.matchAll(/SAVED_ROW_(\d+)/g)) {
+            expect(previous).toContain(lines[Number(marker[1]) - 1]!);
+          }
+        }
+        await active.sendHexBytes(CTRL_O);
+        await active.waitForComposer(TIMEOUT);
+      }
+      const scrollback = await active.captureFullScrollback();
+      expect(scrollback).toContain("Saved read complete.");
+      expect(scrollback).not.toContain("Full saved result unavailable.");
+      expect(savedGateway.requests).toHaveLength(2);
+      expect(active.isAlive()).toBe(true);
+      expect(readFileSync(paths.stderrPath, "utf8")).toBe("");
+    } finally {
+      await active?.kill();
+      savedGateway.stop();
+      rmSync(paths.root, { recursive: true, force: true });
+    }
+  },
+  60_000,
+);
 
 test.skipIf(!tmuxAvailable())(
   "Ctrl-O fills a viewport taller than the prepared overscan cache",

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -2085,11 +2085,15 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
     async () => {
       const originalPrompt = "Preserve this interactive prompt.";
       const finalText = "Interactive recovery completed.";
+      const continued: HoldState = { started: false, cancelled: false };
       const { queuedGateway, stderrPath } = await launchRouteRecoveryTui(
         "fx-tui-recovery-continue-",
         [
           ...Array.from({ length: 10 }, () => retryAfterUnavailable(0)),
-          fakeGatewayFinalText(finalText),
+          () => heldGatewayResponse(continued, [], [
+            { type: "text-delta", id: "answer_1", delta: finalText },
+            { type: "finish", finishReason: { unified: "stop", raw: "stop" } },
+          ]),
         ],
       );
 
@@ -2099,6 +2103,9 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       expect(queuedGateway.requests).toHaveLength(10);
 
       await session!.sendText("/continue");
+      await waitForCondition(() => continued.started, "continued paused response");
+      await session!.waitForText("Thinking", TIMEOUT);
+      continued.release?.();
       try {
         await session!.waitForText(finalText, TIMEOUT);
       } catch (err) {
@@ -2164,6 +2171,79 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
     },
     TIMEOUT * 2,
   );
+
+  for (const outcome of ["finish", "cancel"] as const) {
+    test(
+      `reopened recovery shows progress before response text and can ${outcome}`,
+      async () => {
+        const interrupted: HoldState = { started: false, cancelled: false };
+        const resumed: HoldState = { started: false, cancelled: false };
+        const prompt = "Read before.txt, then report the result.";
+        const finalText = "Reopened recovery completed once.";
+        const { queuedGateway, stderrPath } = await launchRouteRecoveryTui(
+          "fx-tui-recovery-progress-",
+          [
+            fakeGatewayToolCall("read_before_resume", "read_file", { path: "before.txt" }),
+            () => heldGatewayResponse(interrupted),
+            () => heldGatewayResponse(resumed, [], [
+              { type: "text-delta", id: "answer_1", delta: finalText },
+              { type: "finish", finishReason: { unified: "stop", raw: "stop" } },
+            ]),
+          ],
+        );
+        writeFileSync(join(root!, "workspace", "before.txt"), "Completed read survives restart.\n");
+        await session!.sendText(prompt);
+        await waitForCondition(() => interrupted.started, "checkpointed response");
+        await session!.kill();
+        session = null;
+        const resumedStderr = join(root!, "resumed-stderr.log");
+        session = await TmuxSession.create({
+          cmd: `${FX_BIN} --resume-last`,
+          cwd: join(root!, "workspace"),
+          width: 100,
+          height: 32,
+          stderrPath: resumedStderr,
+          env: {
+            HOME: join(root!, "home"),
+            AI_GATEWAY_API_KEY: "fake-route-recovery-key",
+            FX_AUTO_UPGRADE: "0",
+            FX_PERMISSION_MODE: "auto",
+            FX_GATEWAY_BASE_URL: queuedGateway.baseUrl,
+            FX_GATEWAY_CHAT_URL: queuedGateway.chatUrl,
+            FX_E2E_GATEWAY_CHAT_URL: queuedGateway.chatUrl,
+            FX_E2E_GATEWAY_MODELS_URL: `${queuedGateway.baseUrl}/coding-agent/v1/models`,
+            FX_MODEL: MODEL,
+          },
+        });
+        await session.waitForComposer(TIMEOUT);
+        await session.sendText("/continue");
+        await waitForCondition(() => resumed.started, "admitted resumed response");
+        await session.waitForText("Thinking", TIMEOUT);
+        for (let attempt = 0; attempt < 3; attempt++) await session.sendText("/continue");
+        await session.waitForText("wait for the current response to finish", TIMEOUT);
+        expect(queuedGateway.requests).toHaveLength(3);
+        expect(await session.capturePane()).toContain("Thinking");
+
+        if (outcome === "finish") {
+          resumed.release?.();
+          await session.waitForText(finalText, TIMEOUT);
+        } else {
+          await session.sendKeys("Escape");
+          await session.waitForText("What can fx do differently?", TIMEOUT);
+        }
+        await session.waitForPane((pane) => !pane.includes("Thinking") && hasEmptyComposer(pane), TIMEOUT);
+        const scrollback = await session.captureFullScrollback();
+        expect(scrollback.split(prompt).length - 1).toBe(1);
+        expect(scrollback.split("└ Read before.txt").length - 1).toBe(1);
+        expect(scrollback.split(finalText).length - 1).toBe(outcome === "finish" ? 1 : 0);
+        expect(queuedGateway.requests).toHaveLength(3);
+        expect(session.isAlive()).toBe(true);
+        expect(readFileSync(stderrPath, "utf8")).toBe("");
+        expect(readFileSync(resumedStderr, "utf8")).toBe("");
+      },
+      TIMEOUT * 2,
+    );
+  }
 
   test(
     "paused tool lifecycle admits resumed tools on the same turn",


### PR DESCRIPTION
## Summary

- Keep saved tool output intact when paging, resizing, or reopening the full transcript.
- Show progress as soon as a paused response continues, while keeping duplicate requests blocked.
