### PR TITLE
Reconcile completed Responses tool calls before execution

### DIFF
--- a/src/gateway/client.zig
+++ b/src/gateway/client.zig
@@ -6,6 +6,7 @@ const agent_stream_provider = @import("../core/agent/stream_provider.zig");
 const debug_trace = @import("../core/shared/debug_trace.zig");
 const io_mod = @import("../core/shared/io.zig");
 const types = @import("../core/shared/types.zig");
+const json_comparison = @import("json_comparison.zig");
 
 pub fn isRetryableGatewayError(err: anyerror) bool {
     return err == error.HttpConnectionClosing or
@@ -2395,54 +2396,6 @@ fn findStreamedToolInput(records: []const SseStreamedToolInput, id: []const u8) 
     return null;
 }
 
-fn jsonValuesEqual(lhs: std.json.Value, rhs: std.json.Value) bool {
-    if (std.meta.activeTag(lhs) != std.meta.activeTag(rhs)) return false;
-    return switch (lhs) {
-        .null => true,
-        .bool => |value| value == rhs.bool,
-        .integer => |value| value == rhs.integer,
-        .float => |value| value == rhs.float,
-        .number_string => |value| std.mem.eql(u8, value, rhs.number_string),
-        .string => |value| std.mem.eql(u8, value, rhs.string),
-        .array => |values| blk: {
-            if (values.items.len != rhs.array.items.len) break :blk false;
-            for (values.items, rhs.array.items) |left, right| {
-                if (!jsonValuesEqual(left, right)) break :blk false;
-            }
-            break :blk true;
-        },
-        .object => |fields| blk: {
-            if (fields.count() != rhs.object.count()) break :blk false;
-            var iterator = fields.iterator();
-            while (iterator.next()) |field| {
-                const right = rhs.object.get(field.key_ptr.*) orelse break :blk false;
-                if (!jsonValuesEqual(field.value_ptr.*, right)) break :blk false;
-            }
-            break :blk true;
-        },
-    };
-}
-
-fn serializedJsonEqual(
-    alloc: std.mem.Allocator,
-    lhs: []const u8,
-    rhs: []const u8,
-) std.mem.Allocator.Error!bool {
-    if (std.mem.eql(u8, lhs, rhs)) return true;
-
-    var left = std.json.parseFromSlice(std.json.Value, alloc, lhs, .{}) catch |err| switch (err) {
-        error.OutOfMemory => return error.OutOfMemory,
-        else => return false,
-    };
-    defer left.deinit();
-    var right = std.json.parseFromSlice(std.json.Value, alloc, rhs, .{}) catch |err| switch (err) {
-        error.OutOfMemory => return error.OutOfMemory,
-        else => return false,
-    };
-    defer right.deinit();
-    return jsonValuesEqual(left.value, right.value);
-}
-
 fn findEquivalentEndedStreamedToolInput(
     alloc: std.mem.Allocator,
     records: []const SseStreamedToolInput,
@@ -2454,7 +2407,7 @@ fn findEquivalentEndedStreamedToolInput(
     for (records, 0..) |record, i| {
         if (record.state != .ended) continue;
         if (!std.mem.eql(u8, record.name.items, final_name)) continue;
-        if (try serializedJsonEqual(alloc, record.arguments.items, final_arguments)) return i;
+        if (try json_comparison.serializedEqual(alloc, record.arguments.items, final_arguments)) return i;
     }
     return null;
 }

--- a/src/gateway/json_comparison.zig
+++ b/src/gateway/json_comparison.zig
@@ -1,0 +1,98 @@
+const std = @import("std");
+
+pub fn serializedEqual(alloc: std.mem.Allocator, lhs: []const u8, rhs: []const u8) std.mem.Allocator.Error!bool {
+    if (std.mem.eql(u8, lhs, rhs)) return true;
+    var left = std.json.parseFromSlice(std.json.Value, alloc, lhs, .{}) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return false,
+    };
+    defer left.deinit();
+    var right = std.json.parseFromSlice(std.json.Value, alloc, rhs, .{}) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return false,
+    };
+    defer right.deinit();
+
+    const Frame = struct { left: std.json.Value, right: std.json.Value, index: usize = 0 };
+    var pending: std.ArrayList(Frame) = .empty;
+    defer pending.deinit(alloc);
+    try pending.append(alloc, .{ .left = left.value, .right = right.value });
+    while (pending.items.len > 0) {
+        const frame = &pending.items[pending.items.len - 1];
+        if (std.meta.activeTag(frame.left) != std.meta.activeTag(frame.right)) return false;
+        switch (frame.left) {
+            .null => {},
+            .bool => |value| if (value != frame.right.bool) return false,
+            .integer => |value| if (value != frame.right.integer) return false,
+            .float => |value| if (value != frame.right.float) return false,
+            .number_string => |value| if (!std.mem.eql(u8, value, frame.right.number_string)) return false,
+            .string => |value| if (!std.mem.eql(u8, value, frame.right.string)) return false,
+            .array => |values| {
+                if (values.items.len != frame.right.array.items.len) return false;
+                if (frame.index < values.items.len) {
+                    const next = Frame{ .left = values.items[frame.index], .right = frame.right.array.items[frame.index] };
+                    frame.index += 1;
+                    try pending.append(alloc, next);
+                    continue;
+                }
+            },
+            .object => |fields| {
+                if (fields.count() != frame.right.object.count()) return false;
+                if (frame.index < fields.count()) {
+                    const value = frame.right.object.get(fields.keys()[frame.index]) orelse return false;
+                    const next = Frame{ .left = fields.values()[frame.index], .right = value };
+                    frame.index += 1;
+                    try pending.append(alloc, next);
+                    continue;
+                }
+            },
+        }
+        _ = pending.pop();
+    }
+    return true;
+}
+
+test "serialized JSON equality preserves typed values and object order independence" {
+    const cases = [_]struct { left: []const u8, right: []const u8, equal: bool }{
+        .{ .left = "{}", .right = " { } ", .equal = true },
+        .{ .left = "{\"a\":1,\"b\":[true,null]}", .right = "{\"b\":[true,null],\"a\":1}", .equal = true },
+        .{ .left = "{\"a\":\"A\"}", .right = "{\"a\":\"\\u0041\"}", .equal = true },
+        .{ .left = "[1,2]", .right = "[2,1]", .equal = false },
+        .{ .left = "{\"a\":1}", .right = "{\"b\":1}", .equal = false },
+        .{ .left = "1", .right = "1.0", .equal = false },
+        .{ .left = "null", .right = "false", .equal = false },
+        .{ .left = "{]", .right = "{}", .equal = false },
+        .{ .left = "{]", .right = "{]", .equal = true },
+    };
+    for (cases) |case| try std.testing.expectEqual(case.equal, try serializedEqual(std.testing.allocator, case.left, case.right));
+}
+
+fn expectComparisonAllocations(alloc: std.mem.Allocator) !void {
+    try std.testing.expect(try serializedEqual(alloc, "{\"a\":[1,{\"b\":true}]}", " { \"a\" : [1, {\"b\":true}] } "));
+    try std.testing.expect(!try serializedEqual(alloc, "{\"a\":[1,{\"b\":true}]}", "{\"a\":[1,{\"b\":false}]}"));
+}
+
+test "serialized JSON equality releases comparison allocations on failure" {
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, expectComparisonAllocations, .{});
+    try std.testing.expect(try serializedEqual(std.testing.failing_allocator, "{}", "{}"));
+}
+
+test "serialized JSON equality traverses nested values with owned scratch" {
+    const alloc = std.testing.allocator;
+    const depth = 256;
+    var left: std.Io.Writer.Allocating = .init(alloc);
+    defer left.deinit();
+    var right: std.Io.Writer.Allocating = .init(alloc);
+    defer right.deinit();
+    for (0..depth) |_| {
+        try left.writer.writeByte('[');
+        try right.writer.writeAll("[ ");
+    }
+    try left.writer.writeByte('1');
+    try right.writer.writeByte('1');
+    for (0..depth) |_| {
+        try left.writer.writeByte(']');
+        try right.writer.writeAll(" ]");
+    }
+    try std.testing.expect(try serializedEqual(alloc, left.written(), right.written()));
+}

--- a/src/gateway/responses_protocol.zig
+++ b/src/gateway/responses_protocol.zig
@@ -342,6 +342,12 @@ fn checkOptionalIdentity(fields: std.json.ObjectMap, key: []const u8, expected: 
     }
 }
 
+fn optionalOutputIndex(fields: std.json.ObjectMap) error{InvalidEvent}!?i64 {
+    const value = fields.get("output_index") orelse return null;
+    if (value != .integer or value.integer < 0) return error.InvalidEvent;
+    return value.integer;
+}
+
 pub const Reducer = struct {
     content: std.ArrayList(u8) = .empty,
     provider_state: std.Io.Writer.Allocating,
@@ -398,7 +404,7 @@ pub const Reducer = struct {
         const event_type = stringField(parsed.value.object, "type") orelse return false;
 
         if (std.mem.eql(u8, event_type, "response.output_item.added")) {
-            const output_index = integerField(parsed.value.object, "output_index") orelse return false;
+            const output_index = try optionalOutputIndex(parsed.value.object) orelse return false;
             const item = parsed.value.object.get("item") orelse return false;
             if (item != .object) return false;
             const item_type = stringField(item.object, "type") orelse return false;
@@ -436,7 +442,7 @@ pub const Reducer = struct {
         } else if (std.mem.eql(u8, event_type, "response.reasoning_summary_part.done")) {
             if (callbacks.on_reasoning) |callback| callback(callbacks.context, "\n\n");
         } else if (std.mem.eql(u8, event_type, "response.function_call_arguments.delta")) {
-            const output_index = integerField(parsed.value.object, "output_index") orelse return false;
+            const output_index = try optionalOutputIndex(parsed.value.object) orelse return false;
             const delta = stringField(parsed.value.object, "delta") orelse return false;
             const index = findTool(self.tools.items, output_index) orelse return false;
             try self.tools.items[index].reconcileIdentity(alloc, parsed.value.object, "item_id", limits);
@@ -444,13 +450,13 @@ pub const Reducer = struct {
             try appendToolArguments(alloc, &self.tools.items[index].arguments, delta, limits.tool_arguments_bytes);
             if (callbacks.on_tool_input) |callback| callback(callbacks.context, delta);
         } else if (std.mem.eql(u8, event_type, "response.function_call_arguments.done")) {
-            const output_index = integerField(parsed.value.object, "output_index") orelse return false;
+            const output_index = try optionalOutputIndex(parsed.value.object) orelse return false;
             const arguments = stringField(parsed.value.object, "arguments") orelse return error.InvalidEvent;
             const index = findTool(self.tools.items, output_index) orelse return error.ResponsesToolCallConflict;
             try self.tools.items[index].reconcileIdentity(alloc, parsed.value.object, "item_id", limits);
             try self.tools.items[index].finalizeArguments(alloc, arguments, callbacks, limits);
         } else if (std.mem.eql(u8, event_type, "response.output_item.done")) {
-            const output_index = integerField(parsed.value.object, "output_index") orelse return false;
+            const output_index = try optionalOutputIndex(parsed.value.object) orelse return false;
             const item = parsed.value.object.get("item") orelse return false;
             if (item != .object) return false;
             const item_type = stringField(item.object, "type") orelse return false;
@@ -796,6 +802,31 @@ test "Responses finalization retains cancellation and terminal requirements" {
     stream.cancelled.store(true, .seq_cst);
     try std.testing.expectError(error.Cancelled, stream.apply(ToolRecordTest.terminal));
     try std.testing.expectError(error.Cancelled, stream.finish());
+}
+
+test "Responses rejects malformed supplied output indexes without requiring omitted metadata" {
+    const cases = [_][]const u8{
+        "{\"type\":\"response.function_call_arguments.done\",\"output_index\":\"0\",\"arguments\":\"{}\"}",
+        "{\"type\":\"response.output_item.done\",\"output_index\":null,\"item\":{\"type\":\"function_call\",\"arguments\":\"{}\"}}",
+        "{\"type\":\"response.output_item.added\",\"output_index\":-1,\"item\":{\"type\":\"function_call\",\"call_id\":\"bad\",\"name\":\"read_file\"}}",
+        "{\"type\":\"response.function_call_arguments.delta\",\"output_index\":0.0,\"delta\":\"{}\"}",
+    };
+    for (cases) |event| {
+        var stream = ToolRecordTest.init(std.testing.allocator);
+        defer stream.deinit();
+        try stream.apply(ToolRecordTest.start);
+        try stream.apply(ToolRecordTest.finalized);
+        try std.testing.expectError(error.InvalidEvent, stream.apply(event));
+    }
+    var stream = ToolRecordTest.init(std.testing.allocator);
+    defer stream.deinit();
+    try stream.apply(ToolRecordTest.start);
+    try stream.apply(ToolRecordTest.finalized);
+    try stream.apply("{\"type\":\"response.output_item.done\",\"item\":{\"type\":\"function_call\"}}");
+    try stream.apply(ToolRecordTest.terminal);
+    const completion = try stream.finish();
+    defer stream.freeCompletion(completion);
+    try std.testing.expectEqualStrings("{\"path\":\"preview.txt\"}", completion.tool_calls[0].arguments_json);
 }
 
 test "Responses finalization preserves the length finish disposition" {

--- a/src/gateway/responses_protocol.zig
+++ b/src/gateway/responses_protocol.zig
@@ -5,6 +5,7 @@ const model_tool_schema = @import("../core/tooling/model_tool_schema.zig");
 const types = @import("../core/shared/types.zig");
 const image_attachments = @import("../core/images/image_attachments.zig");
 const tool_call_ids = @import("tool_call_ids.zig");
+const json_comparison = @import("json_comparison.zig");
 
 pub const ReplayLimits = struct {
     tool_calls: usize,
@@ -276,15 +277,70 @@ const ToolAccumulator = struct {
     output_index: i64,
     id: []u8,
     name: []u8,
+    item_id: ?[]u8 = null,
     arguments: std.ArrayList(u8) = .empty,
+    arguments_finalized: bool = false,
 
     fn deinit(self: *ToolAccumulator, alloc: std.mem.Allocator) void {
         alloc.free(self.id);
         alloc.free(self.name);
+        if (self.item_id) |id| alloc.free(id);
         self.arguments.deinit(alloc);
         self.* = undefined;
     }
+
+    fn reconcileIdentity(
+        self: *ToolAccumulator,
+        alloc: std.mem.Allocator,
+        fields: std.json.ObjectMap,
+        item_id_key: []const u8,
+        limits: StreamLimits,
+    ) !void {
+        try checkOptionalIdentity(fields, "call_id", self.id);
+        try checkOptionalIdentity(fields, "name", self.name);
+        if (fields.get(item_id_key)) |value| {
+            if (value != .string or value.string.len == 0) return error.InvalidEvent;
+            if (value.string.len > limits.tool_identity_bytes) return error.ToolCallLimitExceeded;
+            if (self.item_id) |id| {
+                if (!std.mem.eql(u8, id, value.string)) return error.ResponsesToolCallConflict;
+            } else {
+                self.item_id = try alloc.dupe(u8, value.string);
+            }
+        }
+    }
+
+    fn finalizeArguments(
+        self: *ToolAccumulator,
+        alloc: std.mem.Allocator,
+        arguments: []const u8,
+        callbacks: StreamCallbacks,
+        limits: StreamLimits,
+    ) !void {
+        if (arguments.len > limits.tool_arguments_bytes) return error.ToolArgumentsTooLarge;
+        if (self.arguments_finalized) {
+            if (!try json_comparison.serializedEqual(alloc, self.arguments.items, arguments)) return error.ResponsesToolCallConflict;
+            return;
+        }
+        const previous_len = self.arguments.items.len;
+        if (std.mem.startsWith(u8, arguments, self.arguments.items)) {
+            const suffix = arguments[previous_len..];
+            try appendToolArguments(alloc, &self.arguments, suffix, limits.tool_arguments_bytes);
+            if (suffix.len > 0) if (callbacks.on_tool_input) |callback| callback(callbacks.context, suffix);
+        } else {
+            try self.arguments.ensureTotalCapacity(alloc, arguments.len);
+            self.arguments.clearRetainingCapacity();
+            self.arguments.appendSliceAssumeCapacity(arguments);
+        }
+        self.arguments_finalized = true;
+    }
 };
+
+fn checkOptionalIdentity(fields: std.json.ObjectMap, key: []const u8, expected: []const u8) !void {
+    if (fields.get(key)) |value| {
+        if (value != .string) return error.InvalidEvent;
+        if (!std.mem.eql(u8, value.string, expected)) return error.ResponsesToolCallConflict;
+    }
+}
 
 pub const Reducer = struct {
     content: std.ArrayList(u8) = .empty,
@@ -324,6 +380,7 @@ pub const Reducer = struct {
         limits: StreamLimits,
     ) !bool {
         if (cancel_flag.load(.seq_cst)) return error.Cancelled;
+        if (self.terminal_seen) return true;
         self.event_count = try checkedAccumulatedSize(self.event_count, 1, limits.events);
         if (limits.count_json_bytes) {
             self.aggregate_bytes = try checkedAccumulatedSize(
@@ -332,8 +389,10 @@ pub const Reducer = struct {
                 limits.aggregate_bytes,
             );
         }
-        var parsed = std.json.parseFromSlice(std.json.Value, alloc, json_text, .{}) catch
-            return error.InvalidEvent;
+        var parsed = std.json.parseFromSlice(std.json.Value, alloc, json_text, .{}) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            else => return error.InvalidEvent,
+        };
         defer parsed.deinit();
         if (parsed.value != .object) return false;
         const event_type = stringField(parsed.value.object, "type") orelse return false;
@@ -348,9 +407,18 @@ pub const Reducer = struct {
                 const name = stringField(item.object, "name") orelse return false;
                 if (findTool(self.tools.items, output_index) == null) {
                     try appendTool(alloc, &self.tools, output_index, call_id, name, limits);
+                    const tool = &self.tools.items[self.tools.items.len - 1];
+                    try tool.reconcileIdentity(alloc, item.object, "id", limits);
+                    if (item.object.get("arguments")) |value| {
+                        if (value != .string) return error.InvalidEvent;
+                        try appendToolArguments(alloc, &tool.arguments, value.string, limits.tool_arguments_bytes);
+                    }
                     if (callbacks.on_tool_start) |callback| {
                         callback(callbacks.context, call_id, name, null);
                     }
+                } else {
+                    const index = findTool(self.tools.items, output_index).?;
+                    try self.tools.items[index].reconcileIdentity(alloc, item.object, "id", limits);
                 }
             }
         } else if (std.mem.eql(u8, event_type, "response.output_text.delta") or
@@ -371,34 +439,23 @@ pub const Reducer = struct {
             const output_index = integerField(parsed.value.object, "output_index") orelse return false;
             const delta = stringField(parsed.value.object, "delta") orelse return false;
             const index = findTool(self.tools.items, output_index) orelse return false;
+            try self.tools.items[index].reconcileIdentity(alloc, parsed.value.object, "item_id", limits);
+            if (self.tools.items[index].arguments_finalized and delta.len > 0) return error.ResponsesToolCallConflict;
             try appendToolArguments(alloc, &self.tools.items[index].arguments, delta, limits.tool_arguments_bytes);
             if (callbacks.on_tool_input) |callback| callback(callbacks.context, delta);
         } else if (std.mem.eql(u8, event_type, "response.function_call_arguments.done")) {
             const output_index = integerField(parsed.value.object, "output_index") orelse return false;
-            const arguments = stringField(parsed.value.object, "arguments") orelse return false;
-            const index = findTool(self.tools.items, output_index) orelse return false;
-            const previous_len = self.tools.items[index].arguments.items.len;
-            if (std.mem.startsWith(u8, arguments, self.tools.items[index].arguments.items)) {
-                const suffix = arguments[previous_len..];
-                try appendToolArguments(alloc, &self.tools.items[index].arguments, suffix, limits.tool_arguments_bytes);
-                if (suffix.len > 0) if (callbacks.on_tool_input) |callback| callback(callbacks.context, suffix);
-            } else {
-                self.tools.items[index].arguments.clearRetainingCapacity();
-                try appendToolArguments(alloc, &self.tools.items[index].arguments, arguments, limits.tool_arguments_bytes);
-            }
+            const arguments = stringField(parsed.value.object, "arguments") orelse return error.InvalidEvent;
+            const index = findTool(self.tools.items, output_index) orelse return error.ResponsesToolCallConflict;
+            try self.tools.items[index].reconcileIdentity(alloc, parsed.value.object, "item_id", limits);
+            try self.tools.items[index].finalizeArguments(alloc, arguments, callbacks, limits);
         } else if (std.mem.eql(u8, event_type, "response.output_item.done")) {
             const output_index = integerField(parsed.value.object, "output_index") orelse return false;
             const item = parsed.value.object.get("item") orelse return false;
             if (item != .object) return false;
             const item_type = stringField(item.object, "type") orelse return false;
             if (std.mem.eql(u8, item_type, "function_call")) {
-                if (findTool(self.tools.items, output_index)) |index| {
-                    if (stringField(item.object, "arguments")) |arguments| {
-                        if (self.tools.items[index].arguments.items.len == 0) {
-                            try appendToolArguments(alloc, &self.tools.items[index].arguments, arguments, limits.tool_arguments_bytes);
-                        }
-                    }
-                }
+                try self.reconcileToolItem(alloc, output_index, item.object, callbacks, limits);
             } else if (std.mem.eql(u8, item_type, "reasoning") and
                 stringField(item.object, "encrypted_content") != null)
             {
@@ -440,6 +497,15 @@ pub const Reducer = struct {
         {
             const response_value = parsed.value.object.get("response") orelse return false;
             if (response_value != .object) return false;
+            if (response_value.object.get("output")) |output| {
+                if (output != .array) return error.InvalidEvent;
+                for (output.array.items, 0..) |item, output_index| {
+                    if (item != .object) continue;
+                    const item_type = stringField(item.object, "type") orelse continue;
+                    if (!std.mem.eql(u8, item_type, "function_call")) continue;
+                    try self.reconcileToolItem(alloc, std.math.cast(i64, output_index) orelse return error.ResourceLimitExceeded, item.object, callbacks, limits);
+                }
+            }
             self.terminal_seen = true;
             self.finish_reason = finishReason(
                 stringField(response_value.object, "status"),
@@ -458,6 +524,23 @@ pub const Reducer = struct {
             return error.ResponseFailed;
         }
         return false;
+    }
+
+    fn reconcileToolItem(
+        self: *Reducer,
+        alloc: std.mem.Allocator,
+        output_index: i64,
+        fields: std.json.ObjectMap,
+        callbacks: StreamCallbacks,
+        limits: StreamLimits,
+    ) !void {
+        const index = findTool(self.tools.items, output_index) orelse return error.ResponsesToolCallConflict;
+        const tool = &self.tools.items[index];
+        try tool.reconcileIdentity(alloc, fields, "id", limits);
+        if (fields.get("arguments")) |value| {
+            if (value != .string) return error.InvalidEvent;
+            try tool.finalizeArguments(alloc, value.string, callbacks, limits);
+        }
     }
 
     pub fn finish(
@@ -495,7 +578,7 @@ pub const Reducer = struct {
             alloc.free(call.arguments_json);
         };
         for (self.tools.items, 0..) |*tool, index| {
-            const arguments = if (tool.arguments.items.len > 0)
+            const arguments = if (tool.arguments_finalized or tool.arguments.items.len > 0)
                 try tool.arguments.toOwnedSlice(alloc)
             else
                 try alloc.dupe(u8, "{}");
@@ -521,6 +604,228 @@ pub const Reducer = struct {
         };
     }
 };
+
+const ToolRecordTest = struct {
+    alloc: std.mem.Allocator,
+    reducer: Reducer,
+    cancelled: std.atomic.Value(bool) = .init(false),
+    context: u8 = 0,
+    const limits = StreamLimits{ .aggregate_bytes = 64 * 1024, .events = 100, .tool_calls = 4, .tool_identity_bytes = 1024, .tool_arguments_bytes = 4096, .provider_state_bytes = 4096 };
+    const start = "{\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"call_1\",\"name\":\"write_file\",\"arguments\":\"\"}}";
+    const finalized = "{\"type\":\"response.function_call_arguments.done\",\"output_index\":0,\"item_id\":\"fc_1\",\"name\":\"write_file\",\"arguments\":\"{\\\"path\\\":\\\"preview.txt\\\"}\"}";
+    const terminal = "{\"type\":\"response.completed\",\"response\":{\"status\":\"completed\"}}";
+
+    fn init(alloc: std.mem.Allocator) ToolRecordTest {
+        return .{ .alloc = alloc, .reducer = .init(alloc) };
+    }
+
+    fn deinit(self: *ToolRecordTest) void {
+        self.reducer.deinit(self.alloc);
+    }
+
+    fn apply(self: *ToolRecordTest, event: []const u8) !void {
+        _ = try self.reducer.applyJson(self.alloc, event, .{ .context = &self.context, .on_content = ignore }, &self.cancelled, null, limits);
+    }
+
+    fn finish(self: *ToolRecordTest) !types.ModelCompletion {
+        return self.reducer.finish(self.alloc, &self.cancelled, limits);
+    }
+
+    fn freeCompletion(self: *ToolRecordTest, completion: types.ModelCompletion) void {
+        types.freeToolCallSlice(self.alloc, @constCast(completion.tool_calls));
+        if (completion.content) |value| self.alloc.free(value);
+        if (completion.provider_state_json) |value| self.alloc.free(value);
+        if (completion.generation_id) |value| self.alloc.free(value);
+    }
+
+    fn ignore(_: *anyopaque, _: []const u8) void {}
+};
+
+test "Responses rejects conflicting completed tool records" {
+    const records = [_][]const u8{
+        "{\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"call_id\":\"call_1\",\"name\":\"read_file\",\"arguments\":\"{\\\"path\\\":\\\"preview.txt\\\"}\"}}",
+        "{\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"call_id\":\"other\",\"name\":\"write_file\",\"arguments\":\"{\\\"path\\\":\\\"preview.txt\\\"}\"}}",
+        "{\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"id\":\"other\",\"call_id\":\"call_1\",\"name\":\"write_file\",\"arguments\":\"{\\\"path\\\":\\\"preview.txt\\\"}\"}}",
+        "{\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"call_id\":\"call_1\",\"name\":\"write_file\",\"arguments\":\"{\\\"path\\\":\\\"final.txt\\\"}\"}}",
+    };
+    for (records) |event| {
+        var stream = ToolRecordTest.init(std.testing.allocator);
+        defer stream.deinit();
+        try stream.apply(ToolRecordTest.start);
+        try stream.apply(ToolRecordTest.finalized);
+        try std.testing.expectError(error.ResponsesToolCallConflict, stream.apply(event));
+    }
+}
+
+test "Responses completed item replaces progressive arguments" {
+    var stream = ToolRecordTest.init(std.testing.allocator);
+    defer stream.deinit();
+    try stream.apply(ToolRecordTest.start);
+    try stream.apply("{\"type\":\"response.function_call_arguments.delta\",\"output_index\":0,\"delta\":\"{\\\"path\\\":\"}");
+    try stream.apply("{\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"call_id\":\"call_1\",\"name\":\"write_file\",\"arguments\":\"{\\\"path\\\":\\\"final.txt\\\"}\"}}");
+    try stream.apply(ToolRecordTest.terminal);
+    const completion = try stream.finish();
+    defer stream.freeCompletion(completion);
+    try std.testing.expectEqualStrings("{\"path\":\"final.txt\"}", completion.tool_calls[0].arguments_json);
+}
+
+test "Responses completed response validates supplied tool snapshots" {
+    var stream = ToolRecordTest.init(std.testing.allocator);
+    defer stream.deinit();
+    try stream.apply(ToolRecordTest.start);
+    try stream.apply(ToolRecordTest.finalized);
+    try std.testing.expectError(error.ResponsesToolCallConflict, stream.apply("{\"type\":\"response.completed\",\"response\":{\"status\":\"completed\",\"output\":[{\"type\":\"function_call\",\"call_id\":\"call_1\",\"name\":\"write_file\",\"arguments\":\"{\\\"path\\\":\\\"final.txt\\\"}\"}]}}"));
+}
+
+test "Responses completed response can finalize progressive arguments within the byte limit" {
+    const alloc = std.testing.allocator;
+    for ([_]usize{ ToolRecordTest.limits.tool_arguments_bytes, ToolRecordTest.limits.tool_arguments_bytes + 1 }) |size| {
+        var stream = ToolRecordTest.init(alloc);
+        defer stream.deinit();
+        try stream.apply(ToolRecordTest.start);
+        try stream.apply("{\"type\":\"response.function_call_arguments.delta\",\"output_index\":0,\"delta\":\"{\"}");
+        const arguments = try alloc.alloc(u8, size);
+        defer alloc.free(arguments);
+        @memset(arguments, ' ');
+        arguments[0] = '{';
+        arguments[size - 1] = '}';
+        const event = try std.json.Stringify.valueAlloc(alloc, .{
+            .type = "response.completed",
+            .response = .{ .status = "completed", .output = .{.{
+                .type = "function_call",
+                .call_id = "call_1",
+                .name = "write_file",
+                .arguments = arguments,
+            }} },
+        }, .{});
+        defer alloc.free(event);
+        if (size > ToolRecordTest.limits.tool_arguments_bytes) {
+            try std.testing.expectError(error.ToolArgumentsTooLarge, stream.apply(event));
+        } else {
+            try stream.apply(event);
+            const completion = try stream.finish();
+            defer stream.freeCompletion(completion);
+            try std.testing.expectEqualStrings(arguments, completion.tool_calls[0].arguments_json);
+        }
+    }
+}
+
+test "Responses finalized arguments cannot receive more deltas" {
+    var stream = ToolRecordTest.init(std.testing.allocator);
+    defer stream.deinit();
+    try stream.apply(ToolRecordTest.start);
+    try stream.apply(ToolRecordTest.finalized);
+    try std.testing.expectError(error.ResponsesToolCallConflict, stream.apply("{\"type\":\"response.function_call_arguments.delta\",\"output_index\":0,\"delta\":\" \"}"));
+}
+
+test "Responses equivalent finalized records retain one accepted argument representation" {
+    var stream = ToolRecordTest.init(std.testing.allocator);
+    defer stream.deinit();
+    try stream.apply(ToolRecordTest.start);
+    try stream.apply(ToolRecordTest.finalized);
+    const equivalent = "{\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"call_1\",\"name\":\"write_file\",\"arguments\":\" { \\\"path\\\" : \\\"preview.txt\\\" } \"}}";
+    try stream.apply(equivalent);
+    try stream.apply(equivalent);
+    try stream.apply(ToolRecordTest.finalized);
+    try stream.apply(ToolRecordTest.terminal);
+    const completion = try stream.finish();
+    defer stream.freeCompletion(completion);
+    try std.testing.expectEqual(@as(usize, 1), completion.tool_calls.len);
+    try std.testing.expectEqualStrings("{\"path\":\"preview.txt\"}", completion.tool_calls[0].arguments_json);
+}
+
+test "Responses final argument evidence does not manufacture an empty object" {
+    const cases = [_]struct { event: []const u8, arguments: []const u8 }{
+        .{ .event = "{\"type\":\"response.function_call_arguments.done\",\"output_index\":0,\"arguments\":\"\"}", .arguments = "" },
+        .{ .event = "{\"type\":\"response.function_call_arguments.done\",\"output_index\":0,\"arguments\":\"[]\"}", .arguments = "[]" },
+        .{ .event = "{\"type\":\"response.function_call_arguments.done\",\"output_index\":0,\"arguments\":\"{]\"}", .arguments = "{]" },
+    };
+    for (cases) |case| {
+        var stream = ToolRecordTest.init(std.testing.allocator);
+        defer stream.deinit();
+        try stream.apply(ToolRecordTest.start);
+        try stream.apply("{\"type\":\"response.function_call_arguments.delta\",\"output_index\":0,\"delta\":\"{\"}");
+        try stream.apply(case.event);
+        try stream.apply(ToolRecordTest.terminal);
+        const completion = try stream.finish();
+        defer stream.freeCompletion(completion);
+        try std.testing.expectEqualStrings(case.arguments, completion.tool_calls[0].arguments_json);
+        try std.testing.expect(try types.ToolArgumentIntegrity.classifyFunctionInput(std.testing.allocator, completion.tool_calls[0].arguments_json) != .valid);
+    }
+}
+
+test "Responses interleaved calls keep independent finalization" {
+    var stream = ToolRecordTest.init(std.testing.allocator);
+    defer stream.deinit();
+    try stream.apply(ToolRecordTest.start);
+    try stream.apply("{\"type\":\"response.output_item.added\",\"output_index\":1,\"item\":{\"type\":\"function_call\",\"id\":\"fc_2\",\"call_id\":\"call_2\",\"name\":\"read_file\",\"arguments\":\"{\"}}");
+    try stream.apply("{\"type\":\"response.function_call_arguments.delta\",\"output_index\":1,\"item_id\":\"fc_2\",\"delta\":\"\\\"path\\\":\\\"second.txt\\\"}\"}");
+    try stream.apply(ToolRecordTest.finalized);
+    try stream.apply("{\"type\":\"response.function_call_arguments.done\",\"output_index\":1,\"item_id\":\"fc_2\",\"name\":\"read_file\",\"arguments\":\"{\\\"path\\\":\\\"second.txt\\\"}\"}");
+    try stream.apply(ToolRecordTest.terminal);
+    const completion = try stream.finish();
+    defer stream.freeCompletion(completion);
+    try std.testing.expectEqual(@as(usize, 2), completion.tool_calls.len);
+    try std.testing.expectEqualStrings("{\"path\":\"preview.txt\"}", completion.tool_calls[0].arguments_json);
+    try std.testing.expectEqualStrings("{\"path\":\"second.txt\"}", completion.tool_calls[1].arguments_json);
+}
+
+test "Responses finalization checks correlation types and rejects unmatched final calls" {
+    const cases = [_]struct { event: []const u8, failure: anyerror }{
+        .{ .event = "{\"type\":\"response.function_call_arguments.done\",\"output_index\":0,\"item_id\":\"other\",\"arguments\":\"{}\"}", .failure = error.ResponsesToolCallConflict },
+        .{ .event = "{\"type\":\"response.function_call_arguments.done\",\"output_index\":0,\"name\":\"read_file\",\"arguments\":\"{}\"}", .failure = error.ResponsesToolCallConflict },
+        .{ .event = "{\"type\":\"response.function_call_arguments.done\",\"output_index\":0,\"item_id\":null,\"arguments\":\"{}\"}", .failure = error.InvalidEvent },
+        .{ .event = "{\"type\":\"response.function_call_arguments.done\",\"output_index\":0,\"arguments\":{}}", .failure = error.InvalidEvent },
+        .{ .event = "{\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"call_id\":null,\"arguments\":\"{}\"}}", .failure = error.InvalidEvent },
+        .{ .event = "{\"type\":\"response.output_item.done\",\"output_index\":1,\"item\":{\"type\":\"function_call\",\"call_id\":\"call_2\",\"arguments\":\"{}\"}}", .failure = error.ResponsesToolCallConflict },
+    };
+    for (cases) |case| {
+        var stream = ToolRecordTest.init(std.testing.allocator);
+        defer stream.deinit();
+        try stream.apply(ToolRecordTest.start);
+        try std.testing.expectError(case.failure, stream.apply(case.event));
+    }
+}
+
+test "Responses finalization retains cancellation and terminal requirements" {
+    var stream = ToolRecordTest.init(std.testing.allocator);
+    defer stream.deinit();
+    try stream.apply(ToolRecordTest.start);
+    try stream.apply(ToolRecordTest.finalized);
+    try std.testing.expectError(error.StreamIncomplete, stream.finish());
+    stream.cancelled.store(true, .seq_cst);
+    try std.testing.expectError(error.Cancelled, stream.apply(ToolRecordTest.terminal));
+    try std.testing.expectError(error.Cancelled, stream.finish());
+}
+
+test "Responses finalization preserves the length finish disposition" {
+    var stream = ToolRecordTest.init(std.testing.allocator);
+    defer stream.deinit();
+    try stream.apply(ToolRecordTest.start);
+    try stream.apply(ToolRecordTest.finalized);
+    try stream.apply("{\"type\":\"response.incomplete\",\"response\":{\"status\":\"incomplete\",\"incomplete_details\":{\"reason\":\"max_output_tokens\"},\"output\":[{\"type\":\"function_call\",\"call_id\":\"call_1\",\"name\":\"write_file\",\"arguments\":\"{\\\"path\\\":\\\"preview.txt\\\"}\"}]}}");
+    const completion = try stream.finish();
+    defer stream.freeCompletion(completion);
+    try std.testing.expectEqual(types.ProviderFinishReason.length, completion.finish_reason);
+}
+
+fn expectToolFinalizationAllocations(alloc: std.mem.Allocator) !void {
+    var stream = ToolRecordTest.init(alloc);
+    defer stream.deinit();
+    try stream.apply(ToolRecordTest.start);
+    try stream.apply("{\"type\":\"response.function_call_arguments.delta\",\"output_index\":0,\"delta\":\"discarded preview\"}");
+    try stream.apply(ToolRecordTest.finalized);
+    try stream.apply("{\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"id\":\"fc_1\",\"arguments\":\" {\\\"path\\\":\\\"preview.txt\\\"} \"}}");
+    try stream.apply("{\"type\":\"response.output_text.delta\",\"delta\":\"finished\"}");
+    try stream.apply("{\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"status\":\"completed\"}}");
+    const completion = try stream.finish();
+    defer stream.freeCompletion(completion);
+    try std.testing.expectEqualStrings("{\"path\":\"preview.txt\"}", completion.tool_calls[0].arguments_json);
+}
+
+test "Responses finalization releases owned state on allocation failure" {
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, expectToolFinalizationAllocations, .{});
+}
 
 fn appendTool(
     alloc: std.mem.Allocator,

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -899,6 +899,7 @@ async function runCodexLoginWithBrowser(
 }
 
 function startFakeCodexToolLoop(options: {
+  responses?: Response[];
   toolCallId?: string;
   toolName?: string;
   toolArguments?: object;
@@ -923,6 +924,7 @@ function startFakeCodexToolLoop(options: {
         ] });
       }
       bodies.push(await request.text());
+      if (options.responses) return options.responses.shift() ?? new Response("unexpected request", { status: 400 });
       if (bodies.length === 1) {
         return new Response(
           'data: {"type":"response.output_item.added","output_index":0,"item":{"type":"reasoning"}}\n\n' +
@@ -990,6 +992,7 @@ function startFakeCodexCapacityLoop() {
 }
 
 function startFakeGrokToolLoop(options: {
+  responses?: Response[];
   toolCallId?: string;
   toolName?: string;
   toolArguments?: object;
@@ -1012,6 +1015,7 @@ function startFakeGrokToolLoop(options: {
         return Response.json({ models: [grokModalityModel("grok-4.20", true)] });
       }
       bodies.push(await request.text());
+      if (options.responses) return options.responses.shift() ?? new Response("unexpected request", { status: 400 });
       if (bodies.length === 1) {
         return new Response(
           'data: {"type":"response.output_item.added","output_index":0,"item":{"type":"reasoning"}}\n\n' +
@@ -4343,6 +4347,103 @@ tmuxTest(
   },
   60_000,
 );
+
+for (const conflict of [false, true]) {
+  test("direct Responses final records " + (conflict ? "reject the current group and preserve earlier work" : "replace progressive arguments before execution"), async () => {
+    for (const provider of ["codex", "grok"] as const) {
+      const profile = mkdtempSync(join(tmpdir(), "fx-" + provider + "-final-record-"));
+      const testGateway = startFakeGateway([]);
+      const completed = { type: "response.completed", response: { status: "completed" } };
+      const item = (id: string, path: string) => ({
+        type: "function_call", id: "fc_" + id, call_id: id, name: "write_file",
+        arguments: JSON.stringify({ path, content: "saved" }),
+      });
+      const prior = item("prior", "prior.txt");
+      const pending = item("pending", "preview.txt");
+      const sibling = item("sibling", "sibling.txt");
+      const final = item("pending", "final.txt");
+      const responses: Response[] = [];
+      if (conflict) responses.push(fakeGatewaySse([
+        { type: "response.output_item.added", output_index: 0, item: { ...prior, arguments: "" } },
+        { type: "response.function_call_arguments.done", output_index: 0, arguments: prior.arguments },
+        { type: "response.output_item.done", output_index: 0, item: prior },
+        completed,
+      ]));
+      const events: object[] = [
+        { type: "response.output_item.added", output_index: 0, item: { ...pending, arguments: "" } },
+        { type: "response.function_call_arguments.delta", output_index: 0, item_id: pending.id, delta: pending.arguments },
+      ];
+      if (conflict) events.push(
+        { type: "response.function_call_arguments.done", output_index: 0, arguments: pending.arguments },
+        { type: "response.output_item.added", output_index: 1, item: { ...sibling, arguments: "" } },
+        { type: "response.function_call_arguments.done", output_index: 1, arguments: sibling.arguments },
+      );
+      events.push(
+        { type: "response.output_item.done", output_index: 0, item: final },
+        { type: "response.completed", response: { status: "completed", output: conflict ? [final, sibling] : [final] } },
+      );
+      responses.push(fakeGatewaySse(events), fakeGatewaySse([
+        { type: "response.output_text.delta", delta: "FINAL_RECORD_OK" }, completed,
+      ]));
+      const direct = provider === "codex" ? startFakeCodexToolLoop({ responses }) : startFakeGrokToolLoop({ responses });
+      try {
+        if (provider === "codex") writeSeededChatGptLogin(profile, direct.accessToken);
+        else writeSeededGrokLogin(profile, direct.accessToken);
+        const model = provider === "codex" ? "gpt-5.6-sol" : "grok-4.20";
+        writeFileSync(join(profile, ".fx", "settings.json"), JSON.stringify({ provider, [provider + "_model"]: model }), { mode: 0o600 });
+        const env = {
+          HOME: profile, AI_GATEWAY_API_KEY: "fixture", VERCEL_OIDC_TOKEN: undefined, FX_MODEL: undefined,
+          FX_DISABLE_KEYCHAIN: "1", FX_AUTO_UPGRADE: "0", FX_SOUND: "0",
+          FX_GATEWAY_BASE_URL: testGateway.baseUrl,
+          FX_E2E_GATEWAY_MODELS_URL: testGateway.baseUrl + "/coding-agent/v1/models",
+          FX_E2E_OPENAI_CODEX_RESPONSES_URL: direct.responsesUrl,
+          FX_E2E_OPENAI_CODEX_MODELS_URL: direct.modelsUrl,
+          FX_E2E_XAI_GROK_RESPONSES_URL: direct.responsesUrl,
+          FX_E2E_XAI_GROK_MODELS_URL: direct.modelsUrl,
+          FX_E2E_XAI_GROK_MODALITIES_URL: "modalitiesUrl" in direct ? direct.modalitiesUrl : undefined,
+        };
+        const result = await runFx(["ask", "--json", "--auto", "Create the requested files containing saved."], { cwd: profile, env, timeoutMs: TIMEOUT });
+        expect(result.code, provider + ": " + result.stdout + "\n" + result.stderr).toBe(conflict ? 1 : 0);
+        expect(result.signal).toBeNull();
+        expect(direct.bodies).toHaveLength(2);
+        expect(existsSync(join(profile, "preview.txt"))).toBe(false);
+        expect(existsSync(join(profile, "sibling.txt"))).toBe(false);
+        expect(existsSync(join(profile, "prior.txt"))).toBe(conflict);
+        expect(existsSync(join(profile, "final.txt"))).toBe(!conflict);
+        expect(readFileSync(join(profile, conflict ? "prior.txt" : "final.txt"), "utf8")).toBe("saved");
+        const resultJson = JSON.parse(result.stdout);
+        if (conflict) expect(resultJson.error).toBe("ResponsesToolCallConflict");
+        else {
+          expect(resultJson.output).toBe("FINAL_RECORD_OK");
+          expect(result.stderr).toBe("Writing final.txt\n");
+        }
+        const detail = await runFx(["session", "--json", "--id", resultJson.session_id], { cwd: profile, env });
+        expect(detail.code).toBe(0);
+        const history = JSON.parse(detail.stdout).history;
+        expect(history).toHaveLength(1);
+        const steps = history[0].execution.tool_steps;
+        expect(steps).toHaveLength(1);
+        expect(steps[0].tool_calls).toHaveLength(1);
+        expect(steps[0].tool_calls[0].id).toBe(conflict ? "prior" : "pending");
+        expect(steps[0].tool_calls[0].arguments_json).toBe(conflict ? prior.arguments : final.arguments);
+        if (conflict) {
+          const resumed = await runFx(["ask", "--json", "--auto", "--resume-id", resultJson.session_id, "Report the completed work without writing more files."], { cwd: profile, env, timeoutMs: TIMEOUT });
+          expect(resumed.code, resumed.stdout + resumed.stderr).toBe(0);
+          expect(resumed.stderr).toBe("");
+          expect(JSON.parse(resumed.stdout).output).toBe("FINAL_RECORD_OK");
+          expect(direct.bodies).toHaveLength(3);
+          const input = JSON.parse(direct.bodies[2]).input;
+          expect(input.filter((entry: { type?: string }) => entry.type === "function_call").map((entry: { call_id: string }) => entry.call_id)).toEqual(["prior"]);
+          expect(input.filter((entry: { type?: string }) => entry.type === "function_call_output").map((entry: { call_id: string }) => entry.call_id)).toEqual(["prior"]);
+        }
+        expect(testGateway.requests).toHaveLength(0);
+      } finally {
+        direct.stop(); testGateway.stop();
+        rmSync(profile, { recursive: true, force: true });
+      }
+    }
+  }, 60_000);
+}
 
 test("direct provider tool identities obey the session boundary before execution", async () => {
   for (const provider of ["codex", "grok"] as const) {

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -900,6 +900,7 @@ async function runCodexLoginWithBrowser(
 
 function startFakeCodexToolLoop(options: {
   responses?: Response[];
+  model?: string;
   toolCallId?: string;
   toolName?: string;
   toolArguments?: object;
@@ -921,7 +922,7 @@ function startFakeCodexToolLoop(options: {
           { slug: "gpt-5.6-sol", visibility: "list", supported_in_api: true, supported_reasoning_levels: [{ effort: "high" }], additional_speed_tiers: [], input_modalities: inputModalities, context_window: 272000 },
           { slug: "gpt-5.6-luna", visibility: "list", supported_in_api: true, supported_reasoning_levels: [{ effort: "medium" }], additional_speed_tiers: [], input_modalities: ["text"], context_window: 272000 },
           { slug: "gpt-5.4-mini", visibility: "list", supported_in_api: true, supported_reasoning_levels: [{ effort: "low" }], additional_speed_tiers: [], input_modalities: ["text"], context_window: 128000 },
-        ] });
+        ].map((model, index) => index === 0 && options.model ? { ...model, slug: options.model } : model) });
       }
       bodies.push(await request.text());
       if (options.responses) return options.responses.shift() ?? new Response("unexpected request", { status: 400 });
@@ -993,6 +994,7 @@ function startFakeCodexCapacityLoop() {
 
 function startFakeGrokToolLoop(options: {
   responses?: Response[];
+  model?: string;
   toolCallId?: string;
   toolName?: string;
   toolArguments?: object;
@@ -1009,10 +1011,10 @@ function startFakeGrokToolLoop(options: {
     async fetch(request) {
       const path = new URL(request.url).pathname;
       if (path === "/models") {
-        return Response.json({ data: [grokSubscriptionModel("grok-4.20", 1_000_000)] });
+        return Response.json({ data: [grokSubscriptionModel(options.model ?? "grok-4.20", 1_000_000)] });
       }
       if (path === "/modalities") {
-        return Response.json({ models: [grokModalityModel("grok-4.20", true)] });
+        return Response.json({ models: [grokModalityModel(options.model ?? "grok-4.20", true)] });
       }
       bodies.push(await request.text());
       if (options.responses) return options.responses.shift() ?? new Response("unexpected request", { status: 400 });
@@ -4385,11 +4387,11 @@ for (const conflict of [false, true]) {
       responses.push(fakeGatewaySse(events), fakeGatewaySse([
         { type: "response.output_text.delta", delta: "FINAL_RECORD_OK" }, completed,
       ]));
-      const direct = provider === "codex" ? startFakeCodexToolLoop({ responses }) : startFakeGrokToolLoop({ responses });
+      const model = "fixture-model";
+      const direct = provider === "codex" ? startFakeCodexToolLoop({ responses, model }) : startFakeGrokToolLoop({ responses, model });
       try {
         if (provider === "codex") writeSeededChatGptLogin(profile, direct.accessToken);
         else writeSeededGrokLogin(profile, direct.accessToken);
-        const model = provider === "codex" ? "gpt-5.6-sol" : "grok-4.20";
         writeFileSync(join(profile, ".fx", "settings.json"), JSON.stringify({ provider, [provider + "_model"]: model }), { mode: 0o600 });
         const env = {
           HOME: profile, AI_GATEWAY_API_KEY: "fixture", VERCEL_OIDC_TOKEN: undefined, FX_MODEL: undefined,

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -4350,8 +4350,9 @@ tmuxTest(
   60_000,
 );
 
-for (const conflict of [false, true]) {
-  test("direct Responses final records " + (conflict ? "reject the current group and preserve earlier work" : "replace progressive arguments before execution"), async () => {
+for (const scenario of ["replace", "conflict", "invalid-index"] as const) {
+  test("direct Responses final records " + scenario, async () => {
+    const conflict = scenario !== "replace";
     for (const provider of ["codex", "grok"] as const) {
       const profile = mkdtempSync(join(tmpdir(), "fx-" + provider + "-final-record-"));
       const testGateway = startFakeGateway([]);
@@ -4381,8 +4382,8 @@ for (const conflict of [false, true]) {
         { type: "response.function_call_arguments.done", output_index: 1, arguments: sibling.arguments },
       );
       events.push(
-        { type: "response.output_item.done", output_index: 0, item: final },
-        { type: "response.completed", response: { status: "completed", output: conflict ? [final, sibling] : [final] } },
+        { type: "response.output_item.done", output_index: scenario === "invalid-index" ? "0" : 0, item: final },
+        scenario === "invalid-index" ? completed : { type: "response.completed", response: { status: "completed", output: conflict ? [final, sibling] : [final] } },
       );
       responses.push(fakeGatewaySse(events), fakeGatewaySse([
         { type: "response.output_text.delta", delta: "FINAL_RECORD_OK" }, completed,
@@ -4414,7 +4415,7 @@ for (const conflict of [false, true]) {
         expect(existsSync(join(profile, "final.txt"))).toBe(!conflict);
         expect(readFileSync(join(profile, conflict ? "prior.txt" : "final.txt"), "utf8")).toBe("saved");
         const resultJson = JSON.parse(result.stdout);
-        if (conflict) expect(resultJson.error).toBe("ResponsesToolCallConflict");
+        if (conflict) expect(resultJson.error).toBe(scenario === "invalid-index" ? (provider === "codex" ? "InvalidOpenAICodexSseEvent" : "InvalidXaiGrokSseEvent") : "ResponsesToolCallConflict");
         else {
           expect(resultJson.output).toBe("FINAL_RECORD_OK");
           expect(result.stderr).toBe("Writing final.txt\n");


### PR DESCRIPTION
## Summary

- Use finalized tool arguments for direct-provider execution instead of earlier streamed previews.
- Reject conflicting completed tool records before executing any call in the response, while preserving earlier work for resume.
- Fail on malformed tool-call routing data instead of silently discarding final records.
- Preserve explicitly empty final arguments for malformed-input recovery.
- Accept equivalent JSON formatting without rewriting saved arguments.
