### PR TITLE
Restore transcript rows after resizing the full viewer

### DIFF
--- a/src/ui/transcript/runtime.zig
+++ b/src/ui/transcript/runtime.zig
@@ -2059,6 +2059,7 @@ test "full transcript primary restore consumes the pending settled resize" {
     };
     runtime.terminal_reset_pending = true;
     runtime.resize_history_row_delta = 4;
+    runtime.owned_top_row = 5;
 
     runtime.repaintRestoredPrimaryTranscriptAfterResize();
 
@@ -2066,6 +2067,26 @@ test "full transcript primary restore consumes the pending settled resize" {
     try std.testing.expectEqual(@as(?ResizeObservation, null), runtime.pending_resize_observation);
     try std.testing.expect(!runtime.terminal_reset_pending);
     try std.testing.expectEqual(@as(?i32, null), runtime.resize_history_row_delta);
+    const invalidations = runtime.render_requests.pendingInvalidations();
+    try std.testing.expectEqual(@as(u8, 1), invalidations.len);
+    try std.testing.expectEqual(@as(u16, 5), invalidations.ranges()[0].top);
+    try std.testing.expectEqual(@as(u16, 24), invalidations.ranges()[0].bottom);
+    try std.testing.expect(runtime.render_requests.hasReason(.external_damage));
+}
+
+test "full transcript resized restore bounds invalidation to the current terminal" {
+    for ([_]u16{ 0, 25 }) |owned_top| {
+        var runtime = TranscriptRuntime{ .layout = std.mem.zeroes(Layout), .owned_top_row = owned_top };
+        runtime.layout.rows = 24;
+        runtime.repaintRestoredPrimaryTranscriptAfterResize();
+        const invalidations = runtime.render_requests.pendingInvalidations();
+        try std.testing.expectEqual(@as(u8, 1), invalidations.len);
+        try std.testing.expectEqual(@as(u16, 1), invalidations.ranges()[0].top);
+        try std.testing.expectEqual(@as(u16, 24), invalidations.ranges()[0].bottom);
+    }
+    var empty = TranscriptRuntime{ .layout = std.mem.zeroes(Layout) };
+    empty.repaintRestoredPrimaryTranscriptAfterResize();
+    try std.testing.expect(empty.render_requests.pendingInvalidations().isEmpty());
 }
 
 test "full transcript recovery starts at closest visible entry before a hidden anchor" {
@@ -6361,6 +6382,15 @@ pub const TranscriptRuntime = struct {
         self.pending_resize_observation = null;
         self.render_requests.acknowledgeSettledResizeCommit();
         self.invalidateTranscriptAnchor("full transcript restored resized primary");
+        // The terminal may reflow its saved primary grid differently from the shadow.
+        // Repaint owned cells without erasing the primary scrollback.
+        if (self.layout.rows > 0) {
+            self.render_requests.requestInvalidation(.{
+                .reason = .external_clear,
+                .top = if (self.owned_top_row == 0 or self.owned_top_row > self.layout.rows) 1 else self.owned_top_row,
+                .bottom = self.layout.rows,
+            });
+        }
         debug_trace.logf(
             "full_transcript_cache",
             "close repaints restored resized primary revision={d} layout={d}x{d}",

--- a/src/ui/transcript/runtime.zig
+++ b/src/ui/transcript/runtime.zig
@@ -2089,6 +2089,26 @@ test "full transcript resized restore bounds invalidation to the current termina
     try std.testing.expect(empty.render_requests.pendingInvalidations().isEmpty());
 }
 
+test "full transcript opening waits for primary damage and remains cancellable" {
+    var runtime = TranscriptRuntime{ .layout = std.mem.zeroes(Layout) };
+    runtime.layout.rows = 24;
+    runtime.layout.cols = 80;
+    try std.testing.expect(runtime.requestFullTranscriptOpen());
+
+    runtime.repaintRestoredPrimaryTranscriptAfterResize();
+    try std.testing.expect(!runtime.requestFullTranscriptOpen());
+    try std.testing.expect(runtime.full_transcript_open_request != null);
+    var interrupted = (try runtime.render_requests.beginAttempt()).?;
+    interrupted.restore();
+    try std.testing.expect(runtime.cancelPendingFullTranscriptOpen());
+    try std.testing.expect(!runtime.requestFullTranscriptOpen());
+
+    var committed = (try runtime.render_requests.beginAttempt()).?;
+    committed.commit(0, 0, false);
+    try std.testing.expect(runtime.requestFullTranscriptOpen());
+    try std.testing.expect(runtime.full_transcript_open_request == null);
+}
+
 test "full transcript recovery starts at closest visible entry before a hidden anchor" {
     const provenance = [_]transcript_blocks.LineProvenance{
         .{ .entry = .{ .entry_id = 10, .entry_class = .unknown_raw } },
@@ -9826,7 +9846,8 @@ pub const TranscriptRuntime = struct {
 
     pub fn requestFullTranscriptOpen(self: *TranscriptRuntime) bool {
         self.full_transcript_restore_open_pending = false;
-        if (self.fullTranscriptPreparedForOpen()) {
+        // Pending primary damage must commit before another buffer can consume it.
+        if (self.fullTranscriptPreparedForOpen() and self.render_requests.pendingInvalidations().isEmpty()) {
             self.full_transcript_open_request = null;
             debug_trace.logf("full_transcript", "open_request state=ready", .{});
             return true;
@@ -9880,6 +9901,7 @@ pub const TranscriptRuntime = struct {
 
     pub fn takeReadyFullTranscriptOpen(self: *TranscriptRuntime) bool {
         const requested = self.full_transcript_open_request orelse return false;
+        if (!self.render_requests.pendingInvalidations().isEmpty()) return false;
         if (self.full_transcript_installed_page_retired) return false;
         const page = if (self.full_transcript_installed_page) |*value| value else return false;
         if (page.prepared_window == null or

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -3130,6 +3130,86 @@ test.skipIf(!tmuxAvailable())(
 );
 
 test.skipIf(!tmuxAvailable())(
+  "Ctrl-O restores wrapped primary rows after resize without losing the draft",
+  async () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "fx-full-transcript-resize-")));
+    const response = Array.from({ length: 28 }, (_, index) => {
+      const row = String(index + 1).padStart(2, "0");
+      return `ROW${row} ALPHA${row}_abcdefghijklmnopqrstuvwxyz0123456789 BRAVO${row}_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789`;
+    }).join("\n\n");
+    const draft = "retained café 日本語";
+    let narrowGrid: string[] = [];
+    try {
+      for (const width of [88, 120]) {
+        const home = join(root, String(width), "home");
+        const workspace = join(root, String(width), "workspace");
+        const stderrPath = join(root, String(width), "stderr.log");
+        mkdirSync(join(home, ".fx"), { recursive: true });
+        mkdirSync(workspace);
+        const gateway = startFakeGateway([fakeGatewayFinalText(response)]);
+        let active: TmuxSession | null = null;
+        try {
+          active = await TmuxSession.create({
+            cmd: FX_BIN,
+            cwd: workspace,
+            env: gatewayEnv(home, gateway),
+            stderrPath,
+            width,
+            height: width === 88 ? 24 : 36,
+          });
+          await active.waitForComposer(TIMEOUT);
+          await active.sendText("Show the prepared paragraphs.");
+          await active.waitForText("BRAVO28_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789", TIMEOUT);
+          await active.waitForStableComposer(TIMEOUT);
+          await active.sendLiteral(draft);
+          await active.waitForText(`┃ ${draft}`, TIMEOUT);
+          const before = await active.capturePaneGrid();
+          if (width === 88) narrowGrid = before;
+          const historyBefore = await active.captureFullScrollback();
+
+          await active.sendKeys("C-o");
+          await active.waitForText("Full detail · ctrl o close", TIMEOUT);
+          if (width === 120) await active.resizeWindow(88, 24, 500);
+          await active.sendKeys("Escape");
+          const restored = await active.waitForStableGrid(
+            narrowGrid, normalizeVolatileStatusRows, 5_000,
+          );
+          expect(normalizeVolatileStatusRows(restored)).toEqual(
+            normalizeVolatileStatusRows(narrowGrid),
+          );
+          const historyAfter = await active.captureFullScrollback();
+          expect(historyAfter).toContain(`┃ ${draft}`);
+          if (width === 120) {
+            const historyMarker = "ROW14 ALPHA14_abcdefghijklmnopqrstuvwxyz0123456789";
+            expect(historyBefore).toContain(historyMarker);
+            expect(historyAfter).toContain(historyMarker);
+          }
+          const events = readFileSync(
+            join(home, ".fx", "sessions", sessionIdFromHome(home), "events.jsonl"), "utf8",
+          );
+          expect(events).toContain("ROW28 ALPHA28_abcdefghijklmnopqrstuvwxyz0123456789");
+
+          await active.sendKeys("C-u");
+          await active.sendText("/quit");
+          await waitForCondition(
+            () => active?.paneStatus().dead === true,
+            "fx to exit after resized transcript restoration",
+          );
+          expect(paneExitMatches(active.paneStatus(), 0)).toBe(true);
+          expect(readFileSync(stderrPath, "utf8")).toBe("");
+        } finally {
+          if (active) await active.kill();
+          gateway.stop();
+        }
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  },
+  TIMEOUT,
+);
+
+test.skipIf(!tmuxAvailable())(
   "Ctrl-O renders read_file results as readable content",
   async () => {
     const root = realpathSync(mkdtempSync(join(tmpdir(), "fx-full-transcript-read-")));

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -3169,7 +3169,11 @@ test.skipIf(!tmuxAvailable())(
 
           await active.sendKeys("C-o");
           await active.waitForText("Full detail · ctrl o close", TIMEOUT);
-          if (width === 120) await active.resizeWindow(88, 24, 500);
+          if (width === 120) {
+            await active.resizeWindow(88, 24, 500);
+            await active.sendKeys("Escape C-o");
+            await active.waitForText("Full detail · ctrl o close", TIMEOUT);
+          }
           await active.sendKeys("Escape");
           const restored = await active.waitForStableGrid(
             narrowGrid, normalizeVolatileStatusRows, 5_000,


### PR DESCRIPTION
## Summary

- Restore readable conversation rows when closing Ctrl+O after a terminal resize, preserving the draft and existing scrollback.
