### PR TITLE
Show commands in shell follow-up activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ fx
 
 The current directory becomes the primary workspace. Enter a prompt, or run `/help` to browse interactive commands. While fx is working, Enter steers the active turn at its next safe model boundary. The pending update shows its first two lines, with an ellipsis when more text is hidden. If a tool is running, fx waits for it to finish; press Escape to interrupt the active work and apply the update as soon as the turn settles.
 
-Tool calls are expanded by default. Enable `Collapse tool calls` in `/settings`, or set `"collapse_tool_calls": true` in `~/.fx/settings.json`, to show one summary per tool-call group in the main transcript. Individual calls remain available in the full transcript with Ctrl+O.
+Tool calls are expanded by default. Enable `Collapse tool calls` in `/settings`, or set `"collapse_tool_calls": true` in `~/.fx/settings.json`, to show one summary per tool-call group in the main transcript. Individual calls remain available in the full transcript with Ctrl+O. Follow-up activity for captured shell commands shows the original command, such as `Observed zig build`, while tool results keep the same execution handle.
 
 The status line hides the workspace path and Git branch by default. Enable the `Status line workspace` option in `/settings`, run `/statusline workspace`, or set it in `~/.fx/settings.json`:
 

--- a/src/acp/prompt.zig
+++ b/src/acp/prompt.zig
@@ -1672,6 +1672,7 @@ fn resolveToolActionDisplayTarget(raw_ctx: *anyopaque, arena: Allocator, call: T
         ctx.toolRegistry(),
         ctx.state.workspace_root,
         &ctx.state.terminal_client,
+        &ctx.state.managed_executions,
         call,
     );
 }

--- a/src/core/app/app_agent_runtime.zig
+++ b/src/core/app/app_agent_runtime.zig
@@ -497,6 +497,7 @@ pub fn Runtime(comptime App: type) type {
                 ctx.tool_registry,
                 ctx.workspace_root,
                 ctx.terminal_client,
+                ctx.managed_executions,
                 call,
             );
         }

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -2458,6 +2458,7 @@ fn resolveToolActionDisplayTarget(raw_ctx: *anyopaque, arena: Allocator, call: T
         ctx.toolRegistry(),
         ctx.workspace_root,
         &ctx.terminal_client,
+        &ctx.managed_executions,
         call,
     );
 }

--- a/src/core/execution/managed_execution.zig
+++ b/src/core/execution/managed_execution.zig
@@ -713,6 +713,22 @@ pub const Runtime = struct {
         return entry.backend();
     }
 
+    /// Copies retained captured-command metadata without reserving output or changing authority.
+    /// The caller owns the returned bytes. Missing and TTY executions return null.
+    pub fn captured_command_alloc(
+        self: *Runtime,
+        alloc: Allocator,
+        execution_id: []const u8,
+    ) Allocator.Error!?[]u8 {
+        const entry = self.acquireEntry(execution_id) orelse return null;
+        defer self.releaseEntry(entry);
+        const zio = io_mod.getIo();
+        entry.mutex.lockUncancelable(zio);
+        defer entry.mutex.unlock(zio);
+        if (entry.backend() != .captured) return null;
+        return try alloc.dupe(u8, entry.command);
+    }
+
     pub fn stateFor(
         self: *Runtime,
         execution_id: []const u8,
@@ -1588,6 +1604,13 @@ test "captured managed execution yields one handle and delivers ordered output o
     var started = try runtime.startCaptured(alloc, input);
     defer started.deinit(alloc);
     try std.testing.expectEqual(SnapshotState.running, started.snapshot.state);
+    try std.testing.expectEqual(@as(?[]u8, null), try runtime.captured_command_alloc(alloc, "missing"));
+    var failing = std.testing.FailingAllocator.init(alloc, .{ .fail_index = 0 });
+    try std.testing.expectError(error.OutOfMemory, runtime.captured_command_alloc(failing.allocator(), input.execution_id));
+    const command = (try runtime.captured_command_alloc(alloc, input.execution_id)).?;
+    defer alloc.free(command);
+    try std.testing.expectEqualStrings(input.command, command);
+    command[0] = 'P';
     try runtime.commitDelivery(started.snapshot.execution_id, started.reservation_id);
 
     var completed = try runtime.wait(alloc, input.execution_id, 2_000, null);
@@ -1605,6 +1628,10 @@ test "captured managed execution yields one handle and delivers ordered output o
     defer repeated.deinit(alloc);
     try std.testing.expectEqual(@as(usize, 0), repeated.snapshot.output_delta.len);
     try runtime.commitDelivery(repeated.snapshot.execution_id, repeated.reservation_id);
+    const retained_command = (try runtime.captured_command_alloc(alloc, input.execution_id)).?;
+    defer alloc.free(retained_command);
+    try std.testing.expectEqualStrings(input.command, retained_command);
+    try std.testing.expect(runtime.isTombstone(input.execution_id));
 }
 
 test "captured stop returns lost when its worker cannot settle" {
@@ -2035,6 +2062,7 @@ test "TTY cursor advances monotonically and delivers each delta once" {
         started.snapshot.execution_id,
         started.reservation_id,
     );
+    try std.testing.expectEqual(@as(?[]u8, null), try runtime.captured_command_alloc(alloc, "tty-cursor"));
 
     try runtime.refreshTty(.{
         .execution_id = "tty-cursor",

--- a/src/core/subagent/agent_adapter.zig
+++ b/src/core/subagent/agent_adapter.zig
@@ -672,6 +672,7 @@ fn resolveToolActionDisplayTarget(raw: *anyopaque, arena: Allocator, call: types
         context.config.tool_context.tool_registry,
         context.config.tool_context.workspace_root,
         context.config.tool_context.terminal_client,
+        context.config.tool_context.managed_executions,
         call,
     );
 }

--- a/src/core/tooling/tool_presentation.zig
+++ b/src/core/tooling/tool_presentation.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const command_policy = @import("command_policy.zig");
+const managed_execution = @import("../execution/managed_execution.zig");
 const file_mutation_contract = @import("file_mutation_contract.zig");
 const text_utils = @import("../shared/text_utils.zig");
 const tool_args = @import("tool_args.zig");
@@ -290,6 +291,7 @@ pub fn resolveTerminalDisplayTarget(
     registry: tool_dispatch.Registry,
     workspace_root: []const u8,
     terminal_client: ?*terminal_client_runtime.Runtime,
+    managed_executions: ?*managed_execution.Runtime,
     call: ToolCall,
 ) !?[]const u8 {
     var scratch_state = std.heap.ArenaAllocator.init(std.heap.c_allocator);
@@ -299,6 +301,12 @@ pub fn resolveTerminalDisplayTarget(
         registry,
         call,
     ) orelse return null;
+    if (managed_executions) |executions| {
+        if (try executions.captured_command_alloc(alloc, session_id)) |command| {
+            defer alloc.free(command);
+            if (command.len != 0) return try formatTerminalDisplayTarget(alloc, workspace_root, command);
+        }
+    }
     const runtime = terminal_client orelse return @as(?[]const u8, try resolveTerminalSessionTargetFromRows(
         alloc,
         workspace_root,
@@ -971,6 +979,80 @@ test "tool presentation uses the resolved skill name for location calls" {
         defer alloc.free(label);
         try std.testing.expectEqualStrings(case.expected, label);
     }
+}
+
+test "captured display target uses retained command without consuming output" {
+    if (comptime builtin.os.tag == .wasi) return;
+    const alloc = std.testing.allocator;
+    var executions = managed_execution.Runtime.init(alloc);
+    defer executions.deinit();
+    const command = "printf LABEL";
+    const admission = @import("../permissions/command_admission.zig");
+    var started = try executions.startCaptured(alloc, .{
+        .execution_id = "shell-label",
+        .command = command,
+        .cwd = "/tmp",
+        .environment = .legacy,
+        .authority = .{ .shell_allowed = .{
+            .fingerprint = .init(admission.CommandContext{
+                .command = command,
+                .resolved_cwd = "/tmp",
+                .target_os = builtin.os.tag,
+                .environment = .legacy,
+            }),
+            .source = .yolo,
+        } },
+        .max_output_bytes = 4096,
+        .timeout_ms = 2_000,
+        .command_artifact_dir = null,
+        .yield_time_ms = 0,
+    });
+    defer started.deinit(alloc);
+    try executions.commitDelivery(started.snapshot.execution_id, started.reservation_id);
+    const call = ToolCall{
+        .id = "observe",
+        .name = "shell",
+        .arguments_json = "{\"action\":\"interact\",\"session_id\":\"shell-label\"}",
+    };
+    const target = (try resolveTerminalDisplayTarget(alloc, test_tool_registry, "/tmp", null, &executions, call)).?;
+    defer alloc.free(target);
+    try std.testing.expectEqualStrings(command, target);
+    const label = try formatPlainAction(alloc, .{
+        .tool_registry = test_tool_registry,
+        .call = call,
+        .display_target = target,
+    });
+    defer alloc.free(label);
+    try std.testing.expectEqualStrings("Waiting for printf LABEL", label);
+
+    var completed = try executions.wait(alloc, "shell-label", 2_000, null);
+    defer completed.deinit(alloc);
+    try std.testing.expectEqualStrings("LABEL", completed.snapshot.output_delta);
+    try executions.commitDelivery(completed.snapshot.execution_id, completed.reservation_id);
+    const retained = (try resolveTerminalDisplayTarget(alloc, test_tool_registry, "/tmp", null, &executions, call)).?;
+    defer alloc.free(retained);
+    try std.testing.expectEqualStrings(command, retained);
+    try std.testing.expectEqualStrings(command, target);
+
+    const missing = (try resolveTerminalDisplayTarget(alloc, test_tool_registry, "/tmp", null, &executions, .{
+        .id = "missing",
+        .name = "shell",
+        .arguments_json = "{\"action\":\"stop\",\"session_id\":\"shell-missing\"}",
+    })).?;
+    defer alloc.free(missing);
+    try std.testing.expectEqualStrings("session shell-missing", missing);
+}
+
+test "terminal display target bounds and sanitizes command metadata" {
+    const alloc = std.testing.allocator;
+    const target = try formatTerminalDisplayTarget(alloc, "/tmp/workspace", "/tmp/workspace/build\n\x1b[31m" ++ ("é" ** 120));
+    defer alloc.free(target);
+    try std.testing.expect(std.mem.startsWith(u8, target, "./build "));
+    try std.testing.expect(target.len <= max_run_command_activity_bytes);
+    try std.testing.expect(std.mem.findScalar(u8, target, '\x1b') == null);
+    try std.testing.expect(std.mem.findScalar(u8, target, '\n') == null);
+    try std.testing.expect(std.unicode.utf8ValidateSlice(target));
+    try std.testing.expect(std.mem.endsWith(u8, target, "..."));
 }
 
 test "terminal display target is call-local across a cold inspect projection update" {

--- a/tests/e2e/tui-terminal-tool.test.ts
+++ b/tests/e2e/tui-terminal-tool.test.ts
@@ -242,7 +242,8 @@ test.skipIf(!tmuxAvailable())(
     expect(interactResult).toContain("CAPTURED_DONE");
     const scrollback = await active.captureFullScrollback();
     expect(scrollback).toContain("Ran sleep 2; printf CAPTURED_DONE");
-    expect(scrollback).toContain(`Observed session ${sessionId}`);
+    expect(scrollback).toContain("Observed sleep 2; printf CAPTURED_DONE");
+    expect(scrollback).not.toContain(`Observed session ${sessionId}`);
     expect(scrollback).not.toContain("Using terminal");
     expect(scrollback).not.toContain("Used terminal");
     expect(readFileSync(fixture.stderrPath, "utf8")).toBe("");
@@ -295,6 +296,9 @@ test.skipIf(!tmuxAvailable())(
     await active.sendText("Stop the exact retained command now.");
     await active.sendKeys("Enter");
     await active.waitForText("PHASE_TWO_READY", TIMEOUT);
+    const scrollback = await active.captureFullScrollback();
+    expect(scrollback).toContain("Stopped printf HANDOFF_READY; sleep 30");
+    expect(scrollback).not.toContain(`Stopped session ${sessionId}`);
     expect(toolResultEnvelope(
       gateway.requests[3]!.body,
       "shell_cross_turn_stop",


### PR DESCRIPTION
## Summary

- Show the original command in captured-shell follow-up activity instead of opaque session IDs, while preserving tool-result handles and TTY labels.