### PR TITLE
Preserve native image context through tools and resume

### DIFF
--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -5608,19 +5608,6 @@ fn processQueuedPromptLoop(
                 config.first_call_tool_choice
             else
                 .auto;
-            var verified_images: std.ArrayList(image_attachments.VerifiedSnapshot) = .empty;
-            if (job.provider != .gateway and job.images.len > 0 and
-                vision_policy.route == .native)
-            {
-                try verified_images.ensureTotalCapacity(overlay_arena, job.images.len);
-                for (job.images) |attachment| {
-                    verified_images.appendAssumeCapacity(try image_attachments.loadVerifiedSnapshot(
-                        overlay_arena,
-                        attachment,
-                        .{ .cancel_flag = config.cancel_flag },
-                    ));
-                }
-            }
             const request_data = agent_stream_provider.RequestData{
                 .model = gateway_model,
                 .instructions = gateway_instructions.items,
@@ -5636,10 +5623,6 @@ fn processQueuedPromptLoop(
                 .provider_options = provider_opts,
                 .max_output_tokens = request_max_output_tokens(request_capabilities),
                 .budget = .{ .cancel_flag = config.cancel_flag },
-                .verified_images = if (verified_images.items.len > 0)
-                    verified_images.items
-                else
-                    null,
             };
             var prepared_request_body: ?[]const u8 = null;
             var request_cost_for_attempt: ?runtime_prompt_context.RequestCost = null;
@@ -5913,7 +5896,6 @@ fn processQueuedPromptLoop(
                 .provider_options = request_data.provider_options,
                 .max_output_tokens = request_data.max_output_tokens,
                 .budget = request_data.budget,
-                .verified_images = request_data.verified_images,
                 .prepared_request_body = prepared_request_body,
                 .trace_ctx = step_ctx,
                 .content_capture_limit = null,

--- a/src/core/agent/runtime/tests/gateway_flow.zig
+++ b/src/core/agent/runtime/tests/gateway_flow.zig
@@ -7057,6 +7057,7 @@ test "processQueuedPrompt preserves provider state during silent-tool continuati
                 &.{previous},
                 null,
                 .{ .tool_calls = 128, .tool_identity_bytes = 256, .tool_arguments_bytes = 4096, .provider_state_bytes = 4096 },
+                .{},
             );
             try std.testing.expectEqualStrings(state[1 .. state.len - 1], wire.written());
         }

--- a/src/gateway/openai_codex.zig
+++ b/src/gateway/openai_codex.zig
@@ -50,10 +50,11 @@ pub fn buildRequest(
 ) ![]u8 {
     try request.validatePrompt();
     try validateModel(request.model);
-    if (request.budget) |budget| {
-        if (budget.cancel_flag) |flag| if (flag.load(.seq_cst)) return error.Cancelled;
-        _ = budget.deadline;
-    }
+    const budget: image_attachments.CaptureBudget = if (request.budget) |value|
+        .{ .deadline = value.deadline, .cancel_flag = value.cancel_flag }
+    else
+        .{};
+    try budget.check();
 
     var instructions: std.Io.Writer.Allocating = .init(alloc);
     defer instructions.deinit();
@@ -73,7 +74,7 @@ pub fn buildRequest(
     try writer.writeAll(",\"store\":false,\"stream\":true,\"instructions\":");
     try std.json.Stringify.value(instructions.written(), .{}, writer);
     try writer.writeAll(",\"input\":[");
-    try writeResponsesInput(writer, alloc, request.messages, request.verified_images);
+    try writeResponsesInput(writer, std.heap.c_allocator, request.messages, request.verified_images, budget);
     try writer.writeByte(']');
 
     _ = try responses_protocol.writeTools(writer, alloc, request.tools);
@@ -122,13 +123,14 @@ fn writeResponsesInput(
     alloc: Allocator,
     messages: []const types.ChatMessage,
     images: ?[]const image_attachments.VerifiedSnapshot,
+    budget: image_attachments.CaptureBudget,
 ) !void {
     return responses_protocol.writeInput(writer, alloc, messages, images, .{
         .tool_calls = max_tool_calls,
         .tool_identity_bytes = max_tool_identity_bytes,
         .tool_arguments_bytes = max_tool_arguments_bytes,
         .provider_state_bytes = max_provider_state_bytes,
-    }) catch |err| switch (err) {
+    }, budget) catch |err| switch (err) {
         error.ProviderStateTooLarge => error.OpenAICodexProviderStateTooLarge,
         error.InvalidProviderState => error.InvalidOpenAICodexProviderState,
         error.ToolCallLimitExceeded => error.OpenAICodexToolCallLimitExceeded,

--- a/src/gateway/responses_protocol.zig
+++ b/src/gateway/responses_protocol.zig
@@ -14,20 +14,30 @@ pub const ReplayLimits = struct {
     provider_state_bytes: usize,
 };
 
+/// Verifies captured image files and releases replay/image scratch before returning.
+/// Scratch must be independent of the writer's request-body arena.
 pub fn writeInput(
     writer: *std.Io.Writer,
-    alloc: std.mem.Allocator,
+    scratch_alloc: std.mem.Allocator,
     messages: []const types.ChatMessage,
     verified_images: ?[]const image_attachments.VerifiedSnapshot,
     limits: ReplayLimits,
+    budget: image_attachments.CaptureBudget,
 ) !void {
-    for (messages) |message| {
-        if (message.role == .assistant) try validateReplayMessage(alloc, message, limits);
+    try budget.check();
+    if (verified_images != null and (messages.len != 1 or
+        messages[0].role != .user or messages[0].images.len != 0))
+    {
+        return error.InvalidVerifiedImagePlacement;
     }
-    var ids = try tool_call_ids.Projection.init(alloc, messages);
-    defer ids.deinit(alloc);
+    for (messages) |message| {
+        if (message.role == .assistant) try validateReplayMessage(scratch_alloc, message, limits);
+    }
+    var ids = try tool_call_ids.Projection.init(scratch_alloc, messages);
+    defer ids.deinit(scratch_alloc);
     var first = true;
-    for (messages, 0..) |message, message_index| {
+    for (messages) |message| {
+        try budget.check();
         switch (message.role) {
             .system => continue,
             .user => {
@@ -41,19 +51,25 @@ pub fn writeInput(
                     first_part = false;
                 };
                 if (verified_images) |images| {
-                    if (message_index == messages.len - 1) {
-                        for (images) |image| {
-                            if (!first_part) try writer.writeByte(',');
-                            try writeInputImage(writer, alloc, image);
-                            first_part = false;
-                        }
+                    for (images) |image| {
+                        if (!first_part) try writer.writeByte(',');
+                        try writeInputImage(writer, image, budget);
+                        first_part = false;
+                    }
+                } else {
+                    for (message.images) |attachment| {
+                        var image = try image_attachments.loadVerifiedSnapshot(scratch_alloc, attachment, budget);
+                        defer image.deinit(scratch_alloc);
+                        if (!first_part) try writer.writeByte(',');
+                        try writeInputImage(writer, image, budget);
+                        first_part = false;
                     }
                 }
                 try writer.writeAll("]}");
             },
             .assistant => {
                 if (message.provider_state_json) |state_json| {
-                    var state = std.json.parseFromSlice(std.json.Value, alloc, state_json, .{}) catch
+                    var state = std.json.parseFromSlice(std.json.Value, scratch_alloc, state_json, .{}) catch
                         return error.InvalidProviderState;
                     defer state.deinit();
                     if (state.value != .array) return error.InvalidProviderState;
@@ -102,7 +118,7 @@ test "Responses request projects long call ids with matching outputs" {
     var out: std.Io.Writer.Allocating = .init(std.testing.allocator);
     defer out.deinit();
     try out.writer.writeByte('[');
-    try writeInput(&out.writer, std.testing.allocator, &messages, null, .{ .tool_calls = 128, .tool_identity_bytes = 256, .tool_arguments_bytes = 4096, .provider_state_bytes = 4096 });
+    try writeInput(&out.writer, std.testing.allocator, &messages, null, .{ .tool_calls = 128, .tool_identity_bytes = 256, .tool_arguments_bytes = 4096, .provider_state_bytes = 4096 }, .{});
     try out.writer.writeByte(']');
     const parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, out.written(), .{});
     defer parsed.deinit();
@@ -124,7 +140,7 @@ test "Responses request preserves opaque tool-call identity" {
     var out: std.Io.Writer.Allocating = .init(std.testing.allocator);
     defer out.deinit();
     try out.writer.writeByte('[');
-    try writeInput(&out.writer, std.testing.allocator, &messages, null, .{ .tool_calls = 128, .tool_identity_bytes = 256, .tool_arguments_bytes = 4096, .provider_state_bytes = 4096 });
+    try writeInput(&out.writer, std.testing.allocator, &messages, null, .{ .tool_calls = 128, .tool_identity_bytes = 256, .tool_arguments_bytes = 4096, .provider_state_bytes = 4096 }, .{});
     try out.writer.writeByte(']');
     const parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, out.written(), .{});
     defer parsed.deinit();
@@ -140,7 +156,7 @@ test "non-object provider-owned arguments retain their Responses representation"
     const messages = [_]types.ChatMessage{.{ .role = .assistant, .tool_calls = &calls }};
     var out: std.Io.Writer.Allocating = .init(std.testing.allocator);
     defer out.deinit();
-    try writeInput(&out.writer, std.testing.allocator, &messages, null, .{ .tool_calls = 128, .tool_identity_bytes = 256, .tool_arguments_bytes = 4096, .provider_state_bytes = 4096 });
+    try writeInput(&out.writer, std.testing.allocator, &messages, null, .{ .tool_calls = 128, .tool_identity_bytes = 256, .tool_arguments_bytes = 4096, .provider_state_bytes = 4096 }, .{});
     try std.testing.expect(std.mem.find(u8, out.written(), "\"arguments\":\"[]\"") != null);
 }
 
@@ -155,7 +171,7 @@ test "non-object function arguments cannot enter a Responses request" {
             .tool_identity_bytes = 256,
             .tool_arguments_bytes = 4096,
             .provider_state_bytes = 4096,
-        }));
+        }, .{}));
     }
 }
 
@@ -181,20 +197,194 @@ fn validateReplayMessage(alloc: std.mem.Allocator, message: types.ChatMessage, l
     }
 }
 
+const ImageInputTest = struct {
+    const limits = ReplayLimits{ .tool_calls = 128, .tool_identity_bytes = 256, .tool_arguments_bytes = 4096, .provider_state_bytes = 4096 };
+
+    fn capture(alloc: std.mem.Allocator, tmp: *std.testing.TmpDir, name: []const u8, bytes: []const u8, id: usize) !types.ImageAttachment {
+        const io_mod = @import("../core/shared/io.zig");
+        try tmp.dir.writeFile(std.testing.io, .{ .sub_path = name, .data = bytes });
+        const path = try io_mod.dirRealpathAlloc(alloc, tmp.dir, name);
+        defer alloc.free(path);
+        const source = [_]types.ImageAttachment{.{ .id = id, .path = @constCast(path), .media_type = @constCast("image/png") }};
+        const owned = try types.dupeImageAttachmentSlice(alloc, &source);
+        defer alloc.free(owned);
+        var attachment = owned[0];
+        errdefer types.freeImageAttachment(alloc, attachment);
+        const snapshot_dir = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+        defer alloc.free(snapshot_dir);
+        try image_attachments.captureImageSnapshot(alloc, &attachment, snapshot_dir);
+        return attachment;
+    }
+
+    fn write(alloc: std.mem.Allocator, writer: *std.Io.Writer, messages: []const types.ChatMessage, verified: ?[]const image_attachments.VerifiedSnapshot) !void {
+        try writer.writeByte('[');
+        try writeInput(writer, alloc, messages, verified, limits, .{});
+        try writer.writeByte(']');
+    }
+};
+
+test "Responses images remain on their owning users across tools and later prompts" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const first = try ImageInputTest.capture(alloc, &tmp, "first.png", "\x89PNG\r\n\x1a\nA", 1);
+    defer types.freeImageAttachment(alloc, first);
+    const second = try ImageInputTest.capture(alloc, &tmp, "second.png", "\x89PNG\r\n\x1a\nB", 2);
+    defer types.freeImageAttachment(alloc, second);
+    const calls = [_]types.ToolCall{.{ .id = "read_1", .name = "read_file", .arguments_json = "{}" }};
+    const messages = [_]types.ChatMessage{
+        .{ .role = .user, .content = "first", .images = &.{first} },
+        .{ .role = .assistant, .tool_calls = &calls },
+        .{ .role = .tool, .tool_call_id = "read_1", .tool_name = "read_file", .content = "read result" },
+        .{ .role = .user, .content = "second", .images = &.{ second, first } },
+        .{ .role = .assistant, .content = "response" },
+        .{ .role = .user, .content = "continue" },
+    };
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    defer out.deinit();
+    try ImageInputTest.write(alloc, &out.writer, &messages, null);
+    const parsed = try std.json.parseFromSlice(std.json.Value, alloc, out.written(), .{});
+    defer parsed.deinit();
+    const items = parsed.value.array.items;
+    try std.testing.expectEqual(@as(usize, 6), items.len);
+    const first_parts = items[0].object.get("content").?.array.items;
+    const second_parts = items[3].object.get("content").?.array.items;
+    try std.testing.expectEqual(@as(usize, 2), first_parts.len);
+    try std.testing.expectEqual(@as(usize, 3), second_parts.len);
+    try std.testing.expectEqualStrings("data:image/png;base64,iVBORw0KGgpB", first_parts[1].object.get("image_url").?.string);
+    try std.testing.expectEqualStrings("data:image/png;base64,iVBORw0KGgpC", second_parts[1].object.get("image_url").?.string);
+    try std.testing.expectEqualStrings("data:image/png;base64,iVBORw0KGgpB", second_parts[2].object.get("image_url").?.string);
+    try std.testing.expectEqual(@as(usize, 1), items[5].object.get("content").?.array.items.len);
+}
+
+test "Responses preverified image input rejects ambiguous message ownership" {
+    const images = [_]image_attachments.VerifiedSnapshot{.{ .bytes = @constCast("verified"), .media_type = "image/png" }};
+    const attachment = types.ImageAttachment{ .path = @constCast("must-not-read"), .media_type = @constCast("image/png") };
+    const cases = [_][]const types.ChatMessage{
+        &.{},
+        &.{.{ .role = .assistant, .content = "not a user" }},
+        &.{ .{ .role = .user, .content = "first" }, .{ .role = .user, .content = "second" } },
+        &.{.{ .role = .user, .content = "mixed", .images = &.{attachment} }},
+    };
+    for (cases) |messages| {
+        var out: std.Io.Writer.Allocating = .init(std.testing.allocator);
+        defer out.deinit();
+        try std.testing.expectError(error.InvalidVerifiedImagePlacement, ImageInputTest.write(std.testing.allocator, &out.writer, messages, &images));
+    }
+}
+
+test "Responses images use captured bytes and reject unavailable snapshots" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const attachment = try ImageInputTest.capture(alloc, &tmp, "source.png", "\x89PNG\r\n\x1a\nA", 1);
+    defer types.freeImageAttachment(alloc, attachment);
+    const messages = [_]types.ChatMessage{.{ .role = .user, .images = &.{attachment} }};
+    try tmp.dir.deleteFile(std.testing.io, "source.png");
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    defer out.deinit();
+    try ImageInputTest.write(alloc, &out.writer, &messages, null);
+    try std.testing.expect(std.mem.find(u8, out.written(), "data:image/png;base64,iVBORw0KGgpB") != null);
+    const snapshot_name = std.fs.path.basename(attachment.snapshot_path.?);
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = snapshot_name, .data = "\x89PNG\r\n\x1a\nB" });
+    try std.testing.expectError(error.ImageSnapshotCorrupt, ImageInputTest.write(alloc, &out.writer, &messages, null));
+    try tmp.dir.deleteFile(std.testing.io, snapshot_name);
+    try std.testing.expectError(error.FileNotFound, ImageInputTest.write(alloc, &out.writer, &messages, null));
+}
+
+test "Responses images release scratch between images and on writer failure" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var bytes: [32 * 1024]u8 = undefined;
+    @memset(&bytes, 'x');
+    @memcpy(bytes[0..8], "\x89PNG\r\n\x1a\n");
+    const attachment = try ImageInputTest.capture(alloc, &tmp, "source.png", &bytes, 1);
+    defer types.freeImageAttachment(alloc, attachment);
+    const messages = [_]types.ChatMessage{.{ .role = .user, .images = &.{ attachment, attachment, attachment } }};
+    var scratch_bytes: [96 * 1024]u8 = undefined;
+    var scratch: std.heap.FixedBufferAllocator = .init(&scratch_bytes);
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    defer out.deinit();
+    try ImageInputTest.write(scratch.allocator(), &out.writer, &messages, null);
+    try std.testing.expectEqual(@as(usize, 0), scratch.end_index);
+    const parsed = try std.json.parseFromSlice(std.json.Value, alloc, out.written(), .{});
+    defer parsed.deinit();
+    const parts = parsed.value.array.items[0].object.get("content").?.array.items;
+    try std.testing.expectEqual(@as(usize, 3), parts.len);
+    for (parts) |part| {
+        const url = part.object.get("image_url").?.string;
+        const encoded = url["data:image/png;base64,".len..];
+        var decoded: [bytes.len]u8 = undefined;
+        try std.base64.standard.Decoder.decode(&decoded, encoded);
+        try std.testing.expectEqualSlices(u8, &bytes, &decoded);
+    }
+    var small_buffer: [80]u8 = undefined;
+    var small_writer: std.Io.Writer = .fixed(&small_buffer);
+    try std.testing.expectError(error.WriteFailed, ImageInputTest.write(scratch.allocator(), &small_writer, &messages, null));
+    try std.testing.expectEqual(@as(usize, 0), scratch.end_index);
+}
+
+fn expectImageInputAllocations(alloc: std.mem.Allocator, attachment: types.ImageAttachment) !void {
+    var out: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer out.deinit();
+    try ImageInputTest.write(alloc, &out.writer, &.{.{ .role = .user, .images = &.{attachment} }}, null);
+}
+
+test "Responses images release verification allocations on failure" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const attachment = try ImageInputTest.capture(alloc, &tmp, "source.png", "\x89PNG\r\n\x1a\nA", 1);
+    defer types.freeImageAttachment(alloc, attachment);
+    try std.testing.checkAllAllocationFailures(alloc, expectImageInputAllocations, .{attachment});
+}
+
+test "Responses image requests obey cancellation and expired deadlines before loading" {
+    var out: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer out.deinit();
+    const attachment = types.ImageAttachment{ .path = @constCast("must-not-read"), .media_type = @constCast("image/png") };
+    const messages = [_]types.ChatMessage{.{ .role = .user, .images = &.{attachment} }};
+    var cancelled: std.atomic.Value(bool) = .init(true);
+    try std.testing.expectError(error.Cancelled, writeInput(&out.writer, std.testing.allocator, &messages, null, ImageInputTest.limits, .{ .cancel_flag = &cancelled }));
+    try std.testing.expectError(error.TimedOut, writeInput(&out.writer, std.testing.allocator, &messages, null, ImageInputTest.limits, .{ .deadline = .fromNow(std.testing.io, .{ .clock = .awake, .raw = .fromMilliseconds(-1) }) }));
+    try std.testing.expectEqual(@as(usize, 0), out.written().len);
+}
+
+test "Responses image encoding observes cancellation after partial output" {
+    const Cancel = struct {
+        fn check(raw: *anyopaque) !void {
+            const out: *std.Io.Writer.Allocating = @ptrCast(@alignCast(raw));
+            if (out.written().len > 1024) return error.Cancelled;
+        }
+    };
+    var bytes: [32 * 1024]u8 = undefined;
+    @memset(&bytes, 'x');
+    var out: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer out.deinit();
+    try std.testing.expectError(error.Cancelled, writeInputImage(&out.writer, .{ .bytes = &bytes, .media_type = "image/png" }, .{ .test_hook = .{ .ctx = &out, .check = Cancel.check } }));
+    try std.testing.expect(out.written().len > 1024);
+    try std.testing.expect(out.written().len < bytes.len);
+}
+
 fn writeInputImage(
     writer: *std.Io.Writer,
-    alloc: std.mem.Allocator,
     image: image_attachments.VerifiedSnapshot,
+    budget: image_attachments.CaptureBudget,
 ) !void {
-    const encoded_len = std.base64.standard.Encoder.calcSize(image.bytes.len);
-    const encoded = try alloc.alloc(u8, encoded_len);
-    defer alloc.free(encoded);
-    _ = std.base64.standard.Encoder.encode(encoded, image.bytes);
+    try budget.check();
     try writer.writeAll("{\"type\":\"input_image\",\"detail\":\"auto\",\"image_url\":\"data:");
     try writer.writeAll(image.media_type);
     try writer.writeAll(";base64,");
-    try writer.writeAll(encoded);
+    var offset: usize = 0;
+    while (offset < image.bytes.len) {
+        try budget.check();
+        const end = @min(offset + 3 * 1024, image.bytes.len);
+        try std.base64.standard.Encoder.encodeWriter(writer, image.bytes[offset..end]);
+        offset = end;
+    }
     try writer.writeAll("\"}");
+    try budget.check();
 }
 
 fn writeComma(writer: *std.Io.Writer, first: *bool) !void {

--- a/src/gateway/xai_grok.zig
+++ b/src/gateway/xai_grok.zig
@@ -43,10 +43,11 @@ pub fn buildRequest(
 ) ![]u8 {
     try request.validatePrompt();
     try validateModel(request.model);
-    if (request.budget) |budget| {
-        if (budget.cancel_flag) |flag| if (flag.load(.seq_cst)) return error.Cancelled;
-        _ = budget.deadline;
-    }
+    const budget: image_attachments.CaptureBudget = if (request.budget) |value|
+        .{ .deadline = value.deadline, .cancel_flag = value.cancel_flag }
+    else
+        .{};
+    try budget.check();
 
     var instructions: std.Io.Writer.Allocating = .init(alloc);
     defer instructions.deinit();
@@ -66,7 +67,7 @@ pub fn buildRequest(
     try writer.writeAll(",\"store\":false,\"stream\":true,\"instructions\":");
     try std.json.Stringify.value(instructions.written(), .{}, writer);
     try writer.writeAll(",\"input\":[");
-    try writeResponsesInput(writer, alloc, request.messages, request.verified_images);
+    try writeResponsesInput(writer, std.heap.c_allocator, request.messages, request.verified_images, budget);
     try writer.writeByte(']');
 
     const tool_count = try responses_protocol.writeTools(writer, alloc, request.tools);
@@ -112,13 +113,14 @@ fn writeResponsesInput(
     alloc: Allocator,
     messages: []const types.ChatMessage,
     images: ?[]const image_attachments.VerifiedSnapshot,
+    budget: image_attachments.CaptureBudget,
 ) !void {
     return responses_protocol.writeInput(writer, alloc, messages, images, .{
         .tool_calls = max_tool_calls,
         .tool_identity_bytes = max_tool_identity_bytes,
         .tool_arguments_bytes = max_tool_arguments_bytes,
         .provider_state_bytes = max_provider_state_bytes,
-    }) catch |err| switch (err) {
+    }, budget) catch |err| switch (err) {
         error.ProviderStateTooLarge => error.XaiGrokProviderStateTooLarge,
         error.InvalidProviderState => error.InvalidXaiGrokProviderState,
         error.ToolCallLimitExceeded => error.XaiGrokToolCallLimitExceeded,

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -4448,6 +4448,104 @@ for (const scenario of ["replace", "conflict", "invalid-index"] as const) {
   }, 60_000);
 }
 
+test("direct providers keep images with their users through tools and resume", async () => {
+  for (const provider of ["codex", "grok"] as const) {
+    const profile = mkdtempSync(join(tmpdir(), "fx-native-image-history-"));
+    const model = "fixture-model";
+    const testGateway = startFakeGateway([]);
+    const terminal = { type: "response.completed", response: { status: "completed" } };
+    const responses = [
+      fakeGatewaySse([
+        { type: "response.output_item.added", output_index: 0, item: { type: "function_call", call_id: "read_1", name: "read_file", arguments: "" } },
+        { type: "response.function_call_arguments.done", output_index: 0, arguments: JSON.stringify({ path: "fixture.txt" }) },
+        terminal,
+      ]),
+      ...Array.from({ length: 3 }, () => fakeGatewaySse([
+        { type: "response.output_text.delta", delta: "IMAGE_HISTORY_OK" }, terminal,
+      ])),
+    ];
+    const direct = provider === "codex"
+      ? startFakeCodexToolLoop({ responses, model, inputModalities: ["text", "image"] })
+      : startFakeGrokToolLoop({ responses, model });
+    try {
+      if (provider === "codex") writeSeededChatGptLogin(profile, direct.accessToken);
+      else writeSeededGrokLogin(profile, direct.accessToken);
+      writeFileSync(join(profile, ".fx", "settings.json"), JSON.stringify({ provider, [provider + "_model"]: model }), { mode: 0o600 });
+      writeFileSync(join(profile, "fixture.txt"), "fixture text");
+      const firstImage = readFileSync(join(REPO_ROOT, "tests/e2e/fixtures/favicon.png"));
+      const secondImage = readFileSync(join(REPO_ROOT, "tests/e2e/fixtures/placeholder-logo.png"));
+      const firstPath = join(profile, "first.png"), secondPath = join(profile, "second.png");
+      writeFileSync(firstPath, firstImage); writeFileSync(secondPath, secondImage);
+      const firstUrl = "data:image/png;base64," + firstImage.toString("base64");
+      const secondUrl = "data:image/png;base64," + secondImage.toString("base64");
+      const env = {
+        HOME: profile, AI_GATEWAY_API_KEY: "fixture", VERCEL_OIDC_TOKEN: undefined, FX_MODEL: undefined,
+        FX_DISABLE_KEYCHAIN: "1", FX_AUTO_UPGRADE: "0", FX_SOUND: "0",
+        FX_GATEWAY_BASE_URL: testGateway.baseUrl,
+        FX_E2E_GATEWAY_MODELS_URL: testGateway.baseUrl + "/coding-agent/v1/models",
+        FX_E2E_OPENAI_CODEX_RESPONSES_URL: direct.responsesUrl,
+        FX_E2E_OPENAI_CODEX_MODELS_URL: direct.modelsUrl,
+        FX_E2E_XAI_GROK_RESPONSES_URL: direct.responsesUrl,
+        FX_E2E_XAI_GROK_MODELS_URL: direct.modelsUrl,
+        FX_E2E_XAI_GROK_MODALITIES_URL: "modalitiesUrl" in direct ? direct.modalitiesUrl : undefined,
+      };
+      const firstPrompt = "Read fixture.txt, then describe the attached image.";
+      const secondPrompt = "Compare the earlier image with this new image.";
+      const imageOwners = (raw: string): Array<{ text: string; images: string[] }> => JSON.parse(raw).input
+        .filter((entry: { role?: string }) => entry.role === "user")
+        .map((entry: { content: Array<{ type: string; text?: string; image_url?: string }> }) => ({
+          text: entry.content.filter(part => part.type === "input_text").map(part => part.text).join(""),
+          images: entry.content.filter(part => part.type === "input_image").map(part => part.image_url!),
+        }))
+        .filter((entry: { images: string[] }) => entry.images.length > 0);
+      const firstOwner = { text: firstPrompt, images: [firstUrl] };
+      const secondOwner = { text: secondPrompt, images: [secondUrl] };
+      const first = await runFx(["ask", "--json", "--auto", "--image", firstPath, firstPrompt], { cwd: profile, env, timeoutMs: TIMEOUT });
+      expect(first.code, first.stdout + first.stderr).toBe(0);
+      expect(first.signal).toBeNull();
+      const sessionId = JSON.parse(first.stdout).session_id;
+      expect(JSON.parse(first.stdout).tool_calls).toEqual([{ name: "read_file", status: "success" }]);
+      expect(direct.bodies).toHaveLength(2);
+      expect(imageOwners(direct.bodies[0])).toEqual([firstOwner]);
+      expect(imageOwners(direct.bodies[1])).toEqual([firstOwner]);
+      unlinkSync(firstPath);
+      const second = await runFx(["ask", "--json", "--auto", "--resume-id", sessionId, "--image", secondPath, secondPrompt], { cwd: profile, env, timeoutMs: TIMEOUT });
+      expect(second.code, second.stdout + second.stderr).toBe(0);
+      expect(second.signal).toBeNull();
+      expect(second.stderr).toBe("");
+      expect(direct.bodies).toHaveLength(3);
+      expect(imageOwners(direct.bodies[2])).toEqual([firstOwner, secondOwner]);
+      const third = await runFx(["ask", "--json", "--auto", "--resume-id", sessionId, "Look again at both earlier images."], { cwd: profile, env, timeoutMs: TIMEOUT });
+      expect(third.code, third.stdout + third.stderr).toBe(0);
+      expect(third.signal).toBeNull();
+      expect(third.stderr).toBe("");
+      expect(direct.bodies).toHaveLength(4);
+      expect(imageOwners(direct.bodies[3])).toEqual([firstOwner, secondOwner]);
+      const detail = await runFx(["session", "--json", "--id", sessionId], { cwd: profile, env });
+      expect(detail.code).toBe(0);
+      const history = JSON.parse(detail.stdout).history;
+      expect(history).toHaveLength(3);
+      expect(history.map((turn: { user: { images?: unknown[] } }) => turn.user.images?.length ?? 0)).toEqual([1, 1, 0]);
+      const imageDir = join(profile, ".fx", "sessions", sessionId, "images");
+      const snapshotName = readdirSync(imageDir).find(name => name.endsWith(".bin") && readFileSync(join(imageDir, name)).equals(firstImage));
+      expect(snapshotName).toBeDefined();
+      writeFileSync(join(imageDir, snapshotName!), secondImage);
+      const rejected = await runFx(["ask", "--json", "--auto", "--resume-id", sessionId, "Inspect the earlier images again."], { cwd: profile, env, timeoutMs: TIMEOUT });
+      expect(rejected.code, rejected.stdout + rejected.stderr).toBe(1);
+      expect(rejected.signal).toBeNull();
+      expect(rejected.stdout + rejected.stderr).toContain("ImageSnapshotCorrupt");
+      expect(direct.bodies).toHaveLength(4);
+      const retained = await runFx(["session", "--json", "--id", sessionId], { cwd: profile, env });
+      expect(retained.code).toBe(0);
+      expect(JSON.parse(retained.stdout).history).toEqual(history);
+      expect(testGateway.requests).toHaveLength(0);
+    } finally {
+      direct.stop(); testGateway.stop();
+      rmSync(profile, { recursive: true, force: true });
+    }
+  }
+}, 60_000);
+
 test("direct provider tool identities obey the session boundary before execution", async () => {
   for (const provider of ["codex", "grok"] as const) {
     for (const bytes of [256, 257]) {


### PR DESCRIPTION
## Summary

- Keep attached images available after tool calls and session resume in direct-provider sessions.
- Keep each image with its original user message when multiple turns contain attachments.
- Fail before sending a request when a replayed image snapshot is missing or corrupt.
- Honor cancellation and deadlines while verifying and encoding native images.
