### PR TITLE
Preserve full transcript history after clearing the display

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ The current directory becomes the primary workspace. Enter a prompt, or run `/he
 
 Tool calls are expanded by default. Enable `Collapse tool calls` in `/settings`, or set `"collapse_tool_calls": true` in `~/.fx/settings.json`, to show one summary per tool-call group in the main transcript. Individual calls remain available in the full transcript with Ctrl+O. Follow-up activity for captured shell commands shows the original command, such as `Observed zig build`, while tool results keep the same execution handle.
 
+Ctrl+L clears the inline display while keeping the conversation available in Ctrl+O. It preserves your draft and conversation context; `/clear` starts a fresh conversation instead.
+
 The status line hides the workspace path and Git branch by default. Enable the `Status line workspace` option in `/settings`, run `/statusline workspace`, or set it in `~/.fx/settings.json`:
 
 ```json

--- a/src/ui/render_engine/transcript_blocks.zig
+++ b/src/ui/render_engine/transcript_blocks.zig
@@ -226,9 +226,8 @@ fn blockKindForEntry(entry: TranscriptEntry) TranscriptBlockKind {
 
 pub fn isEntryVisibleInCompactPresentation(entry: TranscriptEntry) bool {
     return switch (entry) {
-        .raw_bytes => true,
-        .semantic_notice => |notice| notice.visibility == .compact_and_full,
-        else => true,
+        .semantic_notice => |notice| !notice.inline_hidden and notice.visibility == .compact_and_full,
+        inline else => |payload| !payload.inline_hidden,
     };
 }
 
@@ -317,6 +316,7 @@ pub const TranscriptEntry = union(enum) {
     pub const RawBytesEntry = struct {
         id: u32,
         created_at_ms: i64 = 0,
+        inline_hidden: bool = false,
         bytes: []const u8,
         class: RawEntryClass = .unknown_raw,
         lifecycle_pinned: bool = false,
@@ -325,6 +325,7 @@ pub const TranscriptEntry = union(enum) {
     pub const SemanticNoticeEntry = struct {
         id: u32,
         created_at_ms: i64 = 0,
+        inline_hidden: bool = false,
         topic: []const u8,
         tone: types.NoticeTone,
         body: []const u8,
@@ -337,6 +338,7 @@ pub const TranscriptEntry = union(enum) {
     pub const UserTurnEntry = struct {
         id: u32,
         created_at_ms: i64 = 0,
+        inline_hidden: bool = false,
         turn: types.UserTurn,
         skill_tokens: []input_visual_layout.SkillTokenSpan = &.{},
     };
@@ -344,25 +346,35 @@ pub const TranscriptEntry = union(enum) {
     pub const AssistantTurnEntry = struct {
         id: u32,
         created_at_ms: i64 = 0,
+        inline_hidden: bool = false,
         segments: AssistantTurnSegments,
     };
 
     pub const AssistantTableEntry = struct {
         id: u32,
         created_at_ms: i64 = 0,
+        inline_hidden: bool = false,
         table: assistant_presentation.TablePayload,
     };
 
     pub const AssistantCodeBlockEntry = struct {
         id: u32,
         created_at_ms: i64 = 0,
+        inline_hidden: bool = false,
         block: assistant_presentation.CodeBlockPayload,
     };
 
     pub const AssistantThematicRuleEntry = struct {
         id: u32,
         created_at_ms: i64 = 0,
+        inline_hidden: bool = false,
     };
+
+    pub fn hideInline(self: *TranscriptEntry) void {
+        switch (self.*) {
+            inline else => |*payload| payload.inline_hidden = true,
+        }
+    }
 
     pub fn id(self: TranscriptEntry) u32 {
         return switch (self) {
@@ -2098,7 +2110,7 @@ fn renderEntriesInterruptible(
 
     for (entries, 0..) |entry, entry_index| {
         try build_checkpoint.tick(checkpoint);
-        if (options.shouldOmit(entry_index, entry)) continue;
+        if (!isEntryVisibleInCompactPresentation(entry) or options.shouldOmit(entry_index, entry)) continue;
         if (options.overrideForEntry(entry_index, entry)) |override| {
             const block = try normalizeRenderedBlockTail(
                 alloc,

--- a/src/ui/resize_tests.zig
+++ b/src/ui/resize_tests.zig
@@ -6992,6 +6992,37 @@ test "visual epoch reset reanchors at row one and preserves viewport reservation
     try std.testing.expect(std.mem.find(u8, emitted, "\x1b[3J") != null);
     try expectGridContains(&h, "welcome after clear");
     try expectGridNotContains(&h, "old visual epoch");
+    try std.testing.expectEqual(@as(usize, 2), h.shell.entries.items.len);
+
+    var projection = try h.shell.buildFullTranscriptProjection(alloc, null);
+    defer projection.deinit(alloc);
+    const full = try full_transcript_screen.renderProjectionViewportSourceInterruptible(
+        alloc,
+        &projection,
+        null,
+        h.shell.layout.cols,
+        64,
+        0,
+        null,
+    );
+    defer alloc.free(full);
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, full, "old visual epoch"));
+
+    h.shell.closeFullTranscriptState();
+    try h.driveResize(40, 18, 4, true);
+    try expectGridContains(&h, "welcome after clear");
+    try expectGridNotContains(&h, "old visual epoch");
+    _ = try h.shell.appendRawTranscriptEntryClassified(alloc, "new visual epoch\n", .subagent_status);
+    h.frame_redraw = true;
+    try renderTestFooter(&h, &input, &approval, &h.frame_redraw);
+    try h.flush();
+    try expectGridContains(&h, "new visual epoch");
+    try expectGridNotContains(&h, "old visual epoch");
+
+    try h.driveResize(96, 24, 4, true);
+    try expectGridContains(&h, "new visual epoch");
+    try expectGridNotContains(&h, "old visual epoch");
+    try std.testing.expectEqual(min_rows, h.shell.min_visible_viewport_rows);
 }
 
 test "multi-row replaceable line clears every old visual row on replace" {

--- a/src/ui/transcript/runtime_tests.zig
+++ b/src/ui/transcript/runtime_tests.zig
@@ -14234,11 +14234,178 @@ test "pinned status replacement preserves authoritative cache changes and rebase
     }
 }
 
-test "visual epoch replaces ordinary entries and preserves live tool identities" {
+test "visual epoch retains full history across repeated clears and compact rebuilds" {
     const alloc = std.testing.allocator;
     var runtime = lifecycleTestRuntime(null);
     defer runtime.deinit(alloc);
 
+    _ = try runtime.appendRawTranscriptEntryClassified(alloc, "old welcome\n", .welcome);
+    const old_id = try runtime.appendRawTranscriptEntryClassified(alloc, "retained answer\n", .subagent_status);
+    _ = try runtime.appendSemanticNotice(alloc, .{
+        .topic = "history",
+        .tone = .information,
+        .body = "retained notice",
+    });
+    const retained_bytes = runtime.entries.items[1].raw_bytes.bytes.ptr;
+
+    for (0..3) |_| {
+        try runtime.resetVisualEpoch(alloc, "current welcome\n");
+        try std.testing.expectEqual(@as(usize, 3), runtime.entries.items.len);
+        try std.testing.expectEqual(old_id, runtime.entries.items[1].id());
+        try std.testing.expectEqual(retained_bytes, runtime.entries.items[1].raw_bytes.bytes.ptr);
+        try std.testing.expect(runtime.entries.items[1].raw_bytes.inline_hidden);
+        try std.testing.expect(runtime.entries.items[2].semantic_notice.inline_hidden);
+        try std.testing.expectEqualStrings("current welcome\n", runtime.transcript.items);
+
+        var compact = try runtime.prepareTranscriptSource(alloc, null);
+        defer compact.deinit(alloc);
+        try std.testing.expect(std.mem.find(u8, compact.bytes, "retained") == null);
+
+        var projection = try runtime.buildFullTranscriptProjection(alloc, null);
+        defer projection.deinit(alloc);
+        const full = try full_transcript_screen.renderProjectionViewportSourceInterruptible(
+            alloc,
+            &projection,
+            null,
+            runtime.layout.cols,
+            64,
+            0,
+            null,
+        );
+        defer alloc.free(full);
+        try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, full, "retained answer"));
+        try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, full, "retained notice"));
+        try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, full, "current welcome"));
+        try std.testing.expect(std.mem.find(u8, full, "old welcome") == null);
+    }
+
+    _ = try runtime.appendRawTranscriptEntryClassified(alloc, "new answer\n", .subagent_status);
+    var compact = try runtime.prepareTranscriptSource(alloc, null);
+    defer compact.deinit(alloc);
+    try std.testing.expect(std.mem.find(u8, compact.bytes, "new answer") != null);
+    try std.testing.expect(std.mem.find(u8, compact.bytes, "retained") == null);
+
+    runtime.clearTranscript(alloc);
+    try std.testing.expectEqual(@as(usize, 0), runtime.entries.items.len);
+    try std.testing.expectEqual(@as(usize, 0), runtime.transcript.items.len);
+}
+
+test "visual epoch preserves monotonic entry IDs across repeated clears" {
+    const alloc = std.testing.allocator;
+    for ([_]bool{ true, false }) |has_original_welcome| {
+        var runtime = lifecycleTestRuntime(null);
+        defer runtime.deinit(alloc);
+        if (has_original_welcome) {
+            _ = try runtime.appendRawTranscriptEntryClassified(alloc, "original welcome\n", .welcome);
+            runtime.entries.items[0].raw_bytes.created_at_ms = 1234;
+        }
+        var ordinary_ids: [300]u32 = undefined;
+        for (&ordinary_ids) |*id| {
+            id.* = try runtime.appendRawTranscriptEntryClassified(alloc, "retained answer\n", .subagent_status);
+        }
+        const welcome_index: usize = if (has_original_welcome) 0 else ordinary_ids.len;
+        const welcome_id = if (has_original_welcome) runtime.entries.items[0].id() else runtime.next_entry_id;
+        var welcome_created_at: ?i64 = if (has_original_welcome) 1234 else null;
+        const expected_next_id = runtime.next_entry_id + @as(u32, if (has_original_welcome) 0 else 1);
+
+        for (0..3) |_| {
+            try runtime.resetVisualEpoch(alloc, "current welcome\n");
+            try std.testing.expectEqual(@as(usize, ordinary_ids.len + 1), runtime.entries.items.len);
+            try std.testing.expectEqual(expected_next_id, runtime.next_entry_id);
+            const welcome_entry = runtime.entries.items[welcome_index].raw_bytes;
+            try std.testing.expectEqual(welcome_id, welcome_entry.id);
+            try std.testing.expectEqualStrings("current welcome\n", welcome_entry.bytes);
+            if (welcome_created_at) |created_at| {
+                try std.testing.expectEqual(created_at, welcome_entry.created_at_ms);
+            } else {
+                welcome_created_at = welcome_entry.created_at_ms;
+            }
+            var welcome_count: usize = 0;
+            var ordinary_index: usize = 0;
+            for (runtime.entries.items, 0..) |entry, index| {
+                if (index > 0) try std.testing.expect(runtime.entries.items[index - 1].id() < entry.id());
+                if (entry == .raw_bytes and entry.raw_bytes.class == .welcome) {
+                    welcome_count += 1;
+                } else {
+                    try std.testing.expectEqual(ordinary_ids[ordinary_index], entry.id());
+                    try std.testing.expect(entry.raw_bytes.inline_hidden);
+                    ordinary_index += 1;
+                }
+            }
+            try std.testing.expectEqual(@as(usize, 1), welcome_count);
+            try std.testing.expectEqual(ordinary_ids.len, ordinary_index);
+            try std.testing.expectEqualStrings("current welcome\n", runtime.transcript.items);
+        }
+    }
+}
+
+fn checkVisualEpochAllocationFailuresImpl(alloc: Allocator) !void {
+    var runtime = lifecycleTestRuntime(null);
+    defer runtime.deinit(alloc);
+    _ = try runtime.appendRawTranscriptEntryClassified(alloc, "original welcome\n", .welcome);
+    const old_id = try runtime.appendRawTranscriptEntryClassified(alloc, "borrowed answer\n", .subagent_status);
+    const pinned_id = try transcript_store.appendPinnedToolStatusAtomic(&runtime, alloc, "running\n");
+    const old_entries = runtime.entries.items.ptr;
+    const old_payload = runtime.entries.items[1].raw_bytes.bytes.ptr;
+    const old_next_id = runtime.next_entry_id;
+    const before = try std.testing.allocator.dupe(u8, runtime.transcript.items);
+    defer std.testing.allocator.free(before);
+
+    runtime.resetVisualEpoch(alloc, "replacement welcome\n") catch |err| {
+        try std.testing.expectEqual(old_entries, runtime.entries.items.ptr);
+        try std.testing.expectEqual(@as(usize, 3), runtime.entries.items.len);
+        try std.testing.expectEqual(old_next_id, runtime.next_entry_id);
+        try std.testing.expectEqualStrings(before, runtime.transcript.items);
+        try std.testing.expectEqual(old_payload, runtime.entries.items[1].raw_bytes.bytes.ptr);
+        try std.testing.expect(!runtime.entries.items[1].raw_bytes.inline_hidden);
+        try std.testing.expectEqualStrings("borrowed answer\n", runtime.entries.items[1].raw_bytes.bytes);
+        try std.testing.expect(runtime.isLifecyclePinned(pinned_id));
+        return err;
+    };
+    try std.testing.expectEqual(old_id, runtime.entries.items[1].id());
+    try std.testing.expectEqual(old_payload, runtime.entries.items[1].raw_bytes.bytes.ptr);
+    try std.testing.expect(runtime.entries.items[1].raw_bytes.inline_hidden);
+    try std.testing.expect(runtime.isLifecyclePinned(pinned_id));
+}
+
+fn checkVisualEpochAllocationFailures(alloc: Allocator) !void {
+    return checkVisualEpochAllocationFailuresImpl(alloc) catch |err| switch (err) {
+        error.WriteFailed => error.OutOfMemory,
+        else => err,
+    };
+}
+
+test "visual epoch starts a visible assistant tail without resurrecting cleared text" {
+    const alloc = std.testing.allocator;
+    var runtime = lifecycleTestRuntime(null);
+    defer runtime.deinit(alloc);
+    var metrics = Metrics{};
+    _ = try runtime.appendRawTranscriptEntryClassified(alloc, "welcome\n", .welcome);
+    const before_id = try runtime.streamAssistantChunk(alloc, &metrics, "before clear");
+    try runtime.resetVisualEpoch(alloc, "welcome\n");
+    const after_id = try runtime.streamAssistantChunk(alloc, &metrics, "after clear");
+    try std.testing.expect(before_id != after_id);
+    try std.testing.expectEqualStrings("before clear", runtime.lookupAssistantSegments(before_id).?.text.items);
+    var compact = try runtime.prepareTranscriptSource(alloc, null);
+    defer compact.deinit(alloc);
+    try std.testing.expect(std.mem.find(u8, compact.bytes, "before clear") == null);
+    try std.testing.expect(std.mem.find(u8, compact.bytes, "after clear") != null);
+}
+
+test "visual epoch reset is atomic across allocation failures" {
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        checkVisualEpochAllocationFailures,
+        .{},
+    );
+}
+
+test "visual epoch hides ordinary entries and preserves live tool identities through settlement" {
+    const alloc = std.testing.allocator;
+    var runtime = lifecycleTestRuntime(null);
+    defer runtime.deinit(alloc);
+
+    _ = try runtime.appendRawTranscriptEntryClassified(alloc, "original welcome\n", .welcome);
     _ = try runtime.appendRawTranscriptEntryClassified(alloc, "old transcript\n", .subagent_status);
     const entry_id = try startLifecycle(&runtime, alloc, 7, "call-7");
 
@@ -14258,6 +14425,99 @@ test "visual epoch replaces ordinary entries and preserves live tool identities"
         .outcome = .{ .kind = .completed, .summary = "finished" },
     } });
     try std.testing.expect(std.mem.find(u8, runtime.transcript.items, "finished") != null);
+    try std.testing.expectEqual(@as(usize, 3), runtime.entries.items.len);
+    try std.testing.expectEqual(entry_id, runtime.entries.items[2].id());
+    try std.testing.expect(!runtime.entries.items[2].raw_bytes.inline_hidden);
+
+    _ = try runtime.applyToolLifecycle(alloc, .{ .turn_finished = .{
+        .turn_id = 7,
+        .outcome = .completed,
+    } });
+    try runtime.finishLifecycleBatch(alloc);
+    try std.testing.expect(!runtime.isLifecyclePinned(entry_id));
+    try std.testing.expect(std.mem.find(u8, runtime.transcript.items, "finished") != null);
+    try runtime.resetVisualEpoch(alloc, "welcome again\n");
+    try std.testing.expectEqual(@as(usize, 3), runtime.entries.items.len);
+    try std.testing.expectEqual(entry_id, runtime.entries.items[2].id());
+    try std.testing.expect(runtime.entries.items[2].raw_bytes.inline_hidden);
+    try std.testing.expectEqualStrings("welcome again\n", runtime.transcript.items);
+
+    var projection = try runtime.buildFullTranscriptProjection(alloc, null);
+    defer projection.deinit(alloc);
+    const full = try full_transcript_screen.renderProjectionViewportSourceInterruptible(
+        alloc,
+        &projection,
+        null,
+        runtime.layout.cols,
+        64,
+        0,
+        null,
+    );
+    defer alloc.free(full);
+    try std.testing.expect(std.mem.find(u8, full, "old transcript") != null);
+    try std.testing.expect(std.mem.find(u8, full, "finished") != null);
+}
+
+test "visual epoch retains command output blocks and detail associations" {
+    const alloc = std.testing.allocator;
+    var sink = try std.Io.Dir.openFileAbsolute(io_mod.getIo(), "/dev/null", .{ .mode = .write_only });
+    defer sink.close(io_mod.getIo());
+    var runtime = commandOutputTestRuntime(sink);
+    defer runtime.deinit(alloc);
+    var metrics = Metrics{};
+    const styles = commandOutputTestStyles();
+    const id = lifecycleId(1, "retained-command");
+    _ = try runtime.applyToolLifecycle(alloc, .{ .authoritative_started = .{
+        .id = id,
+        .reconciles_provisional_call_id = null,
+        .tool_name = "shell",
+        .activity_kind = .command,
+        .arguments_json = "{\"request\":{\"action\":\"run\",\"command\":\"true\"}}",
+    } });
+    const entry_id = runtime.toolActivityRecord(id).?.entry_id;
+    try runtime.writeCommandOutputChunkForLifecycle(alloc, &metrics, styles, id, .stdout, "retained command result\n", true);
+    try runtime.flushCommandOutputSummaryForLifecycle(alloc, &metrics, styles, id, true);
+    _ = try runtime.applyToolLifecycle(alloc, .{ .terminal = .{
+        .id = id,
+        .outcome = .{ .kind = .completed, .summary = "Retained command complete" },
+        .result = "retained command result\n",
+        .result_memory = .{ .command_process_presentation = .{ .exit_code = 0 } },
+    } });
+    _ = try runtime.applyToolLifecycle(alloc, .{ .turn_finished = .{
+        .turn_id = 1,
+        .outcome = .completed,
+    } });
+    try runtime.finishLifecycleBatch(alloc);
+    const output_id = runtime.toolDetailForEntry(entry_id).?.command_output_entry_id.?;
+    const block_count = runtime.command_output_blocks.items.len;
+    try std.testing.expect(block_count > 0);
+    const blocks_ptr = runtime.command_output_blocks.items.ptr;
+
+    for (0..2) |_| {
+        try runtime.resetVisualEpoch(alloc, "welcome\n");
+        try std.testing.expectEqual(block_count, runtime.command_output_blocks.items.len);
+        try std.testing.expectEqual(blocks_ptr, runtime.command_output_blocks.items.ptr);
+        try std.testing.expectEqual(output_id, runtime.toolDetailForEntry(entry_id).?.command_output_entry_id.?);
+        try std.testing.expect(transcriptContainsEntry(&runtime, output_id));
+        try std.testing.expectEqualStrings("welcome\n", runtime.transcript.items);
+        var projection = try runtime.buildFullTranscriptProjection(alloc, null);
+        defer projection.deinit(alloc);
+        const full = try full_transcript_screen.renderProjectionViewportSourceInterruptible(
+            alloc,
+            &projection,
+            null,
+            runtime.layout.cols,
+            64,
+            0,
+            null,
+        );
+        defer alloc.free(full);
+        try std.testing.expect(std.mem.find(u8, full, "Retained command complete") != null);
+        try std.testing.expect(std.mem.find(u8, full, "retained command result") != null);
+    }
+    runtime.clearTranscript(alloc);
+    try std.testing.expectEqual(@as(usize, 0), runtime.command_output_blocks.items.len);
+    try std.testing.expectEqual(@as(usize, 0), runtime.tool_details.items.len);
 }
 
 test "transcript lifecycle identity updates are idempotent and atomic" {

--- a/src/ui/transcript/store.zig
+++ b/src/ui/transcript/store.zig
@@ -952,27 +952,51 @@ pub fn resetVisualEpoch(self: anytype, alloc: Allocator, welcome: []const u8) !v
     std.debug.assert(welcome.len > 0);
     try self.assertCanMutateTranscript();
 
-    const pinned_count = lifecyclePinCount(self);
     var replacement_entries: std.ArrayList(TranscriptEntry) = .empty;
-    errdefer {
-        for (replacement_entries.items) |*entry| entry.deinit(alloc);
-        replacement_entries.deinit(alloc);
-    }
-    try replacement_entries.ensureTotalCapacity(alloc, pinned_count + 1);
+    errdefer replacement_entries.deinit(alloc);
+    try replacement_entries.ensureTotalCapacity(alloc, self.entries.items.len + 1);
 
+    // Staging borrows retained payloads until publication; only the new welcome
+    // belongs to this scope on failure.
     const welcome_copy = try alloc.dupe(u8, welcome);
-    replacement_entries.appendAssumeCapacity(.{ .raw_bytes = .{
-        .id = self.next_entry_id,
-        .created_at_ms = io_mod.milliTimestamp(),
-        .bytes = welcome_copy,
-        .class = .welcome,
-    } });
-
+    errdefer alloc.free(welcome_copy);
+    var replaced_welcome = false;
+    var hidden_count: usize = 0;
+    var pinned_count: usize = 0;
     for (self.entries.items) |entry| {
-        if (entry != .raw_bytes or !entry.raw_bytes.lifecycle_pinned) continue;
-        replacement_entries.appendAssumeCapacity(
-            try cloneEntryForSnapshot(alloc, entry),
-        );
+        if (entry == .raw_bytes and entry.raw_bytes.class == .welcome) {
+            if (!replaced_welcome) {
+                replacement_entries.appendAssumeCapacity(.{ .raw_bytes = .{
+                    .id = entry.raw_bytes.id,
+                    .created_at_ms = entry.raw_bytes.created_at_ms,
+                    .bytes = welcome_copy,
+                    .class = .welcome,
+                } });
+                replaced_welcome = true;
+            }
+            continue;
+        }
+        const pinned = switch (entry) {
+            .raw_bytes => |raw| raw.lifecycle_pinned,
+            .semantic_notice => |notice| notice.pending_replacement,
+            else => false,
+        };
+        var retained = entry;
+        if (pinned) {
+            pinned_count += 1;
+        } else {
+            retained.hideInline();
+            hidden_count += 1;
+        }
+        replacement_entries.appendAssumeCapacity(retained);
+    }
+    if (!replaced_welcome) {
+        replacement_entries.appendAssumeCapacity(.{ .raw_bytes = .{
+            .id = self.next_entry_id,
+            .created_at_ms = io_mod.milliTimestamp(),
+            .bytes = welcome_copy,
+            .class = .welcome,
+        } });
     }
 
     const cols: u16 = if (self.layout.cols > 0) self.layout.cols else 80;
@@ -997,15 +1021,18 @@ pub fn resetVisualEpoch(self: anytype, alloc: Allocator, welcome: []const u8) !v
     replacement_transcript = .empty;
     self.transcript_cache_origin_untrimmed = rendered_start == 0;
 
-    for (old_entries.items) |*entry| entry.deinit(alloc);
+    for (old_entries.items) |*entry| {
+        if (entry.* == .raw_bytes and entry.raw_bytes.class == .welcome) entry.deinit(alloc);
+    }
     old_entries.deinit(alloc);
     old_transcript.deinit(alloc);
-    for (self.folded_command_blocks.items) |*block| block.deinit(alloc);
-    self.folded_command_blocks.clearRetainingCapacity();
-    for (self.command_output_blocks.items) |*block| block.deinit(alloc);
-    self.command_output_blocks.clearRetainingCapacity();
+    debug_trace.logf(
+        "transcript.visual_epoch_reset",
+        "clear display retained={d} hidden={d} pinned={d}",
+        .{ self.entries.items.len - 1, hidden_count, pinned_count },
+    );
 
-    self.next_entry_id +%= 1;
+    if (!replaced_welcome) self.next_entry_id +%= 1;
     self.last_rendered_cols = cols;
     if (comptime @hasDecl(@TypeOf(self.*), "closeFullTranscriptState")) {
         self.closeFullTranscriptState();
@@ -1194,6 +1221,7 @@ pub fn replaceSemanticNoticeAtomic(
     shadow.entries.items[entry_index] = .{ .semantic_notice = .{
         .id = entry_id,
         .created_at_ms = created_at_ms,
+        .inline_hidden = previous.semantic_notice.inline_hidden,
         .topic = owned.topic,
         .tone = owned.tone,
         .body = owned.body,
@@ -2034,6 +2062,7 @@ pub fn cloneEntryForSnapshot(alloc: Allocator, entry: TranscriptEntry) !Transcri
         .raw_bytes => |raw| .{ .raw_bytes = .{
             .id = raw.id,
             .created_at_ms = raw.created_at_ms,
+            .inline_hidden = raw.inline_hidden,
             .bytes = try alloc.dupe(u8, raw.bytes),
             .class = raw.class,
             .lifecycle_pinned = raw.lifecycle_pinned,
@@ -2048,6 +2077,7 @@ pub fn cloneEntryForSnapshot(alloc: Allocator, entry: TranscriptEntry) !Transcri
             break :blk .{ .semantic_notice = .{
                 .id = notice.id,
                 .created_at_ms = notice.created_at_ms,
+                .inline_hidden = notice.inline_hidden,
                 .topic = owned.topic,
                 .tone = owned.tone,
                 .body = owned.body,
@@ -2062,6 +2092,7 @@ pub fn cloneEntryForSnapshot(alloc: Allocator, entry: TranscriptEntry) !Transcri
             break :blk .{ .user_turn = .{
                 .id = user.id,
                 .created_at_ms = user.created_at_ms,
+                .inline_hidden = user.inline_hidden,
                 .turn = turn,
                 .skill_tokens = skill_tokens,
             } };
@@ -2073,22 +2104,26 @@ pub fn cloneEntryForSnapshot(alloc: Allocator, entry: TranscriptEntry) !Transcri
             break :blk .{ .assistant_turn = .{
                 .id = assistant.id,
                 .created_at_ms = assistant.created_at_ms,
+                .inline_hidden = assistant.inline_hidden,
                 .segments = segments,
             } };
         },
         .assistant_table => |assistant| .{ .assistant_table = .{
             .id = assistant.id,
             .created_at_ms = assistant.created_at_ms,
+            .inline_hidden = assistant.inline_hidden,
             .table = try assistant.table.clone(alloc),
         } },
         .assistant_code_block => |assistant| .{ .assistant_code_block = .{
             .id = assistant.id,
             .created_at_ms = assistant.created_at_ms,
+            .inline_hidden = assistant.inline_hidden,
             .block = try assistant.block.clone(alloc),
         } },
         .assistant_thematic_rule => |assistant| .{ .assistant_thematic_rule = .{
             .id = assistant.id,
             .created_at_ms = assistant.created_at_ms,
+            .inline_hidden = assistant.inline_hidden,
         } },
     };
 }
@@ -2704,7 +2739,7 @@ pub fn tailAssistantSegments(self: anytype) ?*AssistantTurnSegments {
     if (self.entries.items.len == 0) return null;
     const last = &self.entries.items[self.entries.items.len - 1];
     return switch (last.*) {
-        .assistant_turn => |*e| &e.segments,
+        .assistant_turn => |*e| if (e.inline_hidden) null else &e.segments,
         else => null,
     };
 }

--- a/src/ui/transcript/tool_group_projection.zig
+++ b/src/ui/transcript/tool_group_projection.zig
@@ -862,10 +862,6 @@ fn buildWithStyleAndStats(
     try projection.entry_actions.appendNTimes(alloc, .keep, entries.len);
     if (mode == .compact) {
         for (entries, projection.entry_actions.items) |entry, *action| {
-            if (!transcript_blocks.isEntryVisibleInCompactPresentation(entry)) {
-                action.* = .hide;
-                continue;
-            }
             switch (entry) {
                 .raw_bytes => |raw| if (raw.class == .command_output) {
                     action.* = .hide;

--- a/src/ui/transcript/tool_group_projection.zig
+++ b/src/ui/transcript/tool_group_projection.zig
@@ -862,6 +862,10 @@ fn buildWithStyleAndStats(
     try projection.entry_actions.appendNTimes(alloc, .keep, entries.len);
     if (mode == .compact) {
         for (entries, projection.entry_actions.items) |entry, *action| {
+            if (!transcript_blocks.isEntryVisibleInCompactPresentation(entry)) {
+                action.* = .hide;
+                continue;
+            }
             switch (entry) {
                 .raw_bytes => |raw| if (raw.class == .command_output) {
                     action.* = .hide;
@@ -896,6 +900,7 @@ fn buildWithStyleAndStats(
 
     for (entries, 0..) |entry, entry_index| {
         try build_checkpoint.tick(checkpoint);
+        if (mode == .compact and !transcript_blocks.isEntryVisibleInCompactPresentation(entry)) continue;
         const entry_id = toolStatusEntryId(entry) orelse continue;
         const detail = detailForEntry(details, &detail_indices, entry_id, stats);
         if (statusNamesAsk(entry, detail)) continue;
@@ -1047,6 +1052,7 @@ fn buildWithStyleAndStats(
 
         while (index < entries.len) : (index += 1) {
             try build_checkpoint.tick(checkpoint);
+            if (!transcript_blocks.isEntryVisibleInCompactPresentation(entries[index])) continue;
             if (presentation_group_indices[index] != null) break;
             if (toolStatusEntryId(entries[index])) |group_entry_id| {
                 const group_detail = detailForEntry(details, &detail_indices, group_entry_id, stats);

--- a/tests/e2e/tui-input-navigation.test.ts
+++ b/tests/e2e/tui-input-navigation.test.ts
@@ -829,23 +829,70 @@ tmuxTest(
     await typeLiteral(active, draft);
     await waitForActiveFooter(active, (footer) => footer === `┃ ${draft}`);
 
-    await active.sendKeys("C-l");
-    const footer = await waitForActiveFooter(
-      active,
-      (visible) => visible === `┃ ${draft}`,
+    const fullFooter = "Full detail · ctrl o close";
+    const response = "history prompt complete";
+    const openRetainedTranscript = async () => {
+      await active.sendKeys("C-o");
+      const pane = await active.waitForPane(
+        (pane) => pane.includes(fullFooter) && pane.includes(response),
+        READY_TIMEOUT,
+      );
+      expect(pane).toContain("zz-history");
+      expect(pane.split(response)).toHaveLength(2);
+    };
+    const expectClearedInline = async () => {
+      const footer = await waitForActiveFooter(
+        active,
+        (visible) => visible === `┃ ${draft}`,
+      );
+      expect(footer).toBe(`┃ ${draft}`);
+      await active.waitForPane(
+        (pane) => !pane.includes(fullFooter) && !pane.includes(response) &&
+          !pane.includes("zz-history"),
+        READY_TIMEOUT,
+      );
+      const scrollback = stripAnsi(await active.captureFullScrollbackEscapes());
+      expect(scrollback).toContain(draft);
+      expect(scrollback).not.toContain(fullFooter);
+      expect(scrollback).not.toContain(response);
+      expect(scrollback).not.toContain("zz-history");
+    };
+
+    // Establish that the viewer has the response before clearing the display.
+    await openRetainedTranscript();
+    await active.sendKeys("C-o");
+    await waitForActiveFooter(active, (footer) => footer === `┃ ${draft}`);
+    await active.waitForPane(
+      (pane) => !pane.includes(fullFooter) && pane.includes(response),
+      READY_TIMEOUT,
     );
-    expect(footer).toBe(`┃ ${draft}`);
-    await delay(100);
+
+    await active.sendKeys("C-l");
+    await expectClearedInline();
     expect(readFileSync(join(testHome!, "trace.log"), "utf8")).toContain(
       "visual_epoch_reset_requested trigger=ctrl_l",
     );
+
+    await openRetainedTranscript();
+    await active.sendKeys("C-o");
+    await expectClearedInline();
+
+    await active.resizeWindow(72, 20, 300);
+    await expectClearedInline();
+    await openRetainedTranscript();
+    await active.sendKeys("C-o");
+    await expectClearedInline();
     expect(gateway?.requests).toHaveLength(1);
 
     await active.sendKeys("Enter");
     await active.waitForPane(
-      (pane) => gateway?.requests.length === 2 && pane.includes("history prompt complete"),
+      (pane) => gateway?.requests.length === 2 && pane.includes(response),
       READY_TIMEOUT,
     );
+    await active.waitForStableComposer(READY_TIMEOUT);
+    const scrollback = stripAnsi(await active.captureFullScrollbackEscapes());
+    expect(scrollback.split(response)).toHaveLength(2);
+    expect(scrollback).not.toContain("zz-history");
     const followup = gateway!.requests[1]!.body;
     expect(followup).toContain("zz-history");
     expect(followup).toContain("history prompt complete");


### PR DESCRIPTION
## Summary

- Keep retained conversation and tool output available in Ctrl+O after Ctrl+L or native terminal clear.
- Keep cleared content out of the inline display when resizing, closing the full transcript, or continuing the conversation.
- Continue showing new streamed output and live tool updates after clearing without changing the draft or conversation context.