### PR TITLE
Restore legacy session resume and retry empty summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ Compaction handoffs remain internal context for the model. Resuming a session an
 
 In saved sessions, oversized `read_tool_result` responses keep a complete terminal-safe backing copy even when the inline response is clipped. Compaction and later retrieval preserve that copy without masking the explicitly requested text again.
 
+Resuming an older session upgrades its saved permissions and skips empty legacy file-change entries while keeping the conversation and tool results. If the model returns an empty compaction summary, fx retries the summary once without repeating tools. Cancellation or another failed summary leaves the previous context intact.
+
 Use `fx ask` for a single request:
 
 ```bash

--- a/src/core/agent/runtime/context_compaction.zig
+++ b/src/core/agent/runtime/context_compaction.zig
@@ -358,10 +358,6 @@ fn runSummaryCall(
         .content = summarySystemPrompt(),
     }};
     const messages = [_]types.ChatMessage{.{ .role = .user, .content = source_text }};
-    var capture = StreamCapture{ .alloc = alloc, .max_bytes = max_bytes };
-    defer capture.deinit();
-    var delivery = runtime_gateway_step.DeliveryCertainty.init();
-    var attempt_evidence: agent_stream_provider.AttemptEvidence = .{};
     const deadline = std.Io.Clock.Timestamp.fromNow(io_mod.getIo(), .{
         .clock = .awake,
         .raw = .fromMilliseconds(provider_timeout_ms),
@@ -375,61 +371,70 @@ fn runSummaryCall(
             .account_id = request.account_id,
             .tenant_context = request.gateway_team,
         } };
-    var streamed = try runtime_gateway_step.streamModelCompletion(
-        request.stream_provider,
-        alloc,
-        .{
-            .credential = credential,
-            .session_id = request.session_id,
-            .model = request.model,
-            .retry_count = request.retry_count,
-            .instructions = &instructions,
-            .messages = &messages,
-            .tools = .{},
-            .tool_choice = .none,
-            .provider_options = request.provider_options,
-            .max_output_tokens = @intCast(@min(generation_tokens, std.math.maxInt(u32))),
-            .budget = .{ .cancel_flag = request.cancel_flag, .deadline = deadline },
-            .deadline = deadline,
-            .content_capture_limit = max_bytes,
-            .delivery = &delivery,
-            .attempt_evidence = &attempt_evidence,
-            .events = .{ .context = &capture, .emit_fn = onEvent },
-            .admission = .{},
-            .cancel_flag = request.cancel_flag,
-            .trace_ctx = request.trace_ctx,
-        },
-        request.usage,
-        request.usage_allocator,
-    );
-    defer streamed.deinit(alloc);
-    if (request.cancel_flag.load(.seq_cst)) return error.Cancelled;
-    const completion = switch (streamed) {
-        .failed => return error.ContextCompactionUnavailable,
-        .completed => |completed| completed.completion,
-    };
-    if (completion.finish_reason != .stop) return error.IncompleteCompactionHandoff;
-    if (capture.failed) return error.OutOfMemory;
-    if (!capture.saw_content) {
-        if (completion.content) |content| try capture.append(content);
-    }
-    if (capture.saw_tool_call or completion.tool_calls.len > 0) {
-        return error.CompactionToolCallRejected;
-    }
-    if (capture.observed_bytes > capture.text.items.len) {
-        return error.CompactionHandoffTooLarge;
-    }
-    const trimmed = std.mem.trim(u8, capture.text.items, " \t\r\n");
-    if (trimmed.len == 0 or !std.unicode.utf8ValidateSlice(trimmed)) {
-        return error.InvalidCompactionHandoff;
-    }
-    return .{
-        .text = try alloc.dupe(u8, trimmed),
-        .usage = .{
+    var usage: types.ToolUsage = .{};
+    for (0..2) |attempt| {
+        if (request.cancel_flag.load(.seq_cst)) return error.Cancelled;
+        var capture = StreamCapture{ .alloc = alloc, .max_bytes = max_bytes };
+        defer capture.deinit();
+        var delivery = runtime_gateway_step.DeliveryCertainty.init();
+        var attempt_evidence: agent_stream_provider.AttemptEvidence = .{};
+        var streamed = try runtime_gateway_step.streamModelCompletion(
+            request.stream_provider,
+            alloc,
+            .{
+                .credential = credential,
+                .session_id = request.session_id,
+                .model = request.model,
+                .retry_count = if (attempt == 0) request.retry_count else 1,
+                .instructions = &instructions,
+                .messages = &messages,
+                .tools = .{},
+                .tool_choice = .none,
+                .provider_options = request.provider_options,
+                .max_output_tokens = @intCast(@min(generation_tokens, std.math.maxInt(u32))),
+                .budget = .{ .cancel_flag = request.cancel_flag, .deadline = deadline },
+                .deadline = deadline,
+                .content_capture_limit = max_bytes,
+                .delivery = &delivery,
+                .attempt_evidence = &attempt_evidence,
+                .events = .{ .context = &capture, .emit_fn = onEvent },
+                .admission = .{},
+                .cancel_flag = request.cancel_flag,
+                .trace_ctx = request.trace_ctx,
+            },
+            request.usage,
+            request.usage_allocator,
+        );
+        defer streamed.deinit(alloc);
+        if (request.cancel_flag.load(.seq_cst)) return error.Cancelled;
+        const completion = switch (streamed) {
+            .failed => return error.ContextCompactionUnavailable,
+            .completed => |completed| completed.completion,
+        };
+        addUsage(&usage, .{
             .input_tokens = completion.usage.input_tokens orelse 0,
             .output_tokens = completion.usage.output_tokens orelse 0,
-        },
-    };
+        });
+        if (completion.finish_reason != .stop) return error.IncompleteCompactionHandoff;
+        if (capture.failed) return error.OutOfMemory;
+        if (!capture.saw_content) {
+            if (completion.content) |content| try capture.append(content);
+        }
+        if (capture.saw_tool_call or completion.tool_calls.len > 0) {
+            return error.CompactionToolCallRejected;
+        }
+        if (capture.observed_bytes > capture.text.items.len) {
+            return error.CompactionHandoffTooLarge;
+        }
+        const trimmed = std.mem.trim(u8, capture.text.items, " \t\r\n");
+        if (!std.unicode.utf8ValidateSlice(trimmed)) return error.InvalidCompactionHandoff;
+        if (trimmed.len == 0) {
+            if (attempt == 0) debug_trace.eventf("context_compaction", "empty_summary_retry", request.trace_ctx, "attempt=2 model={s}", .{request.model});
+            continue;
+        }
+        return .{ .text = try alloc.dupe(u8, trimmed), .usage = usage };
+    }
+    return error.InvalidCompactionHandoff;
 }
 
 fn addUsage(total: *types.ToolUsage, item: types.ToolUsage) void {
@@ -479,6 +484,7 @@ fn onEvent(raw: *anyopaque, event: agent_stream_provider.Event) void {
 
 const FakeProvider = struct {
     response: []const u8,
+    retry_response: ?[]const u8 = null,
     finish_reason: types.ProviderFinishReason = .stop,
     emit_tool_call: bool = false,
     cancel: bool = false,
@@ -492,6 +498,11 @@ const FakeProvider = struct {
     observed_model: ?[]const u8 = null,
     observed_credential_source: ?types.CredentialSource = null,
     observed_secret: ?[]const u8 = null,
+    observed_deadline: ?std.Io.Clock.Timestamp = null,
+    observed_source_hash: ?u64 = null,
+    same_deadline: bool = true,
+    same_source: bool = true,
+    retry_counts: [2]usize = .{ std.math.maxInt(usize), std.math.maxInt(usize) },
 
     fn provider(self: *FakeProvider) agent_stream_provider.Provider {
         return .{ .context = self, .stream_fn = stream };
@@ -503,7 +514,15 @@ const FakeProvider = struct {
         request: agent_stream_provider.ModelRequest,
     ) !agent_stream_provider.Result {
         const self: *FakeProvider = @ptrCast(@alignCast(raw.?));
+        if (self.request_count < self.retry_counts.len) self.retry_counts[self.request_count] = request.retry_count;
         self.request_count += 1;
+        if (self.request_count == 1) {
+            self.observed_deadline = request.deadline;
+            self.observed_source_hash = std.hash.Wyhash.hash(0, request.messages[0].content orelse "");
+        } else {
+            self.same_deadline = self.same_deadline and std.meta.eql(self.observed_deadline, request.deadline);
+            self.same_source = self.same_source and self.observed_source_hash.? == std.hash.Wyhash.hash(0, request.messages[0].content orelse "");
+        }
         self.saw_no_tools = self.saw_no_tools or
             (request.tools.advertised_names.len == 0 and
                 request.tools.advertised_functions.len == 0 and
@@ -529,13 +548,14 @@ const FakeProvider = struct {
         self.observed_secret = request.credential.secret();
         try request.admission.admit();
         request.delivery.markPossiblySent();
-        request.events.emit(.{ .content_delta = self.response });
+        const response = if (self.request_count > 1) self.retry_response orelse self.response else self.response;
+        request.events.emit(.{ .content_delta = response });
         if (self.emit_tool_call) {
             request.events.emit(.{ .tool_started = .{ .id = "call-1", .name = "read_file" } });
         }
         if (self.cancel) request.cancel_flag.store(true, .seq_cst);
         return .{ .completed = .{ .completion = .{
-            .content = self.response,
+            .content = response,
             .finish_reason = self.finish_reason,
             .usage = .{ .input_tokens = 30, .output_tokens = 12 },
         } } };
@@ -544,6 +564,78 @@ const FakeProvider = struct {
 
 test "compaction result exposes only caller-consumed state" {
     try std.testing.expect(!@hasField(Result, "usage"));
+}
+
+test "empty summary recovery preserves the source model deadline and usage" {
+    for ([_][]const u8{ "", " \n\t " }) |empty| {
+        var provider = FakeProvider{ .response = empty, .retry_response = "The recorded command completed." };
+        var cancel = std.atomic.Value(bool).init(false);
+        const result = try runSummaryCall(std.testing.allocator, .{
+            .stream_provider = provider.provider(),
+            .model = "working-model",
+            .api_key = "test-key",
+            .retry_count = 3,
+            .cancel_flag = &cancel,
+            .accepted_tokens = 256,
+            .generation_tokens = 128,
+            .trace_ctx = .{},
+        }, "Preserve this completed command.", 128, 1024);
+        defer std.testing.allocator.free(result.text);
+        try std.testing.expectEqualStrings("The recorded command completed.", result.text);
+        try std.testing.expectEqual(@as(usize, 2), provider.request_count);
+        try std.testing.expectEqualSlices(usize, &.{ 3, 1 }, &provider.retry_counts);
+        try std.testing.expect(provider.same_source and provider.same_deadline and provider.saw_deadline);
+        try std.testing.expect(provider.saw_no_tools and provider.saw_only_summary_prompt);
+        try std.testing.expectEqualStrings("working-model", provider.observed_model.?);
+        try std.testing.expectEqual(@as(u64, 60), result.usage.input_tokens);
+        try std.testing.expectEqual(@as(u64, 24), result.usage.output_tokens);
+    }
+}
+
+test "empty summary recovery stops after two empty replies" {
+    var provider = FakeProvider{ .response = "" };
+    var cancel = std.atomic.Value(bool).init(false);
+    try std.testing.expectError(error.InvalidCompactionHandoff, runSummaryCall(std.testing.allocator, .{
+        .stream_provider = provider.provider(),
+        .model = "working-model",
+        .api_key = "test-key",
+        .retry_count = 0,
+        .cancel_flag = &cancel,
+        .accepted_tokens = 256,
+        .generation_tokens = 128,
+        .trace_ctx = .{},
+    }, "Preserve the original conversation.", 128, 1024));
+    try std.testing.expectEqual(@as(usize, 2), provider.request_count);
+}
+
+test "empty summary recovery does not retry cancelled or invalid responses" {
+    const cases = [_]struct {
+        response: []const u8,
+        cancel: bool = false,
+        tool_call: bool = false,
+        finish_reason: types.ProviderFinishReason = .stop,
+        expected: error{ Cancelled, InvalidCompactionHandoff, IncompleteCompactionHandoff, CompactionToolCallRejected },
+    }{
+        .{ .response = "", .cancel = true, .expected = error.Cancelled },
+        .{ .response = "\xff", .expected = error.InvalidCompactionHandoff },
+        .{ .response = "", .finish_reason = .length, .expected = error.IncompleteCompactionHandoff },
+        .{ .response = "", .tool_call = true, .expected = error.CompactionToolCallRejected },
+    };
+    for (cases) |case| {
+        var provider = FakeProvider{ .response = case.response, .cancel = case.cancel, .emit_tool_call = case.tool_call, .finish_reason = case.finish_reason };
+        var cancel = std.atomic.Value(bool).init(false);
+        try std.testing.expectError(case.expected, runSummaryCall(std.testing.allocator, .{
+            .stream_provider = provider.provider(),
+            .model = "working-model",
+            .api_key = "test-key",
+            .retry_count = 0,
+            .cancel_flag = &cancel,
+            .accepted_tokens = 256,
+            .generation_tokens = 128,
+            .trace_ctx = .{},
+        }, "Preserve the original conversation.", 128, 1024));
+        try std.testing.expectEqual(@as(usize, 1), provider.request_count);
+    }
 }
 
 test "host-managed compaction carries authority without secret bytes" {

--- a/src/core/app/app_process_runtime.zig
+++ b/src/core/app/app_process_runtime.zig
@@ -91,6 +91,10 @@ pub fn Runtime(comptime App: type) type {
                 error.ConnectionSetupTimedOut => return alloc.dupe(u8, "Connection setup timed out after 30 seconds."),
                 error.TlsInitializationFailed => return alloc.dupe(u8, "Connection setup failed: TLS could not be initialized."),
                 error.ModelImageCapabilityUnavailable => return alloc.dupe(u8, image_attachments.model_image_capability_unavailable_notice),
+                error.InvalidCompactionHandoff => return alloc.dupe(
+                    u8,
+                    "The model did not return a usable context summary. Your existing context was kept. Try /compact again or send a follow-up.",
+                ),
                 error.CompactionResultStorageUnavailable => return alloc.dupe(
                     u8,
                     "Context could not be compacted because older tool results could not be preserved. Save the session or restore writable session storage, then try again.",
@@ -214,6 +218,15 @@ test "formatErrorBody describes terminal connection setup failures plainly" {
     const unrelated_timeout = try Rt.formatErrorBody(alloc, "request failed", error.ConnectionTimedOut);
     defer alloc.free(unrelated_timeout);
     try std.testing.expectEqualStrings("request failed: ConnectionTimedOut", unrelated_timeout);
+}
+
+test "formatErrorBody explains how to retry an unusable compaction summary" {
+    const alloc = std.testing.allocator;
+    const body = try Runtime(DummyApp).formatErrorBody(alloc, "request failed", error.InvalidCompactionHandoff);
+    defer alloc.free(body);
+    try std.testing.expect(std.mem.find(u8, body, "context was kept") != null);
+    try std.testing.expect(std.mem.find(u8, body, "/compact") != null);
+    try std.testing.expect(std.mem.find(u8, body, "follow-up") != null);
 }
 
 test "formatErrorBody explains compaction result storage failure" {

--- a/src/core/session/session_log.zig
+++ b/src/core/session/session_log.zig
@@ -1862,6 +1862,7 @@ pub const CommitPosition = session_replay.CommitPosition;
 
 test {
     _ = session_replay;
+    _ = session_permission_state;
 }
 
 pub const CleanupReport = struct {
@@ -2323,6 +2324,37 @@ pub fn importLegacySnapshotState(
     );
 }
 
+fn discardEmptyLegacyFileEvidence(alloc: Allocator, history: []session.HistoryTurn) !usize {
+    var discarded: usize = 0;
+    for (history) |*turn| {
+        const execution = switch (turn.*) {
+            .assistant => |*entry| &entry.execution,
+            .interrupted => |*entry| &entry.execution,
+            .compacted_summary => continue,
+        };
+        const files = execution.files;
+        var retained_count: usize = 0;
+        for (files) |file| if (file.path.len > 0) {
+            retained_count += 1;
+        };
+        if (retained_count == files.len) continue;
+        const retained = try alloc.alloc(types.FileEvidence, retained_count);
+        var index: usize = 0;
+        for (files) |file| {
+            if (file.path.len == 0) {
+                types.freeFileEvidence(alloc, file);
+            } else {
+                retained[index] = file;
+                index += 1;
+            }
+        }
+        discarded += files.len - retained_count;
+        alloc.free(files);
+        execution.files = retained;
+    }
+    return discarded;
+}
+
 fn importLegacySnapshotStateWithOps(
     alloc: Allocator,
     writable: *WritableSessionDir,
@@ -2333,8 +2365,17 @@ fn importLegacySnapshotStateWithOps(
     metadata_ops: io_mod.DurableOps,
 ) !LoadedWritableSession {
     try recoverInterruptedLegacyImport(alloc, writable);
-    var converted = try state.dupe(alloc);
+    var migrated_permissions = if (state.permission_state.version != session_permission_state.schema_version)
+        try session_permission_state.migrateV1ToV2(alloc, state.permission_state)
+    else
+        null;
+    defer if (migrated_permissions) |*permissions| permissions.deinit(alloc);
+    var import_state = state;
+    if (migrated_permissions) |permissions| import_state.permission_state = permissions;
+    var converted = try import_state.dupe(alloc);
     errdefer converted.deinit(alloc);
+    const discarded = try discardEmptyLegacyFileEvidence(alloc, converted.history);
+    if (discarded > 0) debug_trace.logf("session", "legacy import discarded file evidence count={d} reason=empty_path", .{discarded});
     try projectConversationSnapshotLocators(alloc, converted.history);
 
     const display_path = try io_mod.dirRealpathAlloc(
@@ -3537,6 +3578,115 @@ test "legacy import recovery restores old authority or keeps published current d
         try std.testing.expectEqualStrings(current, retained);
         try std.testing.expect(!try legacyImportRecoveryNeeded(&writable.dir));
     }
+}
+
+test "legacy import migrates permissions before publishing controls" {
+    const alloc = std.testing.allocator;
+    var temp = try TempRoot.init(alloc);
+    defer temp.deinit(alloc);
+    var initial = try testState(alloc, "legacy-permission-import", 20);
+    defer initial.deinit(alloc);
+    initial.permission_state.version = 1;
+    const history = [_]session.HistoryTurn{.{ .assistant = .{
+        .user = .{ .text = @constCast("existing question") },
+        .assistant = @constCast("existing answer"),
+    } }};
+    initial.history = try session.snapshotOwnedContextHistory(alloc, &history, 0, 0);
+    try temp.root.sessions.?.dir.createDir(std.testing.io, initial.id, private_dir_permissions);
+    {
+        var writable = try temp.root.openWritableSessionDir(alloc, initial.id, lock_deadline_ms);
+        var writable_owned = true;
+        defer if (writable_owned) writable.deinit(alloc);
+        try io_mod.durableReplaceVerified(alloc, &writable.dir, manifest_file, "{\"schema_version\":3}\n");
+        var migrated = try importLegacySnapshotState(alloc, &writable, initial, 3, 0, null);
+        writable_owned = false;
+        defer migrated.deinit(alloc);
+        try std.testing.expectEqual(@as(u8, 2), migrated.state.permission_state.version);
+        try std.testing.expectEqual(@as(u8, 1), initial.permission_state.version);
+        try std.testing.expectEqualStrings("existing answer", migrated.state.history[0].assistant.assistant);
+    }
+    var reopened = try temp.root.resumeForWrite(alloc, initial.id, .{});
+    defer reopened.deinit(alloc);
+    try std.testing.expectEqual(@as(u8, 2), reopened.state.permission_state.version);
+    try std.testing.expectEqualStrings("existing question", reopened.state.history[0].assistant.user.text);
+}
+
+test "legacy import omits empty file paths without losing execution history" {
+    const alloc = std.testing.allocator;
+    var temp = try TempRoot.init(alloc);
+    defer temp.deinit(alloc);
+    var initial = try testState(alloc, "legacy-empty-file-import", 20);
+    defer initial.deinit(alloc);
+    var calls = [_]types.ToolCall{.{ .id = "recorded-read", .name = "read_file", .arguments_json = "{\"path\":\"source.txt\"}" }};
+    var results = [_]types.PersistedToolResult{.{
+        .tool_call_id = @constCast("recorded-read"),
+        .tool_name = @constCast("read_file"),
+        .status = .success,
+        .output = @constCast("recorded output"),
+        .output_bytes = 15,
+        .stored_output_bytes = 15,
+    }};
+    var steps = [_]types.ToolExecutionStep{.{ .tool_calls = &calls, .tool_results = &results }};
+    var files = [_]types.FileEvidence{
+        .{ .path = @constCast("source.txt"), .tool_call_id = @constCast("recorded-read"), .tool_name = @constCast("read_file") },
+        .{ .path = @constCast(""), .tool_call_id = @constCast("recorded-read"), .tool_name = @constCast("read_file") },
+        .{ .path = @constCast("before.txt"), .new_path = @constCast("after.txt"), .tool_call_id = @constCast("recorded-read"), .tool_name = @constCast("read_file") },
+    };
+    const history = [_]session.HistoryTurn{
+        .{ .assistant = .{ .user = .{ .text = @constCast("read existing file") }, .assistant = @constCast("read finished"), .execution = .{ .tool_steps = &steps, .files = &files } } },
+        .{ .interrupted = .{ .user = .{ .text = @constCast("cancelled follow-up") }, .execution = .{ .files = files[1..2] } } },
+    };
+    try std.testing.expectError(error.InvalidConversationEvent, session_event.encodeConversationFrame(alloc, .{
+        .seq = 1,
+        .timestamp_ms = 20,
+        .event = .{ .turn_completed = .{ .files = &files } },
+    }));
+    initial.history = try session.snapshotOwnedContextHistory(alloc, &history, 0, 0);
+    try temp.root.sessions.?.dir.createDir(std.testing.io, initial.id, private_dir_permissions);
+    {
+        var writable = try temp.root.openWritableSessionDir(alloc, initial.id, lock_deadline_ms);
+        var writable_owned = true;
+        defer if (writable_owned) writable.deinit(alloc);
+        try io_mod.durableReplaceVerified(alloc, &writable.dir, manifest_file, "{\"schema_version\":3}\n");
+        var migrated = try importLegacySnapshotState(alloc, &writable, initial, 3, 0, null);
+        writable_owned = false;
+        defer migrated.deinit(alloc);
+        try std.testing.expectEqual(@as(usize, 3), initial.history[0].assistant.execution.files.len);
+        try std.testing.expectEqualStrings("", initial.history[0].assistant.execution.files[1].path);
+    }
+    var reopened = try temp.root.resumeForWrite(alloc, initial.id, .{});
+    defer reopened.deinit(alloc);
+    const execution = reopened.state.history[0].assistant.execution;
+    try std.testing.expectEqual(@as(usize, 2), reopened.state.history.len);
+    try std.testing.expectEqual(@as(usize, 1), execution.tool_steps.len);
+    try std.testing.expectEqualStrings("recorded-read", execution.tool_steps[0].tool_calls[0].id);
+    try std.testing.expectEqualStrings("recorded output", execution.tool_steps[0].tool_results[0].preview.?);
+    try std.testing.expectEqual(@as(usize, 2), execution.files.len);
+    try std.testing.expectEqualStrings("source.txt", execution.files[0].path);
+    try std.testing.expectEqualStrings("before.txt", execution.files[1].path);
+    try std.testing.expectEqualStrings("after.txt", execution.files[1].new_path.?);
+    try std.testing.expectEqual(@as(usize, 0), reopened.state.history[1].interrupted.execution.files.len);
+    try std.testing.expectEqualStrings("cancelled follow-up", reopened.state.history[1].interrupted.user.text);
+}
+
+test "legacy import file projection cleans up allocation failures" {
+    const Check = struct {
+        fn run(alloc: Allocator) !void {
+            const files = [_]types.FileEvidence{
+                .{ .path = @constCast(""), .new_path = @constCast("unusable.txt"), .tool_call_id = @constCast("old-call"), .tool_name = @constCast("read_file") },
+                .{ .path = @constCast("retained.txt"), .tool_call_id = @constCast("old-call"), .tool_name = @constCast("read_file") },
+            };
+            var history = [_]session.HistoryTurn{.{ .assistant = .{
+                .user = .{ .text = @constCast("request") },
+                .assistant = @constCast("response"),
+                .execution = .{ .files = try types.dupeFileEvidenceSlice(alloc, &files) },
+            } }};
+            defer types.freeFileEvidenceSlice(alloc, history[0].assistant.execution.files);
+            try std.testing.expectEqual(@as(usize, 1), try discardEmptyLegacyFileEvidence(alloc, &history));
+            try std.testing.expectEqualStrings("retained.txt", history[0].assistant.execution.files[0].path);
+        }
+    };
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, Check.run, .{});
 }
 
 test "legacy import preserves the active retained tail and complete archive" {

--- a/src/core/shared/types.zig
+++ b/src/core/shared/types.zig
@@ -2571,7 +2571,8 @@ fn dupeFileEvidence(alloc: std.mem.Allocator, file: FileEvidence) !FileEvidence 
     };
 }
 
-fn freeFileEvidence(alloc: std.mem.Allocator, file: FileEvidence) void {
+/// Frees one entry's owned strings, not its containing slice.
+pub fn freeFileEvidence(alloc: std.mem.Allocator, file: FileEvidence) void {
     alloc.free(file.path);
     if (file.new_path) |new_path| alloc.free(new_path);
     alloc.free(file.tool_call_id);

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -4278,7 +4278,10 @@ describe("cli: ask success", () => {
                 truncated: false, provider_native: false, created_at_ms: 2, permission_feedback: [],
               }],
             }],
-            files: [], steering: [],
+            files: [
+              { path: "", new_path: null, tool_call_id: "legacy-read", tool_name: "read_file", action: "unknown", status: "success", model_view_covers_full_file: false, stale: false },
+              { path: "past.txt", new_path: null, tool_call_id: "legacy-read", tool_name: "read_file", action: "unknown", status: "success", model_view_covers_full_file: false, stale: false },
+            ], steering: [],
           },
         }];
         writeFileSync(legacyPath, JSON.stringify(legacy) + "\n", { mode: 0o600 });
@@ -4297,7 +4300,7 @@ describe("cli: ask success", () => {
           ["ask", "--json", "--auto", "--resume-id", sessionId, "Convert and continue."],
           { cwd: workspaceRoot, env, timeoutMs: 60_000 },
         );
-        expect(first.code).toBe(0);
+        expect(first.code, first.stderr + first.stdout).toBe(0);
         expect(first.stderr).toBe("");
         expect(JSON.parse(first.stdout)).toMatchObject({
           session_id: sessionId,
@@ -4351,6 +4354,8 @@ describe("cli: ask success", () => {
         expect(preserved.call_id).toBe("legacy-read");
         expect(preserved.completeness).not.toBe("complete");
         expect(readFileSync(join(sessionDir, "tool-results", preserved.artifact_ref), "utf8")).toBe(legacyOutput);
+        const files = records.find((record) => record.event.turn_completed)?.event.turn_completed.files;
+        expect(files.map((file: { path: string }) => file.path)).toEqual(["past.txt"]);
       } finally {
         gateway.stop();
         rmSync(root, { recursive: true, force: true });

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -4850,7 +4850,7 @@ printf '%s' ${JSON.stringify(trailingMarker)} > ${JSON.stringify(effectPath)}
 
   for (const trigger of ["automatic", "manual"] as const) {
     test.skipIf(!tmuxAvailable())(
-      `oversized result retrieval survives ${trigger} compaction and restart`,
+      `oversized result retrieval survives empty ${trigger} summary recovery and restart`,
       async () => {
         const root = createFixtureRoot(`retrieval-compaction-${trigger}`);
         const tracePath = join(root.root, "trace.log");
@@ -4869,6 +4869,7 @@ printf '%s' ${JSON.stringify(trailingMarker)} > ${JSON.stringify(effectPath)}
             compactions++;
             snapshotHandle = body.match(/result-read_tool_result-[a-f0-9-]+\.txt/)?.[0] ?? "";
             expect(snapshotHandle).not.toBe("");
+            if (compactions === 1) return fakeGatewayFinalText("");
             return fakeGatewayFinalText(`The command ran once. Read ${snapshotHandle} at byte 65300 to recover the clipped tail. Do not repeat the command.`);
           }
           switch (step++) {
@@ -4896,7 +4897,7 @@ printf '%s' ${JSON.stringify(trailingMarker)} > ${JSON.stringify(effectPath)}
             }
             case 3:
               if (trigger === "automatic") {
-                expect(compactions).toBe(1);
+                expect(compactions).toBe(2);
                 expect(body).toContain("context_handoff");
               }
               return fakeGatewayFinalText("RETRIEVAL_TURN_COMPLETE");
@@ -4927,7 +4928,10 @@ printf '%s' ${JSON.stringify(trailingMarker)} > ${JSON.stringify(effectPath)}
             expect(compacted).not.toContain("request failed:");
             expect(compacted).toContain("Context compacted.");
           }
-          expect(compactions).toBe(1);
+          expect(compactions).toBe(2);
+          const summaryRequests = gateway.requests.filter((entry) => JSON.parse(entry.body).tools.length === 0);
+          expect(summaryRequests).toHaveLength(2);
+          expect(summaryRequests[1]!.body).toBe(summaryRequests[0]!.body);
           await tui.sendText("/quit");
           expect(await tui.waitForSessionEnd(15000)).toBe(true);
           tui = null;
@@ -4945,7 +4949,7 @@ printf '%s' ${JSON.stringify(trailingMarker)} > ${JSON.stringify(effectPath)}
           expect(resumed.code).toBe(0);
           expect(resumed.stderr).toBe("Reading tool result\n");
           expect(JSON.parse(resumed.stdout).final_output).toBe("RETRIEVAL_RESTART_COMPLETE");
-          expect(gateway.requests).toHaveLength(7);
+          expect(gateway.requests).toHaveLength(8);
           expect(readFileSync(join(root.workspace, "effects.txt"), "utf8")).toBe("once\n");
           expect(readFileSync(tracePath, "utf8")).not.toContain("IncompleteCompactionResult");
         } finally {
@@ -5296,6 +5300,20 @@ printf '%s' ${JSON.stringify(trailingMarker)} > ${JSON.stringify(effectPath)}
         expect(readFileSync(tracePath, "utf8")).not.toContain(
           "[context_compaction] event=installed",
         );
+        responses.push(fakeGatewayFinalText(""), fakeGatewayFinalText(""));
+        await tui.sendText("/compact");
+        const failedSummary = await tui.waitForPane(
+          (pane) => pane.includes("context was kept") && hasEmptyComposer(pane),
+          15_000,
+        );
+        expect(failedSummary.replace(/\s+/g, " ")).toContain("Try /compact again or send a follow-up");
+        expect(gateway.requests).toHaveLength(6);
+        const afterFailure = await runFx(["session", "--id", sessionId, "--json"], {
+          cwd: root.workspace, env: { HOME: root.home },
+        });
+        expect(afterFailure.code).toBe(0);
+        expect(JSON.parse(afterFailure.stdout).history).toHaveLength(3);
+        expect(JSON.parse(afterFailure.stdout).history.some((turn: { kind: string }) => turn.kind === "compacted_summary")).toBe(false);
         expect(readFileSync(stderrPath, "utf8")).toBe("");
       } finally {
         held.dispose();


### PR DESCRIPTION
## Summary

- Resume older sessions whose saved permissions still use the previous format.
- Keep legacy conversations and tool results when their file-change metadata contains empty paths.
- Retry one empty compaction summary with the current model without repeating tools.
- Explain how to retry an unusable summary while keeping the existing context.
