### PR TITLE
Preserve scrollback through full transcript resizes

### DIFF
--- a/src/core/app/app_lifecycle.zig
+++ b/src/core/app/app_lifecycle.zig
@@ -971,21 +971,12 @@ pub fn closeFullTranscript(
         "close_full_transcript restore={s}",
         .{@tagName(primary_restore)},
     );
-    const primary_recovery = if (primary_restore == .changed_resized)
-        try shell.prepareRestoredPrimaryTranscriptRecovery(alloc)
-    else
-        null;
-    defer if (primary_recovery) |bytes| alloc.free(bytes);
     if (terminal.fullTranscriptScreenActive()) {
         try leaveFullTranscriptScreen(terminal, shell, metrics);
     }
     try setFullTranscriptProjection(alloc, shell, .inline_mode);
     switch (primary_restore) {
         .changed => {},
-        .changed_resized => if (primary_recovery) |bytes| {
-            try writeLifecycleTerminalBytes(shell, metrics, bytes);
-            shell.repaintRestoredPrimaryTranscriptAfterResize();
-        },
         .exact => shell.retainRestoredPrimaryTranscript(),
         .resized => shell.repaintRestoredPrimaryTranscriptAfterResize(),
     }
@@ -1664,9 +1655,10 @@ test "full transcript transitions own terminal and projection together" {
     try closeFullTranscript(alloc, &terminal, &shell, &metrics);
     try std.testing.expect(shell.transcript_band_dirty);
     try std.testing.expect(shell.render_requests.hasReason(.transcript));
-    try std.testing.expect(!shell.terminal_reset_pending);
+    try std.testing.expect(shell.terminal_reset_pending);
     try std.testing.expectEqual(@as(?i32, null), shell.resize_history_row_delta);
     shell.layout.cols -= 1;
+    shell.terminal_reset_pending = false;
     shell.transcript_band_dirty = false;
     shell.render_requests.clearReason(.transcript);
 

--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -1432,7 +1432,7 @@ pub fn Runtime(comptime App: type) type {
                     else
                         footer_frame.paint.preserve_scrollback,
                     .reset_terminal = shouldResetPhysicalTerminal(
-                        false,
+                        render_reconciliation.alternate_screen_owns_rendering,
                         app.shell.terminal_reset_pending,
                     ),
                 });
@@ -2731,13 +2731,13 @@ test "core.app_render_runtime rejects prepared transcript outside final plan ban
 }
 
 noinline fn shouldResetPhysicalTerminal(
-    child_view_active: bool,
+    alternate_screen_active: bool,
     main_reset_pending: bool,
 ) bool {
-    return !child_view_active and main_reset_pending;
+    return !alternate_screen_active and main_reset_pending;
 }
 
-test "core.app_render_runtime child presentation cannot reset primary scrollback" {
+test "core.app_render_runtime alternate presentation cannot reset primary scrollback" {
     try std.testing.expect(!shouldResetPhysicalTerminal(true, true));
     try std.testing.expect(!shouldResetPhysicalTerminal(true, false));
     try std.testing.expect(!shouldResetPhysicalTerminal(false, false));
@@ -5136,7 +5136,7 @@ test "core.app_render_runtime full transcript defers repaint until its page is r
     ));
 }
 
-test "core.app_render_runtime changed resized full transcript close preserves primary history without full replay" {
+test "core.app_render_runtime full transcript resize defers history reset until primary restoration" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -5190,21 +5190,34 @@ test "core.app_render_runtime changed resized full transcript close preserves pr
         .hint_row = 18,
     };
     try app.shell.requestTerminalResetAfterResize(&app.metrics, null);
+    var read_offset = try file.length(io_mod.getIo());
     try app.shell.writeTranscript(
         alloc,
         &app.metrics,
         "new output while review is open\n",
         true,
     );
+    for (0..100_000) |_| {
+        try app.shell.prewarmFullTranscriptPage(null, null);
+        _ = try app.shell.pollFullTranscriptPageLoad();
+        if (app.shell.fullTranscriptPreparedForOpen()) break;
+        std.Thread.yield() catch std.atomic.spinLoopHint();
+    }
+    try std.testing.expect(app.shell.fullTranscriptPreparedForOpen());
+    app.shell.render_requests.request(.transcript);
     try Runtime(CoordinatorTestApp).flushRequestedFrame(&app);
+    const resize_bytes = try readCoordinatorFrameBytes(alloc, file, &read_offset);
+    defer alloc.free(resize_bytes);
+    try std.testing.expect(app.terminal.fullTranscriptScreenActive());
+    try std.testing.expect(resize_bytes.len > 0);
+    try std.testing.expect(std.mem.find(u8, resize_bytes, "\x1b[3J") == null);
 
-    var read_offset = try file.length(io_mod.getIo());
     try app_lifecycle.closeFullTranscript(app.alloc, &app.terminal, &app.shell, &app.metrics);
     try Runtime(CoordinatorTestApp).flushRequestedFrame(&app);
     const close_bytes = try readCoordinatorFrameBytes(alloc, file, &read_offset);
     defer alloc.free(close_bytes);
 
-    try std.testing.expect(std.mem.find(u8, close_bytes, "\x1b[3J") == null);
+    try std.testing.expect(std.mem.find(u8, close_bytes, "\x1b[3J") != null);
     try std.testing.expect(close_bytes.len < 16 * 1024);
     try std.testing.expect(try coordinatorGridContains(
         app.shell.shadow_vt.?.*,

--- a/src/ui/transcript/runtime.zig
+++ b/src/ui/transcript/runtime.zig
@@ -2036,10 +2036,10 @@ test "full transcript primary restore repairs resize debt after geometry returns
     runtime.terminal_reset_pending = true;
     try std.testing.expectEqual(FullTranscriptPrimaryRestore.resized, runtime.fullTranscriptPrimaryRestore());
     runtime.full_transcript_content_revision = 8;
-    try std.testing.expectEqual(FullTranscriptPrimaryRestore.changed_resized, runtime.fullTranscriptPrimaryRestore());
+    try std.testing.expectEqual(FullTranscriptPrimaryRestore.resized, runtime.fullTranscriptPrimaryRestore());
 }
 
-test "full transcript primary restore consumes the pending settled resize" {
+test "full transcript resized close queues primary recovery" {
     var runtime = TranscriptRuntime{ .layout = .{
         .rows = 24,
         .cols = 80,
@@ -2065,7 +2065,7 @@ test "full transcript primary restore consumes the pending settled resize" {
 
     try std.testing.expect(!runtime.render_requests.pending_settled_width_reflow);
     try std.testing.expectEqual(@as(?ResizeObservation, null), runtime.pending_resize_observation);
-    try std.testing.expect(!runtime.terminal_reset_pending);
+    try std.testing.expect(runtime.terminal_reset_pending);
     try std.testing.expectEqual(@as(?i32, null), runtime.resize_history_row_delta);
     const invalidations = runtime.render_requests.pendingInvalidations();
     try std.testing.expectEqual(@as(u8, 1), invalidations.len);
@@ -2107,30 +2107,6 @@ test "full transcript opening waits for primary damage and remains cancellable" 
     committed.commit(0, 0, false);
     try std.testing.expect(runtime.requestFullTranscriptOpen());
     try std.testing.expect(runtime.full_transcript_open_request == null);
-}
-
-test "full transcript recovery starts at closest visible entry before a hidden anchor" {
-    const provenance = [_]transcript_blocks.LineProvenance{
-        .{ .entry = .{ .entry_id = 10, .entry_class = .unknown_raw } },
-        .{ .entry = .{ .entry_id = 10, .entry_class = .unknown_raw } },
-        .block_separator,
-        .{ .entry = .{ .entry_id = 14, .entry_class = .tool_status } },
-        .{ .entry = .{ .entry_id = 14, .entry_class = .tool_status } },
-        .{ .entry = .{ .entry_id = 22, .entry_class = .assistant_turn } },
-    };
-
-    try std.testing.expectEqual(
-        @as(?usize, 3),
-        TranscriptRuntime.fullTranscriptRecoveryPredecessorStartLine(&provenance, 18),
-    );
-    try std.testing.expectEqual(
-        @as(?usize, 0),
-        TranscriptRuntime.fullTranscriptRecoveryPredecessorStartLine(&provenance, 10),
-    );
-    try std.testing.expectEqual(
-        @as(?usize, null),
-        TranscriptRuntime.fullTranscriptRecoveryPredecessorStartLine(&provenance, 9),
-    );
 }
 
 test "authoritative lifecycle detail is retained by its compact status entry" {
@@ -4029,7 +4005,6 @@ pub fn renderEntriesToBytes(
 
 pub const FullTranscriptPrimaryRestore = enum {
     changed,
-    changed_resized,
     exact,
     resized,
 };
@@ -4186,7 +4161,6 @@ pub const TranscriptRuntime = struct {
     full_transcript_open_content_revision: ?u64 = null,
     full_transcript_open_cols: u16 = 0,
     full_transcript_open_rows: u16 = 0,
-    full_transcript_primary_recovery_entry_id: ?u32 = null,
     full_transcript_page_load: full_transcript_worker.Load = .{},
     full_transcript_window_load: full_transcript_worker.WindowLoad = .{},
     full_transcript_page_anchor: full_transcript_page.Anchor = .tail,
@@ -6296,7 +6270,6 @@ pub const TranscriptRuntime = struct {
             self.full_transcript_open_content_revision = null;
             self.full_transcript_open_cols = 0;
             self.full_transcript_open_rows = 0;
-            self.full_transcript_primary_recovery_entry_id = null;
             self.resetFullTranscriptPageNavigation();
         }
         self.markTranscriptDirty();
@@ -6310,79 +6283,8 @@ pub const TranscriptRuntime = struct {
         const needs_repair = !same_geometry or
             self.terminal_reset_pending or
             self.resize_history_row_delta != null;
-        if (open_revision != self.full_transcript_content_revision) {
-            return if (needs_repair) .changed_resized else .changed;
-        }
-        return if (needs_repair) .resized else .exact;
-    }
-
-    pub fn prepareRestoredPrimaryTranscriptRecovery(
-        self: *TranscriptRuntime,
-        alloc: Allocator,
-    ) !?[]u8 {
-        const anchor_entry_id = self.full_transcript_primary_recovery_entry_id orelse {
-            debug_trace.logf(
-                "full_transcript_cache",
-                "primary recovery unavailable reason=missing_entry_id revision={d}",
-                .{self.full_transcript_content_revision},
-            );
-            return null;
-        };
-        var source = try self.prepareTranscriptSourceWithFocusedEntry(
-            alloc,
-            anchor_entry_id,
-        );
-        defer source.deinit(alloc);
-        try source.ensureLineIndex(alloc);
-        const start_line = source.tracked_entry_start_line orelse
-            fullTranscriptRecoveryPredecessorStartLine(
-                source.line_provenance,
-                anchor_entry_id,
-            ) orelse {
-            debug_trace.logf(
-                "full_transcript_cache",
-                "primary recovery unavailable reason=no_visible_predecessor entry_id={d} revision={d}",
-                .{ anchor_entry_id, self.full_transcript_content_revision },
-            );
-            return null;
-        };
-        if (start_line >= source.transcript_visible_lines.len or
-            source.transcript_visible_lines.len != source.transcript_line_visual_rows.len)
-        {
-            debug_trace.logf(
-                "full_transcript_cache",
-                "primary recovery unavailable reason=line_index entry_id={d} start_line={d} visible_lines={d} visual_rows={d}",
-                .{
-                    anchor_entry_id,
-                    start_line,
-                    source.transcript_visible_lines.len,
-                    source.transcript_line_visual_rows.len,
-                },
-            );
-            return null;
-        }
-
-        const replay = try transcript_painter.prepareResetReplayDocument(
-            self,
-            alloc,
-            source.bytes,
-            source.transcript_visible_lines[start_line..],
-            source.transcript_line_visual_rows[start_line..],
-            source.hard_lines_end_with_newline,
-            self.layout.rows -| self.layout.content_bottom,
-        );
-        defer if (replay.len > 0) alloc.free(replay);
-
-        const clear_visible = "\x1b[0m\x1b[2J\x1b[H";
-        const recovery = try alloc.alloc(u8, clear_visible.len + replay.len);
-        @memcpy(recovery[0..clear_visible.len], clear_visible);
-        @memcpy(recovery[clear_visible.len..], replay);
-        debug_trace.logf(
-            "full_transcript_cache",
-            "primary recovery prepared entry_id={d} start_line={d} total_lines={d} bytes={d}",
-            .{ anchor_entry_id, start_line, source.transcript_visible_lines.len, recovery.len },
-        );
-        return recovery;
+        if (needs_repair) return .resized;
+        return if (open_revision != self.full_transcript_content_revision) .changed else .exact;
     }
 
     pub fn retainRestoredPrimaryTranscript(self: *TranscriptRuntime) void {
@@ -6397,13 +6299,13 @@ pub const TranscriptRuntime = struct {
     }
 
     pub fn repaintRestoredPrimaryTranscriptAfterResize(self: *TranscriptRuntime) void {
-        self.terminal_reset_pending = false;
+        self.terminal_reset_pending = true;
         self.resize_history_row_delta = null;
         self.pending_resize_observation = null;
         self.render_requests.acknowledgeSettledResizeCommit();
         self.invalidateTranscriptAnchor("full transcript restored resized primary");
-        // The terminal may reflow its saved primary grid differently from the shadow.
-        // Repaint owned cells without erasing the primary scrollback.
+        // A visible-band repaint can discard rows displaced by terminal reflow.
+        // Rebuild them through normal resize recovery after restoring the primary screen.
         if (self.layout.rows > 0) {
             self.render_requests.requestInvalidation(.{
                 .reason = .external_clear,
@@ -6421,8 +6323,6 @@ pub const TranscriptRuntime = struct {
     fn captureFullTranscriptAnchor(self: *TranscriptRuntime, alloc: Allocator) !void {
         _ = alloc;
         self.full_transcript = self.full_transcript.clear_anchor();
-        const fallback_recovery_entry_id = self.primaryRecoveryFallbackEntryId();
-        self.full_transcript_primary_recovery_entry_id = fallback_recovery_entry_id;
         const selection = self.last_viewport_selection orelse return;
         const provenance = self.committedRowProvenance();
         var source: ?transcript_blocks.LineProvenance = null;
@@ -6440,39 +6340,7 @@ pub const TranscriptRuntime = struct {
             self.detailEntryIdForCommandOutputSource(entry_id) orelse entry_id
         else
             null;
-        self.full_transcript_primary_recovery_entry_id =
-            source_entry_id orelse fallback_recovery_entry_id;
         self.full_transcript = self.full_transcript.capture_anchor(anchor_entry_id);
-    }
-
-    fn primaryRecoveryFallbackEntryId(self: *const TranscriptRuntime) ?u32 {
-        if (self.entries.items.len == 0) return null;
-        const retained_entries = @min(
-            self.entries.items.len,
-            @max(@as(usize, self.layout.rows), 1),
-        );
-        return self.entries.items[self.entries.items.len - retained_entries].id();
-    }
-
-    fn fullTranscriptRecoveryPredecessorStartLine(
-        provenance: []const transcript_blocks.LineProvenance,
-        target_entry_id: u32,
-    ) ?usize {
-        var candidate_entry_id: ?u32 = null;
-        var candidate_start_line: ?usize = null;
-        for (provenance, 0..) |source, line_index| {
-            const entry_id = switch (source) {
-                .entry => |entry| entry.entry_id,
-                .folded_command_output => |output| output.entry_id orelse continue,
-                else => continue,
-            };
-            if (entry_id > target_entry_id) continue;
-            if (candidate_entry_id == null or entry_id > candidate_entry_id.?) {
-                candidate_entry_id = entry_id;
-                candidate_start_line = line_index;
-            }
-        }
-        return candidate_start_line;
     }
 
     pub fn fullTranscriptActive(self: *const TranscriptRuntime) bool {

--- a/tests/e2e/tui-full-transcript-brutal.test.ts
+++ b/tests/e2e/tui-full-transcript-brutal.test.ts
@@ -26,6 +26,7 @@ import {
   TmuxSession,
   tmuxAvailable,
 } from "./tmux-helpers";
+import { stdoutFrames } from "./render-lab/tape";
 
 const TIMEOUT = 30_000;
 const INPUT_SANITY_BUDGET_MS = 5_000;
@@ -37,6 +38,8 @@ const LIVE_DONE = "CTRL_O_BRUTAL_LIVE_DONE";
 const DRAFT = "CTRL_O_BRUTAL_UNSENT_DRAFT";
 const RESUME_DRAFT = "CTRL_O_BRUTAL_RESUME_DRAFT";
 const TAIL_SENTINEL = "CTRL_O_TAIL_SENTINEL";
+const VIEWPORT_ALLOWANCE_BYTES = 64 * 1024;
+const RESIZE_SIZES = [[48, 18], [132, 42], [80, 24], [104, 30]] as const;
 const CTRL_O = ["0f"] as const;
 const PAGE_UP = ["1b", "5b", "35", "7e"] as const;
 const PAGE_DOWN = ["1b", "5b", "36", "7e"] as const;
@@ -442,6 +445,55 @@ async function waitForTraceAfter(
   );
 }
 
+async function waitForCommittedFrameAfter(
+  tracePath: string,
+  startByte: number,
+  markers: string[],
+): Promise<void> {
+  const deadline = Date.now() + TIMEOUT;
+  let appended = "";
+  while (Date.now() < deadline) {
+    appended = readFileSync(tracePath).subarray(startByte).toString("utf8");
+    let offset = 0;
+    const committed = [...markers, "attempt_end outcome=committed"].every((marker) => {
+      const index = appended.indexOf(marker, offset);
+      if (index < 0) return false;
+      offset = index + marker.length;
+      return true;
+    });
+    if (committed) return;
+    await sleep(25);
+  }
+  throw new Error(`Timed out waiting for committed ${markers.join(", ")}.\n${appended}`);
+}
+
+async function terminalOutputBytes(tapePath: string): Promise<number> {
+  const deadline = Date.now() + TIMEOUT;
+  while (true) {
+    try {
+      return stdoutFrames(tapePath).reduce((bytes, frame) => bytes + frame.payload.length, 0);
+    } catch (error) {
+      if (!(error instanceof Error) ||
+        !error.message.startsWith("truncated tape frame") || Date.now() >= deadline) throw error;
+      await sleep(25);
+    }
+  }
+}
+
+async function measurePrimaryResize(
+  session: TmuxSession,
+  tracePath: string,
+  tapePath: string,
+  cols: number,
+  rows: number,
+): Promise<number> {
+  const before = await terminalOutputBytes(tapePath);
+  const start = traceSize(tracePath);
+  await session.resizeWindow(cols, rows, 0);
+  await waitForCommittedFrameAfter(tracePath, start, ["settled_reset_committed"]);
+  return await terminalOutputBytes(tapePath) - before;
+}
+
 async function waitForAnyTraceAfter(
   tracePath: string,
   startByte: number,
@@ -565,13 +617,13 @@ async function timeTransition(
   visible: () => Promise<unknown>,
   tapePath?: string,
 ): Promise<void> {
-  const bytesBefore = tapePath === undefined ? undefined : statSync(tapePath).size;
+  const bytesBefore = tapePath === undefined ? undefined : await terminalOutputBytes(tapePath);
   const started = performance.now();
   await action();
   await visible();
   metrics.transitions[kind].push(performance.now() - started);
   if (bytesBefore !== undefined) {
-    metrics.terminalBytes[kind].push(statSync(tapePath!).size - bytesBefore);
+    metrics.terminalBytes[kind].push(await terminalOutputBytes(tapePath!) - bytesBefore);
   }
 }
 
@@ -703,13 +755,7 @@ async function thrashViewer(
       );
     }
 
-    const sizes = [
-      [48, 18],
-      [132, 42],
-      [80, 24],
-      [104, 30],
-    ] as const;
-    const [cols, rows] = sizes[cycle % sizes.length]!;
+    const [cols, rows] = RESIZE_SIZES[cycle % RESIZE_SIZES.length]!;
     const resizeTraceStart = traceSize(tracePath);
     await timeTransition(
       metrics,
@@ -731,12 +777,19 @@ async function thrashViewer(
       tapePath,
     );
 
+    const closeTraceStart = traceSize(tracePath);
     const closeKey = cycle % 3 === 0 ? "C-o" : cycle % 3 === 1 ? "Escape" : "C-c";
     await timeTransition(
       metrics,
       "close",
       () => closeKey === "C-o" ? session.sendHexBytes(CTRL_O) : session.sendKeys(closeKey),
-      () => waitForMode(session, "main", draft),
+      async () => {
+        await waitForCommittedFrameAfter(tracePath, closeTraceStart, [
+          "close_full_transcript restore=resized",
+          "transcript_transition_commit state=stable",
+        ]);
+        await waitForMode(session, "main", draft);
+      },
       tapePath,
     );
     expect(session.paneStatus().dead).toBe(false);
@@ -882,7 +935,7 @@ async function runStress(config: StressConfig): Promise<StressRoot> {
         FX_RECORD_INPUT: "1",
         FX_TRACE_LOG: paths.tracePath,
         FX_TRACE_SCOPES:
-          "full_transcript_cache,full_transcript,scroll,frame_render,terminal_diff,frame_schedule,frame_plan",
+          "full_transcript_cache,full_transcript,scroll,frame_render,terminal_diff,frame_schedule,frame_plan,resize",
       },
       stderrPath: paths.stderrPath,
       width: 104,
@@ -1010,6 +1063,7 @@ async function runStress(config: StressConfig): Promise<StressRoot> {
       paths.tracePath,
       paths.tapePath,
     );
+    const primaryResizeBytes: number[] = [];
     const writeMetrics = () => {
       const summary = {
         config,
@@ -1045,6 +1099,7 @@ async function runStress(config: StressConfig): Promise<StressRoot> {
         resumedMemory: resumedRssKib.length > 0
           ? summarizeMemory(resumedRssKib)
           : null,
+        primaryResizeBytes,
         raw: metrics,
         rawSettled: settledMetrics,
         rawMemory: { primaryRssKib, resumedRssKib },
@@ -1068,6 +1123,13 @@ async function runStress(config: StressConfig): Promise<StressRoot> {
         paths.tracePath,
         paths.tapePath,
       );
+    }
+    // Settled history bounds the streaming prefix measured above at every geometry.
+    await measurePrimaryResize(session, paths.tracePath, paths.tapePath, 120, 36);
+    for (const [cols, rows] of RESIZE_SIZES) {
+      primaryResizeBytes.push(await measurePrimaryResize(
+        session, paths.tracePath, paths.tapePath, cols, rows,
+      ));
     }
     await verifyOldestTranscriptEntrySurvives(session, DRAFT, config);
 
@@ -1106,7 +1168,9 @@ async function runStress(config: StressConfig): Promise<StressRoot> {
     }
     // Full-open cost must remain independent of total chat size.
     expect(summary.terminalBytes.full.maxBytes).toBeLessThan(128 * 1024);
-    expect(summary.terminalBytes.close.maxBytes).toBeLessThan(256 * 1024);
+    expect(summary.terminalBytes.close.maxBytes).toBeLessThan(
+      Math.max(...primaryResizeBytes) + VIEWPORT_ALLOWANCE_BYTES,
+    );
     expect(summary.memory.growthRssKib).toBeLessThan(256 * 1024);
 
     await session.sendKeys("C-u");
@@ -1125,7 +1189,7 @@ async function runStress(config: StressConfig): Promise<StressRoot> {
           ...gatewayEnv(paths.home, resumedGateway),
           FX_TRACE_LOG: paths.resumedTracePath,
           FX_TRACE_SCOPES:
-            "full_transcript_cache,full_transcript,scroll,frame_render,terminal_diff,frame_plan",
+            "full_transcript_cache,full_transcript,scroll,frame_render,terminal_diff,frame_schedule,frame_plan,resize",
         },
         stderrPath: paths.resumedStderrPath,
         width: 96,
@@ -1313,6 +1377,96 @@ test.skipIf(!tmuxAvailable())(
       await active?.kill();
       tallGateway.stop();
       rmSync(paths.root, { recursive: true, force: true });
+    }
+  },
+  60_000,
+);
+
+test.skipIf(!tmuxAvailable())(
+  "Ctrl-O resized close preserves long history within ordinary resize cost",
+  async () => {
+    const paths = makeRoot("resize-recovery-cost");
+    mkdirSync(join(paths.home, ".fx"), { recursive: true });
+    mkdirSync(paths.workspace);
+    const paragraphs = Array.from({ length: 4_000 }, (_, index) =>
+      `ROW${pad(index + 1)} ALPHA_abcdefghijklmnopqrstuvwxyz0123456789 ` +
+      "BRAVO_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+    );
+    const gateway = startFakeGateway([fakeGatewayFinalText(paragraphs.join("\n\n"))]);
+    let session: TmuxSession | null = null;
+    let passed = false;
+    try {
+      session = await TmuxSession.create({
+        cmd: FX_BIN,
+        cwd: paths.workspace,
+        env: {
+          ...gatewayEnv(paths.home, gateway),
+          FX_RECORD: paths.tapePath,
+          FX_TRACE_LOG: paths.tracePath,
+          FX_TRACE_SCOPES: "full_transcript,full_transcript_cache,scroll,frame_schedule,resize",
+        },
+        stderrPath: paths.stderrPath,
+        width: 120,
+        height: 36,
+        minimumHistoryLines: 50_000,
+      });
+      await session.waitForComposer(TIMEOUT);
+      await session.sendText("Return the prepared long response.");
+      await session.waitForText("ROW4000", TIMEOUT);
+      await session.waitForStableComposer(TIMEOUT);
+      await session.sendLiteralText(DRAFT);
+      await waitForMode(session, "main", DRAFT);
+      const completeHistory = async () => {
+        const text = (await session!.captureFullScrollback()).replace(/\s+/g, "");
+        let previous = -1;
+        for (const paragraph of paragraphs) {
+          const needle = paragraph.replace(/\s+/g, "");
+          const index = text.indexOf(needle);
+          expect(index).toBeGreaterThan(previous);
+          expect(text.indexOf(needle, index + 1)).toBe(-1);
+          previous = index;
+        }
+      };
+      await completeHistory();
+      const primaryBytes = await measurePrimaryResize(session, paths.tracePath, paths.tapePath, 88, 24);
+      await completeHistory();
+      await measurePrimaryResize(session, paths.tracePath, paths.tapePath, 120, 36);
+      await session.sendHexBytes(CTRL_O);
+      await waitForMode(session, "full", DRAFT);
+      const resizeStart = traceSize(paths.tracePath);
+      await session.resizeWindow(88, 24, 0);
+      await waitForCommittedFrameAfter(paths.tracePath, resizeStart, ["settled_reset_committed"]);
+      const closeStart = traceSize(paths.tracePath);
+      const beforeClose = await terminalOutputBytes(paths.tapePath);
+      const started = performance.now();
+      session.sendKeysImmediate(["Escape"]);
+      await waitForCommittedFrameAfter(paths.tracePath, closeStart, [
+        "close_full_transcript restore=resized",
+        "transcript_transition_commit state=stable",
+      ]);
+      await waitForMode(session, "main", DRAFT);
+      expect(performance.now() - started).toBeLessThan(2_500);
+      const closeBytes = await terminalOutputBytes(paths.tapePath) - beforeClose;
+      expect(closeBytes).toBeLessThan(primaryBytes + VIEWPORT_ALLOWANCE_BYTES);
+      await completeHistory();
+
+      await session.sendHexBytes(CTRL_O);
+      await waitForMode(session, "full", DRAFT);
+      const beforeOrdinaryClose = await terminalOutputBytes(paths.tapePath);
+      await session.sendKeys("Escape");
+      await waitForMode(session, "main", DRAFT);
+      expect(await terminalOutputBytes(paths.tapePath) - beforeOrdinaryClose).toBeLessThan(256 * 1024);
+      await completeHistory();
+      expect(readFileSync(paths.stderrPath, "utf8")).toBe("");
+      await session.sendKeys("C-u");
+      await session.sendText("/quit");
+      expect(await session.waitForSessionEnd(TIMEOUT)).toBe(true);
+      passed = true;
+    } finally {
+      await session?.kill();
+      gateway.stop();
+      if (passed) rmSync(paths.root, { recursive: true, force: true });
+      else console.error(`retained recovery cost artifacts at ${paths.root}`);
     }
   },
   60_000,

--- a/tests/e2e/tui-full-transcript-brutal.test.ts
+++ b/tests/e2e/tui-full-transcript-brutal.test.ts
@@ -1453,7 +1453,12 @@ test.skipIf(!tmuxAvailable())(
       await session.sendHexBytes(CTRL_O);
       await waitForMode(session, "full", DRAFT);
       const beforeOrdinaryClose = await terminalOutputBytes(paths.tapePath);
+      const ordinaryCloseStart = traceSize(paths.tracePath);
       await session.sendKeys("Escape");
+      await waitForCommittedFrameAfter(paths.tracePath, ordinaryCloseStart, [
+        "close_full_transcript restore=exact",
+        "transcript_transition_commit state=stable",
+      ]);
       await waitForMode(session, "main", DRAFT);
       expect(await terminalOutputBytes(paths.tapePath) - beforeOrdinaryClose).toBeLessThan(256 * 1024);
       await completeHistory();

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -3183,10 +3183,17 @@ test.skipIf(!tmuxAvailable())(
           );
           const historyAfter = await active.captureFullScrollback();
           expect(historyAfter).toContain(`┃ ${draft}`);
-          if (width === 120) {
-            const historyMarker = "ROW14 ALPHA14_abcdefghijklmnopqrstuvwxyz0123456789";
-            expect(historyBefore).toContain(historyMarker);
-            expect(historyAfter).toContain(historyMarker);
+          const beforeText = historyBefore.replace(/\s+/g, "");
+          const afterText = historyAfter.replace(/\s+/g, "");
+          let previousEnd = 0;
+          for (const paragraph of response.split("\n\n")) {
+            const text = paragraph.replace(/\s+/g, "");
+            expect(beforeText).toContain(text);
+            expect(afterText).toContain(text);
+            expect(afterText.split(text)).toHaveLength(2);
+            const start = afterText.indexOf(text, previousEnd);
+            expect(start).toBeGreaterThanOrEqual(previousEnd);
+            previousEnd = start + text.length;
           }
           const events = readFileSync(
             join(home, ".fx", "sessions", sessionIdFromHome(home), "events.jsonl"), "utf8",


### PR DESCRIPTION
## Summary

- Preserve complete conversation scrollback when resizing Ctrl+O, including streaming text and rapid close/reopen actions. Resized closes replay retained history through normal terminal recovery; ordinary opens and closes remain bounded.
