### PR TITLE
Avoid false context exhaustion for image attachments

### DIFF
--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -4728,7 +4728,7 @@ const CompactionContinuation = struct {
         const body = (try provider.buildRequest(alloc, candidate)) orelse
             return error.ContextCompactionUnavailable;
         defer alloc.free(body);
-        return runtime_prompt_context.measureProviderRequest(body);
+        return runtime_prompt_context.measureProviderRequest(std.heap.c_allocator, body, candidate);
     }
 };
 
@@ -4891,7 +4891,7 @@ test "manual compaction fixed context measures prepared skills and host instruct
     try std.testing.expect(std.mem.find(u8, body, "compaction-workflow") != null);
     try std.testing.expect(std.mem.find(u8, body, "HOST_COMPACTION_INSTRUCTIONS") != null);
     const measured = try small.measure(arena, deps.agent_stream_provider, "");
-    try std.testing.expectEqual(runtime_prompt_context.measureProviderRequest(body), measured);
+    try std.testing.expectEqual(try runtime_prompt_context.measureProviderRequest(arena, body, small.request), measured);
     const large = try prepareManualCompactionContinuation(arena, &deps, config, "fixture/model", .{ .context_window = 1_000_000 });
     const large_cost = try large.measure(arena, deps.agent_stream_provider, "");
     try std.testing.expect(large_cost.estimated_input_tokens > measured.estimated_input_tokens);
@@ -5631,15 +5631,16 @@ fn processQueuedPromptLoop(
                 request_data,
             )) |request_body| {
                 prepared_request_body = request_body;
-                const measured_request_cost = runtime_prompt_context.measureProviderRequest(request_body);
-                const request_cost = if (request_token_calibration) |calibration|
-                    if (std.mem.eql(u8, calibration.model, gateway_model))
-                        runtime_prompt_context.calibrateProviderRequest(
-                            measured_request_cost,
-                            calibration.cost,
-                        )
+                const measured_request_cost = try runtime_prompt_context.measureProviderRequest(std.heap.c_allocator, request_body, request_data);
+                const applicable_calibration = if (request_token_calibration) |calibration|
+                    if (std.mem.eql(u8, calibration.model, gateway_model) and calibration.cost.applies(measured_request_cost))
+                        calibration.cost
                     else
-                        measured_request_cost
+                        null
+                else
+                    null;
+                const request_cost = if (applicable_calibration) |calibration|
+                    runtime_prompt_context.calibrateProviderRequest(measured_request_cost, calibration)
                 else
                     measured_request_cost;
                 request_cost_for_attempt = request_cost;
@@ -5659,11 +5660,15 @@ fn processQueuedPromptLoop(
                     "context_compaction",
                     "decision",
                     step_ctx,
-                    "decision={s} request_bytes={d} estimated_tokens={d} usable_tokens={any} high_water_tokens={any} target_tokens={any} accepted_tokens={any} generation_tokens={any}",
+                    "decision={s} request_bytes={d} estimated_tokens={d} text_tokens={d} has_images={} image_baseline={} prior_input_tokens={any} usable_tokens={any} high_water_tokens={any} target_tokens={any} accepted_tokens={any} generation_tokens={any}",
                     .{
                         @tagName(projection_plan.decision),
                         request_cost.serialized_bytes,
                         request_cost.estimated_input_tokens,
+                        request_cost.text_tokens,
+                        request_cost.image_identity != null,
+                        request_cost.image_identity != null and applicable_calibration != null,
+                        if (applicable_calibration) |calibration| calibration.exact_input_tokens else null,
                         projection_plan.usable_input_tokens,
                         projection_plan.high_water_tokens,
                         projection_plan.session_target_tokens,
@@ -7088,7 +7093,7 @@ fn processQueuedPromptLoop(
                 request_token_calibration = .{
                     .model = successful_gateway_model,
                     .cost = .{
-                        .serialized_bytes = request_cost.serialized_bytes,
+                        .request = request_cost,
                         .exact_input_tokens = @intCast(@min(
                             exact_input_tokens,
                             std.math.maxInt(usize),

--- a/src/core/agent/runtime/prompt_context.zig
+++ b/src/core/agent/runtime/prompt_context.zig
@@ -3,6 +3,7 @@ const model_capabilities = @import("../../config/model_capabilities.zig");
 const token_estimate = @import("../../shared/token_estimate.zig");
 const types = @import("../../shared/types.zig");
 const session_runtime = @import("../../session/session.zig");
+const stream_provider = @import("../stream_provider.zig");
 
 const Allocator = std.mem.Allocator;
 const ChatMessage = types.ChatMessage;
@@ -231,23 +232,112 @@ pub fn validateCompactionHandoff(
 
 pub const RequestCost = struct {
     serialized_bytes: usize,
+    text_tokens: usize,
+    /// Null means no image parts. Otherwise visual cost needs applicable usage.
+    image_identity: ?[32]u8 = null,
     estimated_input_tokens: usize,
 };
 
 pub const RequestTokenCalibration = struct {
-    serialized_bytes: usize,
+    request: RequestCost,
     exact_input_tokens: usize,
+
+    pub fn applies(self: RequestTokenCalibration, cost: RequestCost) bool {
+        return self.request.serialized_bytes != 0 and self.exact_input_tokens != 0 and
+            std.meta.eql(cost.image_identity, self.request.image_identity);
+    }
 };
 
-pub fn measureProviderRequest(body: []const u8) RequestCost {
+const ImagePart = struct {
+    type: []const u8 = "",
+    mediaType: ?[]const u8 = null,
+    detail: ?[]const u8 = null,
+    data: ?[]const u8 = null,
+    image_url: ?[]const u8 = null,
+};
+
+const MessageContent = struct {
+    parts: []const ImagePart = &.{},
+
+    pub fn jsonParse(alloc: Allocator, source: anytype, options: std.json.ParseOptions) !MessageContent {
+        if (try source.peekNextTokenType() == .array_begin) {
+            return .{ .parts = try std.json.innerParse([]const ImagePart, alloc, source, options) };
+        }
+        try source.skipValue();
+        return .{};
+    }
+};
+
+const CostMessage = struct {
+    role: []const u8 = "",
+    content: MessageContent = .{},
+};
+
+const CostRequest = struct {
+    prompt: ?[]const CostMessage = null,
+    input: ?[]const CostMessage = null,
+};
+
+pub const MeasurementError = error{ OutOfMemory, InvalidRequestMeasurement };
+
+/// Borrows the prepared body and request; releases parsing scratch before returning.
+/// Image payloads are transport bytes, not text. Their initial token cost is unknown.
+pub fn measureProviderRequest(alloc: Allocator, body: []const u8, request: stream_provider.RequestData) MeasurementError!RequestCost {
+    const has_images = image_input: {
+        if (request.verified_images) |images| if (images.len != 0) break :image_input true;
+        for (request.messages) |message| if (message.images.len != 0) break :image_input true;
+        break :image_input false;
+    };
+    if (!has_images) {
+        const tokens = textTokens(body);
+        return .{ .serialized_bytes = body.len, .text_tokens = tokens, .estimated_input_tokens = tokens };
+    }
+
+    // Typed parsing borrows unescaped payload strings. Value parsing copies them.
+    const parsed = std.json.parseFromSlice(CostRequest, alloc, body, .{
+        .ignore_unknown_fields = true,
+        .allocate = .alloc_if_needed,
+    }) catch |err| return switch (err) {
+        error.OutOfMemory => error.OutOfMemory,
+        else => error.InvalidRequestMeasurement,
+    };
+    defer parsed.deinit();
+    if (parsed.value.prompt != null and parsed.value.input != null) return error.InvalidRequestMeasurement;
+    const messages = parsed.value.prompt orelse parsed.value.input orelse return error.InvalidRequestMeasurement;
     var estimator = token_estimate.StreamingEstimator{};
-    estimator.consume(body);
+    var identity = std.crypto.hash.sha2.Sha256.init(.{});
+    var cursor: usize = 0;
+    var found_image = false;
+    for (messages) |message| {
+        if (!std.mem.eql(u8, message.role, "user")) continue;
+        for (message.content.parts) |part| {
+            const payload = if (parsed.value.input != null and std.mem.eql(u8, part.type, "input_image"))
+                part.image_url orelse return error.InvalidRequestMeasurement
+            else if (parsed.value.prompt != null and std.mem.eql(u8, part.type, "file") and
+                std.mem.startsWith(u8, part.mediaType orelse "", "image/"))
+                part.data orelse return error.InvalidRequestMeasurement
+            else
+                continue;
+            const address = @intFromPtr(payload.ptr);
+            if (address < @intFromPtr(body.ptr)) return error.InvalidRequestMeasurement;
+            const offset = address - @intFromPtr(body.ptr);
+            if (offset < cursor or offset > body.len or payload.len > body.len - offset) return error.InvalidRequestMeasurement;
+            estimator.consume(body[cursor..offset]);
+            cursor = offset + payload.len;
+            for ([_][]const u8{ part.type, part.mediaType orelse "", part.detail orelse "", payload }) |value| {
+                identity.update(std.mem.asBytes(&value.len));
+                identity.update(value);
+            }
+            found_image = true;
+        }
+    }
+    estimator.consume(body[cursor..]);
+    const tokens: usize = @intCast(@min(estimator.estimate(), std.math.maxInt(usize)));
     return .{
         .serialized_bytes = body.len,
-        .estimated_input_tokens = @intCast(@min(
-            estimator.estimate(),
-            std.math.maxInt(usize),
-        )),
+        .text_tokens = tokens,
+        .image_identity = if (found_image) identity.finalResult() else null,
+        .estimated_input_tokens = tokens,
     };
 }
 
@@ -255,21 +345,17 @@ pub fn calibrateProviderRequest(
     cost: RequestCost,
     calibration: RequestTokenCalibration,
 ) RequestCost {
-    if (calibration.serialized_bytes == 0 or calibration.exact_input_tokens == 0) {
-        return cost;
-    }
-    const calibrated_tokens = multiplyDivideCeilSaturating(
-        cost.serialized_bytes,
-        calibration.exact_input_tokens,
-        calibration.serialized_bytes,
-    );
-    return .{
-        .serialized_bytes = cost.serialized_bytes,
-        .estimated_input_tokens = @max(
-            cost.estimated_input_tokens,
-            calibrated_tokens,
-        ),
-    };
+    if (!calibration.applies(cost)) return cost;
+    const calibrated_tokens = if (cost.image_identity != null)
+        if (cost.text_tokens >= calibration.request.text_tokens)
+            calibration.exact_input_tokens +| (cost.text_tokens - calibration.request.text_tokens)
+        else
+            calibration.exact_input_tokens -| (calibration.request.text_tokens - cost.text_tokens)
+    else
+        multiplyDivideCeilSaturating(cost.serialized_bytes, calibration.exact_input_tokens, calibration.request.serialized_bytes);
+    var result = cost;
+    result.estimated_input_tokens = @max(cost.text_tokens, calibrated_tokens);
+    return result;
 }
 
 fn multiplyDivideCeilSaturating(
@@ -511,26 +597,151 @@ test "buildProviderPrompt keeps compacted session context out of instructions" {
 }
 
 test "provider request measurement includes serialized structure" {
-    const compact = measureProviderRequest("{\"prompt\":[{\"role\":\"user\",\"content\":\"same\"}]}");
-    const fragmented = measureProviderRequest(
+    const compact = try measureProviderRequest(std.testing.allocator, "{\"prompt\":[{\"role\":\"user\",\"content\":\"same\"}]}", measurement_test_request(false));
+    const fragmented = try measureProviderRequest(
+        std.testing.allocator,
         "{\"prompt\":[{\"role\":\"user\",\"content\":\"s\"},{\"role\":\"user\",\"content\":\"a\"},{\"role\":\"user\",\"content\":\"m\"},{\"role\":\"user\",\"content\":\"e\"}]}",
+        measurement_test_request(false),
     );
     try std.testing.expect(fragmented.serialized_bytes > compact.serialized_bytes);
     try std.testing.expect(fragmented.estimated_input_tokens > compact.estimated_input_tokens);
 }
 
+test "provider request image accounting excludes encoded payload length" {
+    const suffix = "\"}]}]}";
+    inline for (.{
+        "{\"input\":[{\"role\":\"user\",\"content\":[{\"type\":\"input_image\",\"image_url\":\"data:image/png;base64,",
+        "{\"prompt\":[{\"role\":\"user\",\"content\":[{\"type\":\"file\",\"mediaType\":\"image/png\",\"data\":\"",
+    }) |prefix| {
+        const small = try measureProviderRequest(std.testing.allocator, prefix ++ "AAAA" ++ suffix, measurement_test_request(true));
+        const large = try measureProviderRequest(std.testing.allocator, prefix ++ ("AAAA" ** 1000) ++ suffix, measurement_test_request(true));
+        try std.testing.expect(large.serialized_bytes > small.serialized_bytes);
+        try std.testing.expectEqual(small.text_tokens, large.text_tokens);
+        try std.testing.expectEqual(small.estimated_input_tokens, large.estimated_input_tokens);
+        try std.testing.expect(small.image_identity != null);
+        try std.testing.expect(!std.meta.eql(small.image_identity, large.image_identity));
+    }
+}
+
 test "provider request measurement learns the prior exact token density" {
     const current = RequestCost{
         .serialized_bytes = 1_456_988,
+        .text_tokens = 365_113,
         .estimated_input_tokens = 365_113,
     };
     const calibrated = calibrateProviderRequest(current, .{
-        .serialized_bytes = 767_736,
+        .request = .{ .serialized_bytes = 767_736, .text_tokens = 192_000, .estimated_input_tokens = 192_000 },
         .exact_input_tokens = 398_710,
     });
 
     try std.testing.expect(calibrated.estimated_input_tokens > 695_142);
     try std.testing.expect(calibrated.estimated_input_tokens >= current.estimated_input_tokens);
+}
+
+fn measurement_test_request(with_images: bool) stream_provider.RequestData {
+    return .{
+        .model = "fixture/model",
+        .messages = if (with_images) &.{.{
+            .role = .user,
+            .images = &.{.{ .path = @constCast("fixture.png"), .media_type = @constCast("image/png") }},
+        }} else &.{},
+        .tool_choice = .none,
+        .provider_options = .{},
+    };
+}
+
+test "provider request image accounting preserves text and tool payloads" {
+    const body =
+        \\{"input":[{"role":"user","content":[{"type":"input_text","text":"data:image/png;base64,AAAA"},{"image_url":"data:image/png;base64,BBBB","type":"input_image"}]},{"type":"function_call","arguments":"{\"image_url\":\"AAAA\"}"},{"type":"function_call_output","output":"data:image/png;base64,AAAA"}]}
+    ;
+    const measured = try measureProviderRequest(std.testing.allocator, body, measurement_test_request(true));
+    const without_image_payload =
+        \\{"input":[{"role":"user","content":[{"type":"input_text","text":"data:image/png;base64,AAAA"},{"image_url":"","type":"input_image"}]},{"type":"function_call","arguments":"{\"image_url\":\"AAAA\"}"},{"type":"function_call_output","output":"data:image/png;base64,AAAA"}]}
+    ;
+    try std.testing.expectEqual(textTokens(without_image_payload), measured.text_tokens);
+
+    const file_text = "{\"prompt\":[{\"role\":\"user\",\"content\":[{\"type\":\"file\",\"mediaType\":\"text/plain\",\"data\":\"AAAA\"}]}]}";
+    const non_image = try measureProviderRequest(std.testing.allocator, file_text, measurement_test_request(true));
+    try std.testing.expectEqual(textTokens(file_text), non_image.text_tokens);
+    try std.testing.expectEqual(@as(?[32]u8, null), non_image.image_identity);
+}
+
+test "provider request image calibration uses exact usage plus text growth without compounding" {
+    const first = RequestCost{ .serialized_bytes = 4_000_000, .text_tokens = 100, .image_identity = [_]u8{1} ** 32, .estimated_input_tokens = 100 };
+    var next = first;
+    next.text_tokens = 150;
+    next.estimated_input_tokens = 150;
+    next.serialized_bytes += 200;
+    const calibrated = calibrateProviderRequest(next, .{ .request = first, .exact_input_tokens = 1000 });
+    try std.testing.expectEqual(@as(usize, 1050), calibrated.estimated_input_tokens);
+    try std.testing.expectEqual(@as(usize, 150), calibrated.text_tokens);
+    var third = next;
+    third.text_tokens = 200;
+    third.estimated_input_tokens = 200;
+    const repeated = calibrateProviderRequest(third, .{ .request = calibrated, .exact_input_tokens = 1050 });
+    try std.testing.expectEqual(@as(usize, 1100), repeated.estimated_input_tokens);
+    try std.testing.expectEqual(@as(usize, 1000), calibrateProviderRequest(first, .{ .request = calibrated, .exact_input_tokens = 1050 }).estimated_input_tokens);
+
+    next.image_identity = [_]u8{2} ** 32;
+    try std.testing.expectEqual(next, calibrateProviderRequest(next, .{ .request = first, .exact_input_tokens = 1000 }));
+    next.image_identity = null;
+    try std.testing.expectEqual(next, calibrateProviderRequest(next, .{ .request = first, .exact_input_tokens = 1000 }));
+    try std.testing.expectEqual(first, calibrateProviderRequest(first, .{ .request = next, .exact_input_tokens = 1000 }));
+    try std.testing.expectEqual(first, calibrateProviderRequest(first, .{ .request = first, .exact_input_tokens = 0 }));
+    try std.testing.expectEqual(@as(usize, 150), calibrateProviderRequest(calibrated, .{ .request = third, .exact_input_tokens = 1 }).estimated_input_tokens);
+    try std.testing.expectEqual(std.math.maxInt(usize), calibrateProviderRequest(calibrated, .{ .request = first, .exact_input_tokens = std.math.maxInt(usize) }).estimated_input_tokens);
+}
+
+test "provider request image accounting borrows large payloads and releases scratch" {
+    const alloc = std.testing.allocator;
+    const payload = try alloc.alloc(u8, 4 * 1024 * 1024);
+    defer alloc.free(payload);
+    @memset(payload, 'A');
+    const body = try std.fmt.allocPrint(alloc, "{{\"input\":[{{\"role\":\"user\",\"content\":[{{\"type\":\"input_image\",\"image_url\":\"data:image/png;base64,{s}\"}}]}}]}}", .{payload});
+    defer alloc.free(body);
+    var storage: [8192]u8 = undefined;
+    var scratch = std.heap.FixedBufferAllocator.init(&storage);
+    var tracked = std.testing.FailingAllocator.init(scratch.allocator(), .{});
+    const cost = try measureProviderRequest(tracked.allocator(), body, measurement_test_request(true));
+    try std.testing.expect(cost.text_tokens < 100);
+    try std.testing.expectEqual(tracked.allocated_bytes, tracked.freed_bytes);
+}
+
+test "provider request image identity includes ordering media type and detail" {
+    const alloc = std.testing.allocator;
+    const first = "{\"type\":\"input_image\",\"image_url\":\"data:image/png;base64,AAAA\",\"detail\":\"auto\"}";
+    const second = "{\"type\":\"input_image\",\"image_url\":\"data:image/png;base64,BBBB\"}";
+    const reference = try measureProviderRequest(alloc, "{\"input\":[{\"role\":\"user\",\"content\":[" ++ first ++ "," ++ second ++ "]}]}", measurement_test_request(true));
+    inline for (.{
+        "{\"input\":[{\"role\":\"user\",\"content\":[" ++ second ++ "," ++ first ++ "]}]}",
+        "{\"input\":[{\"role\":\"user\",\"content\":[" ++ first ++ "]}]}",
+        "{\"input\":[{\"role\":\"user\",\"content\":[{\"type\":\"input_image\",\"image_url\":\"data:image/png;base64,AAAA\",\"detail\":\"high\"}," ++ second ++ "]}]}",
+        "{\"input\":[{\"role\":\"user\",\"content\":[{\"type\":\"input_image\",\"image_url\":\"data:image/jpeg;base64,AAAA\",\"detail\":\"auto\"}," ++ second ++ "]}]}",
+    }) |body| {
+        const changed = try measureProviderRequest(alloc, body, measurement_test_request(true));
+        try std.testing.expect(!std.meta.eql(reference.image_identity, changed.image_identity));
+    }
+    var no_storage: [0]u8 = .{};
+    var scratch = std.heap.FixedBufferAllocator.init(&no_storage);
+    const text = try measureProviderRequest(scratch.allocator(), "{\"input\":[]}", measurement_test_request(false));
+    try std.testing.expectEqual(textTokens("{\"input\":[]}"), text.text_tokens);
+}
+
+test "provider request image accounting handles allocation and malformed input failures" {
+    const Probe = struct {
+        fn run(alloc: Allocator) !void {
+            _ = try measureProviderRequest(alloc, "{\"input\":[{\"role\":\"user\",\"content\":[{\"type\":\"input_image\",\"image_url\":\"data:image/png;base64,AAAA\"}]}]}", measurement_test_request(true));
+        }
+    };
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, Probe.run, .{});
+    for ([_][]const u8{
+        "{",
+        "{\"input\":[],\"prompt\":[]}",
+        "{\"input\":[{\"role\":\"user\",\"content\":[{\"type\":\"input_image\"}]}]}",
+        "{\"input\":[{\"role\":\"user\",\"content\":[{\"type\":\"input_image\",\"image_url\":\"escaped\\nimage\"}]}]}",
+    }) |body| {
+        try std.testing.expectError(error.InvalidRequestMeasurement, measureProviderRequest(std.testing.allocator, body, measurement_test_request(true)));
+    }
 }
 
 test "compactor input budget reserves the requested generation" {

--- a/src/core/agent/runtime/tests/gateway_flow.zig
+++ b/src/core/agent/runtime/tests/gateway_flow.zig
@@ -3036,7 +3036,12 @@ test "processQueuedPrompt semantically compacts history at eighty percent and co
     try expectBodyContains(&gateway, 0, "\"toolChoice\":{\"type\":\"none\"}");
     try expectBodyContains(&gateway, 0, "\"tools\":[]");
     try expectBodyContains(&gateway, 1, "context_handoff");
-    try std.testing.expect(prompt_context.measureProviderRequest(gateway.request_bodies.items[1]).estimated_input_tokens <= 4_500);
+    try std.testing.expect((try prompt_context.measureProviderRequest(alloc, gateway.request_bodies.items[1], .{
+        .model = model,
+        .messages = &.{},
+        .tool_choice = .none,
+        .provider_options = .{},
+    })).estimated_input_tokens <= 4_500);
     try expectBodyContains(&gateway, 1, "AUTO_COMPACTION_HOST_INSTRUCTIONS");
     try expectBodyContains(&gateway, 1, "auto-compaction-workflow");
     try expectBodyContains(&gateway, 1, "available_skills");
@@ -3195,6 +3200,65 @@ test "processQueuedPrompt stops after one context overflow recovery" {
     try std.testing.expectEqual(types.TurnPresentationOutcome.failed, hooks.finalized_outcome.?);
 }
 
+test "image context overflow keeps one recovery and preserves the current image" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = try writeTestImagePath(alloc, &tmp);
+    defer alloc.free(path);
+    const image = try testCapturedImage(alloc, &tmp, path, 1);
+    defer types.freeImageAttachment(alloc, image);
+    var images = [_]types.ImageAttachment{image};
+    const overflow = FakeCompletion{
+        .status = .bad_request,
+        .err_body = "{\"error\":{\"code\":\"context_length_exceeded\",\"message\":\"maximum context length exceeded\"}}",
+    };
+    for ([_]bool{ false, true }) |repeated| {
+        const completions = [_]FakeCompletion{
+            overflow,
+            .{ .content = "Retain the previous answer." },
+            if (repeated) overflow else .{ .content = "IMAGE_OVERFLOW_RECOVERED" },
+            .{ .content = "MUST_NOT_RUN" },
+        };
+        var gateway = FakeGateway.init(alloc, &completions);
+        defer gateway.deinit();
+        var hooks = FakeAgentRuntimeDeps.init(alloc);
+        defer hooks.deinit();
+        hooks.available_capability_overrides = &.{.{ .model = "fixture/image", .capabilities = .{
+            .context_window = 128_000,
+            .max_output_tokens = 16_384,
+            .image_input_support = .native,
+            .supports_vision = true,
+            .supports_file_input = true,
+        } }};
+        hooks.capability_overrides = hooks.available_capability_overrides;
+        var fixture = PromptFixture{};
+        var job = fixture.job();
+        job.model = @constCast("fixture/image");
+        job.images = &images;
+        job.authorized_image_catalog = &images;
+        var history = [_]HistoryTurn{.{ .assistant = .{
+            .user = .{ .text = @constCast("prior request") },
+            .assistant = @constCast("prior answer"),
+        } }};
+        job.history = &history;
+        try runFakePrompt(&gateway, &hooks, fixture.config(), job);
+        try std.testing.expectEqual(@as(usize, 3), gateway.request_bodies.items.len);
+        try std.testing.expectEqual(@as(usize, 3), gateway.index);
+        try expectBodyContains(&gateway, 0, "\"type\":\"file\"");
+        try expectBodyContains(&gateway, 1, "\"toolChoice\":{\"type\":\"none\"}");
+        try expectBodyContains(&gateway, 2, "\"type\":\"file\"");
+        try expectBodyContains(&gateway, 2, "context_handoff");
+        if (repeated) {
+            try std.testing.expectEqual(std.http.Status.bad_request, hooks.http_status.?);
+            try std.testing.expectEqual(types.TurnPresentationOutcome.failed, hooks.finalized_outcome.?);
+        } else {
+            try std.testing.expectEqualStrings("IMAGE_OVERFLOW_RECOVERED", hooks.finish_assistant_text.?);
+            try std.testing.expect(hooks.http_status == null);
+        }
+    }
+}
+
 test "cancelled automatic compaction is retried by the next prompt" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
@@ -3317,8 +3381,9 @@ test "retained context automatic compaction continues with the exact recent para
     job.history = @constCast(&history);
     try runFakePrompt(&gateway, &hooks, config, job);
     try std.testing.expectEqual(@as(usize, 3), gateway.request_bodies.items.len);
-    try std.testing.expect(prompt_context.measureProviderRequest(gateway.request_bodies.items[0]).estimated_input_tokens < context_window * 4 / 5);
-    const continued_tokens = prompt_context.measureProviderRequest(gateway.request_bodies.items[2]).estimated_input_tokens;
+    const measurement_request = agent_stream_provider.RequestData{ .model = model, .messages = &.{}, .tool_choice = .none, .provider_options = .{} };
+    try std.testing.expect((try prompt_context.measureProviderRequest(alloc, gateway.request_bodies.items[0], measurement_request)).estimated_input_tokens < context_window * 4 / 5);
+    const continued_tokens = (try prompt_context.measureProviderRequest(alloc, gateway.request_bodies.items[2], measurement_request)).estimated_input_tokens;
     try std.testing.expect(continued_tokens > context_window / 4);
     try std.testing.expect(continued_tokens < context_window);
     try expectBodyContains(&gateway, 1, "OLDER_HISTORY_SENTINEL");

--- a/tests/e2e/fixtures/image-encoding.ts
+++ b/tests/e2e/fixtures/image-encoding.ts
@@ -1,0 +1,36 @@
+import { strict as assert } from "node:assert";
+import { deflateSync, inflateSync } from "node:zlib";
+
+// Equivalent pixels with different transport sizes, both below image admission limits.
+export function equivalentPngEncodings(): Buffer[] {
+  const width = 1024, height = 800, stride = width * 4 + 1;
+  const pixels = Buffer.alloc(stride * height);
+  for (let y = 0; y < height; y++) for (let x = 0; x < width; x++) {
+    pixels.set([0, 128, 128, 255], y * stride + 1 + x * 4);
+  }
+  const header = Buffer.alloc(13);
+  header.writeUInt32BE(width, 0); header.writeUInt32BE(height, 4);
+  header[8] = 8; header[9] = 6;
+  return [9, 0].map(level => {
+    const compressed = deflateSync(pixels, { level });
+    assert.deepEqual(inflateSync(compressed), pixels);
+    const png = Buffer.concat([
+      Buffer.from("89504e470d0a1a0a", "hex"),
+      pngChunk("IHDR", header), pngChunk("IDAT", compressed), pngChunk("IEND", Buffer.alloc(0)),
+    ]);
+    assert.ok(Math.ceil(png.length / 3) * 4 < 5 * 1024 * 1024);
+    return png;
+  });
+}
+
+function pngChunk(type: string, data: Buffer): Buffer {
+  const tag = Buffer.from(type), length = Buffer.alloc(4), checksum = Buffer.alloc(4);
+  length.writeUInt32BE(data.length);
+  let crc = 0xffffffff;
+  for (const bytes of [tag, data]) for (const byte of bytes) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit++) crc = (crc >>> 1) ^ ((crc & 1) ? 0xedb88320 : 0);
+  }
+  checksum.writeUInt32BE((crc ^ 0xffffffff) >>> 0);
+  return Buffer.concat([length, tag, data, checksum]);
+}

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -18,6 +18,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { FX_BIN, REPO_ROOT, runFx, providerVersionTestEnv } from "../evals/eval-helpers";
 import { readTapeFrames } from "./render-lab/tape";
+import { equivalentPngEncodings } from "./fixtures/image-encoding";
 import {
   FAKE_GATEWAY_MODEL,
   fakeGatewayFinalText,
@@ -4453,7 +4454,7 @@ test("direct providers keep images with their users through tools and resume", a
     const profile = mkdtempSync(join(tmpdir(), "fx-native-image-history-"));
     const model = "fixture-model";
     const testGateway = startFakeGateway([]);
-    const terminal = { type: "response.completed", response: { status: "completed" } };
+    const terminal = { type: "response.completed", response: { status: "completed", usage: { input_tokens: 50_000, output_tokens: 10 } } };
     const responses = [
       fakeGatewaySse([
         { type: "response.output_item.added", output_index: 0, item: { type: "function_call", call_id: "read_1", name: "read_file", arguments: "" } },
@@ -4488,6 +4489,7 @@ test("direct providers keep images with their users through tools and resume", a
         FX_E2E_XAI_GROK_RESPONSES_URL: direct.responsesUrl,
         FX_E2E_XAI_GROK_MODELS_URL: direct.modelsUrl,
         FX_E2E_XAI_GROK_MODALITIES_URL: "modalitiesUrl" in direct ? direct.modalitiesUrl : undefined,
+        FX_TRACE_LOG: join(profile, "trace.log"), FX_TRACE_SCOPES: "context_compaction",
       };
       const firstPrompt = "Read fixture.txt, then describe the attached image.";
       const secondPrompt = "Compare the earlier image with this new image.";
@@ -4508,6 +4510,7 @@ test("direct providers keep images with their users through tools and resume", a
       expect(direct.bodies).toHaveLength(2);
       expect(imageOwners(direct.bodies[0])).toEqual([firstOwner]);
       expect(imageOwners(direct.bodies[1])).toEqual([firstOwner]);
+      expect(readFileSync(join(profile, "trace.log"), "utf8")).toContain("has_images=true image_baseline=true");
       unlinkSync(firstPath);
       const second = await runFx(["ask", "--json", "--auto", "--resume-id", sessionId, "--image", secondPath, secondPrompt], { cwd: profile, env, timeoutMs: TIMEOUT });
       expect(second.code, second.stdout + second.stderr).toBe(0);
@@ -4543,6 +4546,67 @@ test("direct providers keep images with their users through tools and resume", a
       direct.stop(); testGateway.stop();
       rmSync(profile, { recursive: true, force: true });
     }
+  }
+}, 60_000);
+
+test("provider context accounting is independent of image encoding size", async () => {
+  const encodings = equivalentPngEncodings();
+  for (const provider of ["gateway", "codex", "grok"] as const) {
+    const estimates: number[] = [];
+    for (const bytes of encodings) {
+      const profile = mkdtempSync(join(tmpdir(), "fx-image-context-"));
+      const model = provider === "gateway" ? "fixture/image" : "fixture-model";
+      const gateway = startFakeGateway([fakeGatewayFinalText("IMAGE_CONTEXT_OK")], {
+        models: [{ id: model, type: "language", tags: ["vision", "file-input", "tool-use"], context_window: 1_000_000 }],
+      });
+      const responses = [fakeGatewaySse([
+        { type: "response.output_text.delta", delta: "IMAGE_CONTEXT_OK" },
+        { type: "response.completed", response: { status: "completed" } },
+      ])];
+      const direct = provider === "codex" ? startFakeCodexToolLoop({ responses, model, inputModalities: ["text", "image"] })
+        : provider === "grok" ? startFakeGrokToolLoop({ responses, model }) : null;
+      try {
+        mkdirSync(join(profile, ".fx"), { recursive: true });
+        if (provider === "codex") writeSeededChatGptLogin(profile, direct!.accessToken);
+        if (provider === "grok") writeSeededGrokLogin(profile, direct!.accessToken);
+        writeFileSync(join(profile, ".fx", "settings.json"), JSON.stringify({ provider, [provider + "_model"]: model }), { mode: 0o600 });
+        const path = join(profile, "image.png"), trace = join(profile, "trace.log");
+        writeFileSync(path, bytes);
+        const result = await runFx(["ask", "--json", "--auto", "--no-save", "--image", path, "Describe the attached image."], {
+          cwd: profile, timeoutMs: TIMEOUT,
+          env: {
+            HOME: profile, AI_GATEWAY_API_KEY: "fixture", VERCEL_OIDC_TOKEN: undefined,
+            FX_MODEL: provider === "gateway" ? model : undefined, FX_DISABLE_KEYCHAIN: "1", FX_AUTO_UPGRADE: "0", FX_SOUND: "0",
+            FX_GATEWAY_BASE_URL: gateway.baseUrl, FX_GATEWAY_CHAT_URL: gateway.chatUrl,
+            FX_E2E_GATEWAY_MODELS_URL: gateway.baseUrl + "/coding-agent/v1/models",
+            FX_E2E_OPENAI_CODEX_RESPONSES_URL: direct?.responsesUrl, FX_E2E_OPENAI_CODEX_MODELS_URL: direct?.modelsUrl,
+            FX_E2E_XAI_GROK_RESPONSES_URL: direct?.responsesUrl, FX_E2E_XAI_GROK_MODELS_URL: direct?.modelsUrl,
+            FX_E2E_XAI_GROK_MODALITIES_URL: direct && "modalitiesUrl" in direct ? direct.modalitiesUrl : undefined,
+            FX_TRACE_LOG: trace, FX_TRACE_SCOPES: "context_compaction",
+          },
+        });
+        expect(result.code, provider + ": " + result.stdout + result.stderr).toBe(0);
+        expect(result.signal).toBeNull();
+        expect(result.stderr).toBe("");
+        expect(JSON.parse(result.stdout).output).toBe("IMAGE_CONTEXT_OK");
+        const bodies = direct?.bodies ?? gateway.requests;
+        expect(bodies).toHaveLength(1);
+        const request = JSON.parse(typeof bodies[0] === "string" ? bodies[0] : bodies[0].body);
+        const parts = (request.input ?? request.prompt).flatMap((message: { content: unknown }) => Array.isArray(message.content) ? message.content : []);
+        const image = parts.find((part: { type?: string }) => part.type === (provider === "gateway" ? "file" : "input_image"));
+        expect(image).toBeDefined();
+        expect(provider === "gateway" ? image.data : image.image_url).toBe((provider === "gateway" ? "" : "data:image/png;base64,") + bytes.toString("base64"));
+        const decision = readFileSync(trace, "utf8");
+        expect(decision).toContain("decision=no_op");
+        expect(decision).toContain("has_images=true image_baseline=false");
+        estimates.push(Number(decision.match(/estimated_tokens=(\d+)/)![1]));
+        if (direct) expect(gateway.requests).toHaveLength(0);
+      } finally {
+        direct?.stop(); gateway.stop();
+        rmSync(profile, { recursive: true, force: true });
+      }
+    }
+    expect(estimates[0]).toBe(estimates[1]);
   }
 }, 60_000);
 


### PR DESCRIPTION
## Summary

- Stop rejecting valid image attachments as oversized conversation context because of their encoding size.
- Use prior provider usage to estimate same-image continuations without multiplying image cost as tool output grows.
