### PR TITLE
Preserve saved history when continuing resumed sessions

### DIFF
--- a/src/ui/render_engine/transcript_blocks.zig
+++ b/src/ui/render_engine/transcript_blocks.zig
@@ -50,6 +50,8 @@ pub const ToolFallbackDisposition = enum {
 
 pub const ToolDetailRecord = struct {
     entry_id: u32,
+    // Recorded identities are archival and cannot pin live output.
+    origin: enum { live, recorded } = .live,
     created_at_ms: i64 = 0,
     tool_name: []u8,
     captured_command: bool = false,

--- a/src/ui/resize_tests.zig
+++ b/src/ui/resize_tests.zig
@@ -7839,3 +7839,44 @@ test "orphan command output does not leak into current compact rows" {
 
     try expectGridOccurrenceCount(&h, "dedupe-command-row", 0);
 }
+
+test "recorded tool rows enter physical history when the viewport advances" {
+    const alloc = std.testing.allocator;
+    var h = try Harness.init(alloc, 60, 12, 4);
+    defer h.deinit();
+    const entry_id = try h.shell.appendRawTranscriptEntryClassified(alloc, "● Wrote receipt.txt\n", .tool_status);
+    try h.shell.attachHistoricalToolDetailWithLifecycle(
+        alloc,
+        entry_id,
+        .{ .id = "saved-write", .name = "write_file", .arguments_json = "{\"path\":\"receipt.txt\"}" },
+        .write,
+        .{
+            .tool_call_id = @constCast("saved-write"),
+            .tool_name = @constCast("write_file"),
+            .status = .success,
+            .output = @constCast("saved result"),
+            .output_bytes = 12,
+            .stored_output_bytes = 12,
+        },
+        .{ .turn_id = 2, .call_id = "saved-write" },
+    );
+    _ = try h.shell.appendRawTranscriptEntry(alloc, "Saved response\n");
+    try h.renderTranscriptFrame();
+    try h.flush();
+    try expectGridContains(&h, "Wrote receipt.txt");
+    try expectGridContains(&h, "Saved response");
+
+    var committed_rows: usize = 0;
+    for (0..16) |i| {
+        var buf: [48]u8 = undefined;
+        _ = try h.shell.appendRawTranscriptEntry(alloc, try std.fmt.bufPrint(&buf, "Continuation row {d}\n", .{i}));
+        try h.renderTranscriptFrame();
+        try h.flush();
+        committed_rows += h.last_frame.committed_scroll_rows;
+        try std.testing.expect(h.last_frame.transcript_history_floor_respected);
+    }
+    try expectGridContains(&h, "Continuation row 15");
+    try std.testing.expect(committed_rows > 0);
+    const anchor = h.shell.transcript_commit_state.stable;
+    try std.testing.expectEqual(anchor.visual_offset, anchor.history_visual_offset);
+}

--- a/src/ui/transcript/runtime.zig
+++ b/src/ui/transcript/runtime.zig
@@ -5520,7 +5520,10 @@ pub const TranscriptRuntime = struct {
         call: types.ToolCall,
     ) !void {
         try self.upsertToolDetailStart(alloc, entry_id, null, call.name, null, call.arguments_json);
-        if (self.toolDetailPtr(entry_id)) |detail| detail.outcome = .failed;
+        if (self.toolDetailPtr(entry_id)) |detail| {
+            detail.outcome = .failed;
+            detail.origin = .recorded;
+        }
     }
 
     pub fn attachHistoricalCommandOutput(
@@ -5554,6 +5557,7 @@ pub const TranscriptRuntime = struct {
             command_artifact_handle,
             if (replayed_output) self.latestCommandOutputEntryId() else null,
         );
+        if (self.toolDetailPtr(entry_id)) |detail| detail.origin = .recorded;
     }
 
     fn upsertToolDetailStart(

--- a/src/ui/transcript/runtime.zig
+++ b/src/ui/transcript/runtime.zig
@@ -5509,6 +5509,7 @@ pub const TranscriptRuntime = struct {
         );
         if (self.toolDetailPtr(entry_id)) |detail| {
             detail.created_at_ms = result.created_at_ms;
+            detail.origin = .recorded;
         }
     }
 

--- a/src/ui/transcript/runtime_tests.zig
+++ b/src/ui/transcript/runtime_tests.zig
@@ -16186,6 +16186,104 @@ test "pending replacement notice holds release until the finished replacement se
     try std.testing.expectEqual(settled.visual_offset, settled.history_visual_offset);
 }
 
+fn appendRecordedWriteForFinalityTest(
+    runtime: *TranscriptRuntime,
+    alloc: Allocator,
+    lifecycle_id: ?types.ToolLifecycleId,
+) !u32 {
+    const entry_id = try runtime.appendRawTranscriptEntryClassified(alloc, "● Wrote receipt.txt\n", .tool_status);
+    try runtime.attachHistoricalToolDetailWithLifecycle(
+        alloc,
+        entry_id,
+        .{ .id = "saved-write", .name = "write_file", .arguments_json = "{\"path\":\"receipt.txt\"}" },
+        .write,
+        .{
+            .tool_call_id = @constCast("saved-write"),
+            .tool_name = @constCast("write_file"),
+            .status = .success,
+            .output = @constCast("saved result"),
+            .output_bytes = 12,
+            .stored_output_bytes = 12,
+        },
+        lifecycle_id,
+    );
+    return entry_id;
+}
+
+test "recorded tool finality does not depend on the current turn watermark" {
+    const alloc = std.testing.allocator;
+    for ([_]?u64{ null, 1, 2, 50_000 }) |turn_id| {
+        var runtime = TranscriptRuntime{ .layout = transcriptTestLayout(88, 24, 20) };
+        defer runtime.deinit(alloc);
+        const id = try appendRecordedWriteForFinalityTest(&runtime, alloc, if (turn_id) |turn|
+            .{ .turn_id = turn, .call_id = "saved-write" }
+        else
+            null);
+        var source = try runtime.prepareTranscriptSource(alloc, null);
+        defer source.deinit(alloc);
+        try std.testing.expectEqual(@as(?usize, null), runtime.transcript_release.finality_floor(source.finality, 0, null));
+        if (turn_id) |turn| {
+            const archived_id = runtime.toolDetailForEntry(id).?.lifecycle_id.?;
+            try std.testing.expectEqual(turn, archived_id.turn_id);
+            try std.testing.expectEqualStrings("saved-write", archived_id.call_id);
+        }
+    }
+}
+
+test "recorded tool finality stays independent of a live turn with the same number" {
+    const alloc = std.testing.allocator;
+    var runtime = TranscriptRuntime{ .layout = transcriptTestLayout(88, 24, 20) };
+    defer runtime.deinit(alloc);
+    _ = try appendRecordedWriteForFinalityTest(&runtime, alloc, .{ .turn_id = 1, .call_id = "saved-write" });
+    _ = try runtime.appendRawTranscriptEntry(alloc, "Saved response\n");
+    const live_id = types.ToolLifecycleId{ .turn_id = 1, .call_id = "live-write" };
+    _ = try runtime.applyToolLifecycle(alloc, .{ .authoritative_started = .{
+        .id = live_id,
+        .reconciles_provisional_call_id = null,
+        .tool_name = "write_file",
+        .activity_kind = .write,
+    } });
+    for ([_]bool{ false, true }) |terminal| {
+        if (terminal) _ = try runtime.applyToolLifecycle(alloc, .{ .terminal = .{
+            .id = live_id,
+            .outcome = .{ .kind = .completed, .summary = "Wrote live file" },
+        } });
+        var source = try runtime.prepareTranscriptSource(alloc, null);
+        defer source.deinit(alloc);
+        const floor = runtime.transcript_release.finality_floor(source.finality, 0, null) orelse return error.TestExpectedLiveFinalityFloor;
+        try std.testing.expect(floor > 0);
+        try std.testing.expect(std.mem.find(u8, source.bytes[0..floor], "Saved response") != null);
+    }
+    _ = try runtime.applyToolLifecycle(alloc, .{ .turn_finished = .{ .turn_id = 1, .outcome = .completed } });
+    try runtime.finishLifecycleBatch(alloc);
+    var finished = try runtime.prepareTranscriptSource(alloc, null);
+    defer finished.deinit(alloc);
+    try std.testing.expectEqual(@as(?usize, null), runtime.transcript_release.finality_floor(finished.finality, runtime.finalizedToolTurnWatermark(), null));
+}
+
+test "recorded tool finality survives an owned snapshot after source retirement" {
+    const alloc = std.testing.allocator;
+    var restored = TranscriptRuntime{ .layout = transcriptTestLayout(88, 24, 20) };
+    defer restored.deinit(alloc);
+    const entry_id = try restored.appendRawTranscriptEntryClassified(alloc, "● Wrote receipt.txt\n", .tool_status);
+    {
+        var original = TranscriptRuntime{ .layout = transcriptTestLayout(88, 24, 20) };
+        defer original.deinit(alloc);
+        const id = try appendRecordedWriteForFinalityTest(&original, alloc, .{ .turn_id = 2, .call_id = "saved-write" });
+        var detail = try transcript_store.cloneToolDetailForSnapshot(alloc, original.toolDetailForEntry(id).?.*);
+        errdefer detail.deinit(alloc);
+        detail.entry_id = entry_id;
+        try restored.tool_details.append(alloc, detail);
+    }
+    var source = try restored.prepareTranscriptSource(alloc, null);
+    defer source.deinit(alloc);
+    try std.testing.expectEqual(@as(?usize, null), restored.transcript_release.finality_floor(source.finality, 0, null));
+    const detail = restored.toolDetailForEntry(entry_id).?;
+    try std.testing.expectEqual(@as(u64, 2), detail.lifecycle_id.?.turn_id);
+    try std.testing.expectEqualStrings("saved-write", detail.lifecycle_id.?.call_id);
+    try std.testing.expectEqualStrings("saved result", detail.result.?);
+}
+
 test "finality candidates keep tool turn and replaceable tail offsets independent" {
     const alloc = std.testing.allocator;
     var runtime = TranscriptRuntime{

--- a/src/ui/transcript/source_preparation.zig
+++ b/src/ui/transcript/source_preparation.zig
@@ -60,7 +60,7 @@ fn entryHiddenByActions(
 
 /// Nominate the entries whose rendered start bytes bound the final flow
 /// prefix: the first entry carrying a live mutation pin, the first rendered
-/// entry of each tool turn, and a trailing assistant entry. Omitted and
+/// entry of each live tool turn, and a trailing assistant entry. Omitted and
 /// hidden entries contribute no flow bytes and are skipped.
 fn collectFinalityNominations(
     self: anytype,
@@ -86,6 +86,7 @@ fn collectFinalityNominations(
     var group_terminality: std.AutoHashMapUnmanaged(types.ToolPresentationGroupId, bool) = .empty;
     defer group_terminality.deinit(alloc);
     for (self.tool_details.items) |detail| {
+        if (detail.origin == .recorded) continue;
         const group = detail.presentation_group_id orelse continue;
         const result = try group_terminality.getOrPut(alloc, group);
         if (!result.found_existing) result.value_ptr.* = true;
@@ -95,6 +96,7 @@ fn collectFinalityNominations(
     var entry_tool_identities: std.AutoHashMapUnmanaged(u32, ToolFinalityIdentity) = .empty;
     defer entry_tool_identities.deinit(alloc);
     for (self.tool_details.items) |detail| {
+        if (detail.origin == .recorded) continue;
         const identity: ToolFinalityIdentity = if (detail.presentation_group_id) |group|
             .{
                 .turn_id = group.turn_id,

--- a/src/ui/transcript/store.zig
+++ b/src/ui/transcript/store.zig
@@ -2172,6 +2172,7 @@ pub fn cloneToolDetailForSnapshot(alloc: Allocator, source: ToolDetailRecord) !T
         .command_process_presentation = source.command_process_presentation,
         .outcome = source.outcome,
         .fallback_disposition = source.fallback_disposition,
+        .origin = source.origin,
         .lifecycle_id = lifecycle_id,
         .presentation_group_id = source.presentation_group_id,
         .command_output_entry_id = source.command_output_entry_id,

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -6789,3 +6789,101 @@ test.skipIf(!tmuxAvailable())(
   },
   120_000,
 );
+
+for (const inspectDetails of [false, true]) {
+  test.skipIf(!tmuxAvailable())(
+    `resumed tool history survives continuation${inspectDetails ? " after full detail resize" : ""}`,
+    async () => {
+      const root = realpathSync(mkdtempSync(join(tmpdir(), "fx-resumed-tool-history-")));
+      const home = join(root, "home");
+      const workspace = join(root, "workspace");
+      const tracePath = join(root, "trace.log");
+      const stderrPath = join(root, "stderr.log");
+      mkdirSync(join(home, ".fx"), { recursive: true });
+      mkdirSync(workspace);
+      writeFileSync(join(home, ".fx", "settings.json"), JSON.stringify({
+        sound: false, permission_mode: "auto", sandbox: "none",
+      }));
+      const ledger = Array.from({ length: 420 }, (_, i) => `ROW_${i + 1} café 東京`).join("\n") + "\n";
+      writeFileSync(join(workspace, "ledger.txt"), ledger);
+      const savedReply = "Created receipt.txt with:\n\nRECEIVED\n\nledger.txt was not changed.";
+      const gateway = startFakeGateway([
+        fakeGatewayToolCall("read-ledger", "read_file", { path: "ledger.txt", line_count: 420 }),
+        fakeGatewayFinalText("ledger.txt contains 420 rows."),
+        fakeGatewayToolCall("write-receipt", "write_file", { path: "receipt.txt", content: "RECEIVED\n" }),
+        fakeGatewayFinalText(savedReply),
+        fakeGatewayToolCall("read-missing", "read_file", { path: "missing.txt" }),
+        fakeGatewayFinalText("missing.txt does not exist."),
+        fakeGatewayFinalText("I created receipt.txt and left ledger.txt unchanged."),
+        fakeGatewayToolCall("write-second", "write_file", { path: "second.txt", content: "AFTER\n" }),
+        fakeGatewayFinalText("Created second.txt once."),
+      ]);
+      let active: TmuxSession | null = null;
+      const prompt = async (text: string) => {
+        const offset = existsSync(tracePath) ? readFileSync(tracePath, "utf8").length : 0;
+        await active!.sendText(text);
+        await waitForCondition(
+          () => existsSync(tracePath) && readFileSync(tracePath, "utf8").slice(offset).includes("event=prompt_finish"),
+          "completed prompt", TIMEOUT,
+        );
+        await active!.waitForComposer(TIMEOUT);
+      };
+      const markers = ["Wrote receipt.txt", "Created receipt.txt with:", "RECEIVED", "ledger.txt was not changed.", "missing.txt does not exist."];
+      const assertHistory = async () => {
+        const plain = stripAnsi(await active!.captureFullScrollbackEscapes());
+        for (const marker of markers) expect(plain).toContain(marker);
+      };
+      try {
+        const env = { ...gatewayEnv(home, gateway), FX_SOUND: "0", FX_TRACE_LOG: tracePath, FX_TRACE_SCOPES: "agent,worker" };
+        active = await TmuxSession.create({ cmd: FX_BIN, cwd: workspace, env, stderrPath, isolated: true, remainOnExit: true, width: 160, height: 48 });
+        await active.waitForComposer(TIMEOUT);
+        await prompt("Read every line of ledger.txt without changing it.");
+        await prompt("Create receipt.txt containing RECEIVED and a newline. Keep ledger.txt unchanged.");
+        await prompt("Read missing.txt once without retrying.");
+        expect(readFileSync(stderrPath, "utf8")).toBe("");
+        const sessionId = sessionIdFromHome(home);
+        const eventsPath = join(home, ".fx", "sessions", sessionId, "events.jsonl");
+        await active.kill();
+        active = await TmuxSession.create({ cmd: `${FX_BIN} --resume-last`, cwd: workspace, env, stderrPath, isolated: true, remainOnExit: true, width: 88, height: 24 });
+        await active.waitForComposer(TIMEOUT);
+        await assertHistory();
+        if (inspectDetails) {
+          await active.sendKeys("C-o");
+          await active.waitForText("Full detail", TIMEOUT);
+          await active.sendKeys("PPage");
+          await active.resizeWindow(60, 18);
+          await Bun.sleep(350);
+          await active.sendKeys("NPage");
+          await active.resizeWindow(88, 24);
+          await Bun.sleep(350);
+          await active.sendKeys("Escape");
+          await active.waitForPane(pane => !pane.includes("Full detail"), TIMEOUT);
+          await Bun.sleep(150);
+        }
+        await prompt("In one sentence, confirm which file you created. Do not use tools.");
+        await assertHistory();
+        await prompt("Create second.txt containing AFTER and a newline. Leave the other files unchanged.");
+        await assertHistory();
+        expect(readFileSync(join(workspace, "receipt.txt"), "utf8")).toBe("RECEIVED\n");
+        expect(readFileSync(join(workspace, "second.txt"), "utf8")).toBe("AFTER\n");
+        expect(readFileSync(join(workspace, "ledger.txt"), "utf8")).toBe(ledger);
+        const events = readFileSync(eventsPath, "utf8").trim().split("\n").map(line => JSON.parse(line).event);
+        expect(events.filter(event => event.tool_result?.call_id === "write-second")).toHaveLength(1);
+        expect(events.find(event => event.tool_result?.call_id === "write-receipt").tool_result.committed_file_presentation.lifecycle_id)
+          .toEqual({ turn_id: 2, call_id: "write-receipt" });
+        expect(events.some(event => event.assistant?.text === savedReply)).toBe(true);
+        expect(gateway.requests).toHaveLength(9);
+        expect(active.isPaneAlive()).toBe(true);
+        expect(readFileSync(stderrPath, "utf8")).toBe("");
+        await active.sendText("/quit");
+        await waitForCondition(() => active!.paneStatus().dead, "session exit", TIMEOUT);
+        expect(paneExitMatches(active.paneStatus(), 0)).toBe(true);
+      } finally {
+        if (active) await active.kill();
+        gateway.stop();
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+    TIMEOUT * 2,
+  );
+}


### PR DESCRIPTION
## Summary

- Preserve saved tool statuses and replies in scrollback when continuing a resumed conversation, including after inspecting and resizing full details.
