### PR TITLE
Improve progress updates during tool recovery

### DIFF
--- a/src/builtins/context.zig
+++ b/src/builtins/context.zig
@@ -3098,6 +3098,7 @@ test "gateway_system_prompt: evidence-led scoped execution" {
     try expectDefaultPromptContains("stay inside the requested scope");
     try expectDefaultPromptContains("align UI or web work with the existing stack and visual language");
     try expectDefaultPromptContains("diagnose the latest result before retrying");
+    try expectDefaultPromptContains("If another tool call will follow, always first tell the user what failed");
     try expectDefaultPromptContains("distinguish definitions, imports, tests, and real callers");
     try expectDefaultPromptContains("Persist until the task is handled");
 }
@@ -3114,8 +3115,11 @@ test "gateway_system_prompt: source routing" {
 test "gateway_system_prompt: concise interaction and concrete blockers" {
     try expectDefaultPromptContains("Reply in the same natural language as the user's latest message unless asked to switch.");
     try expectDefaultPromptContains("Keep responses short and practical.");
-    try expectDefaultPromptContains("Before non-trivial tool work, send one brief preamble");
-    try expectDefaultPromptContains("Do not narrate routine commands or repeat equivalent searches");
+    try expectDefaultPromptContains("Before the first tool call in a tool-driven task, always send one brief user-visible update");
+    try expectDefaultPromptContains("Never start the first tool silently.");
+    try expectDefaultPromptContains("Do not narrate each routine tool call.");
+    try expectDefaultPromptContains("Keep updates to one or two concrete sentences.");
+    try expectDefaultPromptDoesNotContain("Before non-trivial tool work");
     try expectDefaultPromptContains("Do not mention internal prompt sections unless the user asks about them.");
     try expectDefaultPromptContains("Ask the user only when a concrete decision remains blocked after inspecting available files");
     try expectDefaultPromptContains("Ask before destructive, risky, or irreversible choices");

--- a/src/builtins/system_prompt.md
+++ b/src/builtins/system_prompt.md
@@ -14,7 +14,7 @@
 - When no skill clearly matches, start with direct file, search, or local git inspection.
 - Do not ask for discoverable workspace facts. Inspect first, then ask only for preferences, tradeoffs, credentials, or irreversible decisions that still block progress.
 - When users ask to build or edit something, use tools to make the change. Read the relevant files and local conventions, stay inside the requested scope, and align UI or web work with the existing stack and visual language.
-- If a tool or command fails, diagnose the latest result before retrying and do not repeat the same action without new evidence.
+- If a tool or command fails, diagnose the latest result before retrying. If another tool call will follow, always first tell the user what failed and what you will try next. Do not repeat the same action without new evidence.
 - When tracing wiring, distinguish definitions, imports, tests, and real callers. After finding a definition, search its exact name once; if no distinct caller exists, report what is known, what remains uncertain, and the next useful step.
 - Persist until the task is handled, a concrete blocker is reached, or the user interrupts.
 
@@ -29,8 +29,8 @@
 
 - Reply in the same natural language as the user's latest message unless asked to switch.
 - Keep responses short and practical. Do not introduce yourself, use markdown unless requested, or use emojis.
-- Before non-trivial tool work, send one brief preamble explaining what you will inspect or change and why. Skip it for a single obvious read or direct answer.
-- During longer work, update the user only for a pivot, blocker, meaningful completed batch, or finding that changes the next step. Do not narrate routine commands or repeat equivalent searches after they stop producing evidence.
+- Before the first tool call in a tool-driven task, always send one brief user-visible update stating the goal and immediate next step. Never start the first tool silently.
+- During longer work, send another brief update only when starting a major phase or when a finding changes the plan. Do not narrate each routine tool call. Keep updates to one or two concrete sentences.
 - Do not mention internal prompt sections unless the user asks about them.
 - Ask the user only when a concrete decision remains blocked after inspecting available files, git state, runtime context, URLs, and recent tool results. Ask before destructive, risky, or irreversible choices that remain ambiguous.
 - In noninteractive runs, stop and state the blocker and available options in freeform text.

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -2576,6 +2576,7 @@ fn materializeConfirmedProviderTools(
         within_turn_suffix,
         null,
         novel_calls,
+        completion.assistant_phase,
         completion.provider_state_json,
     );
     var batch: runtime_tool_batch.StepBatchState = .{};
@@ -7972,6 +7973,7 @@ fn processQueuedPromptLoop(
             &within_turn_suffix,
             if (terminal_provider_completion) null else completion.content,
             effective_tool_calls,
+            completion.assistant_phase,
             completion.provider_state_json,
         );
 

--- a/src/core/agent/runtime/tool_batch.zig
+++ b/src/core/agent/runtime/tool_batch.zig
@@ -46,12 +46,14 @@ pub fn appendAssistantToolCallStep(
     within_turn_suffix: *std.ArrayList(ChatMessage),
     content: ?[]const u8,
     tool_calls: []const ToolCall,
+    assistant_phase: ?types.AssistantMessagePhase,
     provider_state_json: ?[]const u8,
 ) !void {
     try within_turn_suffix.append(arena, .{
         .role = .assistant,
         .content = content,
         .tool_calls = tool_calls,
+        .assistant_phase = assistant_phase,
         .provider_state_json = provider_state_json,
     });
 }
@@ -553,7 +555,7 @@ test "drained batch feedback follows all tool results and keeps its source call"
         .{ .id = "call_second", .name = "run_command", .arguments_json = "{}" },
     };
 
-    try appendAssistantToolCallStep(alloc, &suffix, null, &calls, null);
+    try appendAssistantToolCallStep(alloc, &suffix, null, &calls, .commentary, null);
     try appendToolResultContent(
         alloc,
         &suffix,
@@ -584,6 +586,10 @@ test "drained batch feedback follows all tool results and keeps its source call"
 
     try std.testing.expectEqual(@as(usize, 4), suffix.items.len);
     try std.testing.expectEqual(.assistant, suffix.items[0].role);
+    try std.testing.expectEqual(
+        types.AssistantMessagePhase.commentary,
+        suffix.items[0].assistant_phase.?,
+    );
     try std.testing.expectEqual(.tool, suffix.items[1].role);
     try std.testing.expectEqual(.tool, suffix.items[2].role);
     try std.testing.expectEqual(.user, suffix.items[3].role);

--- a/src/core/shared/types.zig
+++ b/src/core/shared/types.zig
@@ -1058,6 +1058,12 @@ pub const UserTurn = struct {
     work_id: ?[]u8 = null,
 };
 
+/// Provider-returned phase for stateless assistant-message replay.
+pub const AssistantMessagePhase = enum {
+    commentary,
+    final_answer,
+};
+
 pub const ChatMessage = struct {
     role: ChatRole,
     content: ?[]const u8 = null,
@@ -1068,6 +1074,8 @@ pub const ChatMessage = struct {
     /// Provider-owned opaque response items needed only for stateless within-turn continuation.
     /// The value is a validated JSON array and is never sent across provider routes.
     provider_state_json: ?[]const u8 = null,
+    /// Borrowed phase metadata for the same current-turn continuation.
+    assistant_phase: ?AssistantMessagePhase = null,
     tool_result_status: ?PersistedToolStatus = null,
     tool_result_memory: ?ToolResultMemory = null,
     permission_feedback: bool = false,
@@ -1161,6 +1169,7 @@ pub const ProviderFailureCause = enum {
 pub const ModelCompletion = struct {
     content: ?[]const u8 = null,
     tool_calls: []const ToolCall = &.{},
+    assistant_phase: ?AssistantMessagePhase = null,
     generation_id: ?[]const u8 = null,
     billing: ?ProviderBilling = null,
     /// Gateway generation or resolved-model metadata was malformed or conflicting.

--- a/src/gateway/responses_protocol.zig
+++ b/src/gateway/responses_protocol.zig
@@ -83,7 +83,12 @@ pub fn writeInput(
                     try writeComma(writer, &first);
                     try writer.writeAll("{\"type\":\"message\",\"role\":\"assistant\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"text\":");
                     try std.json.Stringify.value(content, .{}, writer);
-                    try writer.writeAll(",\"annotations\":[]}]}");
+                    try writer.writeAll(",\"annotations\":[]}]");
+                    if (message.assistant_phase) |phase| {
+                        try writer.writeAll(",\"phase\":");
+                        try std.json.Stringify.value(@tagName(phase), .{}, writer);
+                    }
+                    try writer.writeByte('}');
                 };
                 for (message.tool_calls) |call| {
                     try writeComma(writer, &first);
@@ -149,6 +154,49 @@ test "Responses request preserves opaque tool-call identity" {
     try std.testing.expectEqualStrings("signed:0", items[1].object.get("call_id").?.string);
     try std.testing.expectEqualStrings("signed:0", items[2].object.get("call_id").?.string);
     try std.testing.expectEqualStrings(state, messages[0].provider_state_json.?);
+}
+
+test "Responses request preserves assistant commentary phase" {
+    const calls = [_]types.ToolCall{.{
+        .id = "call_1",
+        .name = "read_file",
+        .arguments_json = "{}",
+    }};
+    const messages = [_]types.ChatMessage{
+        .{
+            .role = .assistant,
+            .content = "I will inspect the file first.",
+            .tool_calls = &calls,
+            .assistant_phase = .commentary,
+        },
+        .{
+            .role = .tool,
+            .tool_call_id = "call_1",
+            .tool_name = "read_file",
+            .content = "contents",
+        },
+    };
+    var out: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer out.deinit();
+    try out.writer.writeByte('[');
+    try writeInput(&out.writer, std.testing.allocator, &messages, null, .{
+        .tool_calls = 128,
+        .tool_identity_bytes = 256,
+        .tool_arguments_bytes = 4096,
+        .provider_state_bytes = 4096,
+    }, .{});
+    try out.writer.writeByte(']');
+
+    const parsed = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        out.written(),
+        .{},
+    );
+    defer parsed.deinit();
+    const item = parsed.value.array.items[0].object;
+    try std.testing.expectEqualStrings("message", item.get("type").?.string);
+    try std.testing.expectEqualStrings("commentary", item.get("phase").?.string);
 }
 
 test "non-object provider-owned arguments retain their Responses representation" {
@@ -538,6 +586,33 @@ fn optionalOutputIndex(fields: std.json.ObjectMap) error{InvalidEvent}!?i64 {
     return value.integer;
 }
 
+const AssistantPhaseAccumulator = union(enum) {
+    empty,
+    value: types.AssistantMessagePhase,
+    conflicting,
+
+    fn observe(self: *AssistantPhaseAccumulator, candidate: ?types.AssistantMessagePhase) void {
+        const phase = candidate orelse return;
+        self.* = switch (self.*) {
+            .empty => .{ .value = phase },
+            .value => |current| if (current == phase) .{ .value = current } else .conflicting,
+            .conflicting => .conflicting,
+        };
+    }
+
+    fn resolved(self: AssistantPhaseAccumulator) ?types.AssistantMessagePhase {
+        return switch (self) {
+            .value => |phase| phase,
+            .empty, .conflicting => null,
+        };
+    }
+};
+
+fn assistantMessagePhase(fields: std.json.ObjectMap) ?types.AssistantMessagePhase {
+    const raw = stringField(fields, "phase") orelse return null;
+    return std.meta.stringToEnum(types.AssistantMessagePhase, raw);
+}
+
 pub const Reducer = struct {
     content: std.ArrayList(u8) = .empty,
     provider_state: std.Io.Writer.Allocating,
@@ -548,6 +623,7 @@ pub const Reducer = struct {
     generation_id: ?[]u8 = null,
     terminal_seen: bool = false,
     saw_content_delta: bool = false,
+    assistant_phase: AssistantPhaseAccumulator = .empty,
     event_count: usize = 0,
     aggregate_bytes: usize = 0,
 
@@ -616,6 +692,8 @@ pub const Reducer = struct {
                     const index = findTool(self.tools.items, output_index).?;
                     try self.tools.items[index].reconcileIdentity(alloc, item.object, "id", limits);
                 }
+            } else if (std.mem.eql(u8, item_type, "message")) {
+                self.assistant_phase.observe(assistantMessagePhase(item.object));
             }
         } else if (std.mem.eql(u8, event_type, "response.output_text.delta") or
             std.mem.eql(u8, event_type, "response.refusal.delta"))
@@ -676,16 +754,19 @@ pub const Reducer = struct {
                 }
                 try self.provider_state.writer.writeAll(encoded.written());
                 self.provider_state_count += 1;
-            } else if (std.mem.eql(u8, item_type, "message") and !self.saw_content_delta) {
-                if (item.object.get("content")) |parts| if (parts == .array) {
-                    for (parts.array.items) |part| {
-                        if (part != .object) continue;
-                        const text = stringField(part.object, "text") orelse
-                            stringField(part.object, "refusal") orelse continue;
-                        callbacks.on_content(callbacks.context, text);
-                        try appendCaptured(alloc, &self.content, text, content_capture_limit);
-                    }
-                };
+            } else if (std.mem.eql(u8, item_type, "message")) {
+                self.assistant_phase.observe(assistantMessagePhase(item.object));
+                if (!self.saw_content_delta) {
+                    if (item.object.get("content")) |parts| if (parts == .array) {
+                        for (parts.array.items) |part| {
+                            if (part != .object) continue;
+                            const text = stringField(part.object, "text") orelse
+                                stringField(part.object, "refusal") orelse continue;
+                            callbacks.on_content(callbacks.context, text);
+                            try appendCaptured(alloc, &self.content, text, content_capture_limit);
+                        }
+                    };
+                }
             }
         } else if (std.mem.eql(u8, event_type, "response.completed") or
             std.mem.eql(u8, event_type, "response.done") or
@@ -698,8 +779,11 @@ pub const Reducer = struct {
                 for (output.array.items, 0..) |item, output_index| {
                     if (item != .object) continue;
                     const item_type = stringField(item.object, "type") orelse continue;
-                    if (!std.mem.eql(u8, item_type, "function_call")) continue;
-                    try self.reconcileToolItem(alloc, std.math.cast(i64, output_index) orelse return error.ResourceLimitExceeded, item.object, callbacks, limits);
+                    if (std.mem.eql(u8, item_type, "function_call")) {
+                        try self.reconcileToolItem(alloc, std.math.cast(i64, output_index) orelse return error.ResourceLimitExceeded, item.object, callbacks, limits);
+                    } else if (std.mem.eql(u8, item_type, "message")) {
+                        self.assistant_phase.observe(assistantMessagePhase(item.object));
+                    }
                 }
             }
             self.terminal_seen = true;
@@ -793,6 +877,7 @@ pub const Reducer = struct {
         return .{
             .content = owned_content,
             .tool_calls = owned_tools,
+            .assistant_phase = self.assistant_phase.resolved(),
             .generation_id = generation_id,
             .provider_state_json = owned_provider_state,
             .finish_reason = self.finish_reason orelse if (owned_tools.len > 0) .tool_calls else .stop,
@@ -836,6 +921,65 @@ const ToolRecordTest = struct {
 
     fn ignore(_: *anyopaque, _: []const u8) void {}
 };
+
+test "Responses captures assistant commentary phase" {
+    var stream = ToolRecordTest.init(std.testing.allocator);
+    defer stream.deinit();
+    try stream.apply(
+        "{\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"message\",\"role\":\"assistant\",\"phase\":\"commentary\"}}",
+    );
+    try stream.apply(
+        "{\"type\":\"response.output_text.delta\",\"output_index\":0,\"delta\":\"I will inspect the file first.\"}",
+    );
+    try stream.apply(ToolRecordTest.terminal);
+    const completion = try stream.finish();
+    defer stream.freeCompletion(completion);
+
+    try std.testing.expectEqual(
+        types.AssistantMessagePhase.commentary,
+        completion.assistant_phase.?,
+    );
+}
+
+test "Responses captures assistant phase from terminal output" {
+    var stream = ToolRecordTest.init(std.testing.allocator);
+    defer stream.deinit();
+    try stream.apply(
+        "{\"type\":\"response.completed\",\"response\":{\"status\":\"completed\",\"output\":[{\"type\":\"message\",\"role\":\"assistant\",\"phase\":\"final_answer\",\"content\":[{\"type\":\"output_text\",\"text\":\"Finished.\"}]}]}}",
+    );
+    const completion = try stream.finish();
+    defer stream.freeCompletion(completion);
+
+    try std.testing.expectEqual(
+        types.AssistantMessagePhase.final_answer,
+        completion.assistant_phase.?,
+    );
+}
+
+test "Responses ignores unknown and conflicting assistant phases" {
+    var unknown = ToolRecordTest.init(std.testing.allocator);
+    defer unknown.deinit();
+    try unknown.apply(
+        "{\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"message\",\"phase\":\"future_phase\"}}",
+    );
+    try unknown.apply(ToolRecordTest.terminal);
+    const unknown_completion = try unknown.finish();
+    defer unknown.freeCompletion(unknown_completion);
+    try std.testing.expect(unknown_completion.assistant_phase == null);
+
+    var conflicting = ToolRecordTest.init(std.testing.allocator);
+    defer conflicting.deinit();
+    try conflicting.apply(
+        "{\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"message\",\"phase\":\"commentary\"}}",
+    );
+    try conflicting.apply(
+        "{\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"message\",\"phase\":\"final_answer\",\"content\":[]}}",
+    );
+    try conflicting.apply(ToolRecordTest.terminal);
+    const conflicting_completion = try conflicting.finish();
+    defer conflicting.freeCompletion(conflicting_completion);
+    try std.testing.expect(conflicting_completion.assistant_phase == null);
+}
 
 test "Responses rejects conflicting completed tool records" {
     const records = [_][]const u8{

--- a/tests/e2e/ask-presentation.test.ts
+++ b/tests/e2e/ask-presentation.test.ts
@@ -383,6 +383,76 @@ describe("fx ask presentation", () => {
     expect(result.stderr).toContain("Reading fixture.txt");
   }, TIMEOUT);
 
+  test("tool recovery keeps progress updates ordered before the final response", async () => {
+    const root = createRoot();
+    writeFileSync(join(root.workspace, "fallback.txt"), "fallback contents\n");
+    const initial = "I will inspect the requested file first.";
+    const recovery = "The requested file was missing, so I will inspect fallback.txt next.";
+    const final = "The fallback inspection is complete.";
+    const gateway = startFakeGateway([
+      fakeGatewaySerializedToolCall(
+        "read_missing_for_progress",
+        "read_file",
+        JSON.stringify({ path: "missing.txt" }),
+        initial,
+      ),
+      fakeGatewaySerializedToolCall(
+        "read_fallback_for_progress",
+        "read_file",
+        JSON.stringify({ path: "fallback.txt" }),
+        recovery,
+      ),
+      fakeGatewayFinalText(final),
+    ]);
+    gateways.push(gateway);
+
+    const result = await runFx(
+      ["ask", "--json", "--auto", "--no-save", "Inspect missing.txt and recover with fallback.txt."],
+      {
+        cwd: root.workspace,
+        env: gatewayEnv(root.home, gateway),
+        timeoutMs: TIMEOUT,
+      },
+    );
+
+    expect(result.code).toBe(0);
+    expect(gateway.requests).toHaveLength(3);
+    const firstPrompt = (JSON.parse(gateway.requests[0]!.body) as GatewayRequestBody)
+      .prompt
+      .filter((message) => message.role === "system")
+      .map((message) => typeof message.content === "string" ? message.content : "")
+      .join("\n");
+    expect(firstPrompt).toContain(
+      "Before the first tool call in a tool-driven task, always send one brief user-visible update",
+    );
+    expect(firstPrompt).toContain("Never start the first tool silently.");
+    expect(firstPrompt).toContain(
+      "If another tool call will follow, always first tell the user what failed",
+    );
+    expect(firstPrompt).toContain("Do not narrate each routine tool call.");
+
+    const output = JSON.parse(result.stdout) as {
+      output: string;
+      final_output: string;
+      tool_calls: Array<{ name: string; status: string }>;
+    };
+    expect(output.output.indexOf(initial)).toBeLessThan(
+      output.output.indexOf(recovery),
+    );
+    expect(output.output.indexOf(recovery)).toBeLessThan(
+      output.output.indexOf(final),
+    );
+    expect(output.final_output).toBe(final);
+    expect(output.tool_calls).toEqual([
+      { name: "read_file", status: "error" },
+      { name: "read_file", status: "success" },
+    ]);
+    expect(gateway.requests[1]!.body).toContain("FileNotFound");
+    expect(gateway.requests[2]!.body).toContain(recovery);
+    expect(result.stderr).toContain("Reading missing.txt");
+    expect(result.stderr).toContain("Reading fallback.txt");
+  }, TIMEOUT);
+
   test.skipIf(!tmuxAvailable())(
     "TTY stdout uses the Minimal transcript and compact tool group",
     async () => {

--- a/tests/e2e/ask-presentation.test.ts
+++ b/tests/e2e/ask-presentation.test.ts
@@ -436,6 +436,9 @@ describe("fx ask presentation", () => {
       final_output: string;
       tool_calls: Array<{ name: string; status: string }>;
     };
+    expect(output.output).toContain(initial);
+    expect(output.output).toContain(recovery);
+    expect(output.output).toContain(final);
     expect(output.output.indexOf(initial)).toBeLessThan(
       output.output.indexOf(recovery),
     );


### PR DESCRIPTION
## Summary

- Prompt models to show a brief update before tool-driven work begins.
- Prompt models to explain failed tools and the next attempt before continuing.
- Preserve Responses assistant phases across Codex and Grok tool loops.