### PR TITLE
Stop session picker scans during Ctrl+G relaunch

### DIFF
--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -704,13 +704,27 @@ const SessionPickerLoad = struct {
     const Task = struct {
         thread: ?std.Thread = null,
         done: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+        cancel_requested: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
         home_dir: []u8,
         workspace_root: []u8,
         request: PageRequest,
         catalog: ?subagent_resume_admission.ActionableSessionCatalog = null,
         failure: ?anyerror = null,
 
+        fn requestStop(self: *Task) void {
+            if (!self.done.load(.acquire) and
+                !self.cancel_requested.swap(true, .acq_rel))
+            {
+                debug_trace.logf(
+                    "core",
+                    "session picker load cancellation requested generation={d}",
+                    .{self.request.generation},
+                );
+            }
+        }
+
         fn deinit(self: *Task) void {
+            self.requestStop();
             if (self.thread) |thread| thread.join();
             if (self.catalog) |*catalog| catalog.deinit(std.heap.c_allocator);
             self.request.deinit();
@@ -726,9 +740,22 @@ const SessionPickerLoad = struct {
     next_generation: u64 = 1,
 
     fn deinit(self: *SessionPickerLoad) void {
+        self.requestStop();
         if (self.task) |task| task.deinit();
-        if (self.pending) |*pending| pending.deinit();
         self.* = .{};
+    }
+
+    fn requestStop(self: *SessionPickerLoad) void {
+        if (self.task) |task| task.requestStop();
+        if (self.pending) |*pending| {
+            debug_trace.logf(
+                "core",
+                "session picker request dropped reason=shutdown generation={d}",
+                .{pending.generation},
+            );
+            pending.deinit();
+            self.pending = null;
+        }
     }
 
     fn allocateGeneration(self: *SessionPickerLoad) u64 {
@@ -766,6 +793,7 @@ const SessionPickerLoad = struct {
         if (self.task) |task| {
             if (task.request.generation == generation) {
                 self.abandoned_generation = generation;
+                task.requestStop();
                 debug_trace.logf(
                     "core",
                     "session picker request abandoned reason=cancelled generation={d}",
@@ -880,16 +908,17 @@ const SessionPickerLoad = struct {
     }
 
     fn threadMain(task: *Task) void {
+        defer task.done.store(true, .release);
         var read_only = session_store.Store.initReadOnlyFromHome(
             std.heap.c_allocator,
             task.home_dir,
             task.workspace_root,
         ) catch |err| {
             task.failure = err;
-            task.done.store(true, .release);
             return;
         };
         defer read_only.deinit(std.heap.c_allocator);
+        read_only.resume_cancel_flag = &task.cancel_requested;
 
         task.catalog = subagent_resume_admission.listActionableCatalog(
             read_only,
@@ -901,10 +930,8 @@ const SessionPickerLoad = struct {
             task.request.active_id,
         ) catch |err| {
             task.failure = err;
-            task.done.store(true, .release);
             return;
         };
-        task.done.store(true, .release);
     }
 };
 
@@ -2875,6 +2902,10 @@ pub fn Runtime(comptime App: type) type {
         pub fn deinitPersistence(app: *App) void {
             closeWritableSession(app);
             app.session_persistence.deinit(app.alloc);
+        }
+
+        pub fn requestPersistenceShutdown(app: *App) void {
+            app.session_persistence.session_picker_load.requestStop();
         }
 
         fn LiveHistorySink(comptime SinkApp: type) type {
@@ -9074,6 +9105,69 @@ test "session picker page requests own the active session ID" {
     try std.testing.expectEqualStrings("active-session", request.active_id.?);
 }
 
+test "persistence shutdown drops pending picker work" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const paths = try testPaths(alloc, &tmp);
+    defer {
+        alloc.free(paths.home);
+        alloc.free(paths.workspace);
+    }
+    const home = try TestHome.install(alloc, paths.home);
+    defer home.deinit();
+
+    var app = try TestApp.init(alloc, paths.workspace);
+    defer app.deinit();
+    try configureTestPreferences(&app);
+    try Runtime(TestApp).initializePersistence(&app, true);
+
+    app.session_persistence.session_picker_load.pending =
+        try SessionPickerLoad.PageRequest.init(
+            1,
+            .current_workspace,
+            null,
+            session_store.default_resume_page_limit,
+        );
+
+    Runtime(TestApp).requestPersistenceShutdown(&app);
+
+    try std.testing.expect(app.session_persistence.session_picker_load.pending == null);
+}
+
+test "persistence shutdown cancels an active picker task before joining" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const paths = try testPaths(alloc, &tmp);
+    defer {
+        alloc.free(paths.home);
+        alloc.free(paths.workspace);
+    }
+    const home = try TestHome.install(alloc, paths.home);
+    defer home.deinit();
+
+    var app = try TestApp.init(alloc, paths.workspace);
+    defer app.deinit();
+    try configureTestPreferences(&app);
+    try Runtime(TestApp).initializePersistence(&app, true);
+
+    const task = try createHeldSessionPickerTask(
+        1,
+        "active-session",
+        app.session_persistence.store.?,
+    );
+    task.thread = try std.Thread.spawn(.{}, waitForPickerCancellation, .{task});
+    app.session_persistence.session_picker_load.task = task;
+
+    const started_ms = io_mod.milliTimestamp();
+    Runtime(TestApp).requestPersistenceShutdown(&app);
+    app.session_persistence.session_picker_load.deinit();
+    try std.testing.expect(io_mod.milliTimestamp() - started_ms < 500);
+}
+
 fn createHeldSessionPickerTask(
     generation: u64,
     active_id: []const u8,
@@ -9099,6 +9193,13 @@ fn createHeldSessionPickerTask(
         .request = request,
     };
     return task;
+}
+
+fn waitForPickerCancellation(task: *SessionPickerLoad.Task) void {
+    while (!task.cancel_requested.load(.acquire)) {
+        io_mod.sleep(std.time.ns_per_ms);
+    }
+    task.done.store(true, .release);
 }
 
 fn waitForSessionPickerLoad(app: *TestApp) !void {

--- a/src/core/session/session_store.zig
+++ b/src/core/session/session_store.zig
@@ -492,6 +492,13 @@ pub const Store = struct {
     // Carried on the value so it propagates through the by-value page chain;
     // the UI sets it from the visible screen height.
     resume_page_limit: usize = default_resume_page_limit,
+    resume_cancel_flag: ?*const std.atomic.Value(bool) = null,
+
+    pub fn checkResumeCancellation(self: Store) !void {
+        if (self.resume_cancel_flag) |flag| {
+            if (flag.load(.acquire)) return error.Cancelled;
+        }
+    }
 
     /// Narrow, copyable view of this store for the discovery/migration helpers,
     /// so they depend on `StoreContext` instead of the full facade.
@@ -2147,6 +2154,7 @@ pub const Store = struct {
         if (self.canonical_root.sessions == null) return scan;
         var iter = self.canonical_root.sessions.?.dir.iterate();
         while (try iter.next(io_mod.getIo())) |entry| {
+            try self.checkResumeCancellation();
             if (entry.kind != .directory) continue;
             if (std.mem.eql(u8, entry.name, retired_latest_sessions_dir)) {
                 continue;
@@ -2209,6 +2217,7 @@ pub const Store = struct {
             };
             candidate.summary = undefined;
         }
+        try self.checkResumeCancellation();
         sortSummariesNewestFirst(scan.summaries.items);
         if (mode == .global_read_only_last and scan.summaries.items.len > 0) {
             for (metadata.items) |candidate| {

--- a/src/core/subagent/resume_admission.zig
+++ b/src/core/subagent/resume_admission.zig
@@ -57,9 +57,11 @@ pub fn listActionableCatalog(
         .all_workspaces => try store.list(alloc),
     };
     errdefer session_summary_codec.freeSummaries(alloc, &summaries);
+    try store.checkResumeCancellation();
     const keep = try alloc.alloc(bool, summaries.items.len);
     defer alloc.free(keep);
     for (summaries.items, keep) |summary, *retain| {
+        try store.checkResumeCancellation();
         retain.* = summary.hasResumableContent();
         if (retain.*) {
             if (active_id) |id| {

--- a/src/main.zig
+++ b/src/main.zig
@@ -675,7 +675,9 @@ const App = struct {
             }
         }
         if (comptime host_profile.durable_sessions) {
-            SessionAppRuntime.primeSessionPicker(&app);
+            if (launch.upgrade_relaunch == null) {
+                SessionAppRuntime.primeSessionPicker(&app);
+            }
         }
         const env_disabled = if (io_mod.getenv("FX_AUTO_UPGRADE")) |val|
             std.mem.eql(u8, val, "0") or std.ascii.eqlIgnoreCase(val, "false")
@@ -834,6 +836,7 @@ const App = struct {
         self.stopStream();
 
         self.worker.requestShutdown();
+        SessionAppRuntime.requestPersistenceShutdown(self);
         self.managed_executions.shutdown();
         self.upgrader.stop();
         self.file_index.requestStop();

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -5254,6 +5254,7 @@ test.skipIf(!tmuxAvailable())(
     const installDir = join(root, "install");
     const stderrPath = join(root, "stderr.log");
     const freshStderrPath = join(root, "fresh-stderr.log");
+    const tracePath = join(root, "trace.log");
     const argvLogPath = join(root, "upgrade-argv.log");
     mkdirSync(home);
     mkdirSync(freshHome);
@@ -5275,6 +5276,7 @@ test.skipIf(!tmuxAvailable())(
     try {
       writeFileSync(stderrPath, "");
       writeFileSync(freshStderrPath, "");
+      writeFileSync(tracePath, "");
       active = await TmuxSession.create({
         cmd: shellQuote(installedFx),
         cwd: workspaceRoot,
@@ -5282,6 +5284,8 @@ test.skipIf(!tmuxAvailable())(
           ...gatewayEnv(home, gateway),
           FX_AUTO_UPGRADE: "1",
           FX_E2E_UPGRADE_BASE_URL: release.baseUrl,
+          FX_TRACE_LOG: tracePath,
+          FX_TRACE_SCOPES: "core,session",
         },
         stderrPath,
         width: 110,
@@ -5298,6 +5302,7 @@ test.skipIf(!tmuxAvailable())(
         UPGRADE_TIMEOUT,
       );
       expect(readFileSync(installedFx, "utf8")).toContain(argvLogPath);
+      const traceBeforeUpgrade = readFileSync(tracePath, "utf8");
 
       fresh = await TmuxSession.create({
         cmd: shellQuote(installedFx),
@@ -5322,6 +5327,11 @@ test.skipIf(!tmuxAvailable())(
 
       const updatedNotice = `● fx has been updated to v${version} (notes)`;
       await active.waitForText(updatedNotice, TIMEOUT);
+      await active.waitForComposer(TIMEOUT);
+      const postUpgradeTrace = readFileSync(tracePath, "utf8");
+      expect(postUpgradeTrace.slice(traceBeforeUpgrade.length)).not.toContain(
+        "session picker completion",
+      );
       const resumed = await waitForScrollback(active, "UPGRADE_CTRL_G_INITIAL_DONE");
       expect(resumed).toContain("UPGRADE_CTRL_G_INITIAL_DONE");
       expect(resumed).toContain(updatedNotice);


### PR DESCRIPTION
## Summary

- Stop Ctrl+G upgrade relaunch from waiting for background session-picker scans.
- Cancel in-flight picker work before cleanup joins its worker.
- Skip picker prewarm when the upgraded process resumes an explicit session handoff.