### PR TITLE
Preserve history when resized approvals close

### DIFF
--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -1619,7 +1619,9 @@ pub fn Runtime(comptime App: type) type {
             try build_checkpoint.poll(checkpoint);
             if (footer_frame.paint.reset_terminal) {
                 if (comptime @hasField(App, "terminal")) {
-                    app.terminal.clearTmuxScreenAndHistory(app.alloc);
+                    if (app.terminal.alternate_screen_owner == .none) {
+                        app.terminal.clearTmuxScreenAndHistory(app.alloc);
+                    }
                 }
             }
             var frame_shell = SurfaceFrameShell.init(

--- a/src/main.zig
+++ b/src/main.zig
@@ -4311,6 +4311,7 @@ test {
     _ = @import("ui/footer/surface_invalidation.zig");
     _ = @import("ui/full_transcript_screen.zig");
     _ = @import("ui/render_engine/frame_fixed_point.zig");
+    _ = @import("ui/render_engine/terminal_diff.zig");
     _ = @import("ui/transcript/runtime.zig");
     _ = @import("ui/transcript/runtime_tests.zig");
     _ = @import("core/agent/worker_runtime.zig");

--- a/src/ui/render_engine/frame_builder.zig
+++ b/src/ui/render_engine/frame_builder.zig
@@ -102,6 +102,7 @@ pub fn buildAndFlushFrame(
             plan.layout,
         ),
         options.terminal_transition,
+        terminal_diff.FrameReset.fromPlan(plan.reset_terminal, shell.history_reset_uses_ris),
     );
     defer movement.deinit(alloc);
 

--- a/src/ui/render_engine/frame_retention.zig
+++ b/src/ui/render_engine/frame_retention.zig
@@ -311,6 +311,7 @@ test "validate retains the primary transcript after a normal-screen transition" 
         4,
         0,
         .{ .restore_normal_screen = .{ .mouse_tracking_active = true } },
+        .none,
     );
     defer movement.deinit(std.testing.allocator);
 

--- a/src/ui/render_engine/terminal_diff.zig
+++ b/src/ui/render_engine/terminal_diff.zig
@@ -51,6 +51,17 @@ pub const FrameTerminalTransition = union(enum) {
     }
 };
 
+pub const FrameReset = enum {
+    none,
+    clear,
+    ris,
+
+    pub fn fromPlan(reset_terminal: bool, history_reset_uses_ris: bool) FrameReset {
+        if (!reset_terminal) return .none;
+        return if (history_reset_uses_ris) .ris else .clear;
+    }
+};
+
 pub const FrameCommitInput = struct {
     previous: *vt_emulator.Grid,
     surface: *const frame_surface.FrameSurface,
@@ -124,6 +135,8 @@ pub const PreparedTerminalMovement = struct {
         .expected_scroll_rows = 0,
     },
     terminal_transition: FrameTerminalTransition = .none,
+    reset: FrameReset = .none,
+    sync_prefix_offset: usize = 0,
     reset_replay: bool = false,
     source_rows: u16,
     source_cols: u16,
@@ -148,6 +161,7 @@ pub const PreparedTerminalMovement = struct {
         planned_scroll_rows: u16,
         non_deferable_scroll_rows: u16,
         terminal_transition: FrameTerminalTransition,
+        reset: FrameReset,
         reset_replay: bool,
     ) !void {
         const expected_rows = try resolveTerminalMovementRows(
@@ -166,6 +180,10 @@ pub const PreparedTerminalMovement = struct {
             self.target_cols != target_cols or
             !std.meta.eql(self.scroll_rows, expected_rows) or
             !std.meta.eql(self.terminal_transition, terminal_transition) or
+            self.reset != reset or
+            (self.reset == .ris) != (self.sync_prefix_offset > 0) or
+            self.sync_prefix_offset > self.bytes.len or
+            (self.hasDocumentAppend() and self.sync_prefix_offset > self.document_append_start) or
             self.reset_replay != reset_replay or
             self.segments.terminal_transition.scroll_rows != 0 or
             self.segments.document_append.scroll_rows != self.scroll_rows.materialized_scroll_rows or
@@ -306,7 +324,7 @@ const FrameMovementSegments = struct {
 
     fn fromPreparedMovement(prefix_len: usize, movement: PreparedTerminalMovement) FrameMovementSegments {
         return .{
-            .movement_start = prefix_len,
+            .movement_start = if (movement.sync_prefix_offset == 0) prefix_len else 0,
             .movement_end = prefix_len + movement.bytes.len,
             .document_append = movement.segments.document_append.absolute(prefix_len),
             .alignment_scroll = movement.segments.alignment_scroll.absolute(prefix_len),
@@ -347,6 +365,7 @@ pub fn flushFrame(input: FrameCommitInput) !FrameCommitResult {
     if (input.document_append.reset_replay and !input.surface.plan.reset_terminal) {
         return error.InvalidFrameScrollPlan;
     }
+    const reset = FrameReset.fromPlan(input.surface.plan.reset_terminal, input.history_reset_uses_ris);
     var local_movement: ?PreparedTerminalMovement = null;
     defer if (local_movement) |*movement| movement.deinit(alloc);
     const movement = if (input.prepared_movement) |prepared|
@@ -362,6 +381,7 @@ pub fn flushFrame(input: FrameCommitInput) !FrameCommitResult {
             target.rows,
             0,
             input.terminal_transition,
+            reset,
         );
         break :blk &local_movement.?;
     };
@@ -372,6 +392,7 @@ pub fn flushFrame(input: FrameCommitInput) !FrameCommitResult {
         terminal_scroll_rows,
         input.scroll_plan.preserved_release_rows,
         input.terminal_transition,
+        reset,
         input.document_append.reset_replay,
     );
     const terminal_scroll_bytes = movement.bytes;
@@ -424,7 +445,7 @@ pub fn flushFrame(input: FrameCommitInput) !FrameCommitResult {
         &target,
         repaint_window,
         full_repaint,
-        terminal_scroll_bytes,
+        movement,
     );
     const wire_frame_bytes = wire_frame.written();
     const document_append_range = movement.documentAppendWireRange(prefix_len);
@@ -584,20 +605,15 @@ fn composeWireFrame(
     target: *const vt_emulator.Grid,
     repaint_window: paint_plan.FrameRepaintWindow,
     full_repaint: bool,
-    terminal_scroll_bytes: []const u8,
+    movement: *const PreparedTerminalMovement,
 ) !usize {
-    if (input.surface.plan.reset_terminal and input.history_reset_uses_ris) {
-        // RIS clears modes that fx enables at startup, so restore them before repainting.
-        try wire_frame.writer.writeAll("\x1bc");
-        try wire_frame.writer.writeAll(ui_terminal.interactive_mode_enable_sequence);
-    }
+    // RIS and startup modes precede synchronization; document bytes follow it.
+    try wire_frame.writer.writeAll(movement.bytes[0..movement.sync_prefix_offset]);
+    const prefix_start = wire_frame.written().len;
     if (input.synchronized_update) try wire_frame.writer.writeAll("\x1b[?2026h");
     try wire_frame.writer.writeAll("\x1b[?25l");
-    if (input.surface.plan.reset_terminal) {
-        try wire_frame.writer.writeAll("\x1b[0m\x1b[2J\x1b[3J\x1b[H");
-    }
-    const prefix_len = wire_frame.written().len;
-    try wire_frame.writer.writeAll(terminal_scroll_bytes);
+    const prefix_len = wire_frame.written().len - prefix_start;
+    try wire_frame.writer.writeAll(movement.bytes[movement.sync_prefix_offset..]);
 
     if (!repaint_window.isEmpty()) {
         if (full_repaint) {
@@ -981,19 +997,6 @@ fn cloneAuthoritativeShadow(
     return next;
 }
 
-fn blankResetReplayShadow(
-    alloc: Allocator,
-    authoritative: *const vt_emulator.Grid,
-    target_cols: u16,
-    target_rows: u16,
-) !vt_emulator.Grid {
-    var next = try vt_emulator.Grid.init(alloc, target_cols, target_rows);
-    errdefer next.deinit();
-    next.autowrap = authoritative.autowrap;
-    next.cursor_visible = authoritative.cursor_visible;
-    return next;
-}
-
 test "authoritative shadow clone retains the normal buffer during an alternate screen" {
     var previous = try vt_emulator.Grid.init(std.testing.allocator, 12, 3);
     defer previous.deinit();
@@ -1037,6 +1040,7 @@ test "normal-screen transition precedes document movement in the prepared shadow
         4,
         0,
         transition,
+        .none,
     );
     defer movement.deinit(std.testing.allocator);
 
@@ -1207,6 +1211,7 @@ pub fn prepareTerminalMovement(
         target_rows,
         0,
         .none,
+        if (document_append.reset_replay) .clear else .none,
     );
 }
 
@@ -1220,18 +1225,12 @@ pub fn prepareTerminalMovementForFrame(
     target_rows: u16,
     alignment_clear_start_row: u16,
     terminal_transition: FrameTerminalTransition,
+    reset: FrameReset,
 ) !PreparedTerminalMovement {
-    if (document_append.reset_replay and planned_scroll_rows != 0) {
+    if (document_append.reset_replay and (planned_scroll_rows != 0 or reset == .none)) {
         return error.InvalidFrameScrollPlan;
     }
-    const reset_replay_starts_blank = document_append.reset_replay and switch (terminal_transition) {
-        .none => true,
-        .restore_normal_screen => false,
-    };
-    var post_movement = if (reset_replay_starts_blank)
-        try blankResetReplayShadow(alloc, authoritative, target_cols, target_rows)
-    else
-        try cloneAuthoritativeShadow(alloc, authoritative, target_cols, target_rows);
+    var post_movement = try cloneAuthoritativeShadow(alloc, authoritative, target_cols, target_rows);
     errdefer post_movement.deinit();
 
     var bytes: std.Io.Writer.Allocating = .init(alloc);
@@ -1242,6 +1241,7 @@ pub fn prepareTerminalMovementForFrame(
         &post_movement,
         terminal_transition,
     );
+    const sync_prefix_offset = try appendFrameReset(&bytes, &post_movement, reset);
 
     const document_movement = try appendDocumentMovement(
         &bytes,
@@ -1298,12 +1298,33 @@ pub fn prepareTerminalMovementForFrame(
         },
         .scroll_rows = movement_rows,
         .terminal_transition = terminal_transition,
+        .reset = reset,
+        .sync_prefix_offset = sync_prefix_offset,
         .reset_replay = document_append.reset_replay,
         .source_rows = authoritative.rows,
         .source_cols = authoritative.cols,
         .target_rows = target_rows,
         .target_cols = target_cols,
     };
+}
+
+fn appendFrameReset(
+    bytes: *std.Io.Writer.Allocating,
+    post_movement: *vt_emulator.Grid,
+    reset: FrameReset,
+) !usize {
+    if (reset == .none) return 0;
+    const start = bytes.written().len;
+    var sync_prefix_offset: usize = 0;
+    if (reset == .ris) {
+        try bytes.writer.writeAll("\x1bc");
+        try bytes.writer.writeAll(ui_terminal.interactive_mode_enable_sequence);
+        sync_prefix_offset = bytes.written().len;
+    }
+    try bytes.writer.writeAll("\x1b[0m\x1b[2J\x1b[3J\x1b[H");
+    const segment = try feedMovementSegment(bytes, post_movement, start);
+    if (segment.scroll_rows != 0) return error.InvalidFrameScrollPlan;
+    return sync_prefix_offset;
 }
 
 fn appendTerminalTransition(
@@ -1620,6 +1641,7 @@ const TestFrameCommitOptions = struct {
     terminal_transition: FrameTerminalTransition = .none,
     prepared_movement: ?*const PreparedTerminalMovement = null,
     synchronized_update: ?bool = null,
+    history_reset_uses_ris: bool = false,
 };
 
 fn flush_test_frame(
@@ -1641,6 +1663,7 @@ fn flush_test_frame(
             .{ .include_transcript = true },
         ),
         .synchronized_update = options.synchronized_update orelse true,
+        .history_reset_uses_ris = options.history_reset_uses_ris,
         .scroll_plan = frame_scroll_plan.merge(
             plan.layout.rows,
             1,
@@ -1676,6 +1699,7 @@ test "normal-screen restore and inline repaint commit in one sink write" {
             4,
             0,
             transition,
+            .none,
         );
         defer movement.deinit(std.testing.allocator);
 
@@ -1748,6 +1772,7 @@ test "normal-screen restore preserves saved modes through reset replay" {
         4,
         0,
         transition,
+        .clear,
     );
     defer movement.deinit(std.testing.allocator);
 
@@ -1789,7 +1814,7 @@ test "normal-screen restore preserves saved modes through reset replay" {
     ) orelse return error.TestExpectedNormalScreenRestore;
     try std.testing.expect(sync_start < cursor_hide);
     try std.testing.expect(cursor_hide < reset_clear);
-    try std.testing.expect(reset_clear < restore);
+    try std.testing.expect(restore < reset_clear);
 }
 
 test "normal-screen restore partial write retries to the committed frame" {
@@ -1812,6 +1837,7 @@ test "normal-screen restore partial write retries to the committed frame" {
         4,
         0,
         transition,
+        .none,
     );
     defer uninterrupted_movement.deinit(std.testing.allocator);
     var uninterrupted_sink = TestSink{};
@@ -1846,6 +1872,7 @@ test "normal-screen restore partial write retries to the committed frame" {
         4,
         0,
         transition,
+        .none,
     );
     defer movement.deinit(std.testing.allocator);
     const cut = "\x1b[?2026h".len + "\x1b[?25l".len +
@@ -1877,6 +1904,7 @@ test "normal-screen restore partial write retries to the committed frame" {
         4,
         0,
         transition,
+        .none,
     );
     defer retry_movement.deinit(std.testing.allocator);
     var retry_sink = TestSink{};
@@ -1895,6 +1923,142 @@ test "normal-screen restore partial write retries to the committed frame" {
     try physical.feed(retry_sink.bytes.items);
     try expect_grid_and_cursor_equal(uninterrupted, authoritative);
     try expect_grid_and_cursor_equal(uninterrupted, physical);
+}
+
+test "normal-screen reset replay recovers interrupted controls and accepted document bytes" {
+    const alloc = std.testing.allocator;
+    const transition: FrameTerminalTransition = .{
+        .restore_normal_screen = .{ .mouse_tracking_active = true },
+    };
+    const document_append: frame_scroll_plan.FrameDocumentAppend = .{
+        .bytes = "one\r\ntwo\r\nthree\r\nfour\r\nfive\r\nsix\r\n",
+        .start_row = 1,
+        .start_col = 1,
+        .reset_replay = true,
+    };
+    const reset_sequence = "\x1b[0m\x1b[2J\x1b[3J\x1b[H";
+    var seed = try vt_emulator.Grid.init(alloc, 8, 4);
+    defer seed.deinit();
+    seed.autowrap = false;
+    try seed.feed("normal\x1b[?1049happroval");
+
+    for ([_]FrameReset{ .clear, .ris }) |reset| {
+        var plan = testPlan();
+        plan.reset_terminal = true;
+        var uninterrupted = try cloneAuthoritativeShadow(alloc, &seed, 8, 4);
+        defer uninterrupted.deinit();
+        var movement = try prepareTerminalMovementForFrame(
+            alloc,
+            &uninterrupted,
+            document_append,
+            0,
+            0,
+            8,
+            4,
+            0,
+            transition,
+            reset,
+        );
+        defer movement.deinit(alloc);
+        var sink = TestSink{};
+        defer sink.deinit(alloc);
+        const complete = try flush_test_frame(&uninterrupted, &sink, .{
+            .plan = plan,
+            .surface_shadow = movement.post_movement,
+            .document_append = document_append,
+            .terminal_transition = transition,
+            .prepared_movement = &movement,
+            .history_reset_uses_ris = reset == .ris,
+        });
+        try std.testing.expect(complete.is_committed());
+        const restore = std.mem.find(u8, sink.bytes.items, ui_terminal.alternate_screen_leave_sequence).?;
+        const clear = std.mem.find(u8, sink.bytes.items, reset_sequence).?;
+        const document = std.mem.find(u8, sink.bytes.items, document_append.bytes).?;
+        const content_end = document + document_append.bytes.len;
+        try std.testing.expect(std.mem.startsWith(u8, sink.bytes.items[content_end..], "\x1b[?7l"));
+        const append_end = content_end + "\x1b[?7l".len;
+        try std.testing.expect(restore < clear and clear < document);
+        if (reset == .ris) {
+            const ris = std.mem.find(u8, sink.bytes.items, "\x1bc").?;
+            const sync = std.mem.find(u8, sink.bytes.items, "\x1b[?2026h").?;
+            try std.testing.expect(restore < ris and ris < sync and sync < clear);
+        }
+        try std.testing.expect(!uninterrupted.autowrap);
+
+        const ris = std.mem.find(u8, sink.bytes.items, "\x1bc");
+        const cuts = [_]?usize{
+            restore,
+            restore + ui_terminal.alternate_screen_leave_sequence.len - 1,
+            clear + reset_sequence.len - 1,
+            document + 3,
+            append_end,
+            if (ris) |offset| offset + 1 else null,
+            if (ris) |offset| offset + 2 else null,
+        };
+        for (cuts) |maybe_cut| {
+            const cut = maybe_cut orelse continue;
+            var authoritative = try cloneAuthoritativeShadow(alloc, &seed, 8, 4);
+            defer authoritative.deinit();
+            var physical = try cloneAuthoritativeShadow(alloc, &seed, 8, 4);
+            defer physical.deinit();
+            var failing_sink = TestSink{ .fail_after_prefix = cut };
+            defer failing_sink.deinit(alloc);
+            const failure = flush_test_frame(&authoritative, &failing_sink, .{
+                .plan = plan,
+                .surface_shadow = movement.post_movement,
+                .document_append = document_append,
+                .terminal_transition = transition,
+                .prepared_movement = &movement,
+                .history_reset_uses_ris = reset == .ris,
+            });
+            if (cut == document + 3) {
+                try std.testing.expectError(error.DocumentAppendInterrupted, failure);
+                try physical.feed(failing_sink.bytes.items);
+                try std.testing.expect(!physical.sync_active and physical.cursor_visible);
+                try std.testing.expectEqual(seed.autowrap, physical.autowrap);
+                continue;
+            }
+            const failed = try failure;
+            try std.testing.expectEqual(ShadowCommitState.terminal_partial_write, failed.state());
+            try std.testing.expectEqual(failing_sink.bytes.items.len, failed.bytes_written);
+            try std.testing.expectEqual(cut >= append_end, failed.document_append_applied());
+            try std.testing.expect(failed.terminal_scroll_rows_applied() <= complete.terminal_scroll_rows_applied());
+            try physical.feed(failing_sink.bytes.items);
+
+            var retry_plan = plan;
+            try retry_plan.invalidation.append(failed.retry_invalidation().?);
+            retry_plan.footer_clean_allowed = false;
+            var retry_movement = try prepareTerminalMovementForFrame(
+                alloc,
+                &authoritative,
+                document_append,
+                0,
+                0,
+                8,
+                4,
+                0,
+                transition,
+                reset,
+            );
+            defer retry_movement.deinit(alloc);
+            var retry_sink = TestSink{};
+            defer retry_sink.deinit(alloc);
+            const retried = try flush_test_frame(&authoritative, &retry_sink, .{
+                .plan = retry_plan,
+                .surface_shadow = retry_movement.post_movement,
+                .document_append = document_append,
+                .terminal_transition = transition,
+                .prepared_movement = &retry_movement,
+                .history_reset_uses_ris = reset == .ris,
+            });
+            try std.testing.expect(retried.is_committed());
+            try physical.feed(retry_sink.bytes.items);
+            try expect_grid_and_cursor_equal(uninterrupted, authoritative);
+            try expect_grid_and_cursor_equal(uninterrupted, physical);
+            try std.testing.expectEqual(uninterrupted.autowrap, physical.autowrap);
+            try std.testing.expectEqual(uninterrupted.autowrap, authoritative.autowrap);
+        }
+    }
 }
 
 fn expect_grid_and_cursor_equal(expected: vt_emulator.Grid, actual: vt_emulator.Grid) !void {
@@ -2753,13 +2917,17 @@ test "flushFrame retries resize external clear and reset to uninterrupted state"
         var uninterrupted_physical = try vt_emulator.Grid.init(std.testing.allocator, 8, 4);
         defer uninterrupted_physical.deinit();
         try prepare_physical_grid_for_scenario(&uninterrupted_physical, scenario);
-        var uninterrupted_movement = try prepareTerminalMovement(
+        var uninterrupted_movement = try prepareTerminalMovementForFrame(
             std.testing.allocator,
             &uninterrupted,
             .{},
             0,
+            0,
             plan.layout.cols,
             plan.layout.rows,
+            0,
+            .none,
+            FrameReset.fromPlan(plan.reset_terminal, false),
         );
         defer uninterrupted_movement.deinit(std.testing.allocator);
         var uninterrupted_sink = TestSink{};
@@ -2783,13 +2951,17 @@ test "flushFrame retries resize external clear and reset to uninterrupted state"
         var physical = try vt_emulator.Grid.init(std.testing.allocator, 8, 4);
         defer physical.deinit();
         try prepare_physical_grid_for_scenario(&physical, scenario);
-        var movement = try prepareTerminalMovement(
+        var movement = try prepareTerminalMovementForFrame(
             std.testing.allocator,
             &authoritative,
             .{},
             0,
+            0,
             plan.layout.cols,
             plan.layout.rows,
+            0,
+            .none,
+            FrameReset.fromPlan(plan.reset_terminal, false),
         );
         defer movement.deinit(std.testing.allocator);
         var failing_sink = TestSink{ .fail_after_prefix = 3 };
@@ -2809,13 +2981,17 @@ test "flushFrame retries resize external clear and reset to uninterrupted state"
         var retry_plan = plan;
         try retry_plan.invalidation.append(failed.retry_invalidation().?);
         retry_plan.footer_clean_allowed = false;
-        var retry_movement = try prepareTerminalMovement(
+        var retry_movement = try prepareTerminalMovementForFrame(
             std.testing.allocator,
             &authoritative,
             .{},
             0,
+            0,
             retry_plan.layout.cols,
             retry_plan.layout.rows,
+            0,
+            .none,
+            FrameReset.fromPlan(retry_plan.reset_terminal, false),
         );
         defer retry_movement.deinit(std.testing.allocator);
         var retry_sink = TestSink{};
@@ -3227,7 +3403,11 @@ test "flushFrame rejects stale prepared movement metadata" {
 
     try std.testing.expectError(
         error.InvalidFrameScrollPlan,
-        movement.validateForCommit(&previous, 7, 4, 0, 0, .none, false),
+        movement.validateForCommit(&previous, 7, 4, 0, 0, .none, .none, false),
+    );
+    try std.testing.expectError(
+        error.InvalidFrameScrollPlan,
+        movement.validateForCommit(&previous, 8, 4, 0, 0, .none, .clear, false),
     );
 }
 

--- a/tests/e2e/tui-permissions.test.ts
+++ b/tests/e2e/tui-permissions.test.ts
@@ -177,7 +177,8 @@ function expectAtomicApprovalExit(tapePath: string, frameStart: number) {
   expect(cursorHide).toBeGreaterThan(syncStart);
   if (resetClear >= 0) {
     expect(resetClear).toBeGreaterThan(cursorHide);
-    expect(resetClear).toBeLessThan(restoreIndex);
+    expect(resetClear).toBeGreaterThan(restoreIndex);
+    expect(resetClear).toBeLessThan(syncEnd);
   }
   expect(restoreIndex).toBeGreaterThan(syncStart);
   expect(syncEnd).toBeGreaterThan(restoreIndex);
@@ -364,6 +365,7 @@ describe.skipIf(!tmuxAvailable())("tui: file permissions", () => {
       const root = createIsolatedRoot();
       const target = join(root.workspace, "target.txt");
       const tracePath = join(root.root, "trace.log");
+      const tapePath = join(root.root, "approval-resize.fxtape");
       writeFileSync(target, "original line\n");
       let releaseEdit!: () => void;
       const editReady = new Promise<void>((resolve) => { releaseEdit = resolve; });
@@ -383,7 +385,7 @@ describe.skipIf(!tmuxAvailable())("tui: file permissions", () => {
         width: 120,
         height: 36,
       }, {
-        FX_RECORD: join(root.root, "approval-resize.fxtape"),
+        FX_RECORD: tapePath,
         FX_TRACE_LOG: tracePath,
         FX_TRACE_SCOPES: "agent,permission,frame_commit,scroll",
       });
@@ -411,11 +413,13 @@ describe.skipIf(!tmuxAvailable())("tui: file permissions", () => {
         expect(readFileSync(target, "utf8")).toBe("original line\n");
         await session.resizeWindow(72, 18, 400);
         await waitForFileApproval(session);
+        const approvalExitFrameStart = stdoutFrames(tapePath).length;
         await session.sendKeys(decision);
         await session.waitForPane((pane) => {
           const finished = readFileSync(tracePath, "utf8").match(/event=prompt_finish /g)?.length ?? 0;
           return finished === 2 && composerContains(pane, draft) && !pane.includes(APPLY_QUESTION);
         }, TIMEOUT);
+        expectAtomicApprovalExit(tapePath, approvalExitFrameStart);
         await expectCompleteHistory();
         expect(readFileSync(target, "utf8")).toBe(
           decision === "1" ? "approved line\n" : "original line\n",

--- a/tests/e2e/tui-permissions.test.ts
+++ b/tests/e2e/tui-permissions.test.ts
@@ -15,6 +15,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { FX_BIN, runFx } from "../evals/eval-helpers";
 import {
+  composerContains,
   FAKE_GATEWAY_MODEL,
   fakeGatewayFinalText as finalText,
   fakeGatewaySse,
@@ -351,6 +352,85 @@ async function decide(session: TmuxSession, choice: 1 | 2 | 3) {
 }
 
 describe.skipIf(!tmuxAvailable())("tui: file permissions", () => {
+
+  test("resized file approval restores complete history once", async () => {
+    const paragraphs = Array.from({ length: 28 }, (_, index) => {
+      const row = String(index + 1).padStart(2, "0");
+      return `ROW${row} ALPHA${row}_abcdefghijklmnopqrstuvwxyz0123456789 ` +
+        `BRAVO${row}_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789`;
+    });
+    const draft = "retained approval draft";
+    for (const decision of ["1", "3", "C-c"]) {
+      const root = createIsolatedRoot();
+      const target = join(root.workspace, "target.txt");
+      const tracePath = join(root.root, "trace.log");
+      writeFileSync(target, "original line\n");
+      let releaseEdit!: () => void;
+      const editReady = new Promise<void>((resolve) => { releaseEdit = resolve; });
+      const gateway = startFakeGateway([
+        finalText(paragraphs.join("\n\n")),
+        async () => {
+          await editReady;
+          return toolCall("approval-resize", "edit_file", {
+            path: "target.txt",
+            old_string: "original line\n",
+            new_string: "approved line\n",
+          });
+        },
+        finalText("The edit request has finished."),
+      ]);
+      const { session, stderrPath } = await launch(root, gateway, {
+        width: 120,
+        height: 36,
+      }, {
+        FX_RECORD: join(root.root, "approval-resize.fxtape"),
+        FX_TRACE_LOG: tracePath,
+        FX_TRACE_SCOPES: "agent,permission,frame_commit,scroll",
+      });
+      const expectCompleteHistory = async () => {
+        const text = (await session.captureFullScrollback()).replace(/\s+/g, "");
+        let previous = -1;
+        for (const paragraph of paragraphs) {
+          const needle = paragraph.replace(/\s+/g, "");
+          const index = text.indexOf(needle);
+          expect(index).toBeGreaterThan(previous);
+          expect(text.indexOf(needle, index + 1)).toBe(-1);
+          previous = index;
+        }
+      };
+      try {
+        await session.sendText("Show the prepared paragraphs.");
+        await session.waitForText("ROW28", TIMEOUT);
+        await session.waitForStableComposer(TIMEOUT);
+        await expectCompleteHistory();
+        await session.sendText("Change the prepared file.");
+        await session.waitForPane(() => gateway.requests.length === 2, TIMEOUT);
+        await session.sendLiteralText(draft);
+        releaseEdit();
+        await waitForFileApproval(session);
+        expect(readFileSync(target, "utf8")).toBe("original line\n");
+        await session.resizeWindow(72, 18, 400);
+        await waitForFileApproval(session);
+        await session.sendKeys(decision);
+        await session.waitForPane((pane) => {
+          const finished = readFileSync(tracePath, "utf8").match(/event=prompt_finish /g)?.length ?? 0;
+          return finished === 2 && composerContains(pane, draft) && !pane.includes(APPLY_QUESTION);
+        }, TIMEOUT);
+        await expectCompleteHistory();
+        expect(readFileSync(target, "utf8")).toBe(
+          decision === "1" ? "approved line\n" : "original line\n",
+        );
+        expectCleanStderr(stderrPath);
+        await session.sendKeys("C-u");
+        await session.sendText("/quit");
+        expect(await session.waitForSessionEnd(TIMEOUT)).toBe(true);
+      } finally {
+        releaseEdit();
+        await session.kill();
+        activeSession = null;
+      }
+    }
+  }, 90_000);
 
   test(
     "decomposed prompt and file approval remain visible across resize",


### PR DESCRIPTION
## Summary

- Keep earlier conversation paragraphs in order without duplicates after accepting, rejecting, or cancelling a resized file approval.
