### PR TITLE
Speed up saved conversation discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ fx
 
 The current directory becomes the primary workspace. Enter a prompt, or run `/help` to browse interactive commands. While fx is working, Enter steers the active turn at its next safe model boundary. The pending update shows its first two lines, with an ellipsis when more text is hidden. If a tool is running, fx waits for it to finish; press Escape to interrupt the active work and apply the update as soon as the turn settles.
 
+Use `/resume` to choose a saved conversation. The picker shares its catalog across workspace views and reuses unchanged session summaries between launches. The first catalog build, or recovery from missing cache data, scans saved sessions automatically. Changed sessions are checked again, and closing the picker stops obsolete loading work.
+
 Tool calls are expanded by default. Enable `Collapse tool calls` in `/settings`, or set `"collapse_tool_calls": true` in `~/.fx/settings.json`, to show one summary per tool-call group in the main transcript. Individual calls remain available in the full transcript with Ctrl+O. Follow-up activity for captured shell commands shows the original command, such as `Observed zig build`, while tool results keep the same execution handle.
 
 Ctrl+L clears the inline display while keeping the conversation available in Ctrl+O. It preserves your draft and conversation context; `/clear` starts a fresh conversation instead.

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -45,6 +45,7 @@ const tool_result_errors = @import("../tooling/tool_result_errors.zig");
 const session_display_metadata = @import("../session/session_display_metadata.zig");
 const session_log = @import("../session/session_log.zig");
 const session_store = @import("../session/session_store.zig");
+const session_catalog_cache = @import("../session/session_catalog_cache.zig");
 const session_summary_codec = @import("../session/session_summary_codec.zig");
 const subagent_tool_host = @import("../subagent/tool_host.zig");
 const subagent_authority = @import("../subagent/authority.zig");
@@ -562,16 +563,6 @@ fn optionalStringEql(a: ?[]const u8, b: ?[]const u8) bool {
     return std.mem.eql(u8, a.?, b.?);
 }
 
-fn sessionPickerCacheForScope(
-    persistence: *Persistence,
-    scope: SessionPickerScope,
-) *SessionPickerCatalogCache {
-    return switch (scope) {
-        .current_workspace => &persistence.session_picker_current_cache,
-        .all_workspaces => &persistence.session_picker_all_cache,
-    };
-}
-
 fn replaceSessionPickerPage(
     picker: *SessionPicker,
     alloc: Allocator,
@@ -599,27 +590,35 @@ fn applySessionPickerCatalogPage(
     picker: *SessionPicker,
     alloc: Allocator,
     cache: *const SessionPickerCatalogCache,
+    workspace_root: []const u8,
     continuation: ?session_store.ResumableSessionContinuation,
     limit: usize,
     append: bool,
 ) !void {
+    const workspace = if (picker.scope == .current_workspace) workspace_root else null;
     var selected_index: ?usize = null;
     var page_limit = limit;
     if (!append) {
         page_limit = @max(page_limit, picker.summaries.items.len);
         if (picker.selectedId()) |selected_id| {
-            for (cache.catalog.summaries.items, 0..) |summary, index| {
-                if (!std.mem.eql(u8, summary.id, selected_id)) continue;
-                selected_index = index;
-                page_limit = @max(page_limit, index + 1);
-                break;
+            var index: usize = 0;
+            for (cache.catalog.summaries.items) |summary| {
+                if (workspace) |root| {
+                    if (summary.workspace_root == null or !std.mem.eql(u8, summary.workspace_root.?, root)) continue;
+                }
+                if (std.mem.eql(u8, summary.id, selected_id)) {
+                    selected_index = index;
+                    page_limit = @max(page_limit, index + 1);
+                    break;
+                }
+                index += 1;
             }
         }
     }
     var page = try session_summary_codec.resumablePageFromSummaries(
         alloc,
         cache.catalog.summaries.items,
-        null,
+        workspace,
         null,
         continuation,
         page_limit,
@@ -678,18 +677,14 @@ fn selectionAfterLoadedPage(
 const SessionPickerLoad = struct {
     const PageRequest = struct {
         generation: u64,
-        scope: SessionPickerScope,
         active_id: ?[]u8 = null,
-        limit: usize = session_store.default_resume_page_limit,
 
         fn init(
             generation: u64,
-            scope: SessionPickerScope,
             active_id: ?[]const u8,
-            limit: usize,
         ) !PageRequest {
             const alloc = std.heap.c_allocator;
-            var request: PageRequest = .{ .generation = generation, .scope = scope, .limit = limit };
+            var request: PageRequest = .{ .generation = generation };
             errdefer request.deinit();
             if (active_id) |id| request.active_id = try alloc.dupe(u8, id);
             return request;
@@ -705,10 +700,13 @@ const SessionPickerLoad = struct {
         thread: ?std.Thread = null,
         done: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
         cancel_requested: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+        // Main-loop-owned; worker failures may also set cancel_requested.
+        abandoned: bool = false,
         home_dir: []u8,
         workspace_root: []u8,
         request: PageRequest,
         catalog: ?subagent_resume_admission.ActionableSessionCatalog = null,
+        cache_writer: ?session_catalog_cache.Writer = null,
         failure: ?anyerror = null,
 
         fn requestStop(self: *Task) void {
@@ -727,6 +725,7 @@ const SessionPickerLoad = struct {
             self.requestStop();
             if (self.thread) |thread| thread.join();
             if (self.catalog) |*catalog| catalog.deinit(std.heap.c_allocator);
+            if (self.cache_writer) |*writer| writer.deinit();
             self.request.deinit();
             std.heap.c_allocator.free(self.home_dir);
             std.heap.c_allocator.free(self.workspace_root);
@@ -736,7 +735,6 @@ const SessionPickerLoad = struct {
 
     task: ?*Task = null,
     pending: ?PageRequest = null,
-    abandoned_generation: ?u64 = null,
     next_generation: u64 = 1,
 
     fn deinit(self: *SessionPickerLoad) void {
@@ -792,7 +790,7 @@ const SessionPickerLoad = struct {
     fn cancelGeneration(self: *SessionPickerLoad, generation: u64) void {
         if (self.task) |task| {
             if (task.request.generation == generation) {
-                self.abandoned_generation = generation;
+                task.abandoned = true;
                 task.requestStop();
                 debug_trace.logf(
                     "core",
@@ -821,33 +819,21 @@ const SessionPickerLoad = struct {
 
     fn matchingInitialGeneration(
         self: *const SessionPickerLoad,
-        scope: SessionPickerScope,
         active_id: ?[]const u8,
-        limit: usize,
     ) ?u64 {
         if (self.task) |task| {
-            if (self.abandoned_generation != task.request.generation and
-                initialRequestMatches(task.request, scope, active_id, limit))
+            if (!task.abandoned and
+                optionalStringEql(task.request.active_id, active_id))
             {
                 return task.request.generation;
             }
         }
         if (self.pending) |request| {
-            if (initialRequestMatches(request, scope, active_id, limit)) {
+            if (optionalStringEql(request.active_id, active_id)) {
                 return request.generation;
             }
         }
         return null;
-    }
-
-    fn initialRequestMatches(
-        request: PageRequest,
-        scope: SessionPickerScope,
-        active_id: ?[]const u8,
-        limit: usize,
-    ) bool {
-        return request.scope == scope and
-            request.limit >= limit and optionalStringEql(request.active_id, active_id);
     }
 
     fn startPending(self: *SessionPickerLoad, store: *const session_store.Store) !?u64 {
@@ -887,7 +873,12 @@ const SessionPickerLoad = struct {
             .workspace_root = workspace_root,
             .request = owned_request,
         };
+        task.cache_writer = session_catalog_cache.Writer.init(store.*) catch |err| blk: {
+            debug_trace.logf("core", "session catalog cache writer unavailable err={s}", .{@errorName(err)});
+            break :blk null;
+        };
         task.thread = std.Thread.spawn(.{}, threadMain, .{task}) catch |err| {
+            if (task.cache_writer) |*writer| writer.deinit();
             task.request.deinit();
             alloc.free(task.workspace_root);
             alloc.free(task.home_dir);
@@ -901,14 +892,12 @@ const SessionPickerLoad = struct {
         const task = self.task orelse return null;
         if (!task.done.load(.acquire)) return null;
         self.task = null;
-        if (self.abandoned_generation == task.request.generation) {
-            self.abandoned_generation = null;
-        }
         return task;
     }
 
     fn threadMain(task: *Task) void {
         defer task.done.store(true, .release);
+        const started = io_mod.nanoTimestamp();
         var read_only = session_store.Store.initReadOnlyFromHome(
             std.heap.c_allocator,
             task.home_dir,
@@ -918,20 +907,19 @@ const SessionPickerLoad = struct {
             return;
         };
         defer read_only.deinit(std.heap.c_allocator);
-        read_only.resume_cancel_flag = &task.cancel_requested;
 
         task.catalog = subagent_resume_admission.listActionableCatalog(
             read_only,
             std.heap.c_allocator,
-            switch (task.request.scope) {
-                .current_workspace => .current_workspace,
-                .all_workspaces => .all_workspaces,
-            },
             task.request.active_id,
+            &task.cancel_requested,
+            if (task.cache_writer) |*writer| writer else null,
         ) catch |err| {
+            debug_trace.logf("core", "session picker catalog stopped err={s} elapsed_us={d}", .{ @errorName(err), @divTrunc(io_mod.nanoTimestamp() - started, std.time.ns_per_us) });
             task.failure = err;
             return;
         };
+        debug_trace.logf("core", "session picker catalog loaded sessions={d} elapsed_us={d}", .{ task.catalog.?.summaries.items.len, @divTrunc(io_mod.nanoTimestamp() - started, std.time.ns_per_us) });
     }
 };
 
@@ -1043,8 +1031,7 @@ pub const Persistence = struct {
     process_model_override: ?[]u8 = null,
     session_picker: SessionPicker = .{},
     session_picker_load: SessionPickerLoad = .{},
-    session_picker_current_cache: SessionPickerCatalogCache = .{},
-    session_picker_all_cache: SessionPickerCatalogCache = .{},
+    session_picker_cache: SessionPickerCatalogCache = .{},
     degraded_warning_emitted: bool = false,
     pending_cancelled_command: ?PendingCancelledCommand = null,
     image_snapshot_temp_dir: ?[]u8 = null,
@@ -1055,7 +1042,7 @@ pub const Persistence = struct {
     /// in a static release-binary template.
     pub fn initInto(storage: *Persistence) void {
         comptime {
-            if (std.meta.fields(Persistence).len != 19) {
+            if (std.meta.fields(Persistence).len != 18) {
                 @compileError("update Persistence.initInto for the changed field set");
             }
         }
@@ -1072,8 +1059,7 @@ pub const Persistence = struct {
         storage.process_model_override = null;
         storage.session_picker = .{};
         storage.session_picker_load = .{};
-        storage.session_picker_current_cache = .{};
-        storage.session_picker_all_cache = .{};
+        storage.session_picker_cache = .{};
         storage.degraded_warning_emitted = false;
         storage.pending_cancelled_command = null;
         storage.image_snapshot_temp_dir = null;
@@ -1103,8 +1089,7 @@ pub const Persistence = struct {
         if (self.process_model_override) |model| alloc.free(model);
         self.session_picker.deinit(alloc);
         self.session_picker_load.deinit();
-        self.session_picker_current_cache.deinit();
-        self.session_picker_all_cache.deinit();
+        self.session_picker_cache.deinit();
         self.* = undefined;
     }
 };
@@ -1120,8 +1105,7 @@ test "persistence in-place initialization preserves empty ownership" {
     try std.testing.expect(!persistence.fast_mode_model_bound);
     try std.testing.expect(!persistence.session_picker.active);
     try std.testing.expect(persistence.session_picker_load.task == null);
-    try std.testing.expect(!persistence.session_picker_current_cache.ready);
-    try std.testing.expect(!persistence.session_picker_all_cache.ready);
+    try std.testing.expect(!persistence.session_picker_cache.ready);
     try std.testing.expect(persistence.resume_handoff_intent == .none);
 }
 
@@ -1826,9 +1810,7 @@ pub fn Runtime(comptime App: type) type {
             }
 
             var picker = &app.session_persistence.session_picker;
-            if (picker.load_state != .ready) {
-                app.session_persistence.session_picker_load.cancelGeneration(picker.generation);
-            }
+            const previous_generation = picker.generation;
             picker.deinit(app.alloc);
             picker.active = true;
             picker.load_state = .loading;
@@ -1850,13 +1832,17 @@ pub fn Runtime(comptime App: type) type {
                 resumePageLimitForRows(app.shell.layout.rows)
             else
                 session_store.default_resume_page_limit;
-            const cache = sessionPickerCacheForScope(&app.session_persistence, scope);
+            const loader = &app.session_persistence.session_picker_load;
+            const matching = loader.matchingInitialGeneration(active_id);
+            if (matching != previous_generation) loader.cancelGeneration(previous_generation);
+            const cache = &app.session_persistence.session_picker_cache;
             var cache_visible = false;
             if (cache.matches(active_id)) {
                 try applySessionPickerCatalogPage(
                     picker,
                     app.alloc,
                     cache,
+                    store.workspace_root,
                     null,
                     limit,
                     false,
@@ -1868,16 +1854,13 @@ pub fn Runtime(comptime App: type) type {
                 }
             }
 
-            const loader = &app.session_persistence.session_picker_load;
-            if (loader.matchingInitialGeneration(scope, active_id, limit)) |generation| {
+            if (matching) |generation| {
                 picker.generation = generation;
                 return;
             }
             const request = SessionPickerLoad.PageRequest.init(
                 loader.allocateGeneration(),
-                picker.scope,
                 active_id,
-                limit,
             ) catch |err| {
                 if (!cache_visible) picker.load_state = .failed;
                 try writeSessionPickerError(app, err);
@@ -1897,36 +1880,20 @@ pub fn Runtime(comptime App: type) type {
                 loaded.active_id
             else
                 null;
-            const limit = if (comptime @hasField(App, "shell"))
-                resumePageLimitForRows(app.shell.layout.rows)
-            else
-                session_store.default_resume_page_limit;
             const loader = &app.session_persistence.session_picker_load;
-            for ([_]SessionPickerScope{ .current_workspace, .all_workspaces }) |scope| {
-                const cache = sessionPickerCacheForScope(&app.session_persistence, scope);
-                if (cache.matches(active_id) and cache.isFresh()) continue;
-                if (loader.matchingInitialGeneration(scope, active_id, limit) != null) continue;
-                const request = SessionPickerLoad.PageRequest.init(
-                    loader.allocateGeneration(),
-                    scope,
-                    active_id,
-                    limit,
-                ) catch |err| {
-                    debug_trace.logf(
-                        "core",
-                        "session picker prewarm unavailable scope={s} err={s}",
-                        .{ @tagName(scope), @errorName(err) },
-                    );
-                    continue;
-                };
-                loader.schedule(store, request) catch |err| {
-                    debug_trace.logf(
-                        "core",
-                        "session picker prewarm unavailable scope={s} err={s}",
-                        .{ @tagName(scope), @errorName(err) },
-                    );
-                };
-            }
+            const cache = &app.session_persistence.session_picker_cache;
+            if (cache.matches(active_id) and cache.isFresh()) return;
+            if (loader.matchingInitialGeneration(active_id) != null) return;
+            const request = SessionPickerLoad.PageRequest.init(
+                loader.allocateGeneration(),
+                active_id,
+            ) catch |err| {
+                debug_trace.logf("core", "session picker prewarm unavailable err={s}", .{@errorName(err)});
+                return;
+            };
+            loader.schedule(store, request) catch |err| {
+                debug_trace.logf("core", "session picker prewarm unavailable err={s}", .{@errorName(err)});
+            };
         }
 
         pub fn toggleSessionPickerScope(app: *App) !bool {
@@ -1946,13 +1913,13 @@ pub fn Runtime(comptime App: type) type {
             var task_owned = true;
             defer if (task_owned) task.deinit();
 
+            const active_id = if (app.session_persistence.writable) |*loaded| loaded.active_id else null;
+            const valid = app.session_persistence.store != null and
+                !task.abandoned and optionalStringEql(task.request.active_id, active_id);
             var cache_installed = false;
-            if (task.failure == null) {
+            if (valid and task.failure == null) {
                 if (task.catalog) |*catalog| {
-                    const cache = sessionPickerCacheForScope(
-                        &app.session_persistence,
-                        task.request.scope,
-                    );
+                    const cache = &app.session_persistence.session_picker_cache;
                     cache.install(catalog, task.request.active_id) catch |err| {
                         task.failure = err;
                     };
@@ -1961,14 +1928,13 @@ pub fn Runtime(comptime App: type) type {
             }
 
             const picker = &app.session_persistence.session_picker;
-            const current = picker.active and picker.generation == task.request.generation;
+            const current = valid and picker.active and picker.generation == task.request.generation;
             if (!current) {
                 debug_trace.logf(
                     "core",
-                    "session picker completion {s} scope={s} generation={d}",
+                    "session picker completion {s} generation={d}",
                     .{
                         if (cache_installed) "cached" else "dropped",
-                        @tagName(task.request.scope),
                         task.request.generation,
                     },
                 );
@@ -1976,16 +1942,18 @@ pub fn Runtime(comptime App: type) type {
                 if (picker.load_state != .ready) picker.load_state = .failed;
                 try writeSessionPickerError(app, err);
             } else {
-                const cache = sessionPickerCacheForScope(
-                    &app.session_persistence,
-                    task.request.scope,
-                );
+                const cache = &app.session_persistence.session_picker_cache;
+                const limit = if (comptime @hasField(App, "shell"))
+                    resumePageLimitForRows(app.shell.layout.rows)
+                else
+                    session_store.default_resume_page_limit;
                 applySessionPickerCatalogPage(
                     picker,
                     app.alloc,
                     cache,
+                    app.session_persistence.store.?.workspace_root,
                     null,
-                    task.request.limit,
+                    limit,
                     false,
                 ) catch |err| {
                     picker.load_state = .failed;
@@ -2049,10 +2017,7 @@ pub fn Runtime(comptime App: type) type {
                 loaded.active_id
             else
                 null;
-            const cache = sessionPickerCacheForScope(
-                &app.session_persistence,
-                picker.scope,
-            );
+            const cache = &app.session_persistence.session_picker_cache;
             if (!cache.matches(active_id)) return error.SessionStoreUnavailable;
             const limit = if (comptime @hasField(App, "shell"))
                 resumePageLimitForRows(app.shell.layout.rows)
@@ -2064,6 +2029,7 @@ pub fn Runtime(comptime App: type) type {
                 picker,
                 app.alloc,
                 cache,
+                app.session_persistence.store.?.workspace_root,
                 continuation.view(),
                 limit,
                 true,
@@ -2097,9 +2063,9 @@ pub fn Runtime(comptime App: type) type {
 
         pub fn cancelSessionPicker(app: *App) void {
             const picker = &app.session_persistence.session_picker;
-            if (picker.load_state != .ready) {
-                app.session_persistence.session_picker_load.cancelGeneration(picker.generation);
-            }
+            const loader = &app.session_persistence.session_picker_load;
+            if (loader.task) |task| loader.cancelGeneration(task.request.generation);
+            if (loader.pending) |pending| loader.cancelGeneration(pending.generation);
             picker.deinit(app.alloc);
         }
 
@@ -2119,8 +2085,10 @@ pub fn Runtime(comptime App: type) type {
         }
 
         fn invalidateSessionPickerCaches(app: *App) void {
-            app.session_persistence.session_picker_current_cache.deinit();
-            app.session_persistence.session_picker_all_cache.deinit();
+            const loader = &app.session_persistence.session_picker_load;
+            if (loader.task) |task| loader.cancelGeneration(task.request.generation);
+            if (loader.pending) |pending| loader.cancelGeneration(pending.generation);
+            app.session_persistence.session_picker_cache.deinit();
         }
 
         pub fn moveSessionPicker(app: *App, delta: i32, visible_items: u16) bool {
@@ -8651,7 +8619,7 @@ test "session picker reopen keeps the loaded page visible while refreshing" {
         defer renamed.deinit(alloc);
         try std.testing.expect(try renamed.renameConversation(alloc, "renamed externally"));
     }
-    app.session_persistence.session_picker_current_cache.loaded_at_ns = 0;
+    app.session_persistence.session_picker_cache.loaded_at_ns = 0;
     try Runtime(TestApp).openSessionPicker(&app);
 
     try std.testing.expectEqual(.ready, app.session_persistence.session_picker.load_state);
@@ -8675,7 +8643,7 @@ test "session picker reopen keeps the loaded page visible while refreshing" {
         );
         _ = app.session_persistence.store.?.deleteCommittedSession(alloc, &removed);
     }
-    app.session_persistence.session_picker_current_cache.loaded_at_ns = 0;
+    app.session_persistence.session_picker_cache.loaded_at_ns = 0;
     try Runtime(TestApp).openSessionPicker(&app);
     try waitForSessionPickerPrewarm(&app);
     try std.testing.expectEqual(@as(usize, 1), picker.summaries.items.len);
@@ -8696,12 +8664,13 @@ test "session picker refresh preserves selection and loaded pagination" {
             .updated_at_ms = @intCast(3 - index),
             .conversation_language = .literal("en"),
             .history_len = 1,
+            .workspace_root = @constCast("/workspace"),
         });
         errdefer summary.deinit(alloc);
         try cache.catalog.summaries.append(alloc, summary);
     }
-    try applySessionPickerCatalogPage(&picker, alloc, &cache, null, 1, false);
-    try applySessionPickerCatalogPage(&picker, alloc, &cache, picker.continuation.?.view(), 1, true);
+    try applySessionPickerCatalogPage(&picker, alloc, &cache, "/workspace", null, 1, false);
+    try applySessionPickerCatalogPage(&picker, alloc, &cache, "/workspace", picker.continuation.?.view(), 1, true);
     picker.selected = 1;
     try std.testing.expectEqualStrings("two", picker.selectedId().?);
 
@@ -8711,25 +8680,26 @@ test "session picker refresh preserves selection and loaded pagination" {
         .updated_at_ms = 4,
         .conversation_language = .literal("en"),
         .history_len = 1,
+        .workspace_root = @constCast("/workspace"),
     });
     cache.catalog.summaries.insert(alloc, 0, added) catch |err| {
         added.deinit(alloc);
         return err;
     };
-    try applySessionPickerCatalogPage(&picker, alloc, &cache, null, 1, false);
+    try applySessionPickerCatalogPage(&picker, alloc, &cache, "/workspace", null, 1, false);
     try std.testing.expectEqual(@as(usize, 3), picker.summaries.items.len);
     try std.testing.expectEqual(@as(usize, 2), picker.selected);
     try std.testing.expectEqualStrings("two", picker.selectedId().?);
     try std.testing.expectEqualStrings("two", picker.continuation.?.id);
 
-    try applySessionPickerCatalogPage(&picker, alloc, &cache, picker.continuation.?.view(), 1, true);
+    try applySessionPickerCatalogPage(&picker, alloc, &cache, "/workspace", picker.continuation.?.view(), 1, true);
     try std.testing.expectEqual(@as(usize, 4), picker.summaries.items.len);
     try std.testing.expectEqualStrings("three", picker.summaries.items[3].id);
     try std.testing.expect(!picker.has_more);
     try std.testing.expectEqualStrings("two", picker.selectedId().?);
 }
 
-test "session picker prewarms current and all workspace pages before opening" {
+test "session picker prewarms one catalog for both workspace views" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -8763,8 +8733,7 @@ test "session picker prewarms current and all workspace pages before opening" {
     Runtime(TestApp).primeSessionPicker(&app);
     try waitForSessionPickerPrewarm(&app);
     try std.testing.expect(!app.session_persistence.session_picker.active);
-    try std.testing.expect(app.session_persistence.session_picker_current_cache.ready);
-    try std.testing.expect(app.session_persistence.session_picker_all_cache.ready);
+    try std.testing.expect(app.session_persistence.session_picker_cache.ready);
 
     try Runtime(TestApp).openSessionPicker(&app);
     try std.testing.expectEqual(.ready, app.session_persistence.session_picker.load_state);
@@ -8779,6 +8748,78 @@ test "session picker prewarms current and all workspace pages before opening" {
         "prewarmed-session",
         app.session_persistence.session_picker.selectedId().?,
     );
+}
+
+test "session picker reuses a held catalog after resize and workspace switch" {
+    const alloc = std.testing.allocator;
+    const catalog_alloc = std.heap.c_allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const paths = try testPaths(alloc, &tmp);
+    defer {
+        alloc.free(paths.home);
+        alloc.free(paths.workspace);
+    }
+    const home = try TestHome.install(alloc, paths.home);
+    defer home.deinit();
+
+    for ([_]bool{ false, true }) |finished_before_switch| {
+        var app = try TestApp.init(alloc, paths.workspace);
+        defer app.deinit();
+        try configureTestPreferences(&app);
+        try Runtime(TestApp).initializePersistence(&app, true);
+        try Runtime(TestApp).beginFreshPersistedSession(&app);
+        try app.input_runtime.edit_state.input.appendSlice(alloc, "saved");
+
+        const loader = &app.session_persistence.session_picker_load;
+        const generation = loader.allocateGeneration();
+        const held = try createHeldSessionPickerTask(
+            generation,
+            app.session_persistence.writable.?.active_id,
+            app.session_persistence.store.?,
+        );
+        loader.task = held;
+        held.catalog = .{};
+        for (0..100) |index| {
+            var id_buffer: [32]u8 = undefined;
+            const id = try std.fmt.bufPrint(&id_buffer, "saved-{d}", .{index});
+            var summary = try session_summary_codec.cloneSessionSummary(catalog_alloc, .{
+                .id = @constCast(id),
+                .workspace_root = if (index % 2 == 0) paths.workspace else @constCast("/foreign-workspace"),
+                .created_at_ms = 1,
+                .updated_at_ms = @intCast(100 - index),
+                .conversation_language = .literal("en"),
+                .history_len = 1,
+            });
+            held.catalog.?.summaries.append(catalog_alloc, summary) catch |err| {
+                summary.deinit(catalog_alloc);
+                return err;
+            };
+        }
+        try Runtime(TestApp).openSessionPicker(&app);
+        const picker = &app.session_persistence.session_picker;
+        try std.testing.expect(picker.isLoading());
+        held.done.store(finished_before_switch, .release);
+        app.shell.layout.rows = 80;
+        Runtime(TestApp).primeSessionPicker(&app);
+        try std.testing.expect(try Runtime(TestApp).toggleSessionPickerScope(&app));
+        try std.testing.expect(loader.task == held);
+        try std.testing.expect(loader.pending == null);
+        try std.testing.expectEqual(generation, picker.generation);
+        try std.testing.expect(!held.abandoned);
+        try std.testing.expect(!held.cancel_requested.load(.acquire));
+
+        held.done.store(true, .release);
+        try Runtime(TestApp).pollSessionPicker(&app);
+        try std.testing.expectEqual(SessionPickerScope.all_workspaces, picker.scope);
+        try std.testing.expectEqual(.ready, picker.load_state);
+        try std.testing.expectEqual(resumePageLimitForRows(80), picker.summaries.items.len);
+        try std.testing.expect(picker.has_more);
+        try std.testing.expectEqualStrings("saved", picker.query());
+        try std.testing.expectEqualStrings("saved", app.input_runtime.edit_state.input.items);
+        try std.testing.expectEqualStrings("/foreign-workspace", picker.summaries.items[1].workspace_root.?);
+        try std.testing.expectEqual(@as(usize, 0), app.notices.items.len);
+    }
 }
 
 test "session picker keeps the visible scope when a stale catalog completes" {
@@ -8801,8 +8842,6 @@ test "session picker keeps the visible scope when a stale catalog completes" {
     try Runtime(TestApp).initializePersistence(&app, true);
     try Runtime(TestApp).beginFreshPersistedSession(&app);
 
-    var current_catalog: subagent_resume_admission.ActionableSessionCatalog = .{};
-    defer current_catalog.deinit(catalog_alloc);
     var all_catalog: subagent_resume_admission.ActionableSessionCatalog = .{};
     defer all_catalog.deinit(catalog_alloc);
     try all_catalog.summaries.append(catalog_alloc, .{
@@ -8815,11 +8854,7 @@ test "session picker keeps the visible scope when a stale catalog completes" {
     });
 
     const active_id = app.session_persistence.writable.?.active_id;
-    try app.session_persistence.session_picker_current_cache.install(
-        &current_catalog,
-        active_id,
-    );
-    try app.session_persistence.session_picker_all_cache.install(
+    try app.session_persistence.session_picker_cache.install(
         &all_catalog,
         active_id,
     );
@@ -8834,7 +8869,6 @@ test "session picker keeps the visible scope when a stale catalog completes" {
         active_id,
         app.session_persistence.store.?,
     );
-    stale.request.scope = .all_workspaces;
     stale.catalog = .{};
     try stale.catalog.?.summaries.append(catalog_alloc, .{
         .id = try catalog_alloc.dupe(u8, "stale-foreign-session"),
@@ -9096,6 +9130,11 @@ test "session picker discards a held stale request after cancellation and reopen
     Runtime(TestApp).cancelSessionPicker(&app);
     try std.testing.expect(!picker.active);
     try std.testing.expectEqual(@as(usize, 0), picker.summaries.items.len);
+    try std.testing.expect(held.abandoned);
+    try std.testing.expect(held.cancel_requested.load(.acquire));
+    try std.testing.expect(app.session_persistence.session_picker_load.matchingInitialGeneration(
+        app.session_persistence.writable.?.active_id,
+    ) == null);
     try std.testing.expectEqualStrings(app.session_persistence.writable.?.active_id, held.request.active_id.?);
 
     try Runtime(TestApp).openSessionPicker(&app);
@@ -9120,14 +9159,84 @@ test "session picker discards a held stale request after cancellation and reopen
     try std.testing.expectEqual(@as(usize, 0), app.notices.items.len);
 }
 
+test "session picker source invalidation discards a finished catalog and pending request" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const paths = try testPaths(alloc, &tmp);
+    defer {
+        alloc.free(paths.home);
+        alloc.free(paths.workspace);
+    }
+    const home = try TestHome.install(alloc, paths.home);
+    defer home.deinit();
+    var app = try TestApp.init(alloc, paths.workspace);
+    defer app.deinit();
+    try configureTestPreferences(&app);
+    try Runtime(TestApp).initializePersistence(&app, true);
+    try Runtime(TestApp).beginFreshPersistedSession(&app);
+
+    const loader = &app.session_persistence.session_picker_load;
+    const active_id = app.session_persistence.writable.?.active_id;
+    const held = try createHeldSessionPickerTask(loader.allocateGeneration(), active_id, app.session_persistence.store.?);
+    loader.task = held;
+    held.catalog = .{};
+    held.done.store(true, .release);
+    loader.pending = try SessionPickerLoad.PageRequest.init(loader.allocateGeneration(), active_id);
+
+    Runtime(TestApp).invalidateSessionPickerCaches(&app);
+    try std.testing.expect(held.abandoned);
+    try std.testing.expect(loader.pending == null);
+    try Runtime(TestApp).pollSessionPicker(&app);
+    try std.testing.expect(loader.task == null);
+    try std.testing.expect(!app.session_persistence.session_picker_cache.ready);
+    try std.testing.expectEqual(@as(usize, 0), app.notices.items.len);
+}
+
+test "session picker reports worker failure when the shared stop flag is set" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const paths = try testPaths(alloc, &tmp);
+    defer {
+        alloc.free(paths.home);
+        alloc.free(paths.workspace);
+    }
+    const home = try TestHome.install(alloc, paths.home);
+    defer home.deinit();
+    var app = try TestApp.init(alloc, paths.workspace);
+    defer app.deinit();
+    try configureTestPreferences(&app);
+    try Runtime(TestApp).initializePersistence(&app, true);
+    try Runtime(TestApp).beginFreshPersistedSession(&app);
+
+    const loader = &app.session_persistence.session_picker_load;
+    const generation = loader.allocateGeneration();
+    const active_id = app.session_persistence.writable.?.active_id;
+    const held = try createHeldSessionPickerTask(generation, active_id, app.session_persistence.store.?);
+    loader.task = held;
+    held.failure = error.OutOfMemory;
+    held.cancel_requested.store(true, .release);
+    held.done.store(true, .release);
+    const picker = &app.session_persistence.session_picker;
+    picker.active = true;
+    picker.generation = generation;
+    try std.testing.expectEqual(generation, loader.matchingInitialGeneration(active_id).?);
+
+    try Runtime(TestApp).pollSessionPicker(&app);
+    try std.testing.expect(picker.active);
+    try std.testing.expectEqual(.failed, picker.load_state);
+    try std.testing.expect(!app.session_persistence.session_picker_cache.ready);
+    try std.testing.expectEqual(@as(usize, 1), app.notices.items.len);
+    try std.testing.expect(std.mem.find(u8, app.notices.items[0], "OutOfMemory") != null);
+}
+
 test "session picker page requests own the active session ID" {
     const alloc = std.testing.allocator;
     const active_id = try alloc.dupe(u8, "active-session");
     var request = try SessionPickerLoad.PageRequest.init(
         1,
-        .current_workspace,
         active_id,
-        session_store.default_resume_page_limit,
     );
     defer request.deinit();
     alloc.free(active_id);
@@ -9154,12 +9263,7 @@ test "persistence shutdown drops pending picker work" {
     try Runtime(TestApp).initializePersistence(&app, true);
 
     app.session_persistence.session_picker_load.pending =
-        try SessionPickerLoad.PageRequest.init(
-            1,
-            .current_workspace,
-            null,
-            session_store.default_resume_page_limit,
-        );
+        try SessionPickerLoad.PageRequest.init(1, null);
 
     Runtime(TestApp).requestPersistenceShutdown(&app);
 
@@ -9206,9 +9310,7 @@ fn createHeldSessionPickerTask(
     const alloc = std.heap.c_allocator;
     var request = try SessionPickerLoad.PageRequest.init(
         generation,
-        .current_workspace,
         active_id,
-        session_store.default_resume_page_limit,
     );
     errdefer request.deinit();
     const home_dir = try alloc.dupe(u8, store.home_dir);

--- a/src/core/session/session_catalog_cache.zig
+++ b/src/core/session/session_catalog_cache.zig
@@ -1,0 +1,375 @@
+const std = @import("std");
+const io_mod = @import("../shared/io.zig");
+const debug_trace = @import("../shared/debug_trace.zig");
+const session = @import("session.zig");
+const session_codec = @import("session_codec.zig");
+const session_layout = @import("session_layout.zig");
+const session_store = @import("session_store.zig");
+const summary_codec = @import("session_summary_codec.zig");
+
+const Allocator = std.mem.Allocator;
+const Sha256 = std.crypto.hash.sha2.Sha256;
+const magic = "fx-resume-catalog-v1\n";
+const file_name = ".resume-catalog";
+const max_bytes = 64 * 1024 * 1024;
+const max_records = 100_000;
+const Fingerprint = [Sha256.digest_length]u8;
+
+pub const Entry = struct {
+    fingerprint: ?Fingerprint,
+    value: union(enum) { visible: session_store.SessionSummary, excluded: []u8 },
+
+    fn id(self: Entry) []const u8 {
+        return switch (self.value) {
+            .visible => |summary| summary.id,
+            .excluded => |name| name,
+        };
+    }
+
+    pub fn deinit(self: *Entry, alloc: Allocator) void {
+        switch (self.value) {
+            .visible => |*summary| summary.deinit(alloc),
+            .excluded => |name| alloc.free(name),
+        }
+        self.* = undefined;
+    }
+};
+
+const Summary = struct {
+    workspace_root: ?[]const u8,
+    origin_workspace_root: ?[]const u8,
+    title: ?[]const u8,
+    preview: ?[]const u8,
+    display_metadata_present: bool,
+    created_at_ms: i64,
+    updated_at_ms: i64,
+    history_len: u64,
+    language: []const u8,
+    has_checkpoint: bool,
+    has_managed_children: bool,
+
+    fn from(source: *const session_store.SessionSummary) Summary {
+        return .{
+            .workspace_root = source.workspace_root,
+            .origin_workspace_root = source.origin_workspace_root,
+            .title = source.title,
+            .preview = source.preview,
+            .display_metadata_present = source.display_metadata_present,
+            .created_at_ms = source.created_at_ms,
+            .updated_at_ms = source.updated_at_ms,
+            .history_len = source.history_len,
+            .language = source.conversation_language.view(),
+            .has_checkpoint = source.has_checkpoint,
+            .has_managed_children = source.has_managed_children,
+        };
+    }
+
+    fn clone(self: Summary, alloc: Allocator, id: []const u8) !session_store.SessionSummary {
+        return summary_codec.cloneSessionSummary(alloc, .{
+            .id = @constCast(id),
+            .workspace_root = if (self.workspace_root) |value| @constCast(value) else null,
+            .origin_workspace_root = if (self.origin_workspace_root) |value| @constCast(value) else null,
+            .title = if (self.title) |value| @constCast(value) else null,
+            .preview = if (self.preview) |value| @constCast(value) else null,
+            .display_metadata_present = self.display_metadata_present,
+            .created_at_ms = self.created_at_ms,
+            .updated_at_ms = self.updated_at_ms,
+            .history_len = std.math.cast(usize, self.history_len) orelse return error.InvalidCatalogCache,
+            .conversation_language = try session.ConversationLanguage.fromSlice(self.language),
+            .has_checkpoint = self.has_checkpoint,
+            .has_managed_children = self.has_managed_children,
+        });
+    }
+};
+
+const Row = struct { id: []const u8, fingerprint: []const u8, summary: ?Summary };
+
+/// Owns parsed cache bytes. Reused entries are separately owned by the caller.
+pub const Loaded = struct {
+    bytes: ?[]u8 = null,
+    parsed: ?std.json.Parsed([]Row) = null,
+    index: std.StringHashMapUnmanaged(usize) = .empty,
+
+    pub fn deinit(self: *Loaded, alloc: Allocator) void {
+        self.index.deinit(alloc);
+        if (self.parsed) |*parsed| parsed.deinit();
+        if (self.bytes) |bytes| alloc.free(bytes);
+        self.* = .{};
+    }
+
+    pub fn count(self: *const Loaded) usize {
+        return self.index.count();
+    }
+    pub fn present(self: *const Loaded) bool {
+        return self.parsed != null;
+    }
+    pub fn contains(self: *const Loaded, id: []const u8) bool {
+        return self.index.contains(id);
+    }
+
+    pub fn load(alloc: Allocator, dir: ?io_mod.VerifiedDir, cancelled: ?*const std.atomic.Value(bool)) !Loaded {
+        const root = dir orelse return .{};
+        return loadChecked(alloc, root.dir, cancelled) catch |err| switch (err) {
+            error.OutOfMemory, error.Cancelled => return err,
+            error.FileNotFound => .{},
+            else => blk: {
+                debug_trace.logf("core", "session catalog cache ignored err={s}", .{@errorName(err)});
+                break :blk .{};
+            },
+        };
+    }
+
+    fn loadChecked(alloc: Allocator, dir: std.Io.Dir, cancelled: ?*const std.atomic.Value(bool)) !Loaded {
+        var file = try dir.openFile(io_mod.getIo(), file_name, .{ .follow_symlinks = false, .allow_directory = false, .resolve_beneath = true });
+        defer file.close(io_mod.getIo());
+        const stat = try file.stat(io_mod.getIo());
+        if (stat.kind != .file or stat.nlink > 1 or (stat.permissions.toMode() & 0o077) != 0 or stat.size > max_bytes) return error.InvalidCatalogCache;
+        const bytes = try alloc.alloc(u8, @intCast(stat.size));
+        errdefer alloc.free(bytes);
+        var offset: usize = 0;
+        while (offset < bytes.len) {
+            if (cancelled) |stop| if (stop.load(.acquire)) return error.Cancelled;
+            const end = @min(bytes.len, offset + 64 * 1024);
+            const read = try file.readPositionalAll(io_mod.getIo(), bytes[offset..end], offset);
+            if (read != end - offset) return error.InvalidCatalogCache;
+            offset = end;
+        }
+        if (bytes.len < magic.len + Sha256.digest_length or !std.mem.startsWith(u8, bytes, magic)) return error.InvalidCatalogCache;
+        const payload = bytes[magic.len + Sha256.digest_length ..];
+        var digest: Fingerprint = undefined;
+        Sha256.hash(payload, &digest, .{});
+        if (!std.mem.eql(u8, &digest, bytes[magic.len..][0..Sha256.digest_length])) return error.InvalidCatalogCache;
+        const parsed = try std.json.parseFromSlice([]Row, alloc, payload, .{ .allocate = .alloc_if_needed, .ignore_unknown_fields = false, .max_value_len = max_bytes });
+        errdefer parsed.deinit();
+        if (parsed.value.len > max_records) return error.InvalidCatalogCache;
+        var index: std.StringHashMapUnmanaged(usize) = .empty;
+        errdefer index.deinit(alloc);
+        try index.ensureTotalCapacity(alloc, @intCast(parsed.value.len));
+        for (parsed.value, 0..) |row, i| {
+            if (cancelled) |stop| if (stop.load(.acquire)) return error.Cancelled;
+            try session_layout.validateSessionId(row.id);
+            if (row.fingerprint.len != 64) return error.InvalidCatalogCache;
+            var fingerprint_bytes: Fingerprint = undefined;
+            _ = std.fmt.hexToBytes(&fingerprint_bytes, row.fingerprint) catch return error.InvalidCatalogCache;
+            if (row.summary) |summary| {
+                if (summary.created_at_ms < 0 or summary.updated_at_ms < summary.created_at_ms) return error.InvalidCatalogCache;
+                if (summary.history_len == 0 and !summary.has_checkpoint) return error.InvalidCatalogCache;
+                _ = try session.ConversationLanguage.fromSlice(summary.language);
+                _ = std.math.cast(usize, summary.history_len) orelse return error.InvalidCatalogCache;
+                if (summary.title) |title| {
+                    if (title.len > session_codec.max_session_title_bytes or !std.unicode.utf8ValidateSlice(title)) return error.InvalidCatalogCache;
+                }
+                for ([_]?[]const u8{ summary.workspace_root, summary.origin_workspace_root }) |root| {
+                    if (root) |path| {
+                        if (!std.fs.path.isAbsolute(path) or path.len > std.Io.Dir.max_path_bytes) return error.InvalidCatalogCache;
+                    }
+                }
+            }
+            const entry = index.getOrPutAssumeCapacity(row.id);
+            if (entry.found_existing) return error.InvalidCatalogCache;
+            entry.value_ptr.* = i;
+        }
+        return .{ .bytes = bytes, .parsed = parsed, .index = index };
+    }
+
+    pub fn reuse(self: *const Loaded, alloc: Allocator, id: []const u8, fingerprint_value: Fingerprint) !?Entry {
+        const position = self.index.get(id) orelse return null;
+        const row = self.parsed.?.value[position];
+        const hex = std.fmt.bytesToHex(fingerprint_value, .lower);
+        if (!std.mem.eql(u8, row.fingerprint, &hex)) return null;
+        return try cloneRow(alloc, row, fingerprint_value);
+    }
+
+    fn cloneRow(alloc: Allocator, row: Row, value: Fingerprint) !Entry {
+        return .{ .fingerprint = value, .value = if (row.summary) |summary|
+            .{ .visible = try summary.clone(alloc, row.id) }
+        else
+            .{ .excluded = try alloc.dupe(u8, row.id) } };
+    }
+};
+
+/// A narrow cache-writing handle obtained only from a writable app store.
+pub const Writer = struct {
+    dir: io_mod.VerifiedDir,
+
+    pub fn init(store: session_store.Store) !?Writer {
+        if (store.canonical_root.mode != .writable) return null;
+        const root = store.canonical_root.sessions orelse return null;
+        return .{ .dir = .{ .dir = try root.dir.openDir(io_mod.getIo(), ".", .{ .iterate = true, .follow_symlinks = false }) } };
+    }
+    pub fn deinit(self: *Writer) void {
+        self.dir.close();
+    }
+
+    pub fn save(self: *Writer, alloc: Allocator, entries: []const Entry, cancelled: *const std.atomic.Value(bool)) !void {
+        var payload: std.Io.Writer.Allocating = .init(alloc);
+        defer payload.deinit();
+        try payload.writer.writeByte('[');
+        var written: usize = 0;
+        for (entries) |*entry| {
+            if (cancelled.load(.acquire)) return error.Cancelled;
+            const value = entry.fingerprint orelse continue;
+            if (written == max_records) return error.CatalogCacheTooLarge;
+            if (written != 0) try payload.writer.writeByte(',');
+            const hex = std.fmt.bytesToHex(value, .lower);
+            try std.json.Stringify.value(Row{ .id = entry.id(), .fingerprint = &hex, .summary = switch (entry.value) {
+                .visible => |*summary| Summary.from(summary),
+                .excluded => null,
+            } }, .{}, &payload.writer);
+            written += 1;
+            if (payload.written().len > max_bytes - magic.len - Sha256.digest_length - 1) return error.CatalogCacheTooLarge;
+        }
+        try payload.writer.writeByte(']');
+        if (cancelled.load(.acquire)) return error.Cancelled;
+        var digest: Fingerprint = undefined;
+        Sha256.hash(payload.written(), &digest, .{});
+        var out: std.Io.Writer.Allocating = .init(alloc);
+        defer out.deinit();
+        try out.writer.writeAll(magic);
+        try out.writer.writeAll(&digest);
+        try out.writer.writeAll(payload.written());
+        try io_mod.durableReplaceVerified(alloc, &self.dir, file_name, out.written());
+    }
+};
+
+/// Stats are freshness evidence only. Cache misses still use canonical discovery and admission.
+pub fn fingerprint(dir: std.Io.Dir, id: []const u8) !?Fingerprint {
+    try session_layout.validateSessionId(id);
+    const before = (try statOptional(dir, id)) orelse return null;
+    if (before.kind != .directory) return null;
+    var digest = Sha256.init(.{});
+    addStat(&digest, before);
+    var path_buffer: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    for ([_][]const u8{ "session.json", "events.jsonl" }) |name| {
+        const path = try std.fmt.bufPrint(&path_buffer, "{s}/{s}", .{ id, name });
+        const stat = (try statOptional(dir, path)) orelse return null;
+        if (stat.kind != .file or stat.nlink != 1) return null;
+        addStat(&digest, stat);
+    }
+    const child_path = try std.fmt.bufPrint(&path_buffer, "{s}/subagent", .{id});
+    const child = try statOptional(dir, child_path);
+    if (child) |stat| {
+        if (stat.kind != .directory) return null;
+        digest.update(&.{1});
+        addStat(&digest, stat);
+        for ([_][]const u8{ "owner.json", "control.json" }) |name| {
+            const path = try std.fmt.bufPrint(&path_buffer, "{s}/subagent/{s}", .{ id, name });
+            if (try statOptional(dir, path)) |marker| {
+                if (marker.kind != .file or marker.nlink != 1) return null;
+                digest.update(&.{1});
+                addStat(&digest, marker);
+            } else digest.update(&.{0});
+        }
+    } else digest.update(&.{0});
+    const after = (try statOptional(dir, id)) orelse return null;
+    if (!sameStat(before, after)) return null;
+    var value: Fingerprint = undefined;
+    digest.final(&value);
+    return value;
+}
+
+fn statOptional(dir: std.Io.Dir, path: []const u8) !?std.Io.File.Stat {
+    return dir.statFile(io_mod.getIo(), path, .{ .follow_symlinks = false }) catch |err| switch (err) {
+        error.FileNotFound, error.NotDir => null,
+        else => err,
+    };
+}
+
+fn sameStat(a: std.Io.File.Stat, b: std.Io.File.Stat) bool {
+    return a.inode == b.inode and a.nlink == b.nlink and a.kind == b.kind and a.size == b.size and
+        a.permissions.toMode() == b.permissions.toMode() and a.mtime.nanoseconds == b.mtime.nanoseconds and a.ctime.nanoseconds == b.ctime.nanoseconds;
+}
+
+fn addStat(hash: *Sha256, stat: std.Io.File.Stat) void {
+    const values = [_]u128{ stat.inode, stat.nlink, stat.size, @intFromEnum(stat.kind), stat.permissions.toMode(), @bitCast(@as(i128, stat.mtime.nanoseconds)), @bitCast(@as(i128, stat.ctime.nanoseconds)) };
+    var bytes: [16]u8 = undefined;
+    for (values) |value| {
+        std.mem.writeInt(u128, &bytes, value, .little);
+        hash.update(&bytes);
+    }
+}
+
+test "catalog cache round trips owned rows and ignores incomplete observations" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var writer = Writer{ .dir = .{ .dir = try tmp.dir.openDir(std.testing.io, ".", .{ .iterate = true }) } };
+    defer writer.deinit();
+    var entries = [_]Entry{
+        .{ .fingerprint = @splat(1), .value = .{ .visible = try summary_codec.cloneSessionSummary(alloc, .{
+            .id = @constCast("visible"),
+            .workspace_root = @constCast("/workspace"),
+            .origin_workspace_root = @constCast("/origin"),
+            .title = @constCast("Saved title"),
+            .created_at_ms = 1,
+            .updated_at_ms = 2,
+            .history_len = 3,
+            .conversation_language = .literal("en"),
+        }) } },
+        .{ .fingerprint = @splat(2), .value = .{ .excluded = try alloc.dupe(u8, "private") } },
+        .{ .fingerprint = null, .value = .{ .excluded = try alloc.dupe(u8, "temporary-failure") } },
+    };
+    defer for (&entries) |*entry| entry.deinit(alloc);
+    var stopped = std.atomic.Value(bool).init(false);
+    try writer.save(alloc, &entries, &stopped);
+    var loaded = try Loaded.load(alloc, writer.dir, null);
+    defer loaded.deinit(alloc);
+    try std.testing.expect(loaded.present());
+    try std.testing.expectEqual(@as(usize, 2), loaded.count());
+    try std.testing.expect(!loaded.contains("temporary-failure"));
+    var visible = (try loaded.reuse(alloc, "visible", @splat(1))).?;
+    defer visible.deinit(alloc);
+    try std.testing.expectEqualStrings("Saved title", visible.value.visible.title.?);
+    try std.testing.expectEqual(@as(usize, 3), visible.value.visible.history_len);
+    try std.testing.expect((try loaded.reuse(alloc, "visible", @splat(3))) == null);
+    var excluded = (try loaded.reuse(alloc, "private", @splat(2))).?;
+    defer excluded.deinit(alloc);
+    try std.testing.expectEqualStrings("private", excluded.value.excluded);
+    stopped.store(true, .release);
+    try std.testing.expectError(error.Cancelled, writer.save(alloc, &.{}, &stopped));
+    var retained = try Loaded.load(alloc, writer.dir, null);
+    defer retained.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 2), retained.count());
+}
+
+test "catalog cache corruption and duplicate identifiers require rebuilding" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var writer = Writer{ .dir = .{ .dir = try tmp.dir.openDir(std.testing.io, ".", .{ .iterate = true }) } };
+    defer writer.deinit();
+    const duplicate = Entry{ .fingerprint = @splat(4), .value = .{ .excluded = @constCast("duplicate") } };
+    var stopped = std.atomic.Value(bool).init(false);
+    try writer.save(alloc, &.{ duplicate, duplicate }, &stopped);
+    var invalid = try Loaded.load(alloc, writer.dir, null);
+    defer invalid.deinit(alloc);
+    try std.testing.expect(!invalid.present());
+    try io_mod.durableReplaceVerified(alloc, &writer.dir, file_name, "corrupt cache");
+    var corrupt = try Loaded.load(alloc, writer.dir, null);
+    defer corrupt.deinit(alloc);
+    try std.testing.expect(!corrupt.present());
+}
+
+test "catalog fingerprint detects event appends and child directory permissions" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(std.testing.io, "session/subagent");
+    for ([_][]const u8{ "session/session.json", "session/events.jsonl" }) |path| {
+        var file = try tmp.dir.createFile(std.testing.io, path, .{});
+        defer file.close(std.testing.io);
+        try file.writeStreamingAll(std.testing.io, "{}\n");
+    }
+    const first = (try fingerprint(tmp.dir, "session")).?;
+    var events = try tmp.dir.openFile(std.testing.io, "session/events.jsonl", .{ .mode = .read_write });
+    defer events.close(std.testing.io);
+    try events.writePositionalAll(std.testing.io, "more\n", 3);
+    const appended = (try fingerprint(tmp.dir, "session")).?;
+    try std.testing.expect(!std.mem.eql(u8, &first, &appended));
+    var child = try tmp.dir.openDir(std.testing.io, "session/subagent", .{});
+    defer child.close(std.testing.io);
+    try child.setPermissions(std.testing.io, .fromMode(0o700));
+    const private = (try fingerprint(tmp.dir, "session")).?;
+    try child.setPermissions(std.testing.io, .fromMode(0o755));
+    const changed = (try fingerprint(tmp.dir, "session")).?;
+    try std.testing.expect(!std.mem.eql(u8, &private, &changed));
+}

--- a/src/core/session/session_catalog_cache.zig
+++ b/src/core/session/session_catalog_cache.zig
@@ -365,7 +365,7 @@ test "catalog fingerprint detects event appends and child directory permissions"
     try events.writePositionalAll(std.testing.io, "more\n", 3);
     const appended = (try fingerprint(tmp.dir, "session")).?;
     try std.testing.expect(!std.mem.eql(u8, &first, &appended));
-    var child = try tmp.dir.openDir(std.testing.io, "session/subagent", .{});
+    var child = try tmp.dir.openDir(std.testing.io, "session/subagent", .{ .iterate = true });
     defer child.close(std.testing.io);
     try child.setPermissions(std.testing.io, .fromMode(0o700));
     const private = (try fingerprint(tmp.dir, "session")).?;

--- a/src/core/session/session_codec.zig
+++ b/src/core/session/session_codec.zig
@@ -217,7 +217,7 @@ pub const DurableSessionState = struct {
 
 pub const session_metadata_schema_version: u8 = 4;
 pub const max_session_metadata_bytes: usize = 64 * 1024;
-const max_session_title_bytes: usize = 240;
+pub const max_session_title_bytes: usize = 240;
 
 pub const SessionMetadata = struct {
     schema_version: u8 = session_metadata_schema_version,

--- a/src/core/session/session_discovery.zig
+++ b/src/core/session/session_discovery.zig
@@ -59,6 +59,7 @@ pub const ReadOnlyCandidate = struct {
     summary: SessionSummary,
     storage: CandidateStorage,
     projection_state: ProjectionState,
+    subagent_child: ?bool = null,
 
     pub fn deinit(self: *ReadOnlyCandidate, alloc: Allocator) void {
         self.summary.deinit(alloc);
@@ -263,30 +264,55 @@ pub fn classifyReadOnlyCandidate(
     session_dir: *io_mod.VerifiedDir,
     session_id: []const u8,
 ) !ReadOnlyCandidate {
-    if (try session_log.hasConversationMetadata(alloc, session_dir)) {
-        return classifyConversationCandidate(alloc, session_dir, session_id);
+    return classifyReadOnlyCandidateWithCancellation(alloc, session_dir, session_id, null);
+}
+
+pub fn classifyReadOnlyCandidateCancellable(
+    alloc: Allocator,
+    session_dir: *io_mod.VerifiedDir,
+    session_id: []const u8,
+    cancelled: *const std.atomic.Value(bool),
+) !ReadOnlyCandidate {
+    return classifyReadOnlyCandidateWithCancellation(alloc, session_dir, session_id, cancelled);
+}
+
+fn classifyReadOnlyCandidateWithCancellation(
+    alloc: Allocator,
+    session_dir: *io_mod.VerifiedDir,
+    session_id: []const u8,
+    cancelled: ?*const std.atomic.Value(bool),
+) !ReadOnlyCandidate {
+    if (cancelled) |stop| {
+        if (stop.load(.acquire)) return error.Cancelled;
     }
-    return switch (try classifyAuthority(alloc, session_dir, session_id)) {
+    if (try session_log.readConversationMetadata(alloc, session_dir)) |value| {
+        var metadata = value;
+        defer metadata.deinit();
+        return classifyConversationCandidate(alloc, session_dir, session_id, metadata.value, cancelled);
+    }
+    if (cancelled) |stop| {
+        if (stop.load(.acquire)) return error.Cancelled;
+    }
+    const candidate = switch (try classifyAuthority(alloc, session_dir, session_id)) {
         .schema_v3 => classifySchemaV3Candidate(alloc, session_dir, session_id),
-        .legacy => classifyLegacyCandidate(alloc, session_dir, session_id),
+        .legacy => classifyLegacyCandidateWithCancellation(alloc, session_dir, session_id, cancelled),
     };
+    var owned = try candidate;
+    errdefer owned.deinit(alloc);
+    if (cancelled) |stop| {
+        if (stop.load(.acquire)) return error.Cancelled;
+    }
+    return owned;
 }
 
 fn classifyConversationCandidate(
     alloc: Allocator,
     session_dir: *io_mod.VerifiedDir,
     session_id: []const u8,
+    metadata: session_codec.SessionMetadata,
+    cancelled: ?*const std.atomic.Value(bool),
 ) !ReadOnlyCandidate {
-    const metadata_bytes = (try readOptionalSessionFile(
-        alloc,
-        session_dir,
-        "session.json",
-        session_codec.max_session_metadata_bytes,
-    )) orelse return error.SessionNotFound;
-    defer alloc.free(metadata_bytes);
-    var metadata = try session_codec.decodeSessionMetadata(alloc, metadata_bytes);
-    defer metadata.deinit();
-    if (!std.mem.eql(u8, metadata.value.id, session_id)) {
+    if (!std.mem.eql(u8, metadata.id, session_id)) {
         return error.InvalidSessionFormat;
     }
 
@@ -305,12 +331,19 @@ fn classifyConversationCandidate(
         defer event_file.close(io_mod.getIo());
         var offset: u64 = 0;
         while (offset < event_stat.size) {
-            const line = session_replay.readLineAt(
+            const read = if (cancelled) |stop| session_replay.readLineAtCancellable(
                 alloc,
                 event_file,
                 offset,
                 event_stat.size,
-            ) catch |err| switch (err) {
+                stop,
+            ) else session_replay.readLineAt(
+                alloc,
+                event_file,
+                offset,
+                event_stat.size,
+            );
+            const line = read catch |err| switch (err) {
                 error.TruncatedEventFrame => break,
                 else => return err,
             } orelse break;
@@ -330,38 +363,39 @@ fn classifyConversationCandidate(
         }
     }
 
-    const id = try alloc.dupe(u8, metadata.value.id);
+    const id = try alloc.dupe(u8, metadata.id);
     errdefer alloc.free(id);
-    const origin = try alloc.dupe(u8, metadata.value.origin_workspace_root);
+    const origin = try alloc.dupe(u8, metadata.origin_workspace_root);
     errdefer alloc.free(origin);
-    const workspace = try alloc.dupe(u8, metadata.value.workspace_root);
+    const workspace = try alloc.dupe(u8, metadata.workspace_root);
     errdefer alloc.free(workspace);
-    const title = if (metadata.value.title) |value| try alloc.dupe(u8, value) else null;
+    const title = if (metadata.title) |value| try alloc.dupe(u8, value) else null;
     return .{
         .summary = .{
             .id = id,
             .workspace_root = workspace,
             .origin_workspace_root = origin,
             .title = title,
-            .created_at_ms = metadata.value.created_at_ms,
+            .created_at_ms = metadata.created_at_ms,
             .updated_at_ms = if (history_len == 0 and !has_checkpoint)
-                metadata.value.updated_at_ms
+                metadata.updated_at_ms
             else
                 @max(
-                    metadata.value.updated_at_ms,
+                    metadata.updated_at_ms,
                     std.math.cast(
                         i64,
                         @divFloor(event_stat.mtime.nanoseconds, std.time.ns_per_ms),
                     ) orelse std.math.maxInt(i64),
                 ),
             .conversation_language = session.ConversationLanguage.fromSlice(
-                metadata.value.conversation_language,
+                metadata.conversation_language,
             ) catch return error.InvalidSessionFormat,
             .history_len = history_len,
             .has_checkpoint = has_checkpoint,
         },
         .storage = .conversation,
         .projection_state = .current,
+        .subagent_child = metadata.subagent_child,
     };
 }
 
@@ -452,6 +486,15 @@ pub fn classifyLegacyCandidate(
     session_dir: *io_mod.VerifiedDir,
     session_id: []const u8,
 ) !ReadOnlyCandidate {
+    return classifyLegacyCandidateWithCancellation(alloc, session_dir, session_id, null);
+}
+
+fn classifyLegacyCandidateWithCancellation(
+    alloc: Allocator,
+    session_dir: *io_mod.VerifiedDir,
+    session_id: []const u8,
+    cancelled: ?*const std.atomic.Value(bool),
+) !ReadOnlyCandidate {
     if (try entryExistsRelative(session_dir, "authority.json")) {
         return error.InvalidSessionFormat;
     }
@@ -462,14 +505,7 @@ pub fn classifyLegacyCandidate(
     if (stat.size > automatic_legacy_max_bytes) return error.LegacySessionTooLarge;
     var buffer: [16 * 1024]u8 = undefined;
     var reader = file.readerStreaming(io_mod.getIo(), &buffer);
-    var legacy = session_json.parseLegacySummaryStreaming(
-        LegacyCandidateSummary,
-        alloc,
-        &reader.interface,
-    ) catch |err| switch (err) {
-        error.OutOfMemory => return error.OutOfMemory,
-        else => return err,
-    };
+    var legacy = try readLegacySummary(alloc, &reader.interface, cancelled);
     errdefer legacy.deinit(alloc);
     if (!std.mem.eql(u8, legacy.id, session_id)) {
         return error.InvalidSessionFormat;
@@ -481,6 +517,76 @@ pub fn classifyLegacyCandidate(
         .storage = storage,
         .projection_state = .current,
     };
+}
+
+const CancellableReader = struct {
+    source: *std.Io.Reader,
+    cancelled: ?*const std.atomic.Value(bool),
+    interface: std.Io.Reader,
+
+    fn stream(reader: *std.Io.Reader, writer: *std.Io.Writer, limit: std.Io.Limit) std.Io.Reader.StreamError!usize {
+        const self: *CancellableReader = @fieldParentPtr("interface", reader);
+        if (self.cancelled) |stop| {
+            if (stop.load(.acquire)) return error.ReadFailed;
+        }
+        return self.source.stream(writer, limit.min(.limited(8192)));
+    }
+};
+
+fn readLegacySummary(
+    alloc: Allocator,
+    source: *std.Io.Reader,
+    cancelled: ?*const std.atomic.Value(bool),
+) !LegacyCandidateSummary {
+    var buffer: [8192]u8 = undefined;
+    var reader = CancellableReader{
+        .source = source,
+        .cancelled = cancelled,
+        .interface = .{ .vtable = &.{ .stream = CancellableReader.stream }, .buffer = &buffer, .seek = 0, .end = 0 },
+    };
+    var result = session_json.parseLegacySummaryStreaming(LegacyCandidateSummary, alloc, &reader.interface) catch |err| {
+        if (cancelled) |stop| {
+            if (stop.load(.acquire)) return error.Cancelled;
+        }
+        return err;
+    };
+    errdefer result.deinit(alloc);
+    if (cancelled) |stop| {
+        if (stop.load(.acquire)) return error.Cancelled;
+    }
+    return result;
+}
+
+test "legacy summary cancellation stops after streaming starts" {
+    const alloc = std.testing.allocator;
+    const bytes = "{\"schema_version\":2,\"history\":[{\"user\":\"request\",\"assistant\":\"response\"}]," ++
+        "\"id\":\"legacy\",\"created_at_ms\":1,\"updated_at_ms\":2,\"workspace_root\":null," ++
+        "\"conversation_language\":\"en\",\"history_len\":1}";
+    const Source = struct {
+        input: std.Io.Reader,
+        stopped: *std.atomic.Value(bool),
+        reads: usize = 0,
+        interface: std.Io.Reader = .{ .vtable = &.{ .stream = stream }, .buffer = &.{}, .seek = 0, .end = 0 },
+
+        fn stream(reader: *std.Io.Reader, writer: *std.Io.Writer, limit: std.Io.Limit) std.Io.Reader.StreamError!usize {
+            const self: *@This() = @fieldParentPtr("interface", reader);
+            self.reads += 1;
+            const count = try self.input.stream(writer, limit.min(.limited(32)));
+            self.stopped.store(true, .release);
+            return count;
+        }
+    };
+    var stopped = std.atomic.Value(bool).init(false);
+    var source = Source{ .input = .fixed(bytes), .stopped = &stopped };
+    try std.testing.expectError(error.Cancelled, readLegacySummary(alloc, &source.interface, &stopped));
+    try std.testing.expectEqual(@as(usize, 1), source.reads);
+    try std.testing.expect(source.input.seek > 0 and source.input.seek < bytes.len);
+    stopped.store(false, .release);
+    var complete = std.Io.Reader.fixed(bytes);
+    var summary = try readLegacySummary(alloc, &complete, &stopped);
+    defer summary.deinit(alloc);
+    try std.testing.expectEqualStrings("legacy", summary.id);
+    try std.testing.expectEqual(@as(usize, 1), summary.history_len);
 }
 
 /// Projects a durable session state into the lightweight `SessionSummary`

--- a/src/core/session/session_log.zig
+++ b/src/core/session/session_log.zig
@@ -808,20 +808,45 @@ pub fn hasConversationMetadata(
     alloc: Allocator,
     dir: *io_mod.VerifiedDir,
 ) !bool {
+    const bytes = (try readConversationMetadataBytes(alloc, dir)) orelse return false;
+    defer alloc.free(bytes);
+    return isConversationMetadata(alloc, bytes);
+}
+
+/// Reads and validates current metadata once. The caller owns the decoded value.
+pub fn readConversationMetadata(
+    alloc: Allocator,
+    dir: *io_mod.VerifiedDir,
+) !?session_codec.DecodedSessionMetadata {
+    const bytes = (try readConversationMetadataBytes(alloc, dir)) orelse return null;
+    defer alloc.free(bytes);
+    if (!try isConversationMetadata(alloc, bytes)) return null;
+    return session_codec.decodeSessionMetadata(alloc, bytes) catch |err| switch (err) {
+        error.SessionMetadataTooLarge => error.InvalidSessionFormat,
+        else => err,
+    };
+}
+
+fn readConversationMetadataBytes(alloc: Allocator, dir: *io_mod.VerifiedDir) !?[]u8 {
     const bytes = readManagedFileAlloc(
         alloc,
         dir,
         manifest_file,
         session_codec.max_session_metadata_bytes,
     ) catch |err| switch (err) {
-        error.FileNotFound => return false,
-        error.InvalidSessionFormat => return false,
+        error.FileNotFound, error.InvalidSessionFormat => return null,
         else => return err,
     };
-    defer alloc.free(bytes);
+    return bytes;
+}
+
+fn isConversationMetadata(alloc: Allocator, bytes: []const u8) !bool {
     var parsed = std.json.parseFromSlice(std.json.Value, alloc, bytes, .{
         .parse_numbers = false,
-    }) catch return false;
+    }) catch |err| switch (err) {
+        error.OutOfMemory => return err,
+        else => return false,
+    };
     defer parsed.deinit();
     const object = if (parsed.value == .object) parsed.value.object else return false;
     const version = object.get("schema_version") orelse return false;

--- a/src/core/session/session_replay.zig
+++ b/src/core/session/session_replay.zig
@@ -30,12 +30,38 @@ pub fn readLineAt(
     offset: u64,
     max_end: u64,
 ) !?LineRead {
+    return readLineAtWithCancellation(alloc, file, offset, max_end, null);
+}
+
+pub fn readLineAtCancellable(
+    alloc: Allocator,
+    file: std.Io.File,
+    offset: u64,
+    max_end: u64,
+    cancelled: *const std.atomic.Value(bool),
+) !?LineRead {
+    return readLineAtWithCancellation(alloc, file, offset, max_end, cancelled);
+}
+
+fn readLineAtWithCancellation(
+    alloc: Allocator,
+    file: std.Io.File,
+    offset: u64,
+    max_end: u64,
+    cancelled: ?*const std.atomic.Value(bool),
+) !?LineRead {
+    if (cancelled) |stop| {
+        if (stop.load(.acquire)) return error.Cancelled;
+    }
     if (offset >= max_end) return null;
     var line: std.ArrayList(u8) = .empty;
     errdefer line.deinit(alloc);
     var cursor = offset;
     var chunk: [8192]u8 = undefined;
     while (cursor < max_end) {
+        if (cancelled) |stop| {
+            if (stop.load(.acquire)) return error.Cancelled;
+        }
         const limit = @min(@as(u64, chunk.len), max_end - cursor);
         const count = try file.readPositionalAll(
             io_mod.getIo(),
@@ -70,6 +96,23 @@ pub fn readFirstGeneration(alloc: Allocator, file: std.Io.File) !Identifier {
     var envelope = try readSessionStarted(alloc, file);
     defer envelope.deinit(alloc);
     return envelope.log_generation;
+}
+
+test "cancelled event reads release work before reading another frame" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var file = try tmp.dir.createFile(std.testing.io, "events.jsonl", .{ .read = true });
+    defer file.close(std.testing.io);
+    const bytes = "{\"event\":1}\n";
+    try file.writeStreamingAll(std.testing.io, bytes);
+    var cancelled = std.atomic.Value(bool).init(true);
+    try std.testing.expectError(error.Cancelled, readLineAtCancellable(alloc, file, 0, bytes.len, &cancelled));
+    cancelled.store(false, .release);
+    const line = (try readLineAtCancellable(alloc, file, 0, bytes.len, &cancelled)).?;
+    defer alloc.free(line.bytes);
+    try std.testing.expectEqualStrings(bytes, line.bytes);
+    try std.testing.expectEqual(@as(u64, bytes.len), line.next_offset);
 }
 
 pub fn readSubagentChildIdentity(alloc: Allocator, file: std.Io.File) !bool {

--- a/src/core/session/session_store.zig
+++ b/src/core/session/session_store.zig
@@ -350,6 +350,54 @@ const SessionSummaryScan = struct {
     }
 };
 
+/// Borrows its store's directory handles. The caller owns each returned candidate.
+pub const CandidateIterator = struct {
+    store: Store,
+    entries: ?std.Io.Dir.Iterator,
+    mode: DiscoveryMode = .read_only_list,
+    skipped_invalid: usize = 0,
+
+    pub fn next(self: *CandidateIterator, alloc: Allocator) !?ReadOnlyCandidate {
+        while (try self.nextName(null)) |name| {
+            return self.store.readOnlyCandidate(alloc, name, null) catch |err| switch (err) {
+                error.OutOfMemory => return err,
+                else => {
+                    logDiscoveryError(self.mode, name, null, null, err);
+                    self.skipped_invalid += 1;
+                    continue;
+                },
+            };
+        }
+        return null;
+    }
+
+    /// Returns an owned ID; callers sharing an iterator must serialize advancement.
+    pub fn nextId(
+        self: *CandidateIterator,
+        alloc: Allocator,
+        cancelled: ?*const std.atomic.Value(bool),
+    ) !?[]u8 {
+        const name = (try self.nextName(cancelled)) orelse return null;
+        return try alloc.dupe(u8, name);
+    }
+
+    fn nextName(self: *CandidateIterator, cancelled: ?*const std.atomic.Value(bool)) !?[]const u8 {
+        if (cancelled) |stop| {
+            if (stop.load(.acquire)) return error.Cancelled;
+        }
+        const entries = if (self.entries) |*value| value else return null;
+        while (true) {
+            if (cancelled) |stop| {
+                if (stop.load(.acquire)) return error.Cancelled;
+            }
+            const entry = (try entries.next(io_mod.getIo())) orelse return null;
+            if (entry.kind != .directory or std.mem.eql(u8, entry.name, retired_latest_sessions_dir)) continue;
+            validateSessionId(entry.name) catch continue;
+            return entry.name;
+        }
+    }
+};
+
 test {
     _ = session_child_store;
     _ = session_layout;
@@ -492,13 +540,6 @@ pub const Store = struct {
     // Carried on the value so it propagates through the by-value page chain;
     // the UI sets it from the visible screen height.
     resume_page_limit: usize = default_resume_page_limit,
-    resume_cancel_flag: ?*const std.atomic.Value(bool) = null,
-
-    pub fn checkResumeCancellation(self: Store) !void {
-        if (self.resume_cancel_flag) |flag| {
-            if (flag.load(.acquire)) return error.Cancelled;
-        }
-    }
 
     /// Narrow, copyable view of this store for the discovery/migration helpers,
     /// so they depend on `StoreContext` instead of the full facade.
@@ -1693,6 +1734,31 @@ pub const Store = struct {
         return scan.summaries;
     }
 
+    pub fn readOnlyCandidates(self: Store) CandidateIterator {
+        return .{
+            .store = self,
+            .entries = if (self.canonical_root.sessions) |dir| dir.dir.iterate() else null,
+        };
+    }
+
+    /// The caller owns the candidate. No directory handle escapes this read.
+    pub fn readOnlyCandidate(
+        self: Store,
+        alloc: Allocator,
+        session_id: []const u8,
+        cancelled: ?*const std.atomic.Value(bool),
+    ) !ReadOnlyCandidate {
+        if (cancelled) |stop| {
+            if (stop.load(.acquire)) return error.Cancelled;
+        }
+        var dir = try self.openSessionDir(session_id);
+        defer dir.close();
+        return if (cancelled) |stop|
+            discovery.classifyReadOnlyCandidateCancellable(alloc, &dir, session_id, stop)
+        else
+            classifyReadOnlyCandidate(alloc, &dir, session_id);
+    }
+
     /// Invalidates the derived resume catalog after managed child ownership
     /// changes. The relationship index remains the canonical authority.
     /// Returns owned IDs for every readable ordinary session. Caller frees each
@@ -2172,42 +2238,14 @@ pub const Store = struct {
         errdefer scan.deinit(alloc);
         var metadata: std.ArrayList(DiscoveryCandidateMetadata) = .empty;
         defer metadata.deinit(alloc);
-        if (self.canonical_root.sessions == null) return scan;
-        var iter = self.canonical_root.sessions.?.dir.iterate();
-        while (try iter.next(io_mod.getIo())) |entry| {
-            try self.checkResumeCancellation();
-            if (entry.kind != .directory) continue;
-            if (std.mem.eql(u8, entry.name, retired_latest_sessions_dir)) {
-                continue;
-            }
-            validateSessionId(entry.name) catch continue;
-            var session_dir = self.openSessionDir(entry.name) catch |err| switch (err) {
-                else => {
-                    logDiscoveryError(mode, entry.name, null, null, err);
-                    scan.skipped_invalid += 1;
-                    continue;
-                },
-            };
-            var candidate = classifyReadOnlyCandidate(
-                alloc,
-                &session_dir,
-                entry.name,
-            ) catch |err| switch (err) {
-                error.OutOfMemory => {
-                    session_dir.close();
-                    return error.OutOfMemory;
-                },
-                else => {
-                    session_dir.close();
-                    logDiscoveryError(mode, entry.name, null, null, err);
-                    scan.skipped_invalid += 1;
-                    continue;
-                },
-            };
-            session_dir.close();
+        var iter = self.readOnlyCandidates();
+        iter.mode = mode;
+        while (try iter.next(alloc)) |value| {
+            var candidate = value;
+            const session_id = candidate.summary.id;
             if (probe_managed_children) {
                 candidate.summary.has_managed_children =
-                    self.sessionHasManagedChildren(alloc, entry.name) catch |err| switch (err) {
+                    self.sessionHasManagedChildren(alloc, session_id) catch |err| switch (err) {
                         error.OutOfMemory => {
                             candidate.deinit(alloc);
                             return error.OutOfMemory;
@@ -2217,7 +2255,7 @@ pub const Store = struct {
             }
             logDiscovery(
                 mode,
-                entry.name,
+                session_id,
                 candidate.storage,
                 candidate.projection_state,
                 .listable,
@@ -2238,7 +2276,7 @@ pub const Store = struct {
             };
             candidate.summary = undefined;
         }
-        try self.checkResumeCancellation();
+        scan.skipped_invalid = iter.skipped_invalid;
         sortSummariesNewestFirst(scan.summaries.items);
         if (mode == .global_read_only_last and scan.summaries.items.len > 0) {
             for (metadata.items) |candidate| {

--- a/src/core/subagent/child_state.zig
+++ b/src/core/subagent/child_state.zig
@@ -3,6 +3,7 @@ const domain = @import("domain.zig");
 const io_mod = @import("../shared/io.zig");
 const session_child_store = @import("../session/session_child_store.zig");
 const session_store = @import("../session/session_store.zig");
+const session_discovery = @import("../session/session_discovery.zig");
 const types = @import("../shared/types.zig");
 
 const Allocator = std.mem.Allocator;
@@ -504,6 +505,26 @@ pub fn isManagedChildSession(
     };
 }
 
+/// Reuses discovery's validated identity while retaining all child-marker checks.
+pub fn isListedManagedChildSession(
+    sessions: session_store.Store,
+    alloc: Allocator,
+    candidate: *const session_discovery.ReadOnlyCandidate,
+) !bool {
+    if (candidate.subagent_child == true) return true;
+    var capability = sessions.openListedChildCapabilityReadOnly(alloc, candidate.summary.id) catch |err| switch (err) {
+        error.SessionNotFound => return false,
+        else => return err,
+    };
+    defer capability.deinit();
+    if (try capabilityHasManagedChildMarker(alloc, &capability)) return true;
+    if (candidate.subagent_child) |identity| return identity;
+    return sessions.loadSubagentChildIdentity(alloc, candidate.summary.id) catch |err| switch (err) {
+        error.SessionNotFound => false,
+        else => return err,
+    };
+}
+
 /// Checks only immutable current and legacy child markers. Callers that
 /// already hold a loaded session use its durable `subagent_child` bit and
 /// this marker-only check rather than reopening session state.
@@ -521,6 +542,13 @@ pub fn hasManagedChildMarker(
         else => err,
     };
     defer capability.deinit();
+    return capabilityHasManagedChildMarker(alloc, &capability);
+}
+
+fn capabilityHasManagedChildMarker(
+    alloc: Allocator,
+    capability: *session_child_store.SessionChildCapability,
+) !bool {
     var owner = capability.openFileReadOnly(
         alloc,
         .subagent_control,

--- a/src/core/subagent/resume_admission.zig
+++ b/src/core/subagent/resume_admission.zig
@@ -4,6 +4,8 @@ const io_mod = @import("../shared/io.zig");
 const session = @import("../session/session.zig");
 const session_codec = @import("../session/session_codec.zig");
 const session_store = @import("../session/session_store.zig");
+const session_discovery = @import("../session/session_discovery.zig");
+const catalog_cache = @import("../session/session_catalog_cache.zig");
 const session_summary_codec = @import("../session/session_summary_codec.zig");
 
 const Allocator = std.mem.Allocator;
@@ -46,44 +48,166 @@ pub const ActionableSessionCatalog = struct {
     }
 };
 
+const CatalogRead = struct {
+    store: session_store.Store,
+    candidates: session_store.CandidateIterator,
+    iterator_mutex: std.Io.Mutex = .init,
+    active_id: ?[]const u8,
+    cancelled: *std.atomic.Value(bool),
+    cache: *const catalog_cache.Loaded,
+    changed: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    reused: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
+
+    fn nextId(self: *CatalogRead, alloc: Allocator) !?[]u8 {
+        self.iterator_mutex.lockUncancelable(io_mod.getIo());
+        defer self.iterator_mutex.unlock(io_mod.getIo());
+        return self.candidates.nextId(alloc, self.cancelled);
+    }
+};
+
+const CatalogWorker = struct {
+    read: *CatalogRead,
+    alloc: Allocator,
+    entries: std.ArrayList(catalog_cache.Entry) = .empty,
+    failure: ?anyerror = null,
+
+    fn run(self: *CatalogWorker) void {
+        self.readAll() catch |err| {
+            self.failure = err;
+            self.read.cancelled.store(true, .release);
+        };
+    }
+
+    fn readAll(self: *CatalogWorker) !void {
+        const dir = self.read.store.canonical_root.sessions orelse return;
+        while (try self.read.nextId(self.alloc)) |id| {
+            defer self.alloc.free(id);
+            const before = catalog_cache.fingerprint(dir.dir, id) catch null;
+            if (before) |stamp| {
+                if (try self.read.cache.reuse(self.alloc, id, stamp)) |value| {
+                    var entry = value;
+                    errdefer entry.deinit(self.alloc);
+                    try self.entries.append(self.alloc, entry);
+                    _ = self.read.reused.fetchAdd(1, .monotonic);
+                    continue;
+                }
+            }
+            var candidate = self.read.store.readOnlyCandidate(self.alloc, id, self.read.cancelled) catch |err| switch (err) {
+                error.OutOfMemory, error.Cancelled => return err,
+                else => {
+                    session_discovery.logDiscoveryError(.read_only_list, id, null, null, err);
+                    continue;
+                },
+            };
+            var owned = true;
+            defer if (owned) candidate.deinit(self.alloc);
+            const is_active = if (self.read.active_id) |active| std.mem.eql(u8, id, active) else false;
+            if (is_active and !candidate.summary.hasResumableContent()) continue;
+            if (self.read.cancelled.load(.acquire)) return error.Cancelled;
+            var cacheable = candidate.storage == .conversation;
+            const managed = if (!candidate.summary.hasResumableContent()) true else child_state.isListedManagedChildSession(self.read.store, self.alloc, &candidate) catch |err| switch (err) {
+                error.OutOfMemory => return err,
+                else => blk: {
+                    cacheable = false;
+                    break :blk true;
+                },
+            };
+            const after = if (cacheable) catalog_cache.fingerprint(dir.dir, id) catch null else null;
+            const stable = if (before) |a| if (after) |z| std.mem.eql(u8, &a, &z) else false else false;
+            var entry = catalog_cache.Entry{
+                .fingerprint = if (stable) after else null,
+                .value = if (managed) .{ .excluded = try self.alloc.dupe(u8, id) } else .{ .visible = candidate.summary },
+            };
+            if (!managed) owned = false;
+            errdefer entry.deinit(self.alloc);
+            try self.entries.append(self.alloc, entry);
+            if (stable or self.read.cache.contains(id)) self.read.changed.store(true, .release);
+        }
+    }
+};
+
 pub fn listActionableCatalog(
     store: session_store.Store,
     alloc: Allocator,
-    scope: session_store.SessionListScope,
     active_id: ?[]const u8,
+    cancelled: ?*std.atomic.Value(bool),
+    cache_writer: ?*catalog_cache.Writer,
 ) !ActionableSessionCatalog {
-    var summaries = switch (scope) {
-        .current_workspace => try store.listForWorkspace(alloc),
-        .all_workspaces => try store.list(alloc),
+    if (cancelled) |stop| {
+        if (stop.load(.acquire)) return error.Cancelled;
+    }
+    var local_stop = std.atomic.Value(bool).init(false);
+    const stop_requested = cancelled orelse &local_stop;
+    var cached = try catalog_cache.Loaded.load(std.heap.c_allocator, store.canonical_root.sessions, stop_requested);
+    defer cached.deinit(std.heap.c_allocator);
+    var read = CatalogRead{ .store = store, .candidates = store.readOnlyCandidates(), .active_id = active_id, .cancelled = stop_requested, .cache = &cached };
+    read.changed.store(!cached.present(), .monotonic);
+    // Worker storage is independent of the caller's allocator and ends after the merge.
+    const worker_alloc = std.heap.c_allocator;
+    var workers: [4]CatalogWorker = undefined;
+    for (&workers) |*worker| worker.* = .{ .read = &read, .alloc = worker_alloc };
+    defer for (&workers) |*worker| {
+        for (worker.entries.items) |*entry| entry.deinit(worker_alloc);
+        worker.entries.deinit(worker_alloc);
     };
-    errdefer session_summary_codec.freeSummaries(alloc, &summaries);
-    try store.checkResumeCancellation();
-    const keep = try alloc.alloc(bool, summaries.items.len);
-    defer alloc.free(keep);
-    for (summaries.items, keep) |summary, *retain| {
-        try store.checkResumeCancellation();
-        retain.* = summary.hasResumableContent();
-        if (retain.*) {
-            if (active_id) |id| {
-                retain.* = !std.mem.eql(u8, summary.id, id);
-            }
+    var threads: [workers.len - 1]?std.Thread = @splat(null);
+    errdefer {
+        stop_requested.store(true, .release);
+        for (&threads) |*handle| {
+            if (handle.*) |thread| thread.join();
+            handle.* = null;
         }
-        if (retain.*) retain.* = try isVisibleSession(store, alloc, summary.id);
     }
-
-    var write_index: usize = 0;
-    for (summaries.items, keep, 0..) |*summary, retain, read_index| {
-        if (!retain) {
-            summary.deinit(alloc);
-            continue;
-        }
-        if (write_index != read_index) {
-            summaries.items[write_index] = summary.*;
-        }
-        write_index += 1;
+    for (&threads, workers[1..]) |*handle, *worker| {
+        handle.* = try std.Thread.spawn(.{}, CatalogWorker.run, .{worker});
     }
-    summaries.items.len = write_index;
-    return .{ .summaries = summaries };
+    workers[0].run();
+    for (&threads) |*handle| {
+        handle.*.?.join();
+        handle.* = null;
+    }
+    for (workers) |worker| {
+        if (worker.failure) |err| {
+            if (err != error.Cancelled) return err;
+        }
+    }
+    if (stop_requested.load(.acquire)) return error.Cancelled;
+    var entries: std.ArrayList(catalog_cache.Entry) = .empty;
+    defer {
+        for (entries.items) |*entry| entry.deinit(worker_alloc);
+        entries.deinit(worker_alloc);
+    }
+    for (&workers) |*worker| {
+        try entries.appendSlice(worker_alloc, worker.entries.items);
+        worker.entries.items.len = 0;
+    }
+    var catalog: ActionableSessionCatalog = .{};
+    errdefer catalog.deinit(alloc);
+    var cacheable: usize = 0;
+    for (entries.items) |entry| {
+        if (stop_requested.load(.acquire)) return error.Cancelled;
+        if (entry.fingerprint != null) cacheable += 1;
+        switch (entry.value) {
+            .visible => |summary| {
+                if (active_id) |active| if (std.mem.eql(u8, active, summary.id)) continue;
+                var copy = try session_summary_codec.cloneSessionSummary(alloc, summary);
+                errdefer copy.deinit(alloc);
+                try catalog.summaries.append(alloc, copy);
+            },
+            .excluded => {},
+        }
+    }
+    if (cache_writer) |writer| {
+        if (read.changed.load(.acquire) or cacheable != cached.count()) {
+            writer.save(alloc, entries.items, stop_requested) catch |err| {
+                if (stop_requested.load(.acquire)) return error.Cancelled;
+                @import("../shared/debug_trace.zig").logf("core", "session catalog cache not saved err={s}", .{@errorName(err)});
+            };
+        }
+    }
+    @import("../shared/debug_trace.zig").logf("core", "session catalog cache reused={d} records={d}", .{ read.reused.load(.monotonic), cacheable });
+    session_summary_codec.sortSummariesNewestFirst(catalog.summaries.items);
+    return catalog;
 }
 
 pub fn listVisiblePage(
@@ -346,6 +470,127 @@ fn ensureLoadedExternalPromptAllowed(
     loaded: *const session_store.LoadedWritableSession,
 ) !void {
     if (loaded.state.subagent_child) return error.OneOffSessionNotResumable;
+}
+
+test "actionable catalog preserves discovery and child visibility" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(std.testing.io, "home/.fx");
+    try tmp.dir.createDirPath(std.testing.io, "workspace");
+    const home = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "home");
+    defer alloc.free(home);
+    const workspace = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "workspace");
+    defer alloc.free(workspace);
+    var store = try session_store.Store.initFromHome(alloc, home, workspace);
+    defer store.deinit(alloc);
+    const history = [_]session.HistoryTurn{.{ .assistant = .{
+        .user = .{ .text = @constCast("saved request") },
+        .assistant = @constCast("saved response"),
+    } }};
+    for ([_][]const u8{ "public", "private-bit", "private-marker", "empty" }, 0..) |id, index| {
+        const durable = session_codec.DurableSessionState{
+            .id = @constCast(id),
+            .origin_workspace_root = workspace,
+            .workspace_root = workspace,
+            .created_at_ms = 1,
+            .updated_at_ms = @intCast(index + 1),
+            .conversation_language = session.ConversationLanguage.literal("en"),
+            .history = if (std.mem.eql(u8, id, "empty")) &.{} else @constCast(&history),
+            .total_input_tokens = 0,
+            .total_output_tokens = 0,
+            .preferences = .{ .model = @constCast("test"), .effort = .auto, .fast_mode = false },
+            .subagent_child = std.mem.eql(u8, id, "private-bit"),
+        };
+        var writable = try store.startWritableSession(alloc, durable);
+        writable.deinit(alloc);
+    }
+    const children = child_state.Store{ .sessions = &store, .parent_id = "public" };
+    try children.markChildSession(alloc, "private-marker");
+    var stopped = std.atomic.Value(bool).init(false);
+    var catalog = try listActionableCatalog(store, alloc, null, &stopped, null);
+    defer catalog.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 1), catalog.summaries.items.len);
+    try std.testing.expectEqualStrings("public", catalog.summaries.items[0].id);
+    var reference = try store.list(alloc);
+    defer session_summary_codec.freeSummaries(alloc, &reference);
+    var visible: usize = 0;
+    for (reference.items) |summary| {
+        if (!summary.hasResumableContent() or !try isVisibleSession(store, alloc, summary.id)) continue;
+        try std.testing.expectEqualStrings(summary.id, catalog.summaries.items[visible].id);
+        try std.testing.expectEqual(summary.history_len, catalog.summaries.items[visible].history_len);
+        try std.testing.expectEqual(summary.updated_at_ms, catalog.summaries.items[visible].updated_at_ms);
+        visible += 1;
+    }
+    try std.testing.expectEqual(catalog.summaries.items.len, visible);
+    stopped.store(true, .release);
+    try std.testing.expectError(error.Cancelled, listActionableCatalog(store, alloc, null, &stopped, null));
+    const AllocationCheck = struct {
+        fn run(failing_alloc: Allocator, source: session_store.Store) !void {
+            var result = try listActionableCatalog(source, failing_alloc, null, null, null);
+            defer result.deinit(failing_alloc);
+            try std.testing.expectEqual(@as(usize, 1), result.summaries.items.len);
+        }
+
+        fn candidate(failing_alloc: Allocator, source: session_store.Store) !void {
+            var result = try source.readOnlyCandidate(failing_alloc, "public", null);
+            defer result.deinit(failing_alloc);
+            try std.testing.expectEqualStrings("public", result.summary.id);
+            try std.testing.expectEqual(@as(?bool, false), result.subagent_child);
+        }
+    };
+    try std.testing.checkAllAllocationFailures(alloc, AllocationCheck.run, .{store});
+    try std.testing.checkAllAllocationFailures(alloc, AllocationCheck.candidate, .{store});
+
+    stopped.store(false, .release);
+    var empty_cache: catalog_cache.Loaded = .{};
+    var failed_read = CatalogRead{ .store = store, .candidates = store.readOnlyCandidates(), .active_id = null, .cancelled = &stopped, .cache = &empty_cache };
+    var failing = std.testing.FailingAllocator.init(alloc, .{ .fail_index = 0 });
+    var failed_worker = CatalogWorker{ .read = &failed_read, .alloc = failing.allocator() };
+    defer failed_worker.entries.deinit(failing.allocator());
+    failed_worker.run();
+    try std.testing.expectEqual(error.OutOfMemory, failed_worker.failure.?);
+    try std.testing.expect(stopped.load(.acquire));
+    try std.testing.expectError(error.Cancelled, store.readOnlyCandidate(alloc, "public", &stopped));
+
+    stopped.store(false, .release);
+    var writer = (try catalog_cache.Writer.init(store)).?;
+    defer writer.deinit();
+    var built = try listActionableCatalog(store, alloc, null, &stopped, &writer);
+    defer built.deinit(alloc);
+    var reused = try listActionableCatalog(store, alloc, null, &stopped, &writer);
+    defer reused.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 1), reused.summaries.items.len);
+    try std.testing.expectEqualStrings(built.summaries.items[0].id, reused.summaries.items[0].id);
+    {
+        var changed = try store.resumeForWrite(alloc, "public");
+        defer changed.deinit(alloc);
+        _ = try changed.renameConversation(alloc, "Changed title");
+    }
+    var renamed = try listActionableCatalog(store, alloc, null, &stopped, &writer);
+    defer renamed.deinit(alloc);
+    try std.testing.expectEqualStrings("Changed title", renamed.summaries.items[0].title.?);
+    try io_mod.durableReplaceVerified(alloc, &writer.dir, ".resume-catalog", "truncated cache");
+    var repaired = try listActionableCatalog(store, alloc, null, &stopped, &writer);
+    defer repaired.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 1), repaired.summaries.items.len);
+    try std.testing.expectEqualStrings("Changed title", repaired.summaries.items[0].title.?);
+    const new_owner = child_state.Store{ .sessions = &store, .parent_id = "parent" };
+    try new_owner.markChildSession(alloc, "public");
+    var hidden = try listActionableCatalog(store, alloc, null, &stopped, &writer);
+    defer hidden.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 0), hidden.summaries.items.len);
+    var removed = try store.resumeForWrite(alloc, "empty");
+    try std.testing.expectEqual(.discarded, store.deleteCommittedSession(alloc, &removed));
+    var reconciled = try listActionableCatalog(store, alloc, null, &stopped, &writer);
+    defer reconciled.deinit(alloc);
+    var saved = try catalog_cache.Loaded.load(alloc, writer.dir, null);
+    defer saved.deinit(alloc);
+    try std.testing.expect(saved.present());
+    try std.testing.expect(!saved.contains("empty"));
+    var read_only = try session_store.Store.initReadOnlyFromHome(alloc, home, workspace);
+    defer read_only.deinit(alloc);
+    try std.testing.expect((try catalog_cache.Writer.init(read_only)) == null);
 }
 
 test "managed child marker is hidden from external access" {

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -2195,7 +2195,8 @@ describe("gateway stream lifecycle", () => {
       tui = null;
       expect(readFileSync(stderrPath, "utf8")).toBe("");
       const sessionsDirectory = join(root.home, ".fx", "sessions");
-      const sessionIds = readdirSync(sessionsDirectory);
+      const sessionIds = readdirSync(sessionsDirectory, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory()).map((entry) => entry.name);
       expect(sessionIds).toHaveLength(1);
       const resultsDirectory = join(sessionsDirectory, sessionIds[0]!, "tool-results");
       const mainArtifacts = readdirSync(resultsDirectory).filter((name) =>

--- a/tests/e2e/tui-resume-brutal.test.ts
+++ b/tests/e2e/tui-resume-brutal.test.ts
@@ -44,6 +44,7 @@ type Config = {
 };
 
 type Metrics = {
+  coldProcessOpenMs?: number;
   open: number[];
   scope: number[];
   page: number[];
@@ -451,6 +452,7 @@ async function thrash(
   config: Config,
   metrics: Metrics,
   pid: number,
+  coldStarted: number,
 ): Promise<void> {
   const sizes = [
     [60, 12],
@@ -464,11 +466,17 @@ async function thrash(
       () => session.sendText("/resume"),
       () => waitForMenu(session, REAL_TITLE, "Current workspace"),
     );
+    if (cycle === 0) {
+      metrics.coldProcessOpenMs = performance.now() - coldStarted;
+      expect(metrics.coldProcessOpenMs).toBeLessThan(2_000);
+      expect(metrics.open[0]).toBeLessThan(2_000);
+    }
     await time(
       metrics.scope,
       () => session.sendKeys("Tab"),
       () => waitForMenu(session, FOREIGN_TITLE, "All workspaces"),
     );
+    if (cycle === 0) expect(metrics.scope[0]).toBeLessThan(2_000);
     await time(
       metrics.scope,
       () => session.sendKeys("Tab"),
@@ -522,7 +530,31 @@ async function runStress(config: Config): Promise<Paths> {
   let session: TmuxSession | null = null;
   let profiler: ReturnType<typeof Bun.spawn> | null = null;
   let passed = false;
+  let cacheBuildMs = 0;
   try {
+    const cachePath = join(paths.home, ".fx", "sessions", ".resume-catalog");
+    rmSync(cachePath, { force: true });
+    const buildStarted = performance.now();
+    session = await TmuxSession.create({
+      cmd: FX_BIN,
+      cwd: realpathSync(paths.workspace),
+      env: { ...gatewayEnv(paths.home, gateway), FX_TRACE_LOG: paths.trace, FX_TRACE_SCOPES: "core,session" },
+      stderrPath: paths.stderr, width: 112, height: 32, minimumHistoryLines: 50_000,
+    });
+    await session.waitForComposer(TIMEOUT);
+    await session.sendText("/resume");
+    await waitForMenu(session, REAL_TITLE, "Current workspace");
+    cacheBuildMs = performance.now() - buildStarted;
+    expect(existsSync(cachePath)).toBe(true);
+    await session.sendKeys("Escape");
+    await session.waitForComposer(TIMEOUT);
+    await session.sendText("/quit");
+    expect(await session.waitForSessionEnd(TIMEOUT * 2)).toBe(true);
+    await session.kill();
+    session = null;
+    expect(readFileSync(paths.stderr, "utf8")).toBe("");
+    writeFileSync(paths.stderr, "");
+    const coldStarted = performance.now();
     session = await TmuxSession.create({
       cmd: FX_BIN,
       cwd: realpathSync(paths.workspace),
@@ -534,6 +566,7 @@ async function runStress(config: Config): Promise<Paths> {
       stderrPath: paths.stderr,
       width: 112,
       height: 32,
+      startupWaitMs: 0,
       minimumHistoryLines: Math.max(
         50_000,
         config.chatBatches * config.chatLinesPerBatch * 2,
@@ -558,7 +591,7 @@ async function runStress(config: Config): Promise<Paths> {
       ], { stdout: "pipe", stderr: "pipe" });
     }
 
-    await thrash(session, config, metrics, pid);
+    await thrash(session, config, metrics, pid, coldStarted);
 
     await session.sendText("/resume");
     await waitForMenu(session, REAL_TITLE, "Current workspace");
@@ -591,7 +624,10 @@ async function runStress(config: Config): Promise<Paths> {
         close: summarize(metrics.close),
         resume: summarize(metrics.resume),
       },
+      cacheBuildMs: Number(cacheBuildMs.toFixed(3)),
+      coldProcessOpenMs: Number(metrics.coldProcessOpenMs!.toFixed(3)),
       firstOpenMs: Number(metrics.open[0]!.toFixed(3)),
+      firstScopeSwitchMs: Number(metrics.scope[0]!.toFixed(3)),
       samples: metrics,
       resources: {
         startRssKib: metrics.rssKib[0],
@@ -628,6 +664,9 @@ async function runStress(config: Config): Promise<Paths> {
     passed = true;
     return paths;
   } finally {
+    if (!passed) {
+      writeFileSync(paths.metrics, `${JSON.stringify({ config, cacheBuildMs, samples: metrics }, null, 2)}\n`);
+    }
     if (profiler) {
       try {
         profiler.kill();

--- a/tests/e2e/tui-resume-brutal.test.ts
+++ b/tests/e2e/tui-resume-brutal.test.ts
@@ -547,7 +547,10 @@ async function runStress(config: Config): Promise<Paths> {
     cacheBuildMs = performance.now() - buildStarted;
     expect(existsSync(cachePath)).toBe(true);
     await session.sendKeys("Escape");
-    await session.waitForComposer(TIMEOUT);
+    await session.waitForPane((pane) => {
+      const plain = stripAnsi(pane);
+      return hasEmptyComposer(plain) && !plain.includes("[Current workspace]");
+    }, TIMEOUT);
     await session.sendText("/quit");
     expect(await session.waitForSessionEnd(TIMEOUT * 2)).toBe(true);
     await session.kill();


### PR DESCRIPTION
## Summary

- Open `/resume` faster across launches by reusing unchanged saved-conversation summaries after the initial catalog scan.
- Switch workspace views without rescanning saved conversations.
- Stop obsolete catalog loads when the picker closes, while preserving draft input and selection during refresh.
- Refresh changed or deleted sessions automatically and rebuild missing or damaged cache data.
