### PR TITLE
Fix MCP startup and menu input handoff

### DIFF
--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -1896,6 +1896,9 @@ pub fn Runtime(comptime App: type) type {
                         )) {
                             .inserted => {
                                 if (comptime @hasDecl(App, "closeMcpMenu")) app.closeMcpMenu();
+                                if (comptime @hasDecl(App, "presentProjectMcpPrompt")) {
+                                    if (projectMcpPromptOwnsInput(app)) try app.presentProjectMcpPrompt();
+                                }
                             },
                             .limit_exceeded => try input_limit_feedback.report(
                                 App,

--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -790,6 +790,7 @@ pub fn Runtime(comptime App: type) type {
                 skillsMenuActive(app) or
                 modelMenuActive(app) or
                 sessionMenuActive(app) or
+                mcpMenuActive(app) or
                 helpMenuActive(app);
             var authentication_active = false;
             if (comptime runtime_profile.allows(App, .native_auth)) {
@@ -2875,7 +2876,7 @@ pub fn Runtime(comptime App: type) type {
                     _ = disarmEscapeClear(app);
                     return;
                 }
-                if (cancelCompactCommandMenu(app) or cancelMcpMenu(app) or cancelSettingsMenu(app) or cancelHelpMenu(app) or cancelModelMenu(app) or cancelSkillsMenu(app) or cancelSessionMenu(app)) {
+                if (cancelCompactCommandMenu(app) or (try cancelMcpMenu(app)) or cancelSettingsMenu(app) or cancelHelpMenu(app) or cancelModelMenu(app) or cancelSkillsMenu(app) or cancelSessionMenu(app)) {
                     _ = disarmEscapeClear(app);
                     app.shell.render_requests.request(.footer);
                     return;
@@ -2896,7 +2897,7 @@ pub fn Runtime(comptime App: type) type {
                 _ = disarmEscapeClear(app);
                 return;
             }
-            if (cancelCompactCommandMenu(app) or cancelMcpMenu(app) or cancelSettingsMenu(app) or cancelHelpMenu(app) or cancelModelMenu(app) or cancelSkillsMenu(app) or cancelSessionMenu(app)) {
+            if (cancelCompactCommandMenu(app) or (try cancelMcpMenu(app)) or cancelSettingsMenu(app) or cancelHelpMenu(app) or cancelModelMenu(app) or cancelSkillsMenu(app) or cancelSessionMenu(app)) {
                 _ = disarmEscapeClear(app);
                 app.shell.render_requests.request(.footer);
                 return;
@@ -2963,7 +2964,7 @@ pub fn Runtime(comptime App: type) type {
             return closeHelpMenu(app, true);
         }
 
-        fn cancelMcpMenu(app: *App) bool {
+        fn cancelMcpMenu(app: *App) !bool {
             if (!mcpMenuActive(app)) return false;
             if (comptime @hasField(App, "mcp")) {
                 debug_trace.logf("mcp", "MCP menu escape screen={s} filter={}", .{ @tagName(app.mcp.menu.screen), app.mcp.menu.filter_active });
@@ -2985,6 +2986,9 @@ pub fn Runtime(comptime App: type) type {
             if (comptime @hasDecl(App, "closeMcpMenu")) app.closeMcpMenu();
             app.input_runtime.inputResetState().clearCurrent(app.alloc);
             paste_blocks.clearBlocks(app.alloc, &app.input_runtime.entities.pasted_blocks);
+            if (comptime @hasDecl(App, "presentProjectMcpPrompt")) {
+                if (projectMcpPromptOwnsInput(app)) try app.presentProjectMcpPrompt();
+            }
             return true;
         }
 

--- a/src/core/subagent/authority.zig
+++ b/src/core/subagent/authority.zig
@@ -208,23 +208,45 @@ pub const Resolver = struct {
             .parent_id = self.root_id,
             .options = self.child_store_options,
         };
-        var lock = store.acquireLock(alloc) catch |err| return switch (err) {
-            error.OutOfMemory => error.OutOfMemory,
-            else => error.StoreUnavailable,
+        const work_generation = blk: {
+            var lock = store.acquireLock(alloc) catch |err| return switch (err) {
+                error.OutOfMemory => error.OutOfMemory,
+                else => error.StoreUnavailable,
+            };
+            defer lock.release();
+            var registry = store.load(alloc) catch |err| return switch (err) {
+                error.OutOfMemory => error.OutOfMemory,
+                else => error.StoreUnavailable,
+            };
+            defer registry.deinit(alloc);
+            const child = registry.findById(child_id) orelse return error.ChildNotAttached;
+            if (child.active == null) return error.ChildNotAttached;
+            break :blk child.work_generation;
         };
-        defer lock.release();
-        var registry = store.load(alloc) catch |err| return switch (err) {
-            error.OutOfMemory => error.OutOfMemory,
-            else => error.StoreUnavailable,
-        };
-        defer registry.deinit(alloc);
-        const child = registry.findById(child_id) orelse return error.ChildNotAttached;
-        const permission_mode = if (child.active) |active|
-            active.permission_mode
-        else
-            return error.ChildNotAttached;
+
+        // Host resolution may connect MCP servers; parent state observation must remain available.
         var host = try self.host.resolve(alloc, self.root_id);
         defer host.deinit(alloc);
+
+        const current = blk: {
+            var lock = store.acquireLock(alloc) catch |err| return switch (err) {
+                error.OutOfMemory => error.OutOfMemory,
+                else => error.StoreUnavailable,
+            };
+            defer lock.release();
+            var registry = store.load(alloc) catch |err| return switch (err) {
+                error.OutOfMemory => error.OutOfMemory,
+                else => error.StoreUnavailable,
+            };
+            defer registry.deinit(alloc);
+            const child = registry.findById(child_id) orelse return error.ChildNotAttached;
+            const active = child.active orelse return error.ChildNotAttached;
+            if (child.work_generation != work_generation) return error.ChildNotAttached;
+            break :blk .{
+                .generation = registry.generation,
+                .permission_mode = active.permission_mode,
+            };
+        };
 
         const owned_child_id = try alloc.dupe(u8, child_id);
         errdefer alloc.free(owned_child_id);
@@ -258,7 +280,7 @@ pub const Resolver = struct {
             .generation = authorityGeneration(
                 child_id,
                 self.root_id,
-                registry.generation,
+                current.generation,
                 host.generation,
             ),
             .tools = tools,
@@ -266,7 +288,7 @@ pub const Resolver = struct {
             .rules = rules,
             .grants = try types.dupePermissionGrantSlice(alloc, host.grants),
             .permission_state = permission_state,
-            .permission_mode = permission_mode,
+            .permission_mode = current.permission_mode,
             .mcp_view = mcp_view,
         };
     }
@@ -459,4 +481,137 @@ test "tool authority excludes nested subagents and preserves rules" {
         .permission_mode = .yolo,
     }, "/tmp", "subagent", "subagent", .none);
     try std.testing.expectEqual(ToolAuthorityDecision.unavailable, decision);
+}
+
+test "authority capture permits registry access and rejects changed work" {
+    const io_mod = @import("../shared/io.zig");
+    const Fixture = struct {
+        const Change = enum { none, finish, replace, permission, sibling, host_failure };
+        store: child_state.Store,
+        change: Change,
+        calls: usize = 0,
+
+        fn resolve(raw: ?*anyopaque, alloc: Allocator, _: []const u8) HostResolveError!HostAuthority {
+            const self: *@This() = @ptrCast(@alignCast(raw.?));
+            self.calls += 1;
+            var lock = self.store.acquireLock(alloc) catch return error.HostAuthorityUnavailable;
+            defer lock.release();
+            var registry = self.store.load(alloc) catch return error.HostAuthorityUnavailable;
+            defer registry.deinit(alloc);
+            switch (self.change) {
+                .none => {},
+                .host_failure => return error.HostAuthorityUnavailable,
+                .finish, .replace => {
+                    registry.finish(alloc, "authority-child", "work-one", .completed) catch
+                        return error.HostAuthorityUnavailable;
+                    if (self.change != .finish) {
+                        var work = child_state.ActiveWork{
+                            .id = try alloc.dupe(u8, "work-two"),
+                            .message = try alloc.dupe(u8, "replacement"),
+                            .created_at_ms = 2,
+                        };
+                        defer work.deinit(alloc);
+                        _ = registry.startPersistentWork(alloc, "worker", null, work) catch
+                            return error.HostAuthorityUnavailable;
+                    }
+                },
+                .permission => {
+                    registry.children[0].active.?.permission_mode = .auto;
+                    registry.generation += 1;
+                },
+                .sibling => {
+                    var work = child_state.ActiveWork{
+                        .id = try alloc.dupe(u8, "sibling-work"),
+                        .message = try alloc.dupe(u8, "independent work"),
+                        .created_at_ms = 2,
+                    };
+                    defer work.deinit(alloc);
+                    registry.appendOneOff(alloc, "authority-sibling", work) catch
+                        return error.HostAuthorityUnavailable;
+                },
+            }
+            self.store.save(alloc, registry) catch return error.HostAuthorityUnavailable;
+            return HostAuthority.capture(alloc, &.{ "read_file", "subagent" }, &.{}, .{}, &.{}) catch
+                return error.OutOfMemory;
+        }
+    };
+
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const home = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(home);
+    var sessions = try session_store.Store.initFromHome(alloc, home, home);
+    defer sessions.deinit(alloc);
+    var state: @import("../session/session_codec.zig").DurableSessionState = .{
+        .id = try alloc.dupe(u8, "authority-parent"),
+        .origin_workspace_root = try alloc.dupe(u8, home),
+        .workspace_root = try alloc.dupe(u8, home),
+        .created_at_ms = 1,
+        .updated_at_ms = 1,
+        .conversation_language = @import("../session/session.zig").ConversationLanguage.literal("en"),
+        .preferences = .{
+            .model = try alloc.dupe(u8, "test/model"),
+            .effort = types.ReasoningEffort.literal("low"),
+            .fast_mode = false,
+        },
+        .history = &.{},
+        .total_input_tokens = 0,
+        .total_output_tokens = 0,
+    };
+    defer state.deinit(alloc);
+    var parent = try sessions.startWritableSession(alloc, state);
+    defer parent.deinit(alloc);
+    const store = child_state.Store{ .sessions = &sessions, .parent_id = state.id };
+
+    for (std.enums.values(Fixture.Change)) |change| {
+        var registry = try child_state.Registry.init(alloc, state.id);
+        defer registry.deinit(alloc);
+        var work = child_state.ActiveWork{
+            .id = try alloc.dupe(u8, "work-one"),
+            .message = try alloc.dupe(u8, "original"),
+            .permission_mode = .ask,
+            .created_at_ms = 1,
+        };
+        defer work.deinit(alloc);
+        try registry.appendPersistent(alloc, "authority-child", "worker", "", work);
+        try store.save(alloc, registry);
+        var fixture = Fixture{ .store = store, .change = change };
+        var resolver = Resolver{
+            .sessions = &sessions,
+            .root_id = state.id,
+            .host = .{ .context = &fixture, .resolve_fn = Fixture.resolve },
+        };
+        try std.testing.expectError(error.ChildNotAttached, resolver.resolve(alloc, "missing-child"));
+        try std.testing.expectEqual(@as(usize, 0), fixture.calls);
+        switch (change) {
+            .finish, .replace => try std.testing.expectError(
+                error.ChildNotAttached,
+                resolver.resolve(alloc, "authority-child"),
+            ),
+            .host_failure => try std.testing.expectError(
+                error.HostAuthorityUnavailable,
+                resolver.resolve(alloc, "authority-child"),
+            ),
+            .none, .permission, .sibling => {
+                var snapshot = try resolver.resolve(alloc, "authority-child");
+                defer snapshot.deinit(alloc);
+                try std.testing.expectEqual(
+                    if (change == .permission) types.PermissionMode.auto else types.PermissionMode.ask,
+                    snapshot.permission_mode,
+                );
+                try std.testing.expectEqual(@as(usize, 1), snapshot.tools.len);
+                try std.testing.expectEqualStrings("read_file", snapshot.tools[0]);
+                var current = try store.load(alloc);
+                defer current.deinit(alloc);
+                var host = try HostAuthority.capture(alloc, &.{ "read_file", "subagent" }, &.{}, .{}, &.{});
+                defer host.deinit(alloc);
+                try std.testing.expectEqual(
+                    authorityGeneration("authority-child", state.id, current.generation, host.generation),
+                    snapshot.generation,
+                );
+            },
+        }
+        try std.testing.expectEqual(@as(usize, 1), fixture.calls);
+    }
 }

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -467,7 +467,7 @@ function occurrenceCount(text: string, needle: string): number {
 
 function writeMcpFixture(
   root: FixtureRoot,
-  options: { required?: boolean; toolCount?: number; toolDescription?: string } = {},
+  options: { required?: boolean; toolCount?: number; toolDescription?: string; initializeDelayMs?: number } = {},
 ) {
   const toolCount = options.toolCount ?? 1;
   const toolDescription = JSON.stringify(
@@ -498,7 +498,7 @@ function handle(message) {
     return;
   }
   if (message.method === "initialize") {
-    send({
+    const response = {
       jsonrpc: "2.0",
       id: message.id,
       result: {
@@ -507,7 +507,9 @@ function handle(message) {
         serverInfo: { name: "fixture", version: "1.0.0" },
         instructions: "SECRET_SERVER_INSTRUCTION_SENTINEL",
       },
-    });
+    };
+    if (${options.initializeDelayMs ?? 0} > 0) setTimeout(() => send(response), ${options.initializeDelayMs ?? 0});
+    else send(response);
     return;
   }
   if (message.method === "tools/list") {
@@ -6053,16 +6055,17 @@ printf '%s' ${JSON.stringify(trailingMarker)} > ${JSON.stringify(effectPath)}
     }
   });
 
-  test("canonical subagent executes through the current parent MCP adapters", async () => {
+  test.each([0, 4_000])("canonical subagent executes through parent MCP adapters after %d ms", async (initializeDelayMs) => {
     const root = createFixtureRoot("subagent-mcp-inheritance");
     const tracePath = join(root.root, "trace.log");
-    const mcp = writeMcpFixture(root);
+    const mcp = writeMcpFixture(root, { initializeDelayMs });
     writeFileSync(
       join(root.home, ".fx", "settings.json"),
       JSON.stringify({ permission: { [DYNAMIC_MCP_TOOL_NAME]: "allow" } }),
     );
     const childPrompt = "Select and call the inherited MCP echo fixture.";
     let childCompleted = false;
+    let parentResult = "";
     const gateway = startDynamicFakeGateway(async (body) => {
       if (body.includes('"toolCallId":"child_mcp_call_1"')) {
         expect(toolResultOutput(body, "child_mcp_call_1")).toContain(
@@ -6082,10 +6085,7 @@ printf '%s' ${JSON.stringify(trailingMarker)} > ${JSON.stringify(effectPath)}
         );
       }
       if (body.includes('"toolCallId":"parent_subagent_create_1"')) {
-        expect(toolResultOutput(body, "parent_subagent_create_1")).toContain(
-          "Child MCP execution complete.",
-        );
-        expect(toolResultOutput(body, "parent_subagent_create_1")).not.toContain("child_id");
+        parentResult = toolResultOutput(body, "parent_subagent_create_1");
         return fakeGatewayFinalText("Parent observed child MCP completion.");
       }
       if (body.includes(childPrompt)) {
@@ -6131,6 +6131,8 @@ printf '%s' ${JSON.stringify(trailingMarker)} > ${JSON.stringify(effectPath)}
       const pid = Number.parseInt(readFileSync(mcp.pidPath, "utf8"), 10);
 
       expect(result.code).toBe(0);
+      expect(parentResult).toContain("Child MCP execution complete.");
+      expect(parentResult).not.toContain("child_id");
       expect(json.output).toContain("Parent observed child MCP completion.");
       expect(childCompleted).toBe(true);
       expect(gateway.requestCount()).toBe(5);
@@ -6148,6 +6150,52 @@ printf '%s' ${JSON.stringify(trailingMarker)} > ${JSON.stringify(effectPath)}
       }
       await waitForProcessExit(pid);
     } finally {
+      gateway.stop();
+      rmSync(root.root, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  test("cancelling delegation during MCP startup leaves no child effect or server", async () => {
+    const root = createFixtureRoot("subagent-mcp-startup-cancel");
+    const tracePath = join(root.root, "trace.log");
+    const mcp = writeMcpFixture(root, { initializeDelayMs: 4_000 });
+    const gateway = startDynamicFakeGateway(() => fakeGatewayToolCall("cancelled_child", "subagent", {
+      request: { action: "run", task: "Call the inherited MCP echo tool." },
+    }), {
+      classifierDecision: "clear",
+      models: [{ id: MODEL, type: "language", tags: ["tool-use"] }],
+    });
+    const proc = Bun.spawn([FX_BIN, "ask", "--json", "--auto", "Delegate the MCP call."], {
+      cwd: root.workspace,
+      env: fixtureEnv(root, gateway, tracePath),
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const stdout = new Response(proc.stdout).text();
+    const stderr = new Response(proc.stderr).text();
+    let exited = false;
+    void proc.exited.then(() => { exited = true; });
+    try {
+      const startedDeadline = Date.now() + 10_000;
+      while (!existsSync(mcp.pidPath) && !exited && Date.now() < startedDeadline) await Bun.sleep(25);
+      expect(existsSync(mcp.pidPath)).toBe(true);
+      expect(existsSync(mcp.readyPath)).toBe(false);
+      expect(gateway.requestCount()).toBe(1);
+      const pid = Number.parseInt(readFileSync(mcp.pidPath, "utf8"), 10);
+      proc.kill("SIGINT");
+      const exitDeadline = Date.now() + 10_000;
+      while (!exited && Date.now() < exitDeadline) await Bun.sleep(25);
+      expect(exited).toBe(true);
+      await waitForProcessExit(pid, 8_000);
+      expect(gateway.requestCount()).toBe(1);
+      expect(existsSync(mcp.callLogPath)).toBe(false);
+      expect(await stderr).not.toContain("panic:");
+      expect(await stdout).not.toContain("state_unavailable");
+    } finally {
+      if (!exited) proc.kill("SIGKILL");
+      await proc.exited;
+      await Promise.all([stdout, stderr]);
       gateway.stop();
       rmSync(root.root, { recursive: true, force: true });
     }

--- a/tests/e2e/mcp-stdio.test.ts
+++ b/tests/e2e/mcp-stdio.test.ts
@@ -950,6 +950,65 @@ exec "$FX_MCP_FIXTURE_RUNTIME" "$FX_MCP_FIXTURE_PATH"
   );
 
   test.skipIf(process.platform === "win32" || !tmuxAvailable())(
+    "MCP menu keeps input after project trust reset and reveals pending approval on close",
+    async () => {
+      const root = createRoot("workspace-menu-reset", LEGACY_FIXTURE, {
+        recordLaunchAttempts: true,
+      });
+      moveProfileFixtureToWorkspace(root);
+      gateway = startFakeGateway([], {
+        models: [{ id: MODEL, type: "language", tags: ["tool-use"] }],
+      });
+      const env = fixtureEnv(root, gateway);
+      const approved = await runFx(["mcp", "trust", "approve-all"], {
+        cwd: root.workspace,
+        env,
+      });
+      expect(approved.code).toBe(0);
+      tui = await TmuxSession.create({
+        isolated: true,
+        remainOnExit: true,
+        cwd: root.workspace,
+        width: 120,
+        height: 36,
+        env,
+      });
+      await tui.waitForComposer(15_000);
+      await tui.sendText("/mcp");
+      await tui.waitForPane((pane) => /^\s*fixture\s+Ready\b/m.test(pane), 15_000);
+
+      await tui.sendLiteral("z");
+      await tui.waitForText("Reset all project MCP choices?", 5_000);
+      await tui.sendKeys("Enter");
+      await tui.waitForText("Pending trust", 10_000);
+      await tui.sendLiteral("p");
+      await tui.waitForText("Approve all pending project MCP servers?", 5_000);
+      await tui.sendKeys("Enter");
+      await tui.waitForPane((pane) => /^\s*fixture\s+Ready\b/m.test(pane), 15_000);
+
+      await tui.sendLiteral("z");
+      await tui.waitForText("Reset all project MCP choices?", 5_000);
+      await tui.sendKeys("Enter");
+      await tui.waitForText("Pending trust", 10_000);
+      await tui.sendKeys("Escape");
+      const pane = await tui.waitForPane((text) =>
+        !/^MCP \d+\s/m.test(text) &&
+        text.includes("Project MCP server 'fixture' is defined in .mcp.json"),
+      10_000);
+      expect(pane).not.toContain("Project MCP approval prompts dismissed");
+      await tui.sendLiteral("3");
+      await tui.waitForPane((text) => text.includes("Rejecting project MCP server"), 10_000);
+      const settings = JSON.parse(readFileSync(join(root.home, ".fx", "settings.json"), "utf8"));
+      expect(settings.workspaces[root.workspace].disabledMcpjsonServers).toContain("fixture");
+      expect(await tui.captureFullScrollback()).not.toContain("Project MCP approval prompts dismissed");
+      await tui.kill();
+      tui = null;
+      await expectFixtureProcessesExited(readWire(root.wireLogPath));
+    },
+    60_000,
+  );
+
+  test.skipIf(process.platform === "win32" || !tmuxAvailable())(
     "Escape suppresses project MCP prompts only for the current process",
     async () => {
       const root = createRoot("workspace-escape", MODERN_FIXTURE, {

--- a/tests/e2e/mcp-stdio.test.ts
+++ b/tests/e2e/mcp-stdio.test.ts
@@ -1009,6 +1009,54 @@ exec "$FX_MCP_FIXTURE_RUNTIME" "$FX_MCP_FIXTURE_PATH"
   );
 
   test.skipIf(process.platform === "win32" || !tmuxAvailable())(
+    "MCP preview insertion reveals pending project approval without losing inserted context",
+    async () => {
+      const root = createRoot("workspace-menu-insert", MODERN_FIXTURE, {
+        mode: "features",
+        recordLaunchAttempts: true,
+      });
+      const profilePath = join(root.home, ".fx", "mcp.json");
+      const profileServer = JSON.parse(readFileSync(profilePath, "utf8")).mcp.fixture;
+      moveProfileFixtureToWorkspace(root);
+      writeFileSync(profilePath, JSON.stringify({ mcp: { library: profileServer } }));
+      gateway = startFakeGateway([], {
+        models: [{ id: MODEL, type: "language", tags: ["tool-use"] }],
+      });
+      const env = { ...fixtureEnv(root, gateway), FX_MCP_PROTOCOL_VERSION: "2026-07-28" };
+      expect((await runFx(["mcp", "trust", "approve-all"], {
+        cwd: root.workspace,
+        env,
+      })).code).toBe(0);
+      tui = await TmuxSession.create({ isolated: true, remainOnExit: true, cwd: root.workspace, width: 120, height: 36, env });
+      await tui.waitForComposer(15_000);
+      await tui.sendText("/mcp");
+      await tui.waitForPane((pane) => /^\s*library\s+Ready\b/m.test(pane) && /^\s*fixture\s+Ready\b/m.test(pane), 15_000);
+      await tui.sendLiteral("z");
+      await tui.waitForText("Reset all project MCP choices?", 5_000);
+      await tui.sendKeys("Enter");
+      await tui.waitForText("Pending trust", 10_000);
+      await tui.sendKeys("Tab");
+      await tui.sendKeys("Tab");
+      await tui.waitForText("custom://alpha", 10_000);
+      await tui.sendKeys("Enter");
+      await tui.waitForText("MCP resource", 10_000);
+      await tui.sendLiteral("i");
+      const pane = await tui.waitForPane((text) => !/^MCP \d+\s/m.test(text) &&
+        text.includes("Project MCP server 'fixture' is defined in .mcp.json"), 10_000);
+      expect(pane).toContain("RESOURCE_TEXT");
+      await tui.sendLiteral("3");
+      await tui.waitForText("Rejecting project MCP server", 10_000);
+      expect(JSON.parse(readFileSync(join(root.home, ".fx", "settings.json"), "utf8"))
+        .workspaces[root.workspace].disabledMcpjsonServers).toContain("fixture");
+      expect(await tui.captureFullScrollback()).not.toContain("Project MCP approval prompts dismissed");
+      await tui.kill();
+      tui = null;
+      await expectFixtureProcessesExited(readWire(root.wireLogPath));
+    },
+    50_000,
+  );
+
+  test.skipIf(process.platform === "win32" || !tmuxAvailable())(
     "Escape suppresses project MCP prompts only for the current process",
     async () => {
       const root = createRoot("workspace-escape", MODERN_FIXTURE, {


### PR DESCRIPTION
## Summary

- Let subagents finish while optional MCP servers connect.
- Keep MCP menu shortcuts active after resetting project trust.
- Show pending project MCP approvals when the menu closes.
