### PR TITLE
Frame complete provider stream events

### DIFF
--- a/sdk/browser-test-terminal.html
+++ b/sdk/browser-test-terminal.html
@@ -83,17 +83,17 @@
           streamChunkCount += 1;
           testState.chunks = streamChunkCount;
           if (streamChunkCount === 1) {
-            controller.enqueue(encoded.encode('data: {"type":"text-delta","delta":"STREAM_STARTED"}\n'));
+            controller.enqueue(encoded.encode('data: {"type":"text-delta","delta":"STREAM_STARTED"}\n\n'));
             return;
           }
           if (streamChunkCount <= 128) {
-            controller.enqueue(encoded.encode('data: {"type":"text-delta","delta":"."}\n'));
+            controller.enqueue(encoded.encode('data: {"type":"text-delta","delta":"."}\n\n'));
             return;
           }
           await bufferedStreamFinished;
-          controller.enqueue(encoded.encode('data: {"type":"text-delta","delta":"STREAM_FINISHED"}\n'));
-          controller.enqueue(encoded.encode('data: {"type":"finish","finishReason":{"unified":"stop"},"usage":{"inputTokens":{"total":1},"outputTokens":{"total":2}}}\n'));
-          controller.enqueue(encoded.encode("data: [DONE]\n"));
+          controller.enqueue(encoded.encode('data: {"type":"text-delta","delta":"STREAM_FINISHED"}\n\n'));
+          controller.enqueue(encoded.encode('data: {"type":"finish","finishReason":{"unified":"stop"},"usage":{"inputTokens":{"total":1},"outputTokens":{"total":2}}}\n\n'));
+          controller.enqueue(encoded.encode("data: [DONE]\n\n"));
           controller.close();
           streamSourceClosed = true;
         },

--- a/sdk/index.html
+++ b/sdk/index.html
@@ -186,11 +186,11 @@
       }
       return new Response(new ReadableStream({
         async start(controller) {
-          controller.enqueue(encoded.encode('data: {"type":"text-delta","delta":"hello"}\n'));
+          controller.enqueue(encoded.encode('data: {"type":"text-delta","delta":"hello"}\n\n'));
           await sleep(chunkDelay);
-          controller.enqueue(encoded.encode('data: {"type":"text-delta","delta":" world"}\n'));
-          controller.enqueue(encoded.encode('data: {"type":"finish","finishReason":{"unified":"stop"},"usage":{"inputTokens":{"total":3},"outputTokens":{"total":2}}}\n'));
-          controller.enqueue(encoded.encode("data: [DONE]\n"));
+          controller.enqueue(encoded.encode('data: {"type":"text-delta","delta":" world"}\n\n'));
+          controller.enqueue(encoded.encode('data: {"type":"finish","finishReason":{"unified":"stop"},"usage":{"inputTokens":{"total":3},"outputTokens":{"total":2}}}\n\n'));
+          controller.enqueue(encoded.encode("data: [DONE]\n\n"));
           controller.close();
         },
       }), { status: 200, headers: { "content-type": "text/event-stream" } });

--- a/sdk/node/test-term-features.mjs
+++ b/sdk/node/test-term-features.mjs
@@ -32,9 +32,9 @@ const fetch = async (url, init = {}) => {
   const response = turn === 1 ? "first answer" : "second answer";
   return new Response(new ReadableStream({
     start(controller) {
-      controller.enqueue(encoder.encode(`data: {"type":"text-delta","delta":"${response}"}\n`));
-      controller.enqueue(encoder.encode('data: {"type":"finish","finishReason":{"unified":"stop"},"usage":{"inputTokens":{"total":1},"outputTokens":{"total":2}}}\n'));
-      controller.enqueue(encoder.encode("data: [DONE]\n"));
+      controller.enqueue(encoder.encode(`data: {"type":"text-delta","delta":"${response}"}\n\n`));
+      controller.enqueue(encoder.encode('data: {"type":"finish","finishReason":{"unified":"stop"},"usage":{"inputTokens":{"total":1},"outputTokens":{"total":2}}}\n\n'));
+      controller.enqueue(encoder.encode("data: [DONE]\n\n"));
       controller.close();
     },
   }), { status: 200, headers: { "content-type": "text/event-stream" } });

--- a/sdk/node/test-term-headless.mjs
+++ b/sdk/node/test-term-headless.mjs
@@ -31,11 +31,11 @@ const mockFetch = async (_url, init) => {
   return new Response(new ReadableStream({
     async start(controller) {
       firstChunkAt = performance.now();
-      controller.enqueue(encoded.encode('data: {"type":"text-delta","delta":"streamed"}\n'));
+      controller.enqueue(encoded.encode('data: {"type":"text-delta","delta":"streamed"}\n\n'));
       await new Promise((resolve) => setTimeout(resolve, 20));
-      controller.enqueue(encoded.encode('data: {"type":"text-delta","delta":" response"}\n'));
-      controller.enqueue(encoded.encode('data: {"type":"finish","finishReason":{"unified":"stop"},"usage":{"inputTokens":{"total":1},"outputTokens":{"total":2}}}\n'));
-      controller.enqueue(encoded.encode("data: [DONE]\n"));
+      controller.enqueue(encoded.encode('data: {"type":"text-delta","delta":" response"}\n\n'));
+      controller.enqueue(encoded.encode('data: {"type":"finish","finishReason":{"unified":"stop"},"usage":{"inputTokens":{"total":1},"outputTokens":{"total":2}}}\n\n'));
+      controller.enqueue(encoded.encode("data: [DONE]\n\n"));
       controller.close();
     },
   }), { status: 200, headers: { "content-type": "text/event-stream" } });

--- a/sdk/node/test-term-history.mjs
+++ b/sdk/node/test-term-history.mjs
@@ -24,9 +24,9 @@ const promptHistoryStore = {
 const encoded = new TextEncoder();
 const fetch = async () => new Response(new ReadableStream({
   start(controller) {
-    controller.enqueue(encoded.encode('data: {"type":"text-delta","delta":"ok"}\n'));
-    controller.enqueue(encoded.encode('data: {"type":"finish","finishReason":{"unified":"stop"}}\n'));
-    controller.enqueue(encoded.encode("data: [DONE]\n"));
+    controller.enqueue(encoded.encode('data: {"type":"text-delta","delta":"ok"}\n\n'));
+    controller.enqueue(encoded.encode('data: {"type":"finish","finishReason":{"unified":"stop"}}\n\n'));
+    controller.enqueue(encoded.encode("data: [DONE]\n\n"));
     controller.close();
   },
 }), { status: 200, headers: { "content-type": "text/event-stream" } });

--- a/sdk/tests/test-core-home-unavailable.mjs
+++ b/sdk/tests/test-core-home-unavailable.mjs
@@ -31,10 +31,10 @@ const mockFetch = async (url, init) => {
   }
   return new Response(new ReadableStream({
     start(controller) {
-      controller.enqueue(encoded.encode('data: {"type":"text-delta","delta":"hello"}\n'));
-      controller.enqueue(encoded.encode('data: {"type":"text-delta","delta":" world"}\n'));
-      controller.enqueue(encoded.encode('data: {"type":"finish","finishReason":{"unified":"stop"},"usage":{"inputTokens":{"total":3},"outputTokens":{"total":2}}}\n'));
-      controller.enqueue(encoded.encode("data: [DONE]\n"));
+      controller.enqueue(encoded.encode('data: {"type":"text-delta","delta":"hello"}\n\n'));
+      controller.enqueue(encoded.encode('data: {"type":"text-delta","delta":" world"}\n\n'));
+      controller.enqueue(encoded.encode('data: {"type":"finish","finishReason":{"unified":"stop"},"usage":{"inputTokens":{"total":3},"outputTokens":{"total":2}}}\n\n'));
+      controller.enqueue(encoded.encode("data: [DONE]\n\n"));
       controller.close();
     },
   }), { status: 200, headers: { "content-type": "text/event-stream" } });

--- a/sdk/tests/test-term.mjs
+++ b/sdk/tests/test-term.mjs
@@ -84,25 +84,25 @@ const mockFetch = async (_url, init) => {
     secondRequestBody = JSON.parse(new TextDecoder().decode(init.body));
     return new Response(new ReadableStream({
       start(controller) {
-        controller.enqueue(encoded.encode(`data: {"type":"text-delta","delta":"${steeringAnswer}"}\n`));
-        controller.enqueue(encoded.encode('data: {"type":"finish","finishReason":{"unified":"stop"},"usage":{"inputTokens":{"total":1},"outputTokens":{"total":2}}}\n'));
-        controller.enqueue(encoded.encode("data: [DONE]\n"));
+        controller.enqueue(encoded.encode(`data: {"type":"text-delta","delta":"${steeringAnswer}"}\n\n`));
+        controller.enqueue(encoded.encode('data: {"type":"finish","finishReason":{"unified":"stop"},"usage":{"inputTokens":{"total":1},"outputTokens":{"total":2}}}\n\n'));
+        controller.enqueue(encoded.encode("data: [DONE]\n\n"));
         controller.close();
       },
     }), { status: 200, headers: { "content-type": "text/event-stream" } });
   }
   return new Response(new ReadableStream({
     async start(controller) {
-      controller.enqueue(encoded.encode('data: {"type":"text-delta","delta":"hello"}\n'));
+      controller.enqueue(encoded.encode('data: {"type":"text-delta","delta":"hello"}\n\n'));
       streamStartedAt = performance.now();
       const interval = setInterval(() => {
-        controller.enqueue(encoded.encode('data: {"type":"text-delta","delta":"."}\n'));
+        controller.enqueue(encoded.encode('data: {"type":"text-delta","delta":"."}\n\n'));
       }, 20);
       await firstStreamRelease;
       clearInterval(interval);
-      controller.enqueue(encoded.encode('data: {"type":"text-delta","delta":" world"}\n'));
-      controller.enqueue(encoded.encode('data: {"type":"finish","finishReason":{"unified":"stop"},"usage":{"inputTokens":{"total":1},"outputTokens":{"total":2}}}\n'));
-      controller.enqueue(encoded.encode("data: [DONE]\n"));
+      controller.enqueue(encoded.encode('data: {"type":"text-delta","delta":" world"}\n\n'));
+      controller.enqueue(encoded.encode('data: {"type":"finish","finishReason":{"unified":"stop"},"usage":{"inputTokens":{"total":1},"outputTokens":{"total":2}}}\n\n'));
+      controller.enqueue(encoded.encode("data: [DONE]\n\n"));
       controller.close();
       streamFinishedAt = performance.now();
     },

--- a/src/gateway/client.zig
+++ b/src/gateway/client.zig
@@ -7,6 +7,7 @@ const debug_trace = @import("../core/shared/debug_trace.zig");
 const io_mod = @import("../core/shared/io.zig");
 const types = @import("../core/shared/types.zig");
 const json_comparison = @import("json_comparison.zig");
+const sse = @import("sse.zig");
 
 pub fn isRetryableGatewayError(err: anyerror) bool {
     return err == error.HttpConnectionClosing or
@@ -2939,82 +2940,6 @@ fn parseOptionalNullableBillingInteger(
         null;
 }
 
-const SseLineRead = union(enum) {
-    line: []const u8,
-    read_failed,
-    eof,
-};
-
-const SseEventRead = union(enum) {
-    data: []const u8,
-    done,
-    ignored,
-    read_failed,
-    eof,
-};
-
-const SseEventReader = struct {
-    pending_line: std.ArrayList(u8) = .empty,
-    max_line_bytes: usize,
-
-    fn deinit(self: *@This(), alloc: std.mem.Allocator) void {
-        self.pending_line.deinit(alloc);
-    }
-
-    fn releaseLine(self: *@This()) void {
-        self.pending_line.clearRetainingCapacity();
-    }
-
-    fn next(self: *@This(), alloc: std.mem.Allocator, reader: anytype) !SseEventRead {
-        const line = switch (try self.readLine(alloc, reader)) {
-            .line => |line| line,
-            .read_failed => return .read_failed,
-            .eof => return .eof,
-        };
-
-        const trimmed = std.mem.trimEnd(u8, line, "\r");
-        if (trimmed.len == 0) return .ignored;
-        if (trimmed[0] == ':') return .ignored;
-
-        if (std.mem.eql(u8, trimmed, "DONE")) return .done;
-
-        const data_prefix = "data: ";
-        if (!std.mem.startsWith(u8, trimmed, data_prefix)) return .ignored;
-
-        const json_text = trimmed[data_prefix.len..];
-        if (std.mem.eql(u8, json_text, "[DONE]")) return .done;
-        return .{ .data = json_text };
-    }
-
-    fn readLine(self: *@This(), alloc: std.mem.Allocator, reader: anytype) !SseLineRead {
-        while (true) {
-            const fragment = reader.takeDelimiter('\n') catch |err| switch (err) {
-                error.StreamTooLong => {
-                    const buffered = reader.buffered();
-                    if (buffered.len == 0) return error.GatewaySseReadStalled;
-                    if (buffered.len > self.max_line_bytes - self.pending_line.items.len) {
-                        return error.GatewaySseEventTooLarge;
-                    }
-                    try self.pending_line.appendSlice(alloc, buffered);
-                    reader.tossBuffered();
-                    continue;
-                },
-                error.ReadFailed => return .read_failed,
-            } orelse {
-                if (self.pending_line.items.len > 0) return .{ .line = self.pending_line.items };
-                return .eof;
-            };
-
-            if (fragment.len > self.max_line_bytes - self.pending_line.items.len) {
-                return error.GatewaySseEventTooLarge;
-            }
-            if (self.pending_line.items.len == 0) return .{ .line = fragment };
-            try self.pending_line.appendSlice(alloc, fragment);
-            return .{ .line = self.pending_line.items };
-        }
-    }
-};
-
 fn captureGenerationMetadata(
     alloc: std.mem.Allocator,
     root: std.json.Value,
@@ -3046,7 +2971,7 @@ fn captureGenerationMetadata(
 
 fn consumeSseStream(
     alloc: std.mem.Allocator,
-    reader: anytype,
+    reader: *std.Io.Reader,
     callback_ctx: *anyopaque,
     on_content_chunk: StreamCallback,
     on_tool_start: ?ToolStartCallback,
@@ -3087,7 +3012,7 @@ pub fn consumeGatewaySseStream(
 
 fn consumeSseStreamTraced(
     alloc: std.mem.Allocator,
-    reader: anytype,
+    reader: *std.Io.Reader,
     callback_ctx: *anyopaque,
     on_content_chunk: StreamCallback,
     on_tool_start: ?ToolStartCallback,
@@ -3133,7 +3058,7 @@ fn consumeSseStreamTraced(
     defer if (provider_failure_detail) |detail| alloc.free(detail);
     var data_event_count: usize = 0;
 
-    var event_reader = SseEventReader{ .max_line_bytes = max_sse_event_line_bytes };
+    var event_reader = sse.Reader{ .max_event_bytes = max_sse_event_line_bytes };
     defer event_reader.deinit(alloc);
 
     while (true) {
@@ -3142,17 +3067,13 @@ fn consumeSseStreamTraced(
             break;
         }
 
-        const event = try event_reader.next(alloc, reader);
-        defer event_reader.releaseLine();
-
-        const json_text = switch (event) {
-            .data => |json_text| json_text,
-            .done => {
-                traceSseTermination(resolved_model_trace, "done_without_finish", finish_reason_holder);
+        const payload = event_reader.next(alloc, reader, cancel_flag) catch |err| switch (err) {
+            error.EventTooLarge => return error.GatewaySseEventTooLarge,
+            error.Cancelled => {
+                traceSseTermination(resolved_model_trace, "cancellation", finish_reason_holder);
                 break;
             },
-            .ignored => continue,
-            .read_failed => {
+            error.ReadFailed => {
                 if (cancel_flag.load(.seq_cst)) {
                     traceSseTermination(resolved_model_trace, "cancellation", finish_reason_holder);
                     break;
@@ -3160,18 +3081,23 @@ fn consumeSseStreamTraced(
                 traceSseTermination(resolved_model_trace, "read_failure", finish_reason_holder);
                 return error.ReadFailed;
             },
-            .eof => {
-                traceSseTermination(resolved_model_trace, "eof_without_finish", finish_reason_holder);
-                break;
-            },
+            else => return err,
         };
+        const json_text = payload orelse {
+            traceSseTermination(resolved_model_trace, "eof_without_finish", finish_reason_holder);
+            break;
+        };
+        if (std.mem.eql(u8, json_text, "[DONE]")) {
+            traceSseTermination(resolved_model_trace, "done_without_finish", finish_reason_holder);
+            break;
+        }
         data_event_count += 1;
 
         defer _ = event_arena.reset(.retain_capacity);
         const root = std.json.parseFromSliceLeaky(std.json.Value, event_arena.allocator(), json_text, .{}) catch |err| {
             if (err == error.OutOfMemory) return err;
             traceMalformedSseEvent(json_text.len);
-            continue;
+            return error.InvalidGatewaySseEvent;
         };
         traceParsedSseEvent(alloc, root, json_text.len);
         if (root != .object) continue;
@@ -3642,6 +3568,52 @@ test "SSE text capture keeps arena capacity proportional to the retained respons
     try std.testing.expect(arena.queryCapacity() <= output_bytes * 4);
 }
 
+test "provider framing assembles Gateway data fields" {
+    for ([_][]const u8{
+        "data:{\"type\":\"text-delta\",\"delta\":\"EXPECTED_FINAL\"}\n\n",
+        "data: {\"type\":\"text-delta\",\ndata: \"delta\":\"EXPECTED_FINAL\"}\n\n",
+    }) |answer| {
+        const payload = try std.mem.concat(std.testing.allocator, u8, &.{
+            "data: {\"type\":\"text-delta\",\"delta\":\"CONTROL_PREFIX\\n\"}\n\n",
+            answer,
+            "data: {\"type\":\"finish\",\"finishReason\":{\"unified\":\"stop\"}}\n\n",
+        });
+        defer std.testing.allocator.free(payload);
+        var reader = std.Io.Reader.fixed(payload);
+        var cancelled = std.atomic.Value(bool).init(false);
+        const Noop = struct {
+            fn chunk(_: *anyopaque, _: []const u8) void {}
+        };
+        var completion = try consumeSseStream(std.testing.allocator, &reader, undefined, Noop.chunk, null, &cancelled);
+        defer deinitGatewayCompletion(std.testing.allocator, &completion);
+        try std.testing.expectEqualStrings("CONTROL_PREFIX\nEXPECTED_FINAL", completion.content.?);
+    }
+}
+
+test "provider framing rejects malformed Gateway JSON" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(root);
+    const path = try std.fs.path.join(alloc, &.{ root, "malformed-sse.log" });
+    defer alloc.free(path);
+    debug_trace.resetForTest();
+    defer debug_trace.resetForTest();
+    try debug_trace.configureForTestWithScopes(alloc, path, "sse");
+    var reader = std.Io.Reader.fixed("data: {not-json}\n\ndata: {\"type\":\"finish\",\"finishReason\":{\"unified\":\"stop\"}}\n\n");
+    var cancelled = std.atomic.Value(bool).init(false);
+    const Noop = struct {
+        fn chunk(_: *anyopaque, _: []const u8) void {}
+    };
+    try std.testing.expectError(error.InvalidGatewaySseEvent, consumeSseStream(std.testing.allocator, &reader, undefined, Noop.chunk, null, &cancelled));
+    debug_trace.shutdown();
+    const trace = try readTraceFileForTest(alloc, path);
+    defer alloc.free(trace);
+    try std.testing.expect(std.mem.find(u8, trace, "event type=invalid") != null);
+    try std.testing.expect(std.mem.find(u8, trace, "not-json") == null);
+}
+
 test "consumeSseStream preserves provider finish_reason" {
     const payload =
         "data: {\"type\":\"text-delta\",\"id\":\"t1\",\"delta\":\"Hola\"}\n" ++
@@ -3999,26 +3971,13 @@ test "consumeSseStream treats done before finish as framing only" {
 }
 
 test "consumeSseStream propagates read failure before finish" {
-    const FailingReader = struct {
-        calls: usize = 0,
-
-        fn takeDelimiter(self: *@This(), _: u8) error{ StreamTooLong, ReadFailed }!?[]const u8 {
-            self.calls += 1;
-            return error.ReadFailed;
-        }
-
-        fn buffered(_: *@This()) []const u8 {
-            return "";
-        }
-
-        fn tossBuffered(_: *@This()) void {}
-    };
-
     const Noop = struct {
         fn chunk(_: *anyopaque, _: []const u8) void {}
     };
 
-    var reader = FailingReader{};
+    var reader = std.Io.Reader.failing;
+    var failure_buffer: [1]u8 = undefined;
+    reader.buffer = &failure_buffer;
     var cancel_flag = std.atomic.Value(bool).init(false);
 
     try std.testing.expectError(
@@ -4058,18 +4017,9 @@ test "consumeSseStream traces every terminal cause" {
     var eof_reader = std.Io.Reader.fixed("");
     _ = try consumeSseStream(alloc, &eof_reader, undefined, Noop.chunk, null, &active_flag);
 
-    const FailingReader = struct {
-        fn takeDelimiter(_: *@This(), _: u8) error{ StreamTooLong, ReadFailed }!?[]const u8 {
-            return error.ReadFailed;
-        }
-
-        fn buffered(_: *@This()) []const u8 {
-            return "";
-        }
-
-        fn tossBuffered(_: *@This()) void {}
-    };
-    var failing_reader = FailingReader{};
+    var failing_reader = std.Io.Reader.failing;
+    var failure_buffer: [1]u8 = undefined;
+    failing_reader.buffer = &failure_buffer;
     try std.testing.expectError(
         error.ReadFailed,
         consumeSseStream(alloc, &failing_reader, undefined, Noop.chunk, null, &active_flag),
@@ -5480,7 +5430,7 @@ test "consumeSseStream preserves consolidated tool calls across the transport bu
     }
 }
 
-test "SseEventReader rejects an over-limit event explicitly" {
+test "provider framing rejects an over-limit event explicitly" {
     const alloc = std.testing.allocator;
     const payload = try consolidatedToolCallSseForTest(alloc, 1024);
     defer alloc.free(payload);
@@ -5488,12 +5438,13 @@ test "SseEventReader rejects an over-limit event explicitly" {
     var source = std.Io.Reader.fixed(payload);
     var transfer_buffer: [64]u8 = undefined;
     var buffered = source.limited(.unlimited, &transfer_buffer);
-    var event_reader = SseEventReader{ .max_line_bytes = 512 };
+    var event_reader = sse.Reader{ .max_event_bytes = 512 };
     defer event_reader.deinit(alloc);
+    const cancelled = std.atomic.Value(bool).init(false);
 
     try std.testing.expectError(
-        error.GatewaySseEventTooLarge,
-        event_reader.next(alloc, &buffered.interface),
+        error.EventTooLarge,
+        event_reader.next(alloc, &buffered.interface, &cancelled),
     );
 }
 
@@ -5620,33 +5571,15 @@ test "consumeSseStream frees streamed state on cancellation after a start" {
 }
 
 test "consumeSseStream frees streamed state on read failure" {
-    const FailingReader = struct {
-        index: usize = 0,
-
-        fn takeDelimiter(self: *@This(), _: u8) error{ StreamTooLong, ReadFailed }!?[]const u8 {
-            const lines = [_][]const u8{
-                "data: {\"type\":\"tool-input-start\",\"id\":\"failed\",\"toolName\":\"read_file\"}",
-                "data: {\"type\":\"tool-input-delta\",\"id\":\"failed\",\"delta\":\"{\\\"path\\\":\\\"partial\\\"}\"}",
-            };
-            if (self.index < lines.len) {
-                const line = lines[self.index];
-                self.index += 1;
-                return line;
-            }
-            return error.ReadFailed;
-        }
-
-        fn buffered(_: *@This()) []const u8 {
-            return "";
-        }
-
-        fn tossBuffered(_: *@This()) void {}
-    };
     const Noop = struct {
         fn chunk(_: *anyopaque, _: []const u8) void {}
     };
 
-    var reader = FailingReader{};
+    const payload = "data: {\"type\":\"tool-input-start\",\"id\":\"failed\",\"toolName\":\"read_file\"}\n\n" ++
+        "data: {\"type\":\"tool-input-delta\",\"id\":\"failed\",\"delta\":\"{\\\"path\\\":\\\"partial\\\"}\"}\n\n";
+    var reader = std.Io.Reader.failing;
+    reader.buffer = @constCast(payload);
+    reader.end = payload.len;
     var cancel_flag = std.atomic.Value(bool).init(false);
     try std.testing.expectError(
         error.ReadFailed,
@@ -5719,7 +5652,6 @@ test "consumeSseStream unfiltered trace excludes all payload keys and values" {
     try debug_trace.configureForTest(alloc, trace_path);
 
     const payload =
-        "data: {malformed-json-FX_MALFORMED_SENTINEL}\n\n" ++
         "data: {\"type\":\"FX_UNKNOWN_TYPE_SENTINEL\",\"FX_DYNAMIC_KEY_SENTINEL\":\"FX_UNKNOWN_VALUE_SENTINEL\"}\n\n" ++
         "data: {\"type\":\"text-delta\",\"id\":\"text\",\"delta\":\"FX_MODEL_TEXT_SENTINEL\"}\n\n" ++
         "data: {\"type\":\"tool-input-start\",\"id\":\"safe_call\",\"toolName\":\"read_file\"}\n\n" ++
@@ -5749,7 +5681,6 @@ test "consumeSseStream unfiltered trace excludes all payload keys and values" {
     const trace = try readTraceFileForTest(alloc, trace_path);
     defer alloc.free(trace);
     inline for (.{
-        "event type=invalid",
         "event type=unknown",
         "event type=text-delta",
         "event type=tool-input-start",
@@ -5764,7 +5695,6 @@ test "consumeSseStream unfiltered trace excludes all payload keys and values" {
         try std.testing.expect(std.mem.find(u8, trace, metadata) != null);
     }
     inline for (.{
-        "FX_MALFORMED_SENTINEL",
         "FX_UNKNOWN_TYPE_SENTINEL",
         "FX_DYNAMIC_KEY_SENTINEL",
         "FX_UNKNOWN_VALUE_SENTINEL",

--- a/src/gateway/openai_codex.zig
+++ b/src/gateway/openai_codex.zig
@@ -7,6 +7,7 @@ const io_mod = @import("../core/shared/io.zig");
 const types = @import("../core/shared/types.zig");
 const gateway_client = @import("client.zig");
 const responses_protocol = @import("responses_protocol.zig");
+const sse_stream = @import("sse.zig");
 const model_tool_schema = @import("../core/tooling/model_tool_schema.zig");
 
 const Allocator = std.mem.Allocator;
@@ -432,66 +433,9 @@ fn failureKind(status: std.http.Status) stream_provider.FailureKind {
     };
 }
 
-const SseReader = struct {
-    pending_line: std.ArrayList(u8) = .empty,
-
-    fn deinit(self: *SseReader, alloc: Allocator) void {
-        self.pending_line.deinit(alloc);
-    }
-
-    fn release(self: *SseReader) void {
-        self.pending_line.clearRetainingCapacity();
-    }
-
-    fn next(self: *SseReader, alloc: Allocator, reader: anytype) !?[]const u8 {
-        while (true) {
-            const line = try self.readLine(alloc, reader) orelse return null;
-            const trimmed = std.mem.trim(u8, line, " \t\r");
-            if (trimmed.len == 0 or trimmed[0] == ':') {
-                self.release();
-                continue;
-            }
-            if (!std.mem.startsWith(u8, trimmed, "data:")) {
-                self.release();
-                continue;
-            }
-            const data = std.mem.trim(u8, trimmed["data:".len..], " \t");
-            if (std.mem.eql(u8, data, "[DONE]")) return null;
-            return data;
-        }
-    }
-
-    fn readLine(self: *SseReader, alloc: Allocator, reader: anytype) !?[]const u8 {
-        while (true) {
-            const fragment = reader.takeDelimiter('\n') catch |err| switch (err) {
-                error.StreamTooLong => {
-                    const buffered = reader.buffered();
-                    if (buffered.len == 0) return error.OpenAICodexSseReadStalled;
-                    if (buffered.len > max_sse_line_bytes - self.pending_line.items.len) {
-                        return error.OpenAICodexSseEventTooLarge;
-                    }
-                    try self.pending_line.appendSlice(alloc, buffered);
-                    reader.tossBuffered();
-                    continue;
-                },
-                error.ReadFailed => return error.ReadFailed,
-            } orelse {
-                if (self.pending_line.items.len > 0) return self.pending_line.items;
-                return null;
-            };
-            if (fragment.len > max_sse_line_bytes - self.pending_line.items.len) {
-                return error.OpenAICodexSseEventTooLarge;
-            }
-            if (self.pending_line.items.len == 0) return fragment;
-            try self.pending_line.appendSlice(alloc, fragment);
-            return self.pending_line.items;
-        }
-    }
-};
-
 fn consumeSse(
     alloc: Allocator,
-    reader: anytype,
+    reader: *std.Io.Reader,
     callback_ctx: *anyopaque,
     on_content_chunk: stream_provider.StreamCallback,
     on_tool_start: ?stream_provider.ToolStartCallback,
@@ -503,7 +447,7 @@ fn consumeSse(
 ) !types.ModelCompletion {
     var reducer = responses_protocol.Reducer.init(alloc);
     defer reducer.deinit(alloc);
-    var sse: SseReader = .{};
+    var sse: sse_stream.Reader = .{ .max_event_bytes = max_sse_line_bytes };
     defer sse.deinit(alloc);
     const callbacks = responses_protocol.StreamCallbacks{
         .context = callback_ctx,
@@ -520,8 +464,8 @@ fn consumeSse(
         .tool_arguments_bytes = limits.tool_arguments_bytes,
         .provider_state_bytes = limits.provider_state_bytes,
     };
-    while (try sse.next(alloc, reader)) |json_text| {
-        defer sse.release();
+    while (sse.next(alloc, reader, cancel_flag) catch |err| return mapReducerError(err)) |json_text| {
+        if (std.mem.eql(u8, json_text, "[DONE]")) break;
         if (reducer.applyJson(
             alloc,
             json_text,
@@ -537,6 +481,7 @@ fn consumeSse(
 
 fn mapReducerError(err: anyerror) anyerror {
     return switch (err) {
+        error.EventTooLarge => error.OpenAICodexSseEventTooLarge,
         error.InvalidEvent => error.InvalidOpenAICodexSseEvent,
         error.ResponseFailed => error.OpenAICodexResponseFailed,
         error.StreamIncomplete => error.OpenAICodexStreamIncomplete,

--- a/src/gateway/sse.zig
+++ b/src/gateway/sse.zig
@@ -14,13 +14,14 @@ fn classify(line: []const u8) Line {
 }
 
 fn line_end(bytes: []const u8) usize {
-    const width = std.simd.suggestVectorLength(u8) orelse 1;
-    const Vector = @Vector(width, u8);
     var offset: usize = 0;
-    while (bytes.len - offset >= width) : (offset += width) {
-        const chunk: Vector = bytes[offset..][0..width].*;
-        const matches = @select(bool, chunk == @as(Vector, @splat('\r')), @as(@Vector(width, bool), @splat(true)), chunk == @as(Vector, @splat('\n')));
-        if (std.simd.firstTrue(matches)) |index| return offset + index;
+    if (std.simd.suggestVectorLength(u8)) |width| {
+        const Vector = @Vector(width, u8);
+        while (bytes.len - offset >= width) : (offset += width) {
+            const chunk: Vector = bytes[offset..][0..width].*;
+            const matches = @select(bool, chunk == @as(Vector, @splat('\r')), @as(@Vector(width, bool), @splat(true)), chunk == @as(Vector, @splat('\n')));
+            if (std.simd.firstTrue(matches)) |index| return offset + index;
+        }
     }
     for (bytes[offset..], offset..) |byte, index| {
         if (byte == '\r' or byte == '\n') return index;

--- a/src/gateway/sse.zig
+++ b/src/gateway/sse.zig
@@ -13,6 +13,21 @@ fn classify(line: []const u8) Line {
     return .{ .data = value };
 }
 
+fn line_end(bytes: []const u8) usize {
+    const width = std.simd.suggestVectorLength(u8) orelse 1;
+    const Vector = @Vector(width, u8);
+    var offset: usize = 0;
+    while (bytes.len - offset >= width) : (offset += width) {
+        const chunk: Vector = bytes[offset..][0..width].*;
+        const matches = @select(bool, chunk == @as(Vector, @splat('\r')), @as(@Vector(width, bool), @splat(true)), chunk == @as(Vector, @splat('\n')));
+        if (std.simd.firstTrue(matches)) |index| return offset + index;
+    }
+    for (bytes[offset..], offset..) |byte, index| {
+        if (byte == '\r' or byte == '\n') return index;
+    }
+    return bytes.len;
+}
+
 /// Request-local SSE framing. The caller owns the source and all allocations.
 /// Returned data is borrowed until the next next() call or deinit().
 pub const Reader = struct {
@@ -86,8 +101,7 @@ pub const Reader = struct {
                     if (bytes.len == 0) continue;
                 }
             }
-            const lf = std.mem.findScalar(u8, bytes, '\n') orelse bytes.len;
-            const end = std.mem.findScalar(u8, bytes[0..lf], '\r') orelse lf;
+            const end = line_end(bytes);
             if (end > self.max_event_bytes - self.line.items.len) return error.EventTooLarge;
             if (end < bytes.len) {
                 self.skip_lf = bytes[end] == '\r';
@@ -129,6 +143,22 @@ test "provider framing never dispatches an unfinished event" {
         defer reader.deinit(std.testing.allocator);
         const cancelled = std.atomic.Value(bool).init(false);
         try std.testing.expectEqual(null, try reader.next(std.testing.allocator, &source, &cancelled));
+    }
+}
+
+test "provider framing preserves long fields with mixed delimiters" {
+    var text: [129]u8 = undefined;
+    @memset(&text, 'x');
+    const alloc = std.testing.allocator;
+    for (0..text.len + 1) |size| {
+        const wire = try std.mem.concat(alloc, u8, &.{ "data:", text[0..size], "\r\rdata:tail\n\n" });
+        defer alloc.free(wire);
+        var source = std.Io.Reader.fixed(wire);
+        var reader = Reader{ .max_event_bytes = 256 };
+        defer reader.deinit(alloc);
+        const cancelled = std.atomic.Value(bool).init(false);
+        try std.testing.expectEqualStrings(text[0..size], (try reader.next(alloc, &source, &cancelled)).?);
+        try std.testing.expectEqualStrings("tail", (try reader.next(alloc, &source, &cancelled)).?);
     }
 }
 

--- a/src/gateway/sse.zig
+++ b/src/gateway/sse.zig
@@ -1,0 +1,251 @@
+const std = @import("std");
+
+const Error = error{ OutOfMemory, ReadFailed, Cancelled, EventTooLarge, StreamTooLarge };
+
+const Line = union(enum) { boundary, data: []const u8, ignored };
+
+fn classify(line: []const u8) Line {
+    if (line.len == 0) return .boundary;
+    const colon = std.mem.findScalar(u8, line, ':') orelse line.len;
+    if (!std.mem.eql(u8, line[0..colon], "data")) return .ignored;
+    var value = if (colon < line.len) line[colon + 1 ..] else "";
+    if (value.len > 0 and value[0] == ' ') value = value[1..];
+    return .{ .data = value };
+}
+
+/// Request-local SSE framing. The caller owns the source and all allocations.
+/// Returned data is borrowed until the next next() call or deinit().
+pub const Reader = struct {
+    max_event_bytes: usize,
+    max_total_bytes: ?usize = null,
+    line: std.ArrayList(u8) = .empty,
+    data: std.ArrayList(u8) = .empty,
+    total_bytes: usize = 0,
+    first_line: bool = true,
+    skip_lf: bool = false,
+
+    pub fn deinit(self: *Reader, alloc: std.mem.Allocator) void {
+        self.line.deinit(alloc);
+        self.data.deinit(alloc);
+        self.* = undefined;
+    }
+
+    /// Reads through one blank-line delimiter without waiting for the next event.
+    /// Cancellation is checked before reads; blocked I/O remains source-owned.
+    pub fn next(self: *Reader, alloc: std.mem.Allocator, source: *std.Io.Reader, cancelled: *const std.atomic.Value(bool)) Error!?[]const u8 {
+        self.data.clearRetainingCapacity();
+        var saw_data = false;
+        while (try self.read_line(alloc, source, cancelled)) |raw| {
+            const line = if (self.first_line and std.mem.startsWith(u8, raw, "\xef\xbb\xbf")) raw[3..] else raw;
+            self.first_line = false;
+            switch (classify(line)) {
+                .ignored => {},
+                .boundary => if (saw_data) return self.data.items,
+                .data => |value| {
+                    if (saw_data) {
+                        if (self.data.items.len == self.max_event_bytes) return error.EventTooLarge;
+                        try self.data.append(alloc, '\n');
+                    }
+                    if (value.len > self.max_event_bytes - self.data.items.len) return error.EventTooLarge;
+                    if (!saw_data and self.line.items.len > 0) {
+                        // Reuse owned split-line storage instead of retaining a second large payload.
+                        std.mem.copyForwards(u8, self.line.items[0..value.len], value);
+                        self.line.items.len = value.len;
+                        std.mem.swap(std.ArrayList(u8), &self.line, &self.data);
+                    } else try self.data.appendSlice(alloc, value);
+                    saw_data = true;
+                },
+            }
+        }
+        // EOF is not an event delimiter; consumers still require terminal proof.
+        return null;
+    }
+
+    fn consume(self: *Reader, source: *std.Io.Reader, count: usize) Error!void {
+        if (self.max_total_bytes) |limit| {
+            if (count > limit - self.total_bytes) return error.StreamTooLarge;
+            self.total_bytes += count;
+        }
+        source.toss(count);
+    }
+
+    fn read_line(self: *Reader, alloc: std.mem.Allocator, source: *std.Io.Reader, cancelled: *const std.atomic.Value(bool)) Error!?[]const u8 {
+        self.line.clearRetainingCapacity();
+        while (true) {
+            if (cancelled.load(.seq_cst)) return error.Cancelled;
+            var bytes = source.peekGreedy(1) catch |err| switch (err) {
+                error.EndOfStream => return null,
+                error.ReadFailed => return error.ReadFailed,
+            };
+            if (cancelled.load(.seq_cst)) return error.Cancelled;
+            if (self.skip_lf) {
+                self.skip_lf = false;
+                if (bytes[0] == '\n') {
+                    try self.consume(source, 1);
+                    bytes = bytes[1..];
+                    if (bytes.len == 0) continue;
+                }
+            }
+            const lf = std.mem.findScalar(u8, bytes, '\n') orelse bytes.len;
+            const end = std.mem.findScalar(u8, bytes[0..lf], '\r') orelse lf;
+            if (end > self.max_event_bytes - self.line.items.len) return error.EventTooLarge;
+            if (end < bytes.len) {
+                self.skip_lf = bytes[end] == '\r';
+                try self.consume(source, end + 1);
+                if (self.line.items.len == 0) return bytes[0..end];
+                try self.line.appendSlice(alloc, bytes[0..end]);
+                return self.line.items;
+            }
+            try self.consume(source, end);
+            try self.line.appendSlice(alloc, bytes);
+        }
+    }
+};
+
+test "provider framing preserves data across encoding and chunk boundaries" {
+    const payloads = [_][]const u8{
+        "data: one\ndata:  two \n\ndata:three\n\n",
+        "\xef\xbb\xbf: heartbeat\r\nevent: message\r\ndata: one\r\ndata:  two \r\n\r\ndata:three\r\n\r\n",
+        "data: one\rdata:  two \r\rdata:three\r\r",
+    };
+    for (payloads) |payload| for (1..payload.len + 1) |size| {
+        const buffer = try std.testing.allocator.alloc(u8, size);
+        defer std.testing.allocator.free(buffer);
+        var fixed = std.Io.Reader.fixed(payload);
+        var source = fixed.limited(.unlimited, buffer);
+        var reader = Reader{ .max_event_bytes = 128 };
+        defer reader.deinit(std.testing.allocator);
+        const cancelled = std.atomic.Value(bool).init(false);
+        try std.testing.expectEqualStrings("one\n two ", (try reader.next(std.testing.allocator, &source.interface, &cancelled)).?);
+        try std.testing.expectEqualStrings("three", (try reader.next(std.testing.allocator, &source.interface, &cancelled)).?);
+        try std.testing.expectEqual(null, try reader.next(std.testing.allocator, &source.interface, &cancelled));
+    };
+}
+
+test "provider framing never dispatches an unfinished event" {
+    for ([_][]const u8{ "", ": comment\n\n", "data: partial", "data: partial\n", "data: one\ndata: two\n" }) |payload| {
+        var source = std.Io.Reader.fixed(payload);
+        var reader = Reader{ .max_event_bytes = 128 };
+        defer reader.deinit(std.testing.allocator);
+        const cancelled = std.atomic.Value(bool).init(false);
+        try std.testing.expectEqual(null, try reader.next(std.testing.allocator, &source, &cancelled));
+    }
+}
+
+test "provider framing stops at the delimiter and observes cancellation" {
+    const payload = "data: first\r\r";
+    var source = std.Io.Reader.failing;
+    source.buffer = @constCast(payload);
+    source.end = payload.len;
+    var reader = Reader{ .max_event_bytes = 128 };
+    defer reader.deinit(std.testing.allocator);
+    var cancelled = std.atomic.Value(bool).init(false);
+    try std.testing.expectEqualStrings("first", (try reader.next(std.testing.allocator, &source, &cancelled)).?);
+    cancelled.store(true, .seq_cst);
+    try std.testing.expectError(error.Cancelled, reader.next(std.testing.allocator, &source, &cancelled));
+    cancelled.store(false, .seq_cst);
+    try std.testing.expectError(error.ReadFailed, reader.next(std.testing.allocator, &source, &cancelled));
+}
+
+test "provider framing bounds lines assembled events and ignored wire" {
+    const cases = [_]struct { wire: []const u8, max: usize, expected: ?[]const u8 }{
+        .{ .wire = "data: 12\n\n", .max = 8, .expected = "12" },
+        .{ .wire = "data: 12\n\n", .max = 7, .expected = null },
+        .{ .wire = "data:12\ndata:34\ndata:56\n\n", .max = 8, .expected = "12\n34\n56" },
+        .{ .wire = "data:12\ndata:34\ndata:56\n\n", .max = 7, .expected = null },
+    };
+    for (cases) |case| {
+        var source = std.Io.Reader.fixed(case.wire);
+        var reader = Reader{ .max_event_bytes = case.max };
+        defer reader.deinit(std.testing.allocator);
+        const cancelled = std.atomic.Value(bool).init(false);
+        if (case.expected) |expected| {
+            try std.testing.expectEqualStrings(expected, (try reader.next(std.testing.allocator, &source, &cancelled)).?);
+        } else try std.testing.expectError(error.EventTooLarge, reader.next(std.testing.allocator, &source, &cancelled));
+    }
+    const wire = ": ignored\r\nevent: message\r\ndata:x\r\n\r\n";
+    for ([_]usize{ wire.len, wire.len - 2 }) |limit| {
+        var source = std.Io.Reader.fixed(wire);
+        var reader = Reader{ .max_event_bytes = 64, .max_total_bytes = limit };
+        defer reader.deinit(std.testing.allocator);
+        const cancelled = std.atomic.Value(bool).init(false);
+        if (limit == wire.len) {
+            try std.testing.expectEqualStrings("x", (try reader.next(std.testing.allocator, &source, &cancelled)).?);
+            try std.testing.expectEqual(null, try reader.next(std.testing.allocator, &source, &cancelled));
+        } else try std.testing.expectError(error.StreamTooLarge, reader.next(std.testing.allocator, &source, &cancelled));
+    }
+}
+
+test "provider framing cancellation during a read prevents publication" {
+    const Source = struct {
+        reader: std.Io.Reader,
+        cancelled: std.atomic.Value(bool) = .init(false),
+
+        fn read_vec(raw: *std.Io.Reader, _: [][]u8) std.Io.Reader.Error!usize {
+            const self: *@This() = @fieldParentPtr("reader", raw);
+            self.cancelled.store(true, .seq_cst);
+            raw.buffer[raw.end] = '\n';
+            raw.end += 1;
+            return 0;
+        }
+    };
+    var buffer: [12]u8 = undefined;
+    @memcpy(buffer[0..8], "data: x\n");
+    var source = Source{ .reader = .{ .buffer = &buffer, .seek = 0, .end = 8, .vtable = &.{ .stream = std.Io.Reader.failing.vtable.stream, .readVec = Source.read_vec } } };
+    var reader = Reader{ .max_event_bytes = 64 };
+    defer reader.deinit(std.testing.allocator);
+    try std.testing.expectError(error.Cancelled, reader.next(std.testing.allocator, &source.reader, &source.cancelled));
+}
+
+test "provider framing fuzzes chunk-invariant event data" {
+    const Probe = struct {
+        fn run(_: void, smith: *std.testing.Smith) !void {
+            var text: [128]u8 = undefined;
+            const len = smith.slice(&text);
+            const bytes = text[0..len];
+            for (bytes) |*byte| byte.* = 'a' + byte.* % 26;
+            const alloc = std.testing.allocator;
+            const wire = try std.mem.concat(alloc, u8, &.{ "\xef\xbb\xbfdata:", bytes, "\r\ndata: tail\r\n\r\n" });
+            defer alloc.free(wire);
+            const expected = try std.mem.concat(alloc, u8, &.{ bytes, "\ntail" });
+            defer alloc.free(expected);
+            var fixed = std.Io.Reader.fixed(wire);
+            var buffer: [32]u8 = undefined;
+            var source = fixed.limited(.unlimited, buffer[0 .. 1 + bytes.len % buffer.len]);
+            var reader = Reader{ .max_event_bytes = 256 };
+            defer reader.deinit(alloc);
+            const cancelled = std.atomic.Value(bool).init(false);
+            try std.testing.expectEqualStrings(expected, (try reader.next(alloc, &source.interface, &cancelled)).?);
+            try std.testing.expectEqual(null, try reader.next(alloc, &source.interface, &cancelled));
+        }
+    };
+    try std.testing.fuzz({}, Probe.run, .{ .corpus = &.{ "", "one", "split every field" } });
+}
+
+fn check_allocations(alloc: std.mem.Allocator) !void {
+    var fixed = std.Io.Reader.fixed("data: first\ndata: second\n\n");
+    var buffer: [3]u8 = undefined;
+    var source = fixed.limited(.unlimited, &buffer);
+    var reader = Reader{ .max_event_bytes = 128 };
+    defer reader.deinit(alloc);
+    const cancelled = std.atomic.Value(bool).init(false);
+    try std.testing.expectEqualStrings("first\nsecond", (try reader.next(alloc, &source.interface, &cancelled)).?);
+}
+
+test "provider framing releases allocations on failure" {
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, check_allocations, .{});
+}
+
+test "provider framing reuses split-line storage for large events" {
+    const alloc = std.testing.allocator;
+    const text = "x" ** (64 * 1024);
+    var fixed = std.Io.Reader.fixed("data: " ++ text ++ "\n\n");
+    var buffer: [128]u8 = undefined;
+    var source = fixed.limited(.unlimited, &buffer);
+    var tracked = std.testing.FailingAllocator.init(alloc, .{});
+    var reader = Reader{ .max_event_bytes = 128 * 1024 };
+    defer reader.deinit(tracked.allocator());
+    const cancelled = std.atomic.Value(bool).init(false);
+    try std.testing.expectEqualStrings(text, (try reader.next(tracked.allocator(), &source.interface, &cancelled)).?);
+    try std.testing.expect(tracked.allocated_bytes - tracked.freed_bytes < 2 * text.len);
+}

--- a/src/gateway/xai_grok.zig
+++ b/src/gateway/xai_grok.zig
@@ -7,6 +7,7 @@ const io_mod = @import("../core/shared/io.zig");
 const types = @import("../core/shared/types.zig");
 const gateway_client = @import("client.zig");
 const responses_protocol = @import("responses_protocol.zig");
+const sse_stream = @import("sse.zig");
 const model_tool_schema = @import("../core/tooling/model_tool_schema.zig");
 
 const Allocator = std.mem.Allocator;
@@ -434,90 +435,9 @@ fn failureKind(status: std.http.Status) stream_provider.FailureKind {
     };
 }
 
-const SseReader = struct {
-    pending_line: std.ArrayList(u8) = .empty,
-    aggregate_bytes: usize = 0,
-
-    const Line = struct {
-        bytes: []const u8,
-        wire_bytes: usize,
-    };
-
-    fn deinit(self: *SseReader, alloc: Allocator) void {
-        self.pending_line.deinit(alloc);
-    }
-
-    fn release(self: *SseReader) void {
-        self.pending_line.clearRetainingCapacity();
-    }
-
-    fn next(self: *SseReader, alloc: Allocator, reader: anytype) !?[]const u8 {
-        while (true) {
-            const line = try self.readLine(alloc, reader) orelse return null;
-            self.aggregate_bytes = responses_protocol.checkedAccumulatedSize(
-                self.aggregate_bytes,
-                line.wire_bytes,
-                max_sse_aggregate_bytes,
-            ) catch return error.XaiGrokResourceLimitExceeded;
-            const trimmed = std.mem.trim(u8, line.bytes, " \t\r");
-            if (trimmed.len == 0 or trimmed[0] == ':') {
-                self.release();
-                continue;
-            }
-            if (!std.mem.startsWith(u8, trimmed, "data:")) {
-                self.release();
-                continue;
-            }
-            const data = std.mem.trim(u8, trimmed["data:".len..], " \t");
-            if (std.mem.eql(u8, data, "[DONE]")) return null;
-            return data;
-        }
-    }
-
-    fn readLine(self: *SseReader, alloc: Allocator, reader: anytype) !?Line {
-        while (true) {
-            const fragment = reader.takeDelimiter('\n') catch |err| switch (err) {
-                error.StreamTooLong => {
-                    const buffered = reader.buffered();
-                    if (buffered.len == 0) return error.XaiGrokSseReadStalled;
-                    if (buffered.len > max_sse_line_bytes - self.pending_line.items.len) {
-                        return error.XaiGrokSseEventTooLarge;
-                    }
-                    try self.pending_line.appendSlice(alloc, buffered);
-                    reader.tossBuffered();
-                    continue;
-                },
-                error.ReadFailed => return error.ReadFailed,
-            } orelse {
-                if (self.pending_line.items.len > 0) {
-                    return .{
-                        .bytes = self.pending_line.items,
-                        .wire_bytes = self.pending_line.items.len,
-                    };
-                }
-                return null;
-            };
-            if (fragment.len > max_sse_line_bytes - self.pending_line.items.len) {
-                return error.XaiGrokSseEventTooLarge;
-            }
-            if (self.pending_line.items.len == 0) {
-                return .{
-                    .bytes = fragment,
-                    .wire_bytes = fragment.len + 1,
-                };
-            }
-            try self.pending_line.appendSlice(alloc, fragment);
-            return .{
-                .bytes = self.pending_line.items,
-                .wire_bytes = self.pending_line.items.len + 1,
-            };
-        }
-    }
-};
-
 fn consumeSse(
     alloc: Allocator,
-    reader: anytype,
+    reader: *std.Io.Reader,
     callback_ctx: *anyopaque,
     on_content_chunk: stream_provider.StreamCallback,
     on_tool_start: ?stream_provider.ToolStartCallback,
@@ -528,7 +448,7 @@ fn consumeSse(
 ) !types.ModelCompletion {
     var reducer = responses_protocol.Reducer.init(alloc);
     defer reducer.deinit(alloc);
-    var sse: SseReader = .{};
+    var sse: sse_stream.Reader = .{ .max_event_bytes = max_sse_line_bytes, .max_total_bytes = max_sse_aggregate_bytes };
     defer sse.deinit(alloc);
     const callbacks = responses_protocol.StreamCallbacks{
         .context = callback_ctx,
@@ -546,8 +466,8 @@ fn consumeSse(
         .tool_arguments_bytes = max_tool_arguments_bytes,
         .provider_state_bytes = max_provider_state_bytes,
     };
-    while (try sse.next(alloc, reader)) |json_text| {
-        defer sse.release();
+    while (sse.next(alloc, reader, cancel_flag) catch |err| return mapReducerError(err)) |json_text| {
+        if (std.mem.eql(u8, json_text, "[DONE]")) break;
         if (reducer.applyJson(
             alloc,
             json_text,
@@ -563,6 +483,8 @@ fn consumeSse(
 
 fn mapReducerError(err: anyerror) anyerror {
     return switch (err) {
+        error.EventTooLarge => error.XaiGrokSseEventTooLarge,
+        error.StreamTooLarge => error.XaiGrokResourceLimitExceeded,
         error.InvalidEvent => error.InvalidXaiGrokSseEvent,
         error.ResponseFailed => error.XaiGrokResponseFailed,
         error.StreamIncomplete => error.XaiGrokStreamIncomplete,
@@ -1099,7 +1021,7 @@ fn buildEventCountSse(alloc: Allocator, event_count: usize) ![]u8 {
 
 fn buildIgnoredAggregateSse(alloc: Allocator, wire_bytes: usize) ![]u8 {
     const mixed_ignored_and_data = ": keepalive\n\nretry: 1000\ndata: {}\n\n";
-    const terminal = "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\"}}\n";
+    const terminal = "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\"}}\n\n";
     if (wire_bytes < mixed_ignored_and_data.len + terminal.len) return error.NoSpaceLeft;
     var out: std.Io.Writer.Allocating = .init(alloc);
     errdefer out.deinit();
@@ -1171,21 +1093,23 @@ fn buildProviderStateSse(alloc: Allocator, provider_state_bytes: usize) ![]u8 {
 
 test "xAI Grok SSE reader accepts the exact line bound and rejects one beyond" {
     inline for (.{ max_sse_line_bytes, max_sse_line_bytes + 1 }) |line_bytes| {
-        const bytes = try std.testing.allocator.alloc(u8, line_bytes + 1);
+        const bytes = try std.testing.allocator.alloc(u8, line_bytes + 2);
         defer std.testing.allocator.free(bytes);
         @memcpy(bytes[0.."data: ".len], "data: ");
         @memset(bytes["data: ".len..line_bytes], 'a');
         bytes[line_bytes] = '\n';
+        bytes[line_bytes + 1] = '\n';
         var reader: std.Io.Reader = .fixed(bytes);
-        var sse: SseReader = .{};
+        var sse: sse_stream.Reader = .{ .max_event_bytes = max_sse_line_bytes };
         defer sse.deinit(std.testing.allocator);
+        const cancelled = std.atomic.Value(bool).init(false);
         if (line_bytes == max_sse_line_bytes) {
-            const value = (try sse.next(std.testing.allocator, &reader)).?;
+            const value = (try sse.next(std.testing.allocator, &reader, &cancelled)).?;
             try std.testing.expectEqual(max_sse_line_bytes - "data: ".len, value.len);
         } else {
             try std.testing.expectError(
-                error.XaiGrokSseEventTooLarge,
-                sse.next(std.testing.allocator, &reader),
+                error.EventTooLarge,
+                sse.next(std.testing.allocator, &reader, &cancelled),
             );
         }
     }

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -4449,6 +4449,83 @@ for (const scenario of ["replace", "conflict", "invalid-index"] as const) {
   }, 60_000);
 }
 
+test("provider SSE framing preserves saved and resumed answers", async () => {
+  const prefix = "CONTROL_PREFIX\n", answer = "EXPECTED_FINAL";
+  for (const provider of ["gateway", "codex", "grok"] as const) for (const mode of ["no-space", "multiline", "invalid"]) {
+    const profile = mkdtempSync(join(tmpdir(), "fx-sse-framing-"));
+    const native = provider !== "gateway";
+    const model = native ? "fixture-model" : FAKE_GATEWAY_MODEL;
+    const event = (text: string) => native
+      ? { type: "response.output_text.delta", output_index: 0, content_index: 0, delta: text }
+      : { type: "text-delta", id: "answer", delta: text };
+    const terminal = native
+      ? { type: "response.completed", response: { status: "completed" } }
+      : { type: "finish", finishReason: { unified: mode === "invalid" ? "tool-calls" : "stop" } };
+    const frame = (value: object) => "data: " + JSON.stringify(value) + "\n\n";
+    let wire = frame(event(prefix));
+    if (mode === "invalid") {
+      const input = { path: "read-me.txt" };
+      writeFileSync(join(profile, "read-me.txt"), "not admitted");
+      if (native) {
+        const item = { type: "function_call", id: "fc_read", call_id: "read", name: "read_file", arguments: JSON.stringify(input) };
+        wire += frame({ type: "response.output_item.added", output_index: 1, item });
+        wire += frame({ type: "response.output_item.done", output_index: 1, item });
+      } else wire += frame({ type: "tool-call", toolCallId: "read", toolName: "read_file", input });
+      wire += "data: {invalid-json}\n\n";
+    } else if (mode === "no-space") wire += "data:" + JSON.stringify(event(answer)) + "\n\n";
+    else wire += JSON.stringify(event(answer), null, 2).split("\n").map(line => "data: " + line).join("\n") + "\n\n";
+    wire += frame(terminal);
+    if (mode === "multiline") wire = "\ufeff" + wire.replaceAll("\n", "\r\n");
+    const replies = [new Response(wire, { headers: { "content-type": "text/event-stream" } }), native
+      ? fakeGatewaySse([event("RESUME_OK"), { type: "response.completed", response: { status: "completed" } }])
+      : fakeGatewayFinalText("RESUME_OK")];
+    const gateway = startFakeGateway(native ? [] : replies);
+    const direct = provider === "codex" ? startFakeCodexToolLoop({ model, responses: replies })
+      : provider === "grok" ? startFakeGrokToolLoop({ model, responses: replies }) : null;
+    try {
+      if (provider === "codex") writeSeededChatGptLogin(profile, direct!.accessToken);
+      else if (provider === "grok") writeSeededGrokLogin(profile, direct!.accessToken);
+      mkdirSync(join(profile, ".fx"), { recursive: true });
+      writeFileSync(join(profile, ".fx", "settings.json"), JSON.stringify({ provider, [native ? provider + "_model" : "model"]: model }));
+      const env = {
+        HOME: profile, AI_GATEWAY_API_KEY: "fixture", VERCEL_OIDC_TOKEN: undefined, FX_MODEL: native ? undefined : model,
+        FX_DISABLE_KEYCHAIN: "1", FX_AUTO_UPGRADE: "0", FX_SOUND: "0",
+        FX_GATEWAY_BASE_URL: gateway.baseUrl, FX_E2E_GATEWAY_MODELS_URL: gateway.baseUrl + "/coding-agent/v1/models",
+        FX_GATEWAY_CHAT_URL: gateway.chatUrl, FX_E2E_GATEWAY_CHAT_URL: gateway.chatUrl,
+        FX_E2E_OPENAI_CODEX_RESPONSES_URL: direct?.responsesUrl, FX_E2E_OPENAI_CODEX_MODELS_URL: direct?.modelsUrl,
+        FX_E2E_XAI_GROK_RESPONSES_URL: direct?.responsesUrl, FX_E2E_XAI_GROK_MODELS_URL: direct?.modelsUrl,
+        FX_E2E_XAI_GROK_MODALITIES_URL: direct && "modalitiesUrl" in direct ? direct.modalitiesUrl : undefined,
+      };
+      const first = await runFx(["ask", "--json", "--auto", "Report the supplied answer."], { cwd: profile, env, timeoutMs: TIMEOUT });
+      const output = JSON.parse(first.stdout);
+      expect(first.signal).toBeNull();
+      expect(direct ? direct.bodies.length : gateway.requests.length).toBe(1);
+      if (mode === "invalid") {
+        expect(first.code, first.stdout + first.stderr).toBe(1);
+        expect(output.error).toBe(provider === "gateway" ? "InvalidGatewaySseEvent" : provider === "codex" ? "InvalidOpenAICodexSseEvent" : "InvalidXaiGrokSseEvent");
+        expect(output.tool_calls).toEqual([]);
+      } else {
+        expect(first.code, first.stdout + first.stderr).toBe(0);
+        expect(first.stderr).toBe("");
+        expect(output.output).toBe(prefix + answer);
+        const detail = await runFx(["session", "--json", "--id", output.session_id], { cwd: profile, env });
+        expect(detail.code).toBe(0);
+        expect(JSON.parse(detail.stdout).history[0].assistant).toBe(prefix + answer);
+        const resumed = await runFx(["ask", "--json", "--auto", "--resume-id", output.session_id, "Recall the prior answer."], { cwd: profile, env, timeoutMs: TIMEOUT });
+        expect(resumed.code, resumed.stdout + resumed.stderr).toBe(0);
+        expect(resumed.stderr).toBe("");
+        expect(direct ? direct.bodies.length : gateway.requests.length).toBe(2);
+        const replay = direct ? direct.bodies[1] : gateway.requests[1].body;
+        expect(replay).toContain(JSON.stringify(prefix + answer));
+      }
+      if (native) expect(gateway.requests).toHaveLength(0);
+    } finally {
+      direct?.stop(); gateway.stop();
+      rmSync(profile, { recursive: true, force: true });
+    }
+  }
+}, 60_000);
+
 test("direct providers reconcile final text before saving or releasing tools", async () => {
   const prefix = "COMMENTARY_ITEM\n", answer = "FINAL_ANSWER_ITEM";
   for (const provider of ["codex", "grok"] as const) for (const mode of ["streamed", "final-only", "mixed", "terminal-only", "conflict"]) {


### PR DESCRIPTION
## Summary

- Preserve answer text from multiline or no-space SSE data.
- Accept CR-only line endings and leading UTF-8 byte-order marks.
- Keep complete answers in saved and resumed history across these encodings.
- Fail malformed Gateway response data before executing queued tools.
- Do not treat an unterminated SSE event as a completed response.
