### PR TITLE
Show steering messages immediately in the transcript

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ cd your_project
 fx
 ```
 
-The current directory becomes the primary workspace. Enter a prompt, or run `/help` to browse interactive commands. While fx is working, Enter steers the active turn at its next safe model boundary. The pending update shows its first two lines, with an ellipsis when more text is hidden. If a tool is running, fx waits for it to finish; press Escape to interrupt the active work and apply the update as soon as the turn settles.
+The current directory becomes the primary workspace. Enter a prompt, or run `/help` to browse interactive commands. While fx is working, Enter steers the active turn at its next safe model boundary. When no tool is running, your message appears in the transcript immediately. Updates waiting for a running tool show their first two lines with a dotted rail and an ellipsis when more text is hidden. Press Escape to interrupt the active work and apply the update as soon as the turn settles.
 
 Tool calls are expanded by default. Enable `Collapse tool calls` in `/settings`, or set `"collapse_tool_calls": true` in `~/.fx/settings.json`, to show one summary per tool-call group in the main transcript. Individual calls remain available in the full transcript with Ctrl+O. Follow-up activity for captured shell commands shows the original command, such as `Observed zig build`, while tool results keep the same execution handle.
 

--- a/src/core/agent/worker_runtime.zig
+++ b/src/core/agent/worker_runtime.zig
@@ -307,11 +307,14 @@ pub const CommandOutputChunk = struct {
 
 pub const SteeringPresentationSnapshot = struct {
     messages: [][]u8 = &.{},
+    pending_feedback: [][]u8 = &.{},
     waits_for_tool: bool = false,
 
     pub fn deinit(self: *SteeringPresentationSnapshot, alloc: std.mem.Allocator) void {
         for (self.messages) |message| alloc.free(message);
         if (self.messages.len > 0) alloc.free(self.messages);
+        for (self.pending_feedback) |message| alloc.free(message);
+        if (self.pending_feedback.len > 0) alloc.free(self.pending_feedback);
         self.* = .{};
     }
 };
@@ -1454,6 +1457,25 @@ pub const WorkerRuntime = struct {
         }
         var snapshot: SteeringPresentationSnapshot = .{
             .waits_for_tool = steering_count > 0 and self.hasActiveToolBoundaryLocked(),
+        };
+        errdefer snapshot.deinit(alloc);
+        snapshot.pending_feedback = pending: {
+            var count: usize = 0;
+            for (self.worker_events.items) |event| {
+                if (event == .append_user_feedback) count += 1;
+            }
+            if (count == 0) break :pending &.{};
+            const feedback = try alloc.alloc([]u8, count);
+            errdefer alloc.free(feedback);
+            var written: usize = 0;
+            errdefer for (feedback[0..written]) |message| alloc.free(message);
+            for (self.worker_events.items) |event| {
+                if (event == .append_user_feedback) {
+                    feedback[written] = try alloc.dupe(u8, event.append_user_feedback);
+                    written += 1;
+                }
+            }
+            break :pending feedback;
         };
         if (steering_count == 0) return snapshot;
 
@@ -4286,6 +4308,61 @@ test "immediate steering is visible while the provider cutoff settles" {
     try std.testing.expectEqualStrings("first", snapshot.messages[0]);
     try std.testing.expectEqualStrings("second", snapshot.messages[1]);
     try std.testing.expect(!snapshot.waits_for_tool);
+}
+
+test "steering presentation survives queue to feedback transfer without duplicate input" {
+    const alloc = std.testing.allocator;
+    var runtime = WorkerRuntime{};
+    defer runtime.deinit(alloc);
+    try std.testing.expect(runtime.beginDirectProcessing(41));
+    try runtime.admitInteractivePrompt(alloc, try makePrompt(alloc, "same text", "model"));
+    try runtime.admitInteractivePrompt(alloc, try makePrompt(alloc, "same text", "model"));
+
+    var queued = try runtime.snapshotSteeringPresentation(alloc);
+    defer queued.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 2), queued.messages.len);
+    try std.testing.expectEqual(@as(usize, 0), queued.pending_feedback.len);
+
+    const guidance = try expectContinuedSteering(try runtime.takeSteeringBoundary(alloc, 41, .cancelled));
+    defer {
+        for (guidance) |message| alloc.free(message);
+        alloc.free(guidance);
+    }
+    var consumed = try runtime.snapshotSteeringPresentation(alloc);
+    defer consumed.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 0), consumed.messages.len);
+    try std.testing.expectEqual(@as(usize, 2), consumed.pending_feedback.len);
+    for (consumed.pending_feedback) |message| try std.testing.expectEqualStrings("same text", message);
+
+    var events = runtime.takeEvents();
+    defer freeEventList(alloc, &events);
+    var drained = try runtime.snapshotSteeringPresentation(alloc);
+    defer drained.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 0), drained.pending_feedback.len);
+    try std.testing.expectEqual(@as(usize, 2), events.items.len);
+    runtime.finishProcessing();
+}
+
+test "steering snapshot allocation failure preserves queue and feedback ownership" {
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, struct {
+        fn run(alloc: std.mem.Allocator) !void {
+            const backing = std.testing.allocator;
+            var runtime = WorkerRuntime{};
+            defer runtime.deinit(backing);
+            try std.testing.expect(runtime.beginDirectProcessing(41));
+            try runtime.pushEvent(backing, .{ .append_user_feedback = @constCast("earlier") });
+            try runtime.admitInteractivePrompt(backing, try makePrompt(backing, "later", "model"));
+            var snapshot = runtime.snapshotSteeringPresentation(alloc) catch |err| {
+                try std.testing.expectEqual(@as(usize, 1), runtime.queuedPromptCount());
+                try std.testing.expectEqual(@as(usize, 1), runtime.worker_events.items.len);
+                return err;
+            };
+            defer snapshot.deinit(alloc);
+            try std.testing.expectEqualStrings("earlier", snapshot.pending_feedback[0]);
+            try std.testing.expectEqualStrings("later", snapshot.messages[0]);
+            runtime.finishProcessing();
+        }
+    }.run, .{});
 }
 
 test "tool-blocked steering snapshot owns visible messages in admission order" {

--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -136,11 +136,14 @@ const RenderReconciliation = union(enum) {
 
 const SteeringProjection = struct {
     messages: [][]u8 = &.{},
+    pending_feedback: [][]u8 = &.{},
     waits_for_tool: bool = false,
 
     fn deinit(self: *SteeringProjection, alloc: std.mem.Allocator) void {
         for (self.messages) |message| alloc.free(message);
         if (self.messages.len > 0) alloc.free(self.messages);
+        for (self.pending_feedback) |message| alloc.free(message);
+        if (self.pending_feedback.len > 0) alloc.free(self.pending_feedback);
         self.* = .{};
     }
 };
@@ -287,6 +290,58 @@ fn pendingPromptActivityVisible(app: anytype) bool {
     return pending.phase != .awaiting_auth;
 }
 
+fn buildPendingSteeringCardProjection(
+    alloc: std.mem.Allocator,
+    shell: *const transcript_runtime.TranscriptRuntime,
+    steering: SteeringProjection,
+    checkpoint: ?*build_checkpoint.BuildCheckpoint,
+) !?PendingCardProjection {
+    const queued_count = if (steering.waits_for_tool) 0 else steering.messages.len;
+    var index = steering.pending_feedback.len + queued_count;
+    if (index == 0) return null;
+
+    var card_bytes: std.ArrayList(u8) = .empty;
+    defer card_bytes.deinit(alloc);
+    var row_count: u16 = 0;
+    const row_limit = @max(shell.layout.content_bottom, 1);
+    while (index > 0 and row_count < row_limit) {
+        index -= 1;
+        const message = if (index < steering.pending_feedback.len)
+            steering.pending_feedback[index]
+        else
+            steering.messages[index - steering.pending_feedback.len];
+        const gap: u16 = @intFromBool(card_bytes.items.len > 0);
+        const remaining_rows = row_limit - row_count -| gap;
+        if (remaining_rows == 0) break;
+        const card = try user_message_card.buildUserPromptCardTailForTerminalPresentationInterruptible(
+            alloc,
+            message,
+            &.{},
+            shell.layout.cols,
+            &.{},
+            remaining_rows,
+            checkpoint,
+        );
+        defer alloc.free(card);
+        if (card.len == 0) continue;
+        if (gap > 0) try card_bytes.insert(alloc, 0, '\n');
+        try card_bytes.insertSlice(alloc, 0, card);
+        row_count += @as(u16, @intCast(std.mem.count(u8, card, "\n"))) + gap;
+    }
+    if (row_count == 0) return null;
+    const leading_rows = pendingCardLeadingAdvanceRows(
+        @min(@max(shell.cursor_row, 1), shell.layout.content_bottom),
+        shell.cursor_col,
+        shell.layout.content_bottom,
+    );
+    return .{
+        .bytes = try pendingCardTerminalWireBytes(alloc, card_bytes.items),
+        .row_count = row_count +| leading_rows,
+        .paint_row_count = row_count,
+        .leading_advance_rows = leading_rows,
+    };
+}
+
 fn pendingCardTerminalWireBytes(
     alloc: std.mem.Allocator,
     logical: []const u8,
@@ -347,6 +402,8 @@ fn buildSteeringProjection(comptime App: type, app: *App) !SteeringProjection {
         projection.waits_for_tool = snapshot.waits_for_tool;
         projection.messages = snapshot.messages;
         snapshot.messages = &.{};
+        projection.pending_feedback = snapshot.pending_feedback;
+        snapshot.pending_feedback = &.{};
     }
     return projection;
 }
@@ -1160,6 +1217,10 @@ pub fn Runtime(comptime App: type) type {
                 try buildPendingCardProjection(App, app, presentation_shell, checkpoint)
             else
                 null;
+            const pending_submission_card = pending_card != null;
+            if (pending_card == null and !render_reconciliation.alternate_screen_owns_rendering) {
+                pending_card = try buildPendingSteeringCardProjection(app.alloc, presentation_shell, steering, checkpoint);
+            }
             defer if (pending_card) |*card| card.deinit(app.alloc);
 
             var attempt_invalidations = snapshot.invalidations;
@@ -1732,7 +1793,7 @@ pub fn Runtime(comptime App: type) type {
                 .animation_visible = frame_ctx.activity_result.painted,
                 .yolo_warning_visible = !render_reconciliation.alternate_screen_owns_rendering and
                     footer_frame.composed.danger_status_visible,
-                .pending_prompt_presented = pending_paint_ctx != null,
+                .pending_prompt_presented = pending_submission_card and pending_paint_ctx != null,
             };
         }
 
@@ -2478,6 +2539,52 @@ test "pending prompt projection waits for a paintable terminal width" {
     )).?;
     defer projection.deinit(alloc);
     try std.testing.expect(projection.paint_row_count > 0);
+}
+
+test "pending steering cards preserve feedback order and tool waiting placement" {
+    const alloc = std.testing.allocator;
+    var shell = transcript_runtime.TranscriptRuntime{
+        .layout = .{
+            .cols = 40,
+            .rows = 12,
+            .content_bottom = 8,
+            .divider_top_row = 9,
+            .input_row = 10,
+            .divider_bottom_row = 11,
+            .hint_row = 12,
+        },
+        .cursor_row = 3,
+        .cursor_col = 1,
+    };
+    defer shell.deinit(alloc);
+    var feedback = [_][]u8{@constCast("accepted earlier")};
+    var queued = [_][]u8{@constCast("accepted later")};
+    var steering = SteeringProjection{ .messages = &queued, .pending_feedback = &feedback };
+    var card = (try buildPendingSteeringCardProjection(alloc, &shell, steering, null)).?;
+    defer card.deinit(alloc);
+    const first = std.mem.find(u8, card.bytes, "accepted earlier").?;
+    const second = std.mem.find(u8, card.bytes, "accepted later").?;
+    try std.testing.expect(first < second);
+    try std.testing.expectEqual(@as(usize, 2), std.mem.count(u8, card.bytes, "┃"));
+    try std.testing.expect(std.mem.find(u8, card.bytes, "┋") == null);
+
+    steering.waits_for_tool = true;
+    var waiting = (try buildPendingSteeringCardProjection(alloc, &shell, steering, null)).?;
+    defer waiting.deinit(alloc);
+    try std.testing.expect(std.mem.find(u8, waiting.bytes, "accepted earlier") != null);
+    try std.testing.expect(std.mem.find(u8, waiting.bytes, "accepted later") == null);
+    steering.pending_feedback = &.{};
+    try std.testing.expect((try buildPendingSteeringCardProjection(alloc, &shell, steering, null)) == null);
+
+    steering.waits_for_tool = false;
+    shell.layout.content_bottom = 1;
+    var clipped = (try buildPendingSteeringCardProjection(alloc, &shell, steering, null)).?;
+    defer clipped.deinit(alloc);
+    try std.testing.expectEqual(@as(u16, 1), clipped.paint_row_count);
+    for ([_]u16{ 1, 2 }) |cols| {
+        shell.layout.cols = cols;
+        try std.testing.expect((try buildPendingSteeringCardProjection(alloc, &shell, steering, null)) == null);
+    }
 }
 
 test "pending prompt uses the canonical user turn boundary" {

--- a/src/ui/footer/render_input.zig
+++ b/src/ui/footer/render_input.zig
@@ -577,7 +577,7 @@ pub fn steeringBannerRowsForMessages(
     waits_for_tool: bool,
     width: u16,
 ) u16 {
-    if (messages.len == 0) return 0;
+    if (messages.len == 0 or !waits_for_tool) return 0;
     var rows: u16 = 0;
     for (messages) |message| {
         rows +|= steering_message_layout(message, width, waits_for_tool, max_steering_message_rows).row_count;
@@ -595,14 +595,14 @@ pub fn steeringBannerRows(ctx: RenderContext, width: u16) u16 {
 
 test "steering banner reserves message rows and one composer gap" {
     for ([_]bool{ false, true }) |waiting| {
-        try std.testing.expectEqual(@as(u16, 3), steeringBannerRowsForMessages(&.{"first\nsecond\nthird"}, waiting, 80));
+        try std.testing.expectEqual(@as(u16, if (waiting) 3 else 0), steeringBannerRowsForMessages(&.{"first\nsecond\nthird"}, waiting, 80));
     }
     try std.testing.expectEqual(
         @as(u16, 0),
         steeringBannerRowsForMessages(&.{}, true, 80),
     );
     try std.testing.expectEqual(
-        @as(u16, 3),
+        @as(u16, 0),
         steeringBannerRowsForMessages(&.{ "first", "second" }, false, 80),
     );
     try std.testing.expectEqual(

--- a/src/ui/resize_tests.zig
+++ b/src/ui/resize_tests.zig
@@ -2385,6 +2385,7 @@ test "entry-bound shimmer is suppressed when footer banner covers its row" {
     try expectGridNotContains(&h, "Overlay should fit");
 
     ctx.steering_messages = &.{"pending steering"};
+    ctx.steering_waits_for_tool = true;
     h.frame_redraw = true;
     try renderTestFooterWithContext(&h, &approval, &h.frame_redraw, ctx);
     try h.flush();
@@ -2410,6 +2411,7 @@ test "footer banner keeps a gap after entry-bound activity" {
     var ctx = defaultFooterContext(&input);
     setToolActivity(&ctx, status_id, "Overlay should be hidden by banner");
     ctx.steering_messages = &.{"pending steering"};
+    ctx.steering_waits_for_tool = true;
     h.frame_redraw = true;
     try renderTestFooterWithContext(&h, &approval, &h.frame_redraw, ctx);
     try h.flush();
@@ -2448,6 +2450,7 @@ test "footer banner reserves blank row after bottom entry-bound activity" {
     var ctx = defaultFooterContext(&input);
     setToolActivity(&ctx, status_id, "Creating project");
     ctx.steering_messages = &.{"pending steering"};
+    ctx.steering_waits_for_tool = true;
     h.frame_redraw = true;
     try renderTestFooterWithContext(&h, &approval, &h.frame_redraw, ctx);
     try h.flush();
@@ -2496,6 +2499,7 @@ test "banner-suppressed overlay restore keeps reserved footer gap" {
     try std.testing.expect(!h.shell.shimmer_active);
 
     ctx.steering_messages = &.{"pending steering"};
+    ctx.steering_waits_for_tool = true;
     h.frame_redraw = true;
     try renderTestFooterWithContext(&h, &approval, &h.frame_redraw, ctx);
     try h.flush();
@@ -4308,6 +4312,7 @@ test "render engine preserves transcript footer activity behavior" {
     try std.testing.expectEqual(status_row, try findRowContaining(&h, "Writing render-engine-plan"));
 
     ctx.steering_messages = &.{"pending steering"};
+    ctx.steering_waits_for_tool = true;
     setToolActivity(&ctx, status_id, "Overlay hidden by banner");
     h.frame_redraw = true;
     try renderTestFooterWithContext(&h, &approval, &h.frame_redraw, ctx);

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -2984,6 +2984,22 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
         `┋ ${SPLIT_NEW_USER_PROMPT}`,
       );
       expect(cutoffPane).toMatch(/Thinking|Generating/);
+      const tapeFrames = readTapeFrames(tapePath);
+      const enterIndex = findEnterAfterSubmittedPrompt(tapeFrames, SPLIT_NEW_USER_PROMPT);
+      const firstOutput = tapeFrames.slice(enterIndex + 1).find((frame) => frame.kind === 1)!;
+      expect(firstOutput).toBeDefined();
+      const framesRoot = join(root, "steering-frames");
+      execFileSync(FX_BIN, ["replay", tapePath, "--frames-dir", framesRoot], { encoding: "utf8" });
+      const firstGrid = readFileSync(
+        join(framesRoot, "frames", `${String(firstOutput.index).padStart(4, "0")}.grid.txt`),
+        "utf8",
+      );
+      const firstRows = firstGrid.split(/\r?\n/);
+      const submittedRow = firstRows.findIndex((row) => row.includes(SPLIT_NEW_USER_PROMPT));
+      const activityRow = firstRows.findIndex((row) => /Thinking|Generating/.test(row));
+      expect(submittedRow).toBeGreaterThanOrEqual(0);
+      expect(firstRows[submittedRow]).toContain("┃");
+      expect(submittedRow).toBeLessThan(activityRow);
       await waitForCondition(
         () => firstResponse.cancelled,
         "visible assistant steering cancellation",


### PR DESCRIPTION
## Summary

- Show messages submitted during thinking or generation as transcript cards immediately.
- Keep updates queued while a tool is running.
- Preserve pending messages during transcript handoff without duplicating them.
