### PR TITLE
Bound temporary memory during long agent turns

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ zig build -Doptimize=ReleaseSafe
 
 Run the test suite with `zig build test`. See [CONTRIBUTING.md](CONTRIBUTING.md) for development and contribution guidelines.
 
+A [bounded long-turn memory benchmark](docs/long-turn-memory.md) exercises saved turns against a local model fixture.
+
 ## License
 
 [Apache-2.0](LICENSE)

--- a/benchmarks/long_turn_memory.py
+++ b/benchmarks/long_turn_memory.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Bounded Linux RSS measurement of a saved fx turn against a local Gateway fixture.
+
+Only fx is measured. The fixture never retains requests; changing file contents
+make each read useful.
+Artifacts include RSS samples, stdout/stderr and the private session directory.
+"""
+import argparse
+import hashlib
+import http.server
+import json
+import os
+from pathlib import Path
+import resource
+import signal
+import subprocess
+import sys
+import threading
+import time
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--binary", default="./zig-out/bin/fx")
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--steps", type=int, default=1000)
+    parser.add_argument("--bytes", type=int, default=1024)
+    parser.add_argument("--limit-mib", type=int, default=2048)
+    parser.add_argument("--timeout", type=int, default=600)
+    args = parser.parse_args()
+    if not sys.platform.startswith("linux"):
+        parser.error("RSS measurement requires Linux /proc")
+    binary = str(Path(args.binary).resolve())
+    binary_sha256 = hashlib.sha256(Path(binary).read_bytes()).hexdigest()
+    root = Path(args.output).resolve()
+    root.mkdir(mode=0o700, parents=True, exist_ok=False)
+    home, workspace = root / "home", root / "workspace"
+    (home / ".fx").mkdir(parents=True, mode=0o700)
+    workspace.mkdir()
+    (home / ".fx/settings.json").write_text(json.dumps({"provider": "gateway", "model": "openai/gpt-5.5", "max_agent_steps": 0}))
+    count = 0
+    request_bytes = 0
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def log_message(self, *_):
+            pass
+
+        def reply(self, data, content_type):
+            self.send_response(200)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+
+        def do_GET(self):
+            self.reply(json.dumps({"object": "list", "data": [{"id": "openai/gpt-5.5", "type": "language", "tags": ["tool-use"], "context_window": 1000000}]}).encode(), "application/json")
+
+        def do_POST(self):
+            nonlocal count, request_bytes
+            size = int(self.headers["Content-Length"])
+            self.rfile.read(size)
+            request_bytes = size
+            count += 1
+            if count <= args.steps:
+                text = str(count)
+                (workspace / "evidence.txt").write_text(text + " " + "x" * args.bytes + "\n")
+                call = f"read_{count}"
+                events = [{"type": "tool-call", "toolCallId": call, "toolName": "read_file", "input": {"path": "evidence.txt"}}]
+                reason = "tool-calls"
+            else:
+                events = [{"type": "text-delta", "id": "answer", "delta": "LONG_TURN_COMPLETE"}]
+                reason = "stop"
+            events.append({"type": "finish", "finishReason": {"unified": reason, "raw": reason}, "usage": {"inputTokens": {"total": 3}, "outputTokens": {"total": 5}}})
+            self.reply(("".join("data: " + json.dumps(e) + "\n\n" for e in events) + "data: [DONE]\n\n").encode(), "text/event-stream")
+
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    env = {k: v for k, v in os.environ.items() if not k.startswith(("FX_", "OPENAI_", "GROK_", "XAI_", "AI_GATEWAY_", "VERCEL_"))}
+    base_url = f"http://127.0.0.1:{server.server_port}"
+    env.update(HOME=str(home), AI_GATEWAY_API_KEY="fixture-key", FX_GATEWAY_BASE_URL=base_url, FX_E2E_GATEWAY_CHAT_URL=base_url + "/chat", FX_E2E_GATEWAY_MODELS_URL=base_url + "/coding-agent/v1/models", FX_MODEL="openai/gpt-5.5", FX_MAX_AGENT_STEPS="0")
+
+    def limits():
+        resource.setrlimit(resource.RLIMIT_AS, (args.limit_mib * 1024**2,) * 2)
+        resource.setrlimit(resource.RLIMIT_CORE, (0, 0))
+
+    started = time.monotonic()
+    samples = []
+    with (root / "stdout.json").open("w") as out, (root / "stderr.log").open("w") as err:
+        proc = subprocess.Popen([binary, "ask", "--json", "--yolo", "Read the changing evidence file until the fixture finishes."], cwd=workspace, env=env, stdout=out, stderr=err, preexec_fn=limits, start_new_session=True)
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        while proc.poll() is None:
+            try:
+                status = dict(line.split(":", 1) for line in Path(f"/proc/{proc.pid}/status").read_text().splitlines() if ":" in line)
+                rss = int(status.get("VmRSS", "0 kB").split()[0])
+                samples.append({"seconds": round(time.monotonic() - started, 3), "requests": count, "rss_kib": rss, "request_bytes": request_bytes})
+            except FileNotFoundError:
+                break
+            if time.monotonic() - started > args.timeout:
+                os.killpg(proc.pid, signal.SIGKILL)
+                break
+            time.sleep(0.1)
+        code = proc.wait()
+    server.shutdown()
+    retained = {"execution_json_bytes": 0, "tool_output_bytes": 0, "tool_steps": 0, "conversation_json_bytes": 0}
+
+    def measure(value):
+        if isinstance(value, dict):
+            if isinstance(value.get("tool_steps"), list):
+                size = len(json.dumps(value, separators=(",", ":")).encode())
+                if size > retained["execution_json_bytes"]:
+                    retained.update(execution_json_bytes=size, tool_steps=len(value["tool_steps"]), tool_output_bytes=sum(result.get("output_bytes", 0) for step in value["tool_steps"] for result in step.get("tool_results", [])))
+            for child in value.values():
+                measure(child)
+        elif isinstance(value, list):
+            for child in value:
+                measure(child)
+
+    for checkpoint in list((home / ".fx/sessions").glob("*/checkpoint.json")) + list((home / ".fx/sessions").glob("*/recovery.json")):
+        measure(json.loads(checkpoint.read_text()))
+    for event_log in (home / ".fx/sessions").glob("*/events.jsonl"):
+        retained["conversation_json_bytes"] += event_log.stat().st_size
+        result_count = 0
+        output_bytes = 0
+        for line in event_log.open():
+            value = json.loads(line)
+            measure(value)
+            result = value.get("event", {}).get("tool_result")
+            if isinstance(result, dict):
+                result_count += 1
+                output_bytes += result.get("output_bytes", 0)
+        # This workload has one read per step. Completed v4 turns use normalized
+        # conversation events instead of an embedded execution snapshot.
+        if result_count > retained["tool_steps"]:
+            retained.update(tool_steps=result_count, tool_output_bytes=output_bytes)
+    try:
+        result = json.loads((root / "stdout.json").read_text())
+    except json.JSONDecodeError:
+        result = {}
+    calls = result.get("tool_calls", [])
+    expected = (
+        code == 0
+        and count == args.steps + 1
+        and result.get("final_output") == "LONG_TURN_COMPLETE"
+        and len(calls) == args.steps
+        and all(call.get("name") == "read_file" and call.get("status") == "success" for call in calls)
+        and retained["tool_steps"] == args.steps
+    )
+    report = {"binary": binary, "binary_sha256": binary_sha256, "steps_requested": args.steps, "requests": count, "code": code, "completed": expected, "elapsed_seconds": round(time.monotonic() - started, 3), "peak_rss_kib": max((s["rss_kib"] for s in samples), default=0), "limit_mib": args.limit_mib, "retained": retained, "samples": samples}
+    (root / "measurements.json").write_text(json.dumps(report, indent=2))
+    print(json.dumps({k: v for k, v in report.items() if k != "samples"}, indent=2))
+    return 0 if expected else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/long-turn-memory.md
+++ b/docs/long-turn-memory.md
@@ -1,0 +1,43 @@
+# Long-turn memory
+
+Saved agent turns keep messages and tool results alive across model steps. The
+turn arena must therefore survive until finalization. Temporary work has a
+shorter lifetime:
+
+* Recovery checkpoint reconstruction uses a separate arena. Persistence sinks
+  synchronously copy or serialize the borrowed checkpoint before returning.
+* Provider attempts use a separate arena for HTTP and response-parser scratch.
+  Successful or failed owned results are copied to the caller's allocator before
+  that arena is destroyed. Deferred usage references and failure diagnostics
+  are included in the copy. Stable borrowed provider results remain borrowed.
+
+Both scopes release temporary storage on success, cancellation and error. The
+step limit, history contents, request semantics and retry policy are unchanged.
+The native prepared request body already uses the resetting overlay arena.
+
+## Measure a long saved turn
+
+On Linux, build the native binary and run the local Gateway fixture:
+
+```sh
+zig build -Doptimize=ReleaseSafe
+python3 benchmarks/long_turn_memory.py --output /tmp/fx-memory-proof --steps 1000
+```
+
+The output directory must not already exist. Each step reads a changing file
+of approximately 1 KiB. The fixture supplies deterministic responses and never
+contacts a paid model. It discards request bodies and samples only fx RSS from
+`/proc/<pid>/status` every 100 ms. The fx process has a 2 GiB address-space limit,
+a 600-second deadline and disabled core dumps. Use `--steps 5` for a short smoke.
+
+`measurements.json` records the binary SHA-256, RSS samples, request count and
+retained history measurements. It measures pending execution snapshots and
+completed v4 conversation events separately. Compare current retained output
+with RSS growth; serialized history is not a measurement of allocator capacity.
+A run that exits with `OutOfMemory` does not count as completing the workload.
+
+Focused unit regressions cover 1000 growing checkpoints and 1000 provider
+attempts, including cancellation, transport failure, provider failure and a
+failed checkpoint save. Result-copy tests destroy the source allocator before
+reading the copied response, deferred usage and diagnostics, and inject failures
+at each copy allocation to verify cleanup.

--- a/src/core/agent/runtime/deps.zig
+++ b/src/core/agent/runtime/deps.zig
@@ -31,6 +31,8 @@ const ToolExecutionResult = tool_contracts.ToolExecutionResult;
 const TransportPublicationOutcome = tool_contracts.TransportPublicationOutcome;
 pub const LiveToolAuthority = tool_contracts.LiveToolAuthority;
 
+/// Borrows checkpoint slices only for the call. A sink must synchronously copy
+/// or serialize anything it retains, including when a save fails.
 pub const RecoveryCheckpointEffect = struct {
     set: *const fn (ctx: *anyopaque, checkpoint: session_codec.RecoveryCheckpoint) anyerror!void,
 };

--- a/src/core/agent/runtime/gateway_step.zig
+++ b/src/core/agent/runtime/gateway_step.zig
@@ -63,14 +63,19 @@ pub fn streamModelCompletion(
     };
     var request = request_value;
     request.admission = .{ .context = &admission, .admit_fn = InvocationAdmission.admit };
-    var result = provider.stream(alloc, request) catch |err| {
+    // Only the owned result escapes. HTTP and parser scratch is released after
+    // every attempt, including transport failure and cancellation.
+    var scratch = std.heap.ArenaAllocator.init(std.heap.c_allocator);
+    defer scratch.deinit();
+    const request_alloc = scratch.allocator();
+    var result = provider.stream(request_alloc, request) catch |err| {
         runtime_telemetry.recordGatewayCallMetric(request.model, started_at_ms, 0, 0, 0, 0, request.trace_ctx.turn_id, request.trace_ctx.step_id, request.trace_ctx.subagent_id, @errorName(err), "");
         if (admission.observation) |observation| try observation.fail(
             if (request.delivery.load() == .possibly_sent) .ambiguous_delivery else .unbilled,
         );
         return err;
     };
-    errdefer result.deinit(alloc);
+    defer result.deinit(request_alloc);
     const observation = admission.observation orelse
         return agent_stream_provider.failResult(error.ProviderAdmissionMissing);
 
@@ -101,7 +106,10 @@ pub fn streamModelCompletion(
             }
         },
     }
-    return result;
+    return switch (result) {
+        .completed => |value| if (value.ownership == .borrowed) result else try result.dupe(alloc),
+        .failed => |value| if (value.ownership == .borrowed) result else try result.dupe(alloc),
+    };
 }
 
 fn recordProviderResultMetric(
@@ -150,6 +158,67 @@ fn recordProviderResultMetric(
             .request_shape = if (failure) |value| value.diagnostics.request_shape orelse "" else "",
         },
     );
+}
+
+test "gateway request scratch is released across success failure cancellation and retries" {
+    const Fake = struct {
+        mode: usize = 0,
+
+        fn stream(raw: ?*anyopaque, alloc: Allocator, request: agent_stream_provider.ModelRequest) !StreamResult {
+            const self: *@This() = @ptrCast(@alignCast(raw.?));
+            try request.admission.admit();
+            const payload = try alloc.alloc(u8, 64 * 1024);
+            defer alloc.free(payload);
+            @memset(payload, 'x');
+            const content = try alloc.dupe(u8, "owned response");
+            if (self.mode == 1 or self.mode == 2) {
+                defer alloc.free(content);
+                return if (self.mode == 1) error.ConnectionResetByPeer else error.Cancelled;
+            }
+            if (self.mode == 3) return .{ .failed = .{ .kind = .server_error, .detail = content, .ownership = .owned } };
+            return .{ .completed = .{ .completion = .{ .content = content }, .ownership = .owned } };
+        }
+
+        fn emit(_: *anyopaque, _: agent_stream_provider.Event) void {}
+    };
+    var turn = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer turn.deinit();
+    var fake: Fake = .{};
+    var cancel: std.atomic.Value(bool) = .init(false);
+    for (0..1000) |attempt| {
+        fake.mode = attempt % 4;
+        var delivery = DeliveryCertainty.init();
+        var evidence: AttemptEvidence = .{};
+        const result = streamModelCompletion(.{ .context = &fake, .stream_fn = Fake.stream }, turn.allocator(), .{
+            .credential = .{ .direct = .{ .secret_bytes = "fixture-key", .source = .ai_gateway_api_key } },
+            .model = "fixture-model",
+            .retry_count = 1,
+            .messages = &.{},
+            .tool_choice = .auto,
+            .provider_options = .{},
+            .trace_ctx = .{},
+            .content_capture_limit = null,
+            .delivery = &delivery,
+            .attempt_evidence = &evidence,
+            .events = .{ .context = &fake, .emit_fn = Fake.emit },
+            .cancel_flag = &cancel,
+            .provider_attempt_owner = .agent,
+        }, null, std.testing.allocator);
+        if (fake.mode == 1) {
+            try std.testing.expectError(error.ConnectionResetByPeer, result);
+        } else if (fake.mode == 2) {
+            try std.testing.expectError(error.Cancelled, result);
+        } else {
+            var owned = try result;
+            defer owned.deinit(turn.allocator());
+            const content = switch (owned) {
+                .completed => |completed| completed.completion.content.?,
+                .failed => |failure| failure.detail.?,
+            };
+            try std.testing.expectEqualStrings("owned response", content);
+        }
+        try std.testing.expect(turn.queryCapacity() < 128 * 1024);
+    }
 }
 
 fn failureMetricCode(kind: agent_stream_provider.FailureKind) u16 {

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -3264,7 +3264,6 @@ noinline fn recoveryCheckpointAssistantSource(
 fn persistRecoveryCheckpoint(
     deps: *const AgentRuntimeDeps,
     finalization: *const TurnFinalizationGuard,
-    arena: Allocator,
     job: QueuedPrompt,
     current_turn_messages: []const ChatMessage,
     assistant_source: []const u8,
@@ -3280,6 +3279,11 @@ fn persistRecoveryCheckpoint(
     trace_ctx: TraceContext,
 ) !void {
     const effect = deps.recovery_checkpoint orelse return;
+    // Every sink copies or serializes the borrowed checkpoint synchronously.
+    // Retaining these full-history reconstructions in the turn arena is quadratic.
+    var scratch = std.heap.ArenaAllocator.init(std.heap.c_allocator);
+    defer scratch.deinit();
+    const arena = scratch.allocator();
     const execution = try runtime_execution_memory.buildExecutionMemory(
         arena,
         current_turn_messages,
@@ -3330,6 +3334,59 @@ fn persistRecoveryCheckpoint(
 
 fn streamSucceeded(result: runtime_gateway_step.StreamResult) bool {
     return std.meta.activeTag(result) == .completed;
+}
+
+test "recovery checkpoints do not accumulate temporary history copies in the turn arena" {
+    const support = @import("tests/support.zig");
+    const Sink = struct {
+        checkpoint: ?session_codec.RecoveryCheckpoint = null,
+        fail: bool = false,
+
+        fn set(raw: *anyopaque, checkpoint: session_codec.RecoveryCheckpoint) !void {
+            const self: *@This() = @ptrCast(@alignCast(raw));
+            if (self.fail) return error.CheckpointWriteFailed;
+            const next = try checkpoint.dupe(std.testing.allocator);
+            if (self.checkpoint) |*old| old.deinit(std.testing.allocator);
+            self.checkpoint = next;
+        }
+    };
+    var sink: Sink = .{};
+    defer if (sink.checkpoint) |*checkpoint| checkpoint.deinit(std.testing.allocator);
+    var fake = support.FakeAgentRuntimeDeps.init(std.testing.allocator);
+    defer fake.deinit();
+    var deps = fake.deps();
+    deps.ctx = &sink;
+    deps.recovery_checkpoint = .{ .set = Sink.set };
+    var fixture: support.PromptFixture = .{};
+    var finalization = TurnFinalizationGuard.init(&deps, 1, support.testLifecycleContext(
+        hooks.RuntimeView.empty(),
+        std.testing.allocator,
+        fixture.workspace_root,
+    ));
+    defer finalization.deinit();
+    var turn = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer turn.deinit();
+    const alloc = turn.allocator();
+    var messages: std.ArrayList(ChatMessage) = .empty;
+    for (0..1000) |step_index| {
+        const id = try std.fmt.allocPrint(alloc, "read_{d}", .{step_index});
+        const calls = try alloc.alloc(ToolCall, 1);
+        calls[0] = .{ .id = id, .name = "read_file", .arguments_json = "{\"path\":\"evidence.txt\"}" };
+        try messages.appendSlice(alloc, &.{
+            .{ .role = .assistant, .tool_calls = calls },
+            .{ .role = .tool, .tool_call_id = id, .tool_name = "read_file", .tool_result_status = .success, .content = "current evidence" ** 16 },
+        });
+        const retained_bytes = turn.queryCapacity();
+        try persistRecoveryCheckpoint(&deps, &finalization, fixture.job(), messages.items, "partial", "model", false, false, 10, 1, false, .transport_interrupted, .retry_request, .confirmed, .{});
+        try std.testing.expectEqual(retained_bytes, turn.queryCapacity());
+        try std.testing.expectEqual(step_index + 1, sink.checkpoint.?.execution.tool_steps.len);
+        try std.testing.expectEqualStrings(id, sink.checkpoint.?.execution.tool_steps[step_index].tool_calls[0].id);
+    }
+    sink.fail = true;
+    const retained_bytes = turn.queryCapacity();
+    try std.testing.expectError(error.CheckpointWriteFailed, persistRecoveryCheckpoint(&deps, &finalization, fixture.job(), messages.items, "cancelled", "model", false, false, 10, 1, false, .transport_interrupted, .pause, .confirmed, .{}));
+    try std.testing.expectEqual(retained_bytes, turn.queryCapacity());
+    try std.testing.expectEqual(@as(usize, 1000), sink.checkpoint.?.execution.tool_steps.len);
 }
 
 fn streamFailure(result: runtime_gateway_step.StreamResult) ?agent_stream_provider.Failure {
@@ -5409,7 +5466,6 @@ fn processQueuedPromptLoop(
                 try persistRecoveryCheckpoint(
                     deps,
                     finalization,
-                    arena,
                     job,
                     within_turn_suffix.items,
                     try recoveryCheckpointAssistantSource(
@@ -5447,7 +5503,6 @@ fn processQueuedPromptLoop(
                 try persistRecoveryCheckpoint(
                     deps,
                     finalization,
-                    arena,
                     job,
                     within_turn_suffix.items,
                     try recoveryCheckpointAssistantSource(
@@ -5861,7 +5916,6 @@ fn processQueuedPromptLoop(
                 try persistRecoveryCheckpoint(
                     deps,
                     finalization,
-                    arena,
                     job,
                     within_turn_suffix.items,
                     stream_ctx.interruption_source_or(""),
@@ -5958,7 +6012,6 @@ fn processQueuedPromptLoop(
                     try persistRecoveryCheckpoint(
                         deps,
                         finalization,
-                        arena,
                         job,
                         within_turn_suffix.items,
                         try recoveryCheckpointAssistantSource(
@@ -6056,7 +6109,6 @@ fn processQueuedPromptLoop(
                 try persistRecoveryCheckpoint(
                     deps,
                     finalization,
-                    arena,
                     job,
                     within_turn_suffix.items,
                     try recoveryCheckpointAssistantSource(
@@ -6099,7 +6151,6 @@ fn processQueuedPromptLoop(
                     try persistRecoveryCheckpoint(
                         deps,
                         finalization,
-                        arena,
                         job,
                         within_turn_suffix.items,
                         try recoveryCheckpointAssistantSource(
@@ -6367,7 +6418,6 @@ fn processQueuedPromptLoop(
                 try persistRecoveryCheckpoint(
                     deps,
                     finalization,
-                    arena,
                     job,
                     within_turn_suffix.items,
                     try recoveryCheckpointAssistantSource(
@@ -6461,7 +6511,6 @@ fn processQueuedPromptLoop(
                 try persistRecoveryCheckpoint(
                     deps,
                     finalization,
-                    arena,
                     job,
                     within_turn_suffix.items,
                     try recoveryCheckpointAssistantSource(
@@ -6557,7 +6606,6 @@ fn processQueuedPromptLoop(
                     try persistRecoveryCheckpoint(
                         deps,
                         finalization,
-                        arena,
                         job,
                         within_turn_suffix.items,
                         try recoveryCheckpointAssistantSource(
@@ -6598,7 +6646,6 @@ fn processQueuedPromptLoop(
                         try persistRecoveryCheckpoint(
                             deps,
                             finalization,
-                            arena,
                             job,
                             within_turn_suffix.items,
                             try recoveryCheckpointAssistantSource(
@@ -6893,7 +6940,6 @@ fn processQueuedPromptLoop(
                     try persistRecoveryCheckpoint(
                         deps,
                         finalization,
-                        arena,
                         job,
                         within_turn_suffix.items,
                         try recoveryCheckpointAssistantSource(
@@ -6933,7 +6979,6 @@ fn processQueuedPromptLoop(
                         try persistRecoveryCheckpoint(
                             deps,
                             finalization,
-                            arena,
                             job,
                             within_turn_suffix.items,
                             try recoveryCheckpointAssistantSource(

--- a/src/core/agent/stream_provider.zig
+++ b/src/core/agent/stream_provider.zig
@@ -301,6 +301,9 @@ pub const Completed = struct {
     completion: types.ModelCompletion = .{},
     usage: UsageOutcome = .{ .unavailable = .unbilled },
     ownership: ResultOwnership = .borrowed,
+    /// Native references normally borrow completion/credential fields. Copies
+    /// escaping a request allocator own their reference strings separately.
+    usage_ownership: ResultOwnership = .borrowed,
 };
 
 pub const Failure = struct {
@@ -315,6 +318,53 @@ pub const Result = union(enum) {
     completed: Completed,
     failed: Failure,
 
+    /// Returns a fully owned copy, including deferred usage and diagnostics.
+    /// The caller releases it with deinit using the same allocator.
+    pub fn dupe(self: Result, alloc: Allocator) Allocator.Error!Result {
+        switch (self) {
+            .failed => |failure| {
+                var copy = Result{ .failed = failure };
+                copy.failed.ownership = .owned;
+                copy.failed.detail = null;
+                copy.failed.diagnostics = .{};
+                errdefer copy.deinit(alloc);
+                if (failure.detail) |value| copy.failed.detail = try alloc.dupe(u8, value);
+                if (failure.diagnostics.schema) |value| copy.failed.diagnostics.schema = try alloc.dupe(u8, value);
+                if (failure.diagnostics.request_shape) |value| copy.failed.diagnostics.request_shape = try alloc.dupe(u8, value);
+                return copy;
+            },
+            .completed => |completed| {
+                var copy = Result{ .completed = completed };
+                copy.completed.ownership = .owned;
+                copy.completed.usage = .{ .unavailable = .unbilled };
+                copy.completed.usage_ownership = .owned;
+                const dst = &copy.completed.completion;
+                const src = completed.completion;
+                const strings = .{ "content", "generation_id", "provider_failure_detail", "provider_state_json" };
+                inline for (strings) |field| @field(dst, field) = null;
+                dst.tool_calls = &.{};
+                dst.billing = null;
+                errdefer copy.deinit(alloc);
+                inline for (strings) |field| {
+                    if (@field(src, field)) |value| @field(dst, field) = try alloc.dupe(u8, value);
+                }
+                dst.tool_calls = try types.dupeToolCallSlice(alloc, src.tool_calls);
+                if (src.billing) |billing| {
+                    var owned = billing;
+                    owned.model = try alloc.dupe(u8, billing.model);
+                    dst.billing = owned;
+                }
+                // Publish the union only after its fallible payload is complete.
+                const usage: UsageOutcome = switch (completed.usage) {
+                    .deferred => |reference| .{ .deferred = try dupeUsageReference(alloc, reference) },
+                    else => completed.usage,
+                };
+                copy.completed.usage = usage;
+                return copy;
+            },
+        }
+    }
+
     /// Providers mark allocated response fields as `owned`; test and embedded
     /// providers may return stable borrowed fields instead.
     pub fn deinit(self: *Result, alloc: Allocator) void {
@@ -326,6 +376,15 @@ pub const Result = union(enum) {
                 types.freeToolCallSlice(alloc, @constCast(completed.completion.tool_calls));
                 if (completed.completion.provider_failure_detail) |detail| alloc.free(@constCast(detail));
                 if (completed.completion.provider_state_json) |state| alloc.free(@constCast(state));
+                if (completed.usage_ownership == .owned) switch (completed.usage) {
+                    .deferred => |reference| {
+                        alloc.free(reference.generation_id);
+                        alloc.free(reference.scope);
+                        if (reference.tenant) |value| alloc.free(value);
+                        if (reference.account_id) |value| alloc.free(value);
+                    },
+                    else => {},
+                };
             },
             .failed => |failure| if (failure.ownership == .owned) {
                 if (failure.detail) |detail| alloc.free(detail);
@@ -336,6 +395,117 @@ pub const Result = union(enum) {
         self.* = undefined;
     }
 };
+
+fn dupeUsageReference(alloc: Allocator, source: DeferredUsageReference) Allocator.Error!DeferredUsageReference {
+    const generation_id = try alloc.dupe(u8, source.generation_id);
+    errdefer alloc.free(generation_id);
+    const scope = try alloc.dupe(u8, source.scope);
+    errdefer alloc.free(scope);
+    const tenant = if (source.tenant) |value| try alloc.dupe(u8, value) else null;
+    errdefer if (tenant) |value| alloc.free(value);
+    const account_id = if (source.account_id) |value| try alloc.dupe(u8, value) else null;
+    return .{
+        .provider = source.provider,
+        .generation_id = generation_id,
+        .scope = scope,
+        .tenant = tenant,
+        .account_id = account_id,
+        .credential_source = source.credential_source,
+        .credential_identity = source.credential_identity,
+    };
+}
+
+test "owned stream result copies survive the source allocator and allocation failures" {
+    const source = Result{ .completed = .{
+        .completion = .{
+            .content = "answer",
+            .tool_calls = &.{.{
+                .id = "call_1",
+                .name = "read_file",
+                .arguments_json = "{\"path\":\"file.txt\"}",
+                .provisional_id = "pending_1",
+                .provider_result = "provider output",
+            }},
+            .generation_id = "gen_1",
+            .provider_failure_detail = "detail",
+            .provider_state_json = "[]",
+            .billing = .{
+                .created_at_ms = 1,
+                .model = "fixture-model",
+                .total_cost = 0,
+                .input_tokens = 3,
+                .output_tokens = 1,
+                .cache_read_tokens = 0,
+                .cache_write_tokens = 0,
+                .reasoning_tokens = null,
+                .billable_web_search_calls = 0,
+            },
+            .finish_reason = .tool_calls,
+        },
+        .usage = .{ .deferred = .{
+            .provider = .gateway,
+            .generation_id = "gen_1",
+            .scope = "http://127.0.0.1",
+            .tenant = "team",
+            .account_id = "account",
+            .credential_source = .ai_gateway_api_key,
+            .credential_identity = null,
+        } },
+    } };
+    const Copy = struct {
+        fn check(alloc: Allocator, original: Result) !void {
+            var copied = blk: {
+                var scratch = std.heap.ArenaAllocator.init(std.testing.allocator);
+                defer scratch.deinit();
+                const temporary = try original.dupe(scratch.allocator());
+                break :blk try temporary.dupe(alloc);
+            };
+            defer copied.deinit(alloc);
+            const completion = copied.completed.completion;
+            try std.testing.expectEqualStrings("answer", completion.content.?);
+            try std.testing.expectEqualStrings("gen_1", completion.generation_id.?);
+            try std.testing.expectEqualStrings("detail", completion.provider_failure_detail.?);
+            try std.testing.expectEqualStrings("[]", completion.provider_state_json.?);
+            try std.testing.expectEqualStrings("fixture-model", completion.billing.?.model);
+            try std.testing.expectEqualStrings("call_1", completion.tool_calls[0].id);
+            try std.testing.expectEqualStrings("read_file", completion.tool_calls[0].name);
+            try std.testing.expectEqualStrings("{\"path\":\"file.txt\"}", completion.tool_calls[0].arguments_json);
+            try std.testing.expectEqualStrings("pending_1", completion.tool_calls[0].provisional_id.?);
+            try std.testing.expectEqualStrings("provider output", completion.tool_calls[0].provider_result.?);
+            const reference = copied.completed.usage.deferred;
+            try std.testing.expectEqualStrings("gen_1", reference.generation_id);
+            try std.testing.expectEqualStrings("http://127.0.0.1", reference.scope);
+            try std.testing.expectEqualStrings("team", reference.tenant.?);
+            try std.testing.expectEqualStrings("account", reference.account_id.?);
+        }
+    };
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, Copy.check, .{source});
+}
+
+test "owned failure copies preserve diagnostics after source teardown and allocation failures" {
+    const Copy = struct {
+        fn check(alloc: Allocator) !void {
+            var copied = blk: {
+                var scratch = std.heap.ArenaAllocator.init(std.testing.allocator);
+                defer scratch.deinit();
+                const source = Result{ .failed = .{
+                    .kind = .rate_limited,
+                    .detail = @constCast("retry later"),
+                    .diagnostics = .{ .schema = @constCast("schema"), .request_shape = @constCast("shape") },
+                    .retry_after_seconds = 3,
+                } };
+                const temporary = try source.dupe(scratch.allocator());
+                break :blk try temporary.dupe(alloc);
+            };
+            defer copied.deinit(alloc);
+            try std.testing.expectEqualStrings("retry later", copied.failed.detail.?);
+            try std.testing.expectEqualStrings("schema", copied.failed.diagnostics.schema.?);
+            try std.testing.expectEqualStrings("shape", copied.failed.diagnostics.request_shape.?);
+            try std.testing.expectEqual(@as(?u64, 3), copied.failed.retry_after_seconds);
+        }
+    };
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, Copy.check, .{});
+}
 
 pub inline fn failResult(err: anytype) @TypeOf(err)!Result {
     return @errorCast(failResultDynamic(err));


### PR DESCRIPTION
Long saved turns retain each full recovery-checkpoint reconstruction, plus provider HTTP/parser scratch, in the turn arena until the turn ends. Rebuilding a growing history repeatedly therefore accumulates obsolete copies and can exhaust memory during an otherwise ordinary task.

Give checkpoint reconstruction and each provider attempt their own temporary arena. Persistence sinks synchronously copy or serialize the checkpoint; owned provider results are deep-copied before request storage is released, including deferred usage references and failure diagnostics. Existing history, retry behavior, and step limits are preserved.

The included deterministic benchmark uses a local Gateway fixture with changing 1 KiB file reads, a 2 GiB address-space cap, and a 600-second deadline. On Ubuntu x86_64 with Zig 0.16 ReleaseSafe:

| Version | Successful tool steps | Peak fx RSS | Retained tool output |
| --- | ---: | ---: | ---: |
| Upstream `478960a8` | 482, then `OutOfMemory` | 1433.7 MiB | 0.50 MiB |
| This fix | 1000, completed | 82.2 MiB | 1.03 MiB |

Validation includes 1000 growing checkpoint saves, 1000 provider attempts covering success, cancellation and failures, allocation-failure injection for result copies, and runtime CLI/ACP/TUI checks for recovery, retry, cancellation, streaming and persistent child turns. Full CI passed on all four native platforms for `21fd1b6d`: [full run](https://github.com/acking-you/fx/actions/runs/33961697797).

Required classification: `type: bug` .

Fixes #686
