### PR TITLE
Preserve native terminal response outcomes

### DIFF
--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -6812,19 +6812,23 @@ fn processQueuedPromptLoop(
                 );
                 attempt_failure_diagnostic = diagnostic;
                 latest_recovery_diagnostic = diagnostic;
-                const decision = model_response_recovery.decide(.{
-                    .cause = cause,
-                    .delivery = .possibly_sent,
-                    .attempts = .{ .consumed = semantic_attempt + 1, .limit = semantic_limit },
-                    .pacing = retry_pacing,
-                    .output = if (partial_assistant.len > 0) .partial else .none,
-                    .tool = effectiveRecoveryToolEvidence(
-                        preserved_tool_evidence,
-                        attempt_completion,
-                        &stream_ctx,
-                    ),
-                    .cancelled = config.cancel_flag.load(.seq_cst),
-                });
+                const non_retryable = attempt_completion.provider_failure_cause == .non_retryable;
+                const decision = if (non_retryable)
+                    model_response_recovery.Decision{ .strategy = .stop, .required_action = .change_request }
+                else
+                    model_response_recovery.decide(.{
+                        .cause = cause,
+                        .delivery = .possibly_sent,
+                        .attempts = .{ .consumed = semantic_attempt + 1, .limit = semantic_limit },
+                        .pacing = retry_pacing,
+                        .output = if (partial_assistant.len > 0) .partial else .none,
+                        .tool = effectiveRecoveryToolEvidence(
+                            preserved_tool_evidence,
+                            attempt_completion,
+                            &stream_ctx,
+                        ),
+                        .cancelled = config.cancel_flag.load(.seq_cst),
+                    });
                 if (attempt_disposition == .provider_failure or
                     attempt_completion.provider_failure_cause == .gateway_stream_timeout)
                 {
@@ -6840,7 +6844,7 @@ fn processQueuedPromptLoop(
                         decision.reserve_provider_attempt,
                     );
                 }
-                const route_changed = disableFastRouteAfterFailure(
+                const route_changed = !non_retryable and disableFastRouteAfterFailure(
                     &route_fast_mode,
                     &gateway_model,
                     job.model,
@@ -6990,7 +6994,9 @@ fn processQueuedPromptLoop(
                     completionContentBytes(attempt_completion),
                     attempt_completion.tool_calls.len,
                 });
-                if (finish_reason == .provider_error) {
+                if (attempt_completion.provider_failure_cause == .non_retryable) {
+                    try deps.push_system_notice(deps.ctx, diagnostic.view());
+                } else if (finish_reason == .provider_error) {
                     if (replay_safe) {
                         try pushTerminalProviderFailureStatus(
                             deps,

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -6799,6 +6799,8 @@ fn processQueuedPromptLoop(
                 const finish_reason = attempt_completion.finish_reason;
                 const cause: model_response_recovery.FailureCause = if (attempt_completion.provider_failure_cause == .gateway_stream_timeout)
                     .provider_stream_timeout
+                else if (attempt_completion.provider_failure_cause == .rate_limited)
+                    .rate_limited
                 else if (attempt_disposition == .interrupted)
                     .response_interrupted
                 else if (finish_reason.? == .content_filter)

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -6998,6 +6998,21 @@ fn processQueuedPromptLoop(
                 });
                 if (attempt_completion.provider_failure_cause == .non_retryable) {
                     try deps.push_system_notice(deps.ctx, diagnostic.view());
+                    const failed_assistant_source = stream_ctx.interruption_source_or("");
+                    if (stop_state.retained_candidate == null and
+                        std.mem.trim(u8, failed_assistant_source, " \t\r\n").len > 0)
+                    {
+                        try runtime_interruption.persistFailedPartialTurnOnce(
+                            deps,
+                            finalization,
+                            job,
+                            failed_assistant_source,
+                            &interrupted_persisted,
+                            step_ctx,
+                            within_turn_suffix.items,
+                            &stop_state.terminal_materializing,
+                        );
+                    }
                 } else if (finish_reason == .provider_error) {
                     if (replay_safe) {
                         try pushTerminalProviderFailureStatus(

--- a/src/core/agent/runtime/tests/gateway_flow.zig
+++ b/src/core/agent/runtime/tests/gateway_flow.zig
@@ -7092,6 +7092,29 @@ test "processQueuedPrompt exhaustion pauses without invoking route recovery" {
     try expectRouteStatus(&hooks, 0, .terminal_provider_error, "⚠ Provider unavailable · provider_error: route failed · recovery paused after 1/1 attempts");
 }
 
+test "processQueuedPrompt stops nonretryable provider outcomes without releasing tools" {
+    const alloc = std.testing.allocator;
+    const calls = [_]ToolCall{toolCall("rejected_call", "read_file", "{\"path\":\"a.txt\"}")};
+    const completions = [_]FakeCompletion{
+        .{ .finish_reason = .provider_error, .provider_failure_cause = .non_retryable, .provider_failure_detail = "invalid_prompt: request rejected", .tool_calls = &calls },
+        .{ .content = "must not be requested" },
+    };
+    var gateway = FakeGateway.init(alloc, &completions);
+    defer gateway.deinit();
+    var hooks = FakeAgentRuntimeDeps.init(alloc);
+    defer hooks.deinit();
+    var fixture = PromptFixture{};
+    var config = fixture.config();
+    config.max_provider_attempts = 2;
+
+    try std.testing.expectError(error.ModelError, runFakePrompt(&gateway, &hooks, config, fixture.job()));
+    try std.testing.expectEqual(@as(usize, 1), gateway.request_models.items.len);
+    try std.testing.expectEqual(@as(usize, 0), hooks.executed_names.items.len);
+    try std.testing.expectEqual(@as(usize, 0), hooks.route_recovery_statuses.items.len);
+    try std.testing.expectEqual(@as(usize, 1), hooks.system_notices.items.len);
+    try std.testing.expect(std.mem.find(u8, hooks.system_notices.items[0], "invalid_prompt: request rejected") != null);
+}
+
 test "processQueuedPrompt spacer newline is skipped for ask first tool" {
     const alloc = std.testing.allocator;
     const chunks = [_][]const u8{"Using tool"};

--- a/src/core/agent/runtime/tests/gateway_flow.zig
+++ b/src/core/agent/runtime/tests/gateway_flow.zig
@@ -5634,6 +5634,35 @@ test "processQueuedPrompt disables provider option fast after a replay safe SSE 
     try expectBodyContains(&gateway, 1, "\"providerOptions\":{\"gateway\":{\"caching\":\"auto\"}}");
 }
 
+test "processQueuedPrompt preserves fast mode after a streamed rate limit" {
+    const alloc = std.testing.allocator;
+    const completions = [_]FakeCompletion{
+        .{ .finish_reason = .provider_error, .provider_failure_cause = .rate_limited, .provider_failure_detail = "rate_limit_exceeded: retry later" },
+        .{ .content = "Recovered" },
+    };
+    var gateway = FakeGateway.init(alloc, &completions);
+    defer gateway.deinit();
+    const overrides = [_]ModelCapabilityOverride{.{
+        .model = "fixture/model",
+        .capabilities = model_capabilities.resolveCapabilities("fixture/model", .{ .supports_fast_mode = true }),
+    }};
+    var hooks = FakeAgentRuntimeDeps.init(alloc);
+    hooks.capability_overrides = &overrides;
+    defer hooks.deinit();
+    var fixture = PromptFixture{};
+    var job = fixture.job();
+    job.model = @constCast("fixture/model");
+    var config = fixture.config();
+    config.fast_mode = true;
+    config.max_provider_attempts = 2;
+
+    try runFakePrompt(&gateway, &hooks, config, job);
+
+    try std.testing.expectEqual(@as(usize, 2), gateway.request_models.items.len);
+    for (0..2) |index| try expectBodyContains(&gateway, index, "\"speed\":\"fast\"");
+    try std.testing.expectEqual(@as(?types.ModelRecoveryCause, .rate_limited), hooks.route_recovery_statuses.items[0].cause);
+}
+
 test "processQueuedPrompt disables provider option fast after a replay safe HTTP failure" {
     const alloc = std.testing.allocator;
     const completions = [_]FakeCompletion{

--- a/src/core/agent/runtime/tests/gateway_flow.zig
+++ b/src/core/agent/runtime/tests/gateway_flow.zig
@@ -7123,9 +7123,10 @@ test "processQueuedPrompt exhaustion pauses without invoking route recovery" {
 
 test "processQueuedPrompt stops nonretryable provider outcomes without releasing tools" {
     const alloc = std.testing.allocator;
+    const chunks = [_][]const u8{"accepted partial response"};
     const calls = [_]ToolCall{toolCall("rejected_call", "read_file", "{\"path\":\"a.txt\"}")};
     const completions = [_]FakeCompletion{
-        .{ .finish_reason = .provider_error, .provider_failure_cause = .non_retryable, .provider_failure_detail = "invalid_prompt: request rejected", .tool_calls = &calls },
+        .{ .chunks = &chunks, .content = "accepted partial response", .finish_reason = .provider_error, .provider_failure_cause = .non_retryable, .provider_failure_detail = "invalid_prompt: request rejected", .tool_calls = &calls },
         .{ .content = "must not be requested" },
     };
     var gateway = FakeGateway.init(alloc, &completions);
@@ -7142,6 +7143,11 @@ test "processQueuedPrompt stops nonretryable provider outcomes without releasing
     try std.testing.expectEqual(@as(usize, 0), hooks.route_recovery_statuses.items.len);
     try std.testing.expectEqual(@as(usize, 1), hooks.system_notices.items.len);
     try std.testing.expect(std.mem.find(u8, hooks.system_notices.items[0], "invalid_prompt: request rejected") != null);
+    try std.testing.expectEqual(@as(usize, 1), hooks.history_turns.items.len);
+    const interrupted = hooks.history_turns.items[0].interrupted;
+    try std.testing.expectEqualStrings("accepted partial response", interrupted.assistant.?);
+    try std.testing.expectEqual(@as(?types.InterruptedTerminalReason, .failed), interrupted.terminal_reason);
+    try std.testing.expectEqual(@as(usize, 0), interrupted.execution.tool_steps.len);
 }
 
 test "processQueuedPrompt spacer newline is skipped for ask first tool" {

--- a/src/core/shared/types.zig
+++ b/src/core/shared/types.zig
@@ -1286,6 +1286,7 @@ pub const ProviderFinishReason = enum {
 
 pub const ProviderFailureCause = enum {
     gateway_stream_timeout,
+    non_retryable,
 };
 
 pub const ModelCompletion = struct {

--- a/src/core/shared/types.zig
+++ b/src/core/shared/types.zig
@@ -1287,6 +1287,7 @@ pub const ProviderFinishReason = enum {
 pub const ProviderFailureCause = enum {
     gateway_stream_timeout,
     non_retryable,
+    rate_limited,
 };
 
 pub const ModelCompletion = struct {

--- a/src/gateway/openai_codex.zig
+++ b/src/gateway/openai_codex.zig
@@ -488,7 +488,6 @@ fn mapReducerError(err: anyerror) anyerror {
     return switch (err) {
         error.EventTooLarge => error.OpenAICodexSseEventTooLarge,
         error.InvalidEvent => error.InvalidOpenAICodexSseEvent,
-        error.ResponseFailed => error.OpenAICodexResponseFailed,
         error.StreamIncomplete => error.OpenAICodexStreamIncomplete,
         error.ToolCallLimitExceeded => error.OpenAICodexToolCallLimitExceeded,
         error.ToolArgumentsTooLarge => error.OpenAICodexToolArgumentsTooLarge,

--- a/src/gateway/responses_protocol.zig
+++ b/src/gateway/responses_protocol.zig
@@ -829,6 +829,8 @@ pub const Reducer = struct {
     finish_reason: ?types.ProviderFinishReason = null,
     usage: types.Usage = .{},
     generation_id: ?[]u8 = null,
+    provider_failure_detail: ?[]u8 = null,
+    provider_failure_cause: ?types.ProviderFailureCause = null,
     terminal_seen: bool = false,
     text_parts: std.AutoHashMapUnmanaged(TextKey, TextPart) = .empty,
     last_text_key: ?TextKey = null,
@@ -849,6 +851,7 @@ pub const Reducer = struct {
         for (self.tools.items) |*tool| tool.deinit(alloc);
         self.tools.deinit(alloc);
         if (self.generation_id) |id| alloc.free(id);
+        if (self.provider_failure_detail) |detail| alloc.free(detail);
         self.* = undefined;
     }
 
@@ -970,11 +973,16 @@ pub const Reducer = struct {
             }
         } else if (std.mem.eql(u8, event_type, "response.completed") or
             std.mem.eql(u8, event_type, "response.done") or
-            std.mem.eql(u8, event_type, "response.incomplete"))
+            std.mem.eql(u8, event_type, "response.incomplete") or
+            std.mem.eql(u8, event_type, "response.failed"))
         {
-            const response_value = parsed.value.object.get("response") orelse return false;
-            if (response_value != .object) return false;
-            if (response_value.object.get("output")) |output| {
+            const response_value = parsed.value.object.get("response") orelse return error.InvalidEvent;
+            if (response_value != .object) return error.InvalidEvent;
+            const status = try terminal_status(event_type, response_value.object);
+            if (status == .failed) {
+                const failure = response_value.object.get("error");
+                try self.accept_failure(alloc, if (failure != null and failure.? == .object) failure.?.object else .{});
+            } else if (response_value.object.get("output")) |output| {
                 if (output != .array) return error.InvalidEvent;
                 for (output.array.items, 0..) |item, output_index| {
                     if (cancel_flag.load(.seq_cst)) return error.Cancelled;
@@ -994,7 +1002,7 @@ pub const Reducer = struct {
             if (cancel_flag.load(.seq_cst)) return error.Cancelled;
             self.terminal_seen = true;
             self.finish_reason = finishReason(
-                stringField(response_value.object, "status"),
+                status,
                 response_value.object,
                 self.tools.items.len > 0,
             );
@@ -1004,10 +1012,11 @@ pub const Reducer = struct {
                 self.generation_id = try alloc.dupe(u8, id);
             }
             return true;
-        } else if (std.mem.eql(u8, event_type, "response.failed") or
-            std.mem.eql(u8, event_type, "error"))
-        {
-            return error.ResponseFailed;
+        } else if (std.mem.eql(u8, event_type, "error")) {
+            try self.accept_failure(alloc, parsed.value.object);
+            self.terminal_seen = true;
+            self.finish_reason = .provider_error;
+            return true;
         }
         return false;
     }
@@ -1058,6 +1067,19 @@ pub const Reducer = struct {
             try self.reasoning_items.insert(alloc, low, .{ .output_index = output_index, .id_hash = id_hash, .json = json });
         }
         self.reasoning_bytes = total;
+    }
+
+    fn accept_failure(self: *Reducer, alloc: std.mem.Allocator, fields: std.json.ObjectMap) !void {
+        const code = stringField(fields, "code") orelse "provider_error";
+        const message = stringField(fields, "message") orelse "Provider response failed";
+        const bounded_code = types.ModelFailureDiagnostic.init(code);
+        const bounded_message = types.ModelFailureDiagnostic.init(message);
+        var buffer: [2 * types.ModelFailureDiagnostic.max_bytes + 2]u8 = undefined;
+        const text = try std.fmt.bufPrint(&buffer, "{s}: {s}", .{ bounded_code.view(), bounded_message.view() });
+        const detail = types.ModelFailureDiagnostic.init(text);
+        self.provider_failure_detail = try alloc.dupe(u8, detail.view());
+        self.provider_failure_cause = if (std.mem.eql(u8, code, "server_error") or
+            std.mem.eql(u8, code, "rate_limit_exceeded")) null else .non_retryable;
     }
 
     fn accept_text(
@@ -1233,11 +1255,15 @@ pub const Reducer = struct {
         }
         const generation_id = self.generation_id;
         self.generation_id = null;
+        const provider_failure_detail = self.provider_failure_detail;
+        self.provider_failure_detail = null;
         return .{
             .content = owned_content,
             .tool_calls = owned_tools,
             .assistant_phase = self.assistant_phase.resolved(),
             .generation_id = generation_id,
+            .provider_failure_detail = provider_failure_detail,
+            .provider_failure_cause = self.provider_failure_cause,
             .provider_state_json = owned_provider_state,
             .finish_reason = self.finish_reason orelse if (owned_tools.len > 0) .tool_calls else .stop,
             .usage = self.usage,
@@ -1276,6 +1302,7 @@ const ToolRecordTest = struct {
         if (completion.content) |value| self.alloc.free(value);
         if (completion.provider_state_json) |value| self.alloc.free(value);
         if (completion.generation_id) |value| self.alloc.free(value);
+        if (completion.provider_failure_detail) |value| self.alloc.free(value);
     }
 
     fn ignore(_: *anyopaque, _: []const u8) void {}
@@ -1444,6 +1471,114 @@ test "Responses text finalization preserves mixed streamed and final-only items"
     const completion = try stream.finish();
     defer stream.freeCompletion(completion);
     try std.testing.expectEqualStrings("COMMENTARY_ITEM\nFINAL_ANSWER_ITEM", completion.content.?);
+}
+
+test "Responses terminal failures retain provider diagnostics as outcomes" {
+    for ([_][]const u8{
+        "{\"type\":\"response.failed\",\"response\":{\"id\":\"resp_failed\",\"status\":\"failed\",\"error\":{\"code\":\"server_error\",\"message\":\"temporarily unavailable\"}}}",
+        "{\"type\":\"error\",\"code\":\"server_error\",\"message\":\"temporarily unavailable\"}",
+    }) |event| {
+        var stream = ToolRecordTest.init(std.testing.allocator);
+        defer stream.deinit();
+        try stream.apply(event);
+        const completion = try stream.finish();
+        defer stream.freeCompletion(completion);
+        try std.testing.expectEqual(types.ProviderFinishReason.provider_error, completion.finish_reason.?);
+        try std.testing.expectEqualStrings("server_error: temporarily unavailable", completion.provider_failure_detail.?);
+    }
+}
+
+test "Responses terminal incomplete event does not require nested status" {
+    var stream = ToolRecordTest.init(std.testing.allocator);
+    defer stream.deinit();
+    try stream.apply("{\"type\":\"response.incomplete\",\"response\":{\"incomplete_details\":{\"reason\":\"max_output_tokens\"}}}");
+    const completion = try stream.finish();
+    defer stream.freeCompletion(completion);
+    try std.testing.expectEqual(types.ProviderFinishReason.length, completion.finish_reason.?);
+}
+
+test "Responses terminal failure classification is conservative and diagnostics are bounded" {
+    const cases = .{
+        .{ "server_error", false },
+        .{ "rate_limit_exceeded", false },
+        .{ "invalid_prompt", true },
+        .{ "unknown_code", true },
+    };
+    inline for (cases) |case| {
+        var stream = ToolRecordTest.init(std.testing.allocator);
+        defer stream.deinit();
+        const event = try std.json.Stringify.valueAlloc(std.testing.allocator, .{
+            .type = "response.failed",
+            .response = .{ .id = "resp_failure", .@"error" = .{ .code = case[0], .message = "é" ** 512 }, .usage = .{ .input_tokens = 7, .output_tokens = 3 } },
+        }, .{});
+        defer std.testing.allocator.free(event);
+        try stream.apply(event);
+        const completion = try stream.finish();
+        defer stream.freeCompletion(completion);
+        try std.testing.expectEqual(case[1], completion.provider_failure_cause == .non_retryable);
+        try std.testing.expect(completion.provider_failure_detail.?.len <= types.ModelFailureDiagnostic.max_bytes);
+        try std.testing.expect(std.unicode.utf8ValidateSlice(completion.provider_failure_detail.?));
+        try std.testing.expect(std.mem.startsWith(u8, completion.provider_failure_detail.?, case[0]));
+        try std.testing.expectEqualStrings("resp_failure", completion.generation_id.?);
+        try std.testing.expectEqual(@as(?u64, 7), completion.usage.input_tokens);
+        try std.testing.expectEqual(@as(?u64, 3), completion.usage.output_tokens);
+    }
+    var stream = ToolRecordTest.init(std.testing.allocator);
+    defer stream.deinit();
+    try stream.apply("{\"type\":\"response.failed\",\"response\":{\"error\":null}}");
+    const completion = try stream.finish();
+    defer stream.freeCompletion(completion);
+    try std.testing.expectEqual(types.ProviderFinishReason.provider_error, completion.finish_reason.?);
+    try std.testing.expectEqual(types.ProviderFailureCause.non_retryable, completion.provider_failure_cause.?);
+    try std.testing.expect(completion.provider_failure_detail.?.len > 0);
+}
+
+test "Responses terminal metadata rejects contradictions before publishing final text" {
+    for ([_][]const u8{
+        "{\"type\":\"response.completed\",\"response\":{\"status\":\"incomplete\",\"output\":[{\"type\":\"message\",\"content\":[{\"type\":\"output_text\",\"text\":\"must not publish\"}]}]}}",
+        "{\"type\":\"response.incomplete\",\"response\":{\"status\":\"completed\"}}",
+        "{\"type\":\"response.failed\",\"response\":{\"status\":42}}",
+        "{\"type\":\"response.done\",\"response\":{\"status\":\"in_progress\"}}",
+    }) |event| {
+        var stream = TextRecordTest.init(std.testing.allocator);
+        defer stream.deinit();
+        try std.testing.expectError(error.InvalidEvent, stream.apply(event));
+        try stream.expect_emitted("");
+    }
+}
+
+test "Responses terminal failure retains progress without final-only output" {
+    var stream = TextRecordTest.init(std.testing.allocator);
+    defer stream.deinit();
+    try stream.delta(0, 0, "partial");
+    try stream.apply(ToolRecordTest.start);
+    try stream.apply("{\"type\":\"response.failed\",\"response\":{\"error\":{\"code\":\"server_error\",\"message\":\"retry\"},\"output\":[{\"type\":\"message\",\"content\":[{\"type\":\"output_text\",\"text\":\"must not publish\"}]}]}}");
+    try stream.expect_emitted("partial");
+    const completion = try stream.reducer.finish(stream.alloc, &stream.cancelled, stream.limits);
+    var owned: stream_provider.Result = .{ .completed = .{ .completion = completion, .ownership = .owned } };
+    defer owned.deinit(stream.alloc);
+    try std.testing.expectEqualStrings("partial", completion.content.?);
+    try std.testing.expectEqual(@as(usize, 1), completion.tool_calls.len);
+    try std.testing.expectEqual(types.ProviderCompletionDisposition.provider_failure, types.classifyProviderCompletion(completion));
+}
+
+test "Responses terminal failure releases allocations and obeys cancellation" {
+    const Scenario = struct {
+        fn run(alloc: std.mem.Allocator) !void {
+            var stream = ToolRecordTest.init(alloc);
+            defer stream.deinit();
+            try stream.apply(ToolRecordTest.start);
+            try stream.apply("{\"type\":\"response.failed\",\"response\":{\"id\":\"resp_failure\",\"error\":{\"code\":\"server_error\",\"message\":\"retry\"}}}");
+            const completion = try stream.finish();
+            defer stream.freeCompletion(completion);
+        }
+    };
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, Scenario.run, .{});
+    var stream = ToolRecordTest.init(std.testing.allocator);
+    defer stream.deinit();
+    stream.cancelled.store(true, .seq_cst);
+    try std.testing.expectError(error.Cancelled, stream.apply("{\"type\":\"error\",\"code\":\"server_error\"}"));
+    try std.testing.expectError(error.Cancelled, stream.finish());
 }
 
 const TextRecordTest = struct {
@@ -1992,14 +2127,36 @@ fn findTool(tools: []const ToolAccumulator, output_index: i64) ?usize {
     return null;
 }
 
+const TerminalStatus = enum { completed, incomplete, failed, cancelled };
+
+fn terminal_status(event_type: []const u8, response: std.json.ObjectMap) error{InvalidEvent}!TerminalStatus {
+    const expected: ?TerminalStatus = if (std.mem.eql(u8, event_type, "response.completed"))
+        .completed
+    else if (std.mem.eql(u8, event_type, "response.incomplete"))
+        .incomplete
+    else if (std.mem.eql(u8, event_type, "response.failed"))
+        .failed
+    else
+        null;
+    if (response.get("status")) |value| {
+        if (value != .string) return error.InvalidEvent;
+        const status = std.meta.stringToEnum(TerminalStatus, value.string) orelse return error.InvalidEvent;
+        if (expected) |kind| if (status != kind) return error.InvalidEvent;
+        return status;
+    }
+    if (expected) |kind| return kind;
+    if (response.get("error")) |value| if (value != .null) return .failed;
+    if (response.get("incomplete_details")) |value| if (value != .null) return .incomplete;
+    return .completed;
+}
+
 fn finishReason(
-    status: ?[]const u8,
+    status: TerminalStatus,
     response: std.json.ObjectMap,
     has_tools: bool,
 ) types.ProviderFinishReason {
-    const value = status orelse return if (has_tools) .tool_calls else .stop;
-    if (std.mem.eql(u8, value, "completed")) return if (has_tools) .tool_calls else .stop;
-    if (std.mem.eql(u8, value, "incomplete")) {
+    if (status == .completed) return if (has_tools) .tool_calls else .stop;
+    if (status == .incomplete) {
         if (response.get("incomplete_details")) |details| if (details == .object) {
             if (stringField(details.object, "reason")) |reason| {
                 if (std.mem.eql(u8, reason, "max_output_tokens")) return .length;
@@ -2008,10 +2165,7 @@ fn finishReason(
         };
         return .provider_error;
     }
-    if (std.mem.eql(u8, value, "failed") or std.mem.eql(u8, value, "cancelled")) {
-        return .provider_error;
-    }
-    return if (has_tools) .tool_calls else .other;
+    return .provider_error;
 }
 
 fn parseUsage(response: std.json.ObjectMap) types.Usage {

--- a/src/gateway/responses_protocol.zig
+++ b/src/gateway/responses_protocol.zig
@@ -1078,8 +1078,12 @@ pub const Reducer = struct {
         const text = try std.fmt.bufPrint(&buffer, "{s}: {s}", .{ bounded_code.view(), bounded_message.view() });
         const detail = types.ModelFailureDiagnostic.init(text);
         self.provider_failure_detail = try alloc.dupe(u8, detail.view());
-        self.provider_failure_cause = if (std.mem.eql(u8, code, "server_error") or
-            std.mem.eql(u8, code, "rate_limit_exceeded")) null else .non_retryable;
+        self.provider_failure_cause = if (std.mem.eql(u8, code, "server_error"))
+            null
+        else if (std.mem.eql(u8, code, "rate_limit_exceeded"))
+            .rate_limited
+        else
+            .non_retryable;
     }
 
     fn accept_text(
@@ -1516,6 +1520,9 @@ test "Responses terminal failure classification is conservative and diagnostics 
         const completion = try stream.finish();
         defer stream.freeCompletion(completion);
         try std.testing.expectEqual(case[1], completion.provider_failure_cause == .non_retryable);
+        if (std.mem.eql(u8, case[0], "rate_limit_exceeded")) {
+            try std.testing.expectEqual(@as(?types.ProviderFailureCause, .rate_limited), completion.provider_failure_cause);
+        }
         try std.testing.expect(completion.provider_failure_detail.?.len <= types.ModelFailureDiagnostic.max_bytes);
         try std.testing.expect(std.unicode.utf8ValidateSlice(completion.provider_failure_detail.?));
         try std.testing.expect(std.mem.startsWith(u8, completion.provider_failure_detail.?, case[0]));

--- a/src/gateway/xai_grok.zig
+++ b/src/gateway/xai_grok.zig
@@ -491,7 +491,6 @@ fn mapReducerError(err: anyerror) anyerror {
         error.EventTooLarge => error.XaiGrokSseEventTooLarge,
         error.StreamTooLarge => error.XaiGrokResourceLimitExceeded,
         error.InvalidEvent => error.InvalidXaiGrokSseEvent,
-        error.ResponseFailed => error.XaiGrokResponseFailed,
         error.StreamIncomplete => error.XaiGrokStreamIncomplete,
         error.ToolCallLimitExceeded => error.XaiGrokToolCallLimitExceeded,
         error.ToolArgumentsTooLarge => error.XaiGrokToolArgumentsTooLarge,

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -4632,13 +4632,13 @@ test("native reasoning snapshots survive tools and saved resume exactly once", a
 }, 60_000);
 
 test("native terminal outcomes preserve recovery and incomplete warnings", async () => {
-  for (const provider of ["gateway", "codex", "grok"] as const) for (const mode of ["transient", "partial", "tool", "rejected", "length", "length-with-status"]) {
+  for (const provider of ["gateway", "codex", "grok"] as const) for (const mode of ["transient", "partial", "tool", "rejected", "rejected-partial", "length", "length-with-status"]) {
     const native = provider !== "gateway";
     if (!native && mode !== "transient") continue;
     const profile = mkdtempSync(join(tmpdir(), "fx-native-outcomes-"));
     const model = native ? "fixture-model" : FAKE_GATEWAY_MODEL;
     const limited = mode.startsWith("length");
-    const rejected = mode === "rejected";
+    const rejected = mode.startsWith("rejected");
     const event = (text: string) => native
       ? { type: "response.output_text.delta", output_index: 0, content_index: 0, delta: text }
       : { type: "text-delta", id: "answer", delta: text };
@@ -4647,10 +4647,11 @@ test("native terminal outcomes preserve recovery and incomplete warnings", async
       : { type: "finish", finishReason: { unified: "stop" } };
     const events: object[] = [];
     if (mode === "partial") events.push(event("DISCARDED_PREVIEW"));
+    if (mode === "rejected-partial") events.push(event("REJECTED_PARTIAL"));
     if (limited) events.push(event("LIMITED_ANSWER"));
     if (mode === "tool" || rejected) {
       writeFileSync(join(profile, "read-me.txt"), "must not be read by the failed attempt");
-      events.push({ type: "response.output_item.added", output_index: 0, item: { type: "function_call", id: "fc_failed", call_id: "failed", name: "read_file", arguments: JSON.stringify({ path: "read-me.txt" }) } });
+      events.push({ type: "response.output_item.added", output_index: 1, item: { type: "function_call", id: "fc_failed", call_id: "failed", name: "read_file", arguments: JSON.stringify({ path: "read-me.txt" }) } });
     }
     const failure = { code: rejected ? "invalid_prompt" : "server_error", message: rejected ? "OUTCOME_REJECTED" : "OUTCOME_RETRY" };
     if (limited) events.push({ type: "response.incomplete", response: { id: "resp_limited", ...(mode === "length-with-status" ? { status: "incomplete" } : {}), output: [], incomplete_details: { reason: "max_output_tokens" } } });
@@ -4687,6 +4688,24 @@ test("native terminal outcomes preserve recovery and incomplete warnings", async
       if (rejected) {
         expect(result.stderr).toContain("invalid_prompt: OUTCOME_REJECTED");
         expect(result.stderr).not.toContain("retrying");
+        if (mode === "rejected-partial") {
+          const detail = await runFx(["session", "--json", "--id", output.session_id], { cwd: profile, env });
+          expect(detail.code).toBe(0);
+          const history = JSON.parse(detail.stdout).history;
+          expect(history).toHaveLength(1);
+          expect(history[0].kind).toBe("interrupted");
+          expect(history[0].assistant).toBe("REJECTED_PARTIAL");
+          expect(history[0].execution?.tool_steps ?? []).toEqual([]);
+          expect(history[0].tool_call).toBeNull();
+          expect(history[0].completed_tool_names).toEqual([]);
+          const resumed = await runFx(["ask", "--json", "--auto", "--resume-id", output.session_id, "Continue from the saved partial answer without using tools."], { cwd: profile, env, timeoutMs: TIMEOUT });
+          expect(resumed.code, resumed.stdout + resumed.stderr).toBe(0);
+          expect(JSON.parse(resumed.stdout).output).toBe("RECOVERED_OK");
+          expect(direct!.bodies).toHaveLength(2);
+          const input = JSON.parse(direct!.bodies[1]).input;
+          expect(JSON.stringify(input)).toContain("REJECTED_PARTIAL");
+          expect(input.filter((item: { type?: string }) => item.type === "function_call")).toEqual([]);
+        }
       } else {
         expect(output.output).toBe(limited ? "LIMITED_ANSWER" : "RECOVERED_OK");
         expect(result.stderr).toContain(limited ? "response hit provider length limit" : "OUTCOME_RETRY");

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -4631,6 +4631,82 @@ test("native reasoning snapshots survive tools and saved resume exactly once", a
   }
 }, 60_000);
 
+test("native terminal outcomes preserve recovery and incomplete warnings", async () => {
+  for (const provider of ["gateway", "codex", "grok"] as const) for (const mode of ["transient", "partial", "tool", "rejected", "length", "length-with-status"]) {
+    const native = provider !== "gateway";
+    if (!native && mode !== "transient") continue;
+    const profile = mkdtempSync(join(tmpdir(), "fx-native-outcomes-"));
+    const model = native ? "fixture-model" : FAKE_GATEWAY_MODEL;
+    const limited = mode.startsWith("length");
+    const rejected = mode === "rejected";
+    const event = (text: string) => native
+      ? { type: "response.output_text.delta", output_index: 0, content_index: 0, delta: text }
+      : { type: "text-delta", id: "answer", delta: text };
+    const terminal = native
+      ? { type: "response.completed", response: { id: "resp_ok", status: "completed", output: [], usage: { input_tokens: 1, output_tokens: 1 } } }
+      : { type: "finish", finishReason: { unified: "stop" } };
+    const events: object[] = [];
+    if (mode === "partial") events.push(event("DISCARDED_PREVIEW"));
+    if (limited) events.push(event("LIMITED_ANSWER"));
+    if (mode === "tool" || rejected) {
+      writeFileSync(join(profile, "read-me.txt"), "must not be read by the failed attempt");
+      events.push({ type: "response.output_item.added", output_index: 0, item: { type: "function_call", id: "fc_failed", call_id: "failed", name: "read_file", arguments: JSON.stringify({ path: "read-me.txt" }) } });
+    }
+    const failure = { code: rejected ? "invalid_prompt" : "server_error", message: rejected ? "OUTCOME_REJECTED" : "OUTCOME_RETRY" };
+    if (limited) events.push({ type: "response.incomplete", response: { id: "resp_limited", ...(mode === "length-with-status" ? { status: "incomplete" } : {}), output: [], incomplete_details: { reason: "max_output_tokens" } } });
+    else if (native) events.push({ type: "response.failed", response: { id: "resp_failed", status: "failed", error: failure, output: [], usage: null } });
+    else events.push({ type: "error", error: failure }, { type: "finish", finishReason: { unified: "error" } });
+    const replies = [fakeGatewaySse(events), fakeGatewaySse([event("RECOVERED_OK"), terminal])];
+    const gateway = startFakeGateway(native ? [] : replies);
+    const direct = provider === "codex" ? startFakeCodexToolLoop({ model, responses: replies })
+      : provider === "grok" ? startFakeGrokToolLoop({ model, responses: replies }) : null;
+    try {
+      if (provider === "codex") writeSeededChatGptLogin(profile, direct!.accessToken);
+      else if (provider === "grok") writeSeededGrokLogin(profile, direct!.accessToken);
+      mkdirSync(join(profile, ".fx"), { recursive: true });
+      writeFileSync(join(profile, ".fx", "settings.json"), JSON.stringify({ provider, [native ? provider + "_model" : "model"]: model }));
+      const env = {
+        HOME: profile, AI_GATEWAY_API_KEY: "fixture", VERCEL_OIDC_TOKEN: undefined, FX_MODEL: native ? undefined : model,
+        FX_DISABLE_KEYCHAIN: "1", FX_AUTO_UPGRADE: "0", FX_SOUND: "0",
+        FX_GATEWAY_BASE_URL: gateway.baseUrl, FX_E2E_GATEWAY_MODELS_URL: gateway.baseUrl + "/coding-agent/v1/models",
+        FX_GATEWAY_CHAT_URL: gateway.chatUrl, FX_E2E_GATEWAY_CHAT_URL: gateway.chatUrl,
+        FX_E2E_OPENAI_CODEX_RESPONSES_URL: direct?.responsesUrl, FX_E2E_OPENAI_CODEX_MODELS_URL: direct?.modelsUrl,
+        FX_E2E_XAI_GROK_RESPONSES_URL: direct?.responsesUrl, FX_E2E_XAI_GROK_MODELS_URL: direct?.modelsUrl,
+        FX_E2E_XAI_GROK_MODALITIES_URL: direct && "modalitiesUrl" in direct ? direct.modalitiesUrl : undefined,
+      };
+      const result = await runFx(["ask", "--json", "--auto", "Report the supplied answer without using tools."], { cwd: profile, env, timeoutMs: TIMEOUT });
+      expect(result.signal).toBeNull();
+      expect(result.code, result.stdout + result.stderr).toBe(rejected ? 1 : 0);
+      expect(direct ? direct.bodies.length : gateway.requests.length).toBe(rejected || limited ? 1 : 2);
+      const output = JSON.parse(result.stdout);
+      expect(output.tool_calls).toEqual([]);
+      if (native && !limited) {
+        const usage = JSON.parse(readFileSync(join(profile, ".fx", "sessions", output.session_id, "usage-v2.json"), "utf8"));
+        expect(usage.snapshot.billing).toBe("incomplete");
+      }
+      if (rejected) {
+        expect(result.stderr).toContain("invalid_prompt: OUTCOME_REJECTED");
+        expect(result.stderr).not.toContain("retrying");
+      } else {
+        expect(output.output).toBe(limited ? "LIMITED_ANSWER" : "RECOVERED_OK");
+        expect(result.stderr).toContain(limited ? "response hit provider length limit" : "OUTCOME_RETRY");
+        const detail = await runFx(["session", "--json", "--id", output.session_id], { cwd: profile, env });
+        expect(detail.code).toBe(0);
+        const history = JSON.parse(detail.stdout).history;
+        expect(history).toHaveLength(1);
+        expect(history[0].assistant).toBe(limited ? "LIMITED_ANSWER" : "RECOVERED_OK");
+        expect(history[0].execution.tool_steps).toEqual([]);
+        if (mode === "partial") expect(direct!.bodies[1]).not.toContain("DISCARDED_PREVIEW");
+      }
+      if (native) expect(gateway.requests).toHaveLength(0);
+    } finally {
+      direct?.stop();
+      gateway.stop();
+      rmSync(profile, { recursive: true, force: true });
+    }
+  }
+}, 60_000);
+
 test("provider SSE framing preserves saved and resumed answers", async () => {
   const prefix = "CONTROL_PREFIX\n", answer = "EXPECTED_FINAL";
   for (const provider of ["gateway", "codex", "grok"] as const) for (const mode of ["no-space", "multiline", "invalid"]) {


### PR DESCRIPTION
## Summary

- Retry transient failures delivered inside native provider streams.
- Preserve Fast mode when retrying native rate-limit errors.
- Keep rejected-request details visible without retrying the request.
- Keep partial answers available on resume after a native request is rejected.
- Preserve output-limit warnings when incomplete responses omit status.
- Reject conflicting terminal statuses before accepting final output.
