### PR TITLE
Preserve scoped package arguments in MCP commands

### DIFF
--- a/src/core/input/picker_state.zig
+++ b/src/core/input/picker_state.zig
@@ -221,6 +221,8 @@ pub const State = struct {
     fn rawFilePickerQuery(self: *const State, editor: *const editor_state.State) ?FilePickerQuery {
         if (self.rawModelPickerQuery(editor) != null) return null;
         if (self.rawProviderPickerQuery(editor) != null) return null;
+        const command_text = std.mem.trimStart(u8, editor.input.items, " \t\r\n");
+        if (tokenMatchesAt(command_text, 0, "/mcp")) return null;
         return findFilePickerQuery(editor.input.items, editor.cursor);
     }
 
@@ -722,6 +724,60 @@ test "model picker query takes precedence over file syntax" {
     try editor.setText(alloc, "/model @provider");
     try std.testing.expect(state.activeModelPickerQuery(&editor) != null);
     try std.testing.expectEqual(@as(?FilePickerQuery, null), state.activeFilePickerQuery(&editor));
+}
+
+test "MCP arguments stay literal while ordinary file queries remain eligible" {
+    const alloc = std.testing.allocator;
+    var editor: editor_state.State = .{};
+    defer editor.deinit(alloc);
+    var state: State = .{};
+    defer state.deinit(alloc);
+
+    const literal_inputs = [_][]const u8{
+        "/mcp add memory npx -y @modelcontextprotocol/server-memory@2026.8.31",
+        " \t/mcp\tadd memory npx @scope/package",
+        "\n/mcp add memory npx @scope/package",
+    };
+    for (literal_inputs) |input| {
+        try editor.setText(alloc, input);
+        try std.testing.expect(state.activeFilePickerQuery(&editor) == null);
+        try std.testing.expect(state.inlinePickerTriggerKind(&editor) != .file);
+        _ = editor.setCursor(input.len - 1);
+        try std.testing.expect(state.activeFilePickerQuery(&editor) == null);
+    }
+
+    const file_inputs = [_][]const u8{
+        "read @src/main.zig",
+        "/mcpx @src/main.zig",
+        "explain /mcp @src/main.zig",
+        "/review @src/main.zig",
+    };
+    for (file_inputs) |input| {
+        try editor.setText(alloc, input);
+        try std.testing.expectEqualStrings("src/main.zig", state.activeFilePickerQuery(&editor).?.query);
+        try std.testing.expectEqual(InlinePickerKind.file, state.inlinePickerTriggerKind(&editor).?);
+    }
+}
+
+test "MCP argument edits and history do not retain file picker ownership" {
+    const alloc = std.testing.allocator;
+    var editor: editor_state.State = .{};
+    defer editor.deinit(alloc);
+    var state: State = .{};
+    defer state.deinit(alloc);
+
+    try editor.setText(alloc, "read @scope/package");
+    state.dismissInlinePicker(.file);
+    try editor.setText(alloc, "/mcp add memory npx @scope/package");
+    state.reconcileInlinePickerAfterEdit(&editor);
+    try std.testing.expect(!state.isInlinePickerSuppressed(.file));
+    state.resetInlinePickerForHistoryRecall(&editor);
+    try std.testing.expect(state.activeFilePickerQuery(&editor) == null);
+    try std.testing.expect(state.inlinePickerTriggerKind(&editor) != .file);
+
+    try editor.setText(alloc, "read @scope/package");
+    state.reconcileInlinePickerAfterEdit(&editor);
+    try std.testing.expectEqualStrings("scope/package", state.activeFilePickerQuery(&editor).?.query);
 }
 
 test "picker dismissal lasts for one trigger episode" {

--- a/tests/e2e/mcp-stdio.test.ts
+++ b/tests/e2e/mcp-stdio.test.ts
@@ -816,6 +816,57 @@ exec "$FX_MCP_FIXTURE_RUNTIME" "$FX_MCP_FIXTURE_PATH"
     await expectFixtureProcessesExited(readWire(root.wireLogPath));
   }, 25_000);
 
+  for (const matchingPath of [false, true]) {
+    test.skipIf(process.platform === "win32" || !tmuxAvailable())(
+      `MCP slash add preserves scoped arguments with ${matchingPath ? "a matching" : "no matching"} local path`,
+      async () => {
+        const root = createRoot(`scoped-add-${matchingPath}`, LEGACY_FIXTURE);
+        const configPath = join(root.home, ".fx", "mcp.json");
+        writeFileSync(configPath, JSON.stringify({ mcp: {} }));
+        const packageArg = "@modelcontextprotocol/server-memory@2026.8.31";
+        if (matchingPath) {
+          const directory = join(root.workspace, "modelcontextprotocol");
+          mkdirSync(directory);
+          writeFileSync(join(directory, "server-memory@2026.8.31-extra"), "local file");
+        }
+        gateway = startFakeGateway([], {
+          models: [{ id: MODEL, type: "language", tags: ["tool-use"] }],
+        });
+        tui = await TmuxSession.create({
+          isolated: true,
+          remainOnExit: true,
+          cwd: root.workspace,
+          width: 180,
+          height: 36,
+          env: {
+            ...fixtureEnv(root, gateway),
+            FX_MCP_PROTOCOL_VERSION: "2025-11-25",
+            FX_MCP_LEGACY_VERSION: "2025-11-25",
+            FX_MCP_WIRE_LOG: root.wireLogPath,
+            FX_MCP_PID_PATH: join(root.root, "literal.pid"),
+          },
+        });
+        await tui.waitForComposer(15_000);
+        await tui.sendLiteral(`/mcp add literal ${process.execPath} ${LEGACY_FIXTURE} ${packageArg}`);
+        if (matchingPath) await tui.sendKeys("Tab");
+        await tui.sendKeys("Enter");
+        await tui.waitForText("Saved MCP server 'literal'", 5_000);
+        expect(JSON.parse(readFileSync(configPath, "utf8")).mcp.literal.command)
+          .toEqual([process.execPath, LEGACY_FIXTURE, packageArg]);
+        expect(await tui.captureFullScrollback()).not.toContain("no matching files");
+        await tui.sendText("/mcp");
+        await tui.waitForPane((pane) => /^\s*literal\s+Ready\b/m.test(pane), 10_000);
+        expect(gateway.requests).toHaveLength(0);
+        await tui.sendKeys("Escape");
+        await tui.waitForPane((pane) => !/^MCP \d+\s/m.test(pane), 5_000);
+        await tui.sendText("/exit");
+        await waitForTtyAskExit(tui, 0);
+        await expectFixtureProcessesExited(readWire(root.wireLogPath));
+      },
+      30_000,
+    );
+  }
+
   test("headless project MCP traces encode hostile server names on recovery", async () => {
     const root = createRoot("workspace-trace-name", MODERN_FIXTURE, {
       mode: "crash_always",


### PR DESCRIPTION
## Summary

- Submit `/mcp` commands containing scoped npm packages on the first Enter.
- Keep Tab from replacing MCP arguments with matching local filenames.
