### PR TITLE
Show requested skill load status

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ Skills are advertised in a stable catalog sized to the selected model's context 
 
 Explicit `$skill-name` mentions load the selected instructions before the model starts work. The `skill` tool accepts an advertised `location` and an optional relative `resource`, returning the complete document or a visible failure. Omitting `resource` or passing an empty string reads `SKILL.md`. File and tool-result limits still apply, and an explicit `skill_chunk_bytes` limit blocks a complete read that would exceed it. Existing named, offset-based calls remain supported.
 
+In the interactive shell, explicitly requested skills show a named load summary before the assistant replies. These automatic loads are not counted as tool calls; a loaded status confirms prepared instructions, not that the model followed them.
+
 ## Documentation
 
 Read the [fx documentation](https://fx.sh/docs).

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -4271,6 +4271,9 @@ fn processQueuedPromptInner(
         };
         if (explicit_section.?.notice) |notice| try deps.pushContextNotice(notice);
         if (explicit_section.?.diagnostic_notice) |notice| try deps.pushContextNotice(notice);
+        if (deps.push_interactive_notice) |push_notice| {
+            if (explicit_section.?.load_notice) |notice| try push_notice(deps.ctx, notice);
+        }
     }
     try appendStablePromptContext(arena, deps, config, if (skill_section) |section| section.text else null, &stable_prefix);
     const active_history = job.history;

--- a/src/core/agent/runtime/tests/gateway_flow.zig
+++ b/src/core/agent/runtime/tests/gateway_flow.zig
@@ -4316,6 +4316,67 @@ test "processQueuedPrompt prepares skill metadata from the supplied inventory" {
     try expectGatewayPromptTextCount(&gateway, 0, "- release: Release the package", 1);
 }
 
+test "explicit skill loads publish one interactive summary without extra tool calls" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(std.testing.io, "requested-workflow");
+    var file = try tmp.dir.createFile(std.testing.io, "requested-workflow/SKILL.md", .{});
+    defer file.close(std.testing.io);
+    try file.writeStreamingAll(std.testing.io, "---\nname: requested-workflow\ndescription: Requested workflow\n---\nREQUESTED_SKILL_CONTENT\n");
+    const path = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "requested-workflow");
+    defer alloc.free(path);
+    const skills = [_]@import("../../../skills/skill_runtime.zig").Skill{.{
+        .name = "requested-workflow",
+        .description = "Requested workflow",
+        .path = path,
+        .source = .workspace_shared,
+    }};
+    const read_call = [_]ToolCall{toolCall("status_read", "read_file", "{\"path\":\"file.txt\"}")};
+    var gateway = FakeGateway.init(alloc, &.{
+        .{ .content = "Finished", .chunks = &.{"Finished"} },
+        .{ .content = "Finished" },
+        .{ .tool_calls = &read_call },
+        .{ .content = "Finished after read" },
+    });
+    defer gateway.deinit();
+    var hooks = FakeAgentRuntimeDeps.init(alloc);
+    defer hooks.deinit();
+    hooks.enable_interactive_notices = true;
+    var fixture = PromptFixture{};
+    var config = fixture.config();
+    config.skill_catalog = .{ .skills = &skills };
+    var job = fixture.job();
+    job.prompt = @constCast("Use $requested-workflow.");
+    try runFakePrompt(&gateway, &hooks, config, job);
+    try std.testing.expectEqual(@as(usize, 1), hooks.interactive_notices.items.len);
+    try std.testing.expectEqualStrings("1 requested skill loaded\n└ Loaded skill requested-workflow", hooks.interactive_notices.items[0].body);
+    try std.testing.expectEqual(@as(usize, 1), gateway.request_bodies.items.len);
+    try expectBodyContains(&gateway, 0, "REQUESTED_SKILL_CONTENT");
+    try expectBodyNotContains(&gateway, 0, "1 requested skill loaded");
+    try std.testing.expectEqual(@as(usize, 0), hooks.executed_names.items.len);
+    const notice_index = logIndex(&hooks, "interactive_notice::1 requested skill loaded\n└ Loaded skill requested-workflow") orelse return error.TestExpectedEqual;
+    const reply_index = reply: {
+        for (hooks.log.items, 0..) |entry, index| {
+            if (std.mem.startsWith(u8, entry, "text:") and std.mem.find(u8, entry, "Finished") != null) break :reply index;
+        }
+        return error.TestExpectedReply;
+    };
+    try std.testing.expect(notice_index < reply_index);
+
+    hooks.enable_interactive_notices = false;
+    try runFakePrompt(&gateway, &hooks, config, job);
+    try std.testing.expectEqual(@as(usize, 1), hooks.interactive_notices.items.len);
+    try std.testing.expectEqualStrings(gateway.request_bodies.items[0], gateway.request_bodies.items[1]);
+
+    hooks.enable_interactive_notices = true;
+    try runFakePrompt(&gateway, &hooks, config, job);
+    try std.testing.expectEqual(@as(usize, 2), hooks.interactive_notices.items.len);
+    try std.testing.expectEqual(@as(usize, 4), gateway.request_bodies.items.len);
+    try std.testing.expectEqual(@as(usize, 1), hooks.executed_names.items.len);
+    try std.testing.expectEqualStrings("read_file", hooks.executed_names.items[0]);
+}
+
 test "unchanged skill catalog keeps its request prefix across user turns" {
     const alloc = std.testing.allocator;
     const skills = [_]@import("../../../skills/skill_runtime.zig").Skill{.{

--- a/src/core/skills/skill_invocation.zig
+++ b/src/core/skills/skill_invocation.zig
@@ -4,6 +4,7 @@ const model_context_encoding = @import("../shared/model_context_encoding.zig");
 const skill_contract = @import("skill_contract.zig");
 const skill_runtime = @import("skill_runtime.zig");
 const text_utils = @import("../shared/text_utils.zig");
+const types = @import("../shared/types.zig");
 const tool_result_limits = @import("../tooling/tool_result_limits.zig");
 const context_limits = @import("../config/context_limits.zig");
 const test_debug_trace = if (@import("builtin").is_test)
@@ -181,16 +182,18 @@ pub const ExplicitBinding = struct {
     path: []const u8,
 };
 
-/// Owns `text` and both optional notices.
+/// Owns `text` and all optional notices.
 pub const ExplicitPromptSection = struct {
     text: []u8,
     notice: ?[]u8 = null,
     diagnostic_notice: ?[]u8 = null,
+    load_notice: ?types.SemanticNotice = null,
 
     pub fn deinit(self: *ExplicitPromptSection, alloc: Allocator) void {
         alloc.free(self.text);
         if (self.notice) |notice| alloc.free(notice);
         if (self.diagnostic_notice) |notice| alloc.free(notice);
+        if (self.load_notice) |notice| types.freeSemanticNotice(alloc, notice);
         self.* = .{ .text = &.{} };
     }
 };
@@ -217,6 +220,9 @@ pub fn buildExplicitPromptSection(
     defer notices.deinit();
     var diagnostic_notices: std.Io.Writer.Allocating = .init(alloc);
     defer diagnostic_notices.deinit();
+    var load_rows: std.Io.Writer.Allocating = .init(alloc);
+    defer load_rows.deinit();
+    var loaded: usize = 0;
 
     try out.writer.writeAll(
         "Explicitly invoked skill content for this query:\n" ++
@@ -224,33 +230,65 @@ pub fn buildExplicitPromptSection(
             "Follow each skill's complete instructions and required resources before substantive work.\n" ++
             "If a skill cannot be followed, state the blocker instead of silently substituting another workflow.\n",
     );
-    for (binding_plan) |entry| switch (entry) {
-        .bound => |binding| try appendExplicitSkill(
-            alloc,
-            &out.writer,
-            &notices.writer,
-            &diagnostic_notices,
-            catalog,
-            binding.name,
-            binding.path,
-            limits,
-            cancel_flag,
-            context_limits.emergency_ceiling_bytes -| out.written().len,
-        ),
-        .ambiguous => |name| {
-            const failure = try formatAmbiguousSkill(alloc, catalog.skills, name, 4096);
-            defer alloc.free(failure);
-            try out.writer.writeAll(failure);
-            try out.writer.writeByte('\n');
-        },
-    };
+    for (binding_plan, 0..) |entry, index| {
+        try load_rows.writer.writeAll(if (index + 1 == binding_plan.len) "\n└ " else "\n├ ");
+        switch (entry) {
+            .bound => |binding| if (try appendExplicitSkill(
+                alloc,
+                &out.writer,
+                &notices.writer,
+                &diagnostic_notices,
+                &load_rows.writer,
+                catalog,
+                binding.name,
+                binding.path,
+                limits,
+                cancel_flag,
+                context_limits.emergency_ceiling_bytes -| out.written().len,
+            )) {
+                loaded += 1;
+            },
+            .ambiguous => |name| {
+                const failure = try formatAmbiguousSkill(alloc, catalog.skills, name, 4096);
+                defer alloc.free(failure);
+                try out.writer.writeAll(failure);
+                try out.writer.writeByte('\n');
+                try appendExplicitLoadRow(alloc, &load_rows.writer, name, failure);
+            },
+        }
+    }
+
+    const failed = binding_plan.len - loaded;
+    const summary = if (failed == 0)
+        try std.fmt.allocPrint(alloc, "{d} requested skill{s} loaded{s}", .{ loaded, if (loaded == 1) "" else "s", load_rows.written() })
+    else
+        try std.fmt.allocPrint(alloc, "Requested skills · {d} loaded · {d} failed{s}", .{ loaded, failed, load_rows.written() });
+    errdefer alloc.free(summary);
 
     const text = try out.toOwnedSlice();
     errdefer alloc.free(text);
     const notice = if (notices.written().len > 0) try notices.toOwnedSlice() else null;
     errdefer if (notice) |value| alloc.free(value);
     const diagnostic_notice = if (diagnostic_notices.written().len > 0) try diagnostic_notices.toOwnedSlice() else null;
-    return .{ .text = text, .notice = notice, .diagnostic_notice = diagnostic_notice };
+    return .{
+        .text = text,
+        .notice = notice,
+        .diagnostic_notice = diagnostic_notice,
+        .load_notice = .{ .topic = "", .tone = if (failed == 0) .neutral else .warning, .body = summary },
+    };
+}
+
+fn appendExplicitLoadRow(alloc: Allocator, out: *std.Io.Writer, name: []const u8, failure: ?[]const u8) !void {
+    const row = if (failure) |detail|
+        try std.fmt.allocPrint(alloc, "Could not load {s}: {s}", .{ name, detail })
+    else
+        try std.fmt.allocPrint(alloc, "Loaded skill {s}", .{name});
+    defer alloc.free(row);
+    const redacted = try tool_result_limits.prepareRedactedOutput(alloc, row);
+    defer alloc.free(redacted);
+    const safe = try text_utils.encodeTerminalSafe(alloc, redacted, context_limits.emergency_ceiling_bytes);
+    defer alloc.free(safe.bytes);
+    try out.writeAll(safe.bytes);
 }
 
 test "explicit skill requests report ambiguous names without selecting a source" {
@@ -263,6 +301,9 @@ test "explicit skill requests report ambiguous names without selecting a source"
     defer section.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, section.text, "ambiguous") != null);
     try std.testing.expect(std.mem.find(u8, section.text, "already loaded") == null);
+    try expectContains(section.load_notice.?.body, "Requested skills · 0 loaded · 1 failed");
+    try expectContains(section.load_notice.?.body, "Could not load review:");
+    try expectNotContains(section.load_notice.?.body, "Loaded skill review");
 }
 
 test "explicit skills include complete instructions beyond the default chunk" {
@@ -280,6 +321,36 @@ test "explicit skills include complete instructions beyond the default chunk" {
     defer section.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, section.text, "BEGIN INSTRUCTIONS") != null);
     try std.testing.expect(std.mem.find(u8, section.text, "COMPLETE TAIL") != null);
+    try std.testing.expectEqualStrings("1 requested skill loaded\n└ Loaded skill workflow", section.load_notice.?.body);
+    const bindings = [_]ExplicitBinding{ .{ .name = "workflow", .path = path }, .{ .name = "workflow", .path = path } };
+    var repeated = try buildExplicitPromptSection(alloc, .{ .skills = &skills }, "$workflow $workflow", &bindings, .{}, null);
+    defer repeated.deinit(alloc);
+    try std.testing.expectEqualStrings(section.text, repeated.text);
+    try std.testing.expectEqualStrings(section.load_notice.?.body, repeated.load_notice.?.body);
+    var cancelled = std.atomic.Value(bool).init(true);
+    try std.testing.expectError(error.Cancelled, buildExplicitPromptSection(alloc, .{ .skills = &skills }, "$workflow", &.{}, .{}, &cancelled));
+}
+
+test "explicit load rows keep untrusted names and diagnostics terminal safe" {
+    const alloc = std.testing.allocator;
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    defer out.deinit();
+    try appendExplicitLoadRow(alloc, &out.writer, "workflow\n\x1b[2J", "Failed\r\nAPI_KEY=private-skill-secret");
+    try expectContains(out.written(), "Could not load workflow");
+    try std.testing.expect(text_utils.isTerminalSafe(out.written()));
+    try expectNotContains(out.written(), "\n");
+    try expectNotContains(out.written(), "\x1b");
+    try expectNotContains(out.written(), "private-skill-secret");
+}
+
+test "explicit load summary reports a missing bound skill without success" {
+    const alloc = std.testing.allocator;
+    var section = try buildExplicitPromptSection(alloc, .{ .skills = &.{} }, "Use the selected workflow", &.{.{ .name = "missing-workflow", .path = "/unavailable/workflow" }}, .{}, null);
+    defer section.deinit(alloc);
+    try expectContains(section.load_notice.?.body, "Requested skills · 0 loaded · 1 failed");
+    try expectContains(section.load_notice.?.body, "Could not load missing-workflow:");
+    try expectContains(section.load_notice.?.body, "not found at advertised location");
+    try expectNotContains(section.text, "<skill_content");
 }
 
 test "skill resource defaults preserve whole and legacy reads" {
@@ -483,13 +554,14 @@ fn appendExplicitSkill(
     out: *std.Io.Writer,
     notices: *std.Io.Writer,
     diagnostic_notices: *std.Io.Writer.Allocating,
+    load_rows: *std.Io.Writer,
     catalog: Catalog,
     name: []const u8,
     location: []const u8,
     limits: context_limits.Values,
     cancel_flag: ?*std.atomic.Value(bool),
     remaining_bytes: usize,
-) !void {
+) !bool {
     const result = try loadByIdentityWithOptions(alloc, catalog, name, location, null, 0, limits, null, .{ .mode = .whole, .cancel_flag = cancel_flag });
     defer freeExecuteResult(alloc, result);
     if (result.modelOutput().len +| 1 > remaining_bytes) return error.SkillContextTooLarge;
@@ -505,6 +577,12 @@ fn appendExplicitSkill(
             if (!std.mem.endsWith(u8, notice, "\n")) try diagnostic_notices.writer.writeByte('\n');
         }
     }
+    const failure: ?[]const u8 = switch (result) {
+        .loaded => |output| if (output.complete) null else "Complete instructions were not loaded.",
+        .failure => |output| output.model_output,
+    };
+    try appendExplicitLoadRow(alloc, load_rows, name, failure);
+    return failure == null;
 }
 
 /// Resolves and reads one skill from an already discovered catalog.
@@ -1958,10 +2036,14 @@ test "explicit invocation reports user byte ceilings without partial success" {
     try expectContains(explicit.text, "name=\"skill_chunk_bytes\" action=\"blocked\"");
     try expectNotContains(explicit.text, "TAIL MUST WAIT");
     try std.testing.expect(explicit.notice != null);
+    try expectContains(explicit.load_notice.?.body, "0 loaded · 1 failed");
+    try expectContains(explicit.load_notice.?.body, "Could not load workflow:");
+    try expectNotContains(explicit.load_notice.?.body, "Loaded skill workflow");
 
     var fuzzy = try buildExplicitPromptSection(alloc, catalog, "please improve this workflow", &.{}, limits, null);
     defer fuzzy.deinit(alloc);
     try std.testing.expectEqual(@as(usize, 0), fuzzy.text.len);
+    try std.testing.expect(fuzzy.load_notice == null);
 
     limits.skill_chunk_bytes = .{ .value = .{ .bytes = 0 }, .source = .command_line };
     var zero_chunk = try buildExplicitPromptSection(alloc, catalog, "$workflow", &.{}, limits, null);

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -743,6 +743,70 @@ describe("gateway stream lifecycle", () => {
     }
   }, 45_000);
 
+  test.skipIf(!tmuxAvailable())("requested skill status reflects prepared content without tool activity", async () => {
+    const root = createFixtureRoot("requested-skill-status");
+    for (const [directory, name, body] of [
+      ["first", "status-first", "FIRST_REQUESTED_CONTENT"],
+      ["second", "status-second", "SECOND_REQUESTED_CONTENT"],
+      ["duplicate-a", "status-duplicate", "AMBIGUOUS_CONTENT_A"],
+      ["duplicate-b", "status-duplicate", "AMBIGUOUS_CONTENT_B"],
+    ]) {
+      const path = join(root.workspace, ".agents", "skills", directory!);
+      mkdirSync(path, { recursive: true });
+      writeFileSync(join(path, "SKILL.md"), `---\nname: ${name}\ndescription: Status fixture\n---\n${body}\n`);
+    }
+    let requestCount = 0;
+    const gateway = startDynamicFakeGateway((body) => {
+      const text = promptText(body);
+      expect(text).toContain("FIRST_REQUESTED_CONTENT");
+      expect(text).not.toContain("requested skills loaded");
+      expect(text).not.toContain("AMBIGUOUS_CONTENT_A");
+      expect(text).not.toContain("AMBIGUOUS_CONTENT_B");
+      if (requestCount++ === 0) {
+        expect(text).toContain("SECOND_REQUESTED_CONTENT");
+        return fakeGatewayFinalText("STATUS_FIRST_COMPLETE");
+      }
+      expect(text).toContain('Skill "status-duplicate" is ambiguous');
+      return fakeGatewayFinalText("STATUS_MIXED_COMPLETE");
+    });
+    const stderrPath = join(root.root, "stderr.log");
+    let tui: TmuxSession | null = null;
+    try {
+      tui = await TmuxSession.create({ cwd: root.workspace, env: fixtureEnv(root, gateway, join(root.root, "trace.log")), stderrPath, width: 100, height: 36 });
+      await tui.waitForComposer(15_000);
+      await tui.sendText("Use $status-first and $status-second.");
+      await tui.waitForPane((pane) => pane.includes("STATUS_FIRST_COMPLETE") && hasEmptyComposer(pane), 15_000);
+      const first = await tui.captureFullScrollback();
+      expect(first).toContain("2 requested skills loaded");
+      expect(first).toContain("Loaded skill status-first");
+      expect(first).toContain("Loaded skill status-second");
+      expect(first.indexOf("2 requested skills loaded")).toBeLessThan(first.indexOf("STATUS_FIRST_COMPLETE"));
+      expect(first).not.toContain("tool call");
+      await tui.resizeWindow(48, 36);
+      await tui.sendText("Use $status-first and $status-duplicate.");
+      await tui.waitForPane((pane) => pane.includes("STATUS_MIXED_COMPLETE") && hasEmptyComposer(pane), 15_000);
+      const mixed = await tui.captureFullScrollback();
+      expect(mixed.replace(/\s+/g, " ")).toContain("Requested skills · 1 loaded · 1 failed");
+      expect(mixed).toContain("Could not load status-duplicate");
+      expect(mixed).toContain("ambiguous");
+      expect(mixed).not.toContain("Loaded skill status-duplicate");
+      expect(mixed).not.toContain("tool call");
+      await tui.sendKeys("C-o");
+      await tui.waitForText("Could not load status-duplicate", 5_000);
+      await tui.sendKeys("C-o");
+      await tui.waitForComposer(5_000);
+      expect(gateway.requests).toHaveLength(2);
+      await tui.sendText("/quit");
+      expect(await tui.waitForSessionEnd(10_000)).toBe(true);
+      tui = null;
+      expect(readFileSync(stderrPath, "utf8")).toBe("");
+    } finally {
+      if (tui) await tui.kill();
+      gateway.stop();
+      rmSync(root.root, { recursive: true, force: true });
+    }
+  }, 45_000);
+
   test.skipIf(!tmuxAvailable())("explicit skill context survives cancellation and a fresh turn", async () => {
     const root = createFixtureRoot("skill-cancel-recover");
     const directory = join(root.workspace, ".agents", "skills", "cancel-workflow");
@@ -774,6 +838,7 @@ describe("gateway stream lifecycle", () => {
       expect(advertisedSkillPath(gateway.requests[0]!.body, first)).toBe(directory);
       expect(advertisedSkillPath(gateway.requests[1]!.body, second)).toBe(directory);
       expect(await tui.captureFullScrollback()).toContain("SKILL_RECOVERY_COMPLETE");
+      expect((await tui.captureFullScrollback()).match(/1 requested skill loaded/g)).toHaveLength(2);
       await tui.sendText("/quit");
       expect(await tui.waitForSessionEnd(10_000)).toBe(true);
       tui = null;

--- a/tests/e2e/tui-slash-menu.test.ts
+++ b/tests/e2e/tui-slash-menu.test.ts
@@ -3615,6 +3615,14 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       expect(firstPrompt).toContain(fixture.bodyB);
       expect(firstPrompt).not.toContain(fixture.bodyA);
 
+      const loadScrollback = await session.captureFullScrollback();
+      expect(countOccurrences(loadScrollback, "1 requested skill loaded")).toBe(1);
+      expect(loadScrollback).toContain("Loaded skill exact-picker");
+      expect(loadScrollback.indexOf("1 requested skill loaded")).toBeLessThan(
+        loadScrollback.indexOf("exact picker selection complete"),
+      );
+      expect(loadScrollback).not.toContain("1 tool call");
+
       expect(
         countOccurrences(
           await session.captureFullScrollback(),


### PR DESCRIPTION
## Summary

- Show explicit skill load results before the first assistant reply.
- Name successfully loaded skills and show why requested skills could not load.
- Keep automatic loads separate from tool activity and visible in the full transcript.
