### PR TITLE
Clear the composer before cancelling active work

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ Tool calls are expanded by default. Enable `Collapse tool calls` in `/settings`,
 
 When a tool targets a directory with additional project instructions, fx shows `Reading project instructions before continuing:` before the agent decides whether to retry. This refresh does not add a failure or “command not run” count to the tool summary.
 
+While fx is working, Ctrl+C clears a nonempty composer without interrupting the turn. Press Ctrl+C again with an empty composer to cancel the active work.
+
 Ctrl+L clears the inline display while keeping the conversation available in Ctrl+O. It preserves your draft and conversation context; `/clear` starts a fresh conversation instead.
 
 The status line hides the workspace path and Git branch by default. Enable the `Status line workspace` option in `/settings`, run `/statusline workspace`, or set it in `~/.fx/settings.json`:

--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -1533,7 +1533,7 @@ pub fn Runtime(comptime App: type) type {
         }
 
         fn handleSemanticCtrlC(app: *App) !void {
-            if (interrupt_rt.hasActiveOperation(app) and draftHasState(app)) {
+            if (app.stream.active and draftHasState(app)) {
                 clearDraftState(app, "ctrl_c");
                 app.shell.render_requests.request(.footer);
                 return;

--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -1533,6 +1533,12 @@ pub fn Runtime(comptime App: type) type {
         }
 
         fn handleSemanticCtrlC(app: *App) !void {
+            if (interrupt_rt.hasActiveOperation(app) and draftHasState(app)) {
+                clearDraftState(app, "ctrl_c");
+                app.shell.render_requests.request(.footer);
+                return;
+            }
+
             const now = io_mod.milliTimestamp();
             const transition = gesture_state.pressCtrlCExit(
                 app.input_runtime.gestures,
@@ -10262,6 +10268,46 @@ test "app_input_runtime raw and Kitty Ctrl-C preserve double-press exit" {
 
         try feedRoutingBytes(&app, sequence);
         try std.testing.expect(app.should_exit);
+    }
+}
+
+test "app_input_runtime active Ctrl-C clears drafts before cancelling work" {
+    const sequences = [_][]const u8{ "\x03", "\x1b[99;5u" };
+    const drafts = [_]RoutingDraftKind{ .text, .paste, .image };
+    for (sequences) |sequence| {
+        for (drafts) |draft| {
+            for ([_]bool{ false, true }) |tool_active| {
+                const alloc = std.testing.allocator;
+                var app = try RoutingFakeApp.init(alloc);
+                defer app.deinit();
+                app.stream.active = true;
+                if (tool_active) {
+                    _ = try app.shell.applyToolLifecycle(alloc, .{ .authoritative_started = .{
+                        .id = .{ .turn_id = 1, .call_id = "command" },
+                        .reconciles_provisional_call_id = null,
+                        .tool_name = "shell",
+                        .activity_kind = .command,
+                    } });
+                }
+                try seedRoutingDraftForGuard(&app, draft);
+                app.shell.render_requests.clearReason(.footer);
+
+                try feedRoutingBytes(&app, sequence);
+
+                try std.testing.expect(!Runtime(RoutingFakeApp).draftHasState(&app));
+                try std.testing.expect(app.stream.active);
+                try std.testing.expect(!app.worker.cancel_requested);
+                try std.testing.expect(!app.input_runtime.gestures.ctrlCExitArmed());
+                try std.testing.expect(!app.should_exit);
+                try std.testing.expect(app.shell.render_requests.hasReason(.footer));
+
+                try feedRoutingBytes(&app, sequence);
+
+                try std.testing.expect(app.worker.cancel_requested);
+                try std.testing.expect(app.input_runtime.gestures.ctrlCExitArmed());
+                try std.testing.expect(!app.should_exit);
+            }
+        }
     }
 }
 

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -2832,6 +2832,10 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       expect(rowContaining(thinkingGrid, submittedPrompt)).toBe(
         rowContaining(preEnterGrid, submittedPrompt),
       );
+      expect(composerContains(thinkingGrid.join("\n"), newerDraft)).toBe(true);
+      await session.sendKeys("C-c");
+      expect(composerContains((await session.capturePaneGrid()).join("\n"), newerDraft)).toBe(false);
+      expect(hold.cancelled).toBe(false);
       await session.sendKeys("C-c");
       const cancelledPane = await session.waitForText(
         "What can fx do differently?",
@@ -2855,7 +2859,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       expect(frameCommitted).toBeGreaterThanOrEqual(0);
       expect(promptQueued).toBeGreaterThan(frameCommitted);
       expect(workerBegin).toBeGreaterThan(promptQueued);
-      expect(composerContains(cancelledPane, newerDraft)).toBe(true);
+      expect(composerContains(cancelledPane, newerDraft)).toBe(false);
 
       expect(hold.cancelled).toBe(true);
       expect(readFileSync(stderrPath, "utf8")).toBe("");

--- a/tests/e2e/tui-interrupt-recovery.test.ts
+++ b/tests/e2e/tui-interrupt-recovery.test.ts
@@ -63,6 +63,79 @@ afterEach(async () => {
 
 describe.skipIf(SKIP)("tui: interrupt recovery", () => {
   test(
+    "Ctrl-C clears the composer before cancelling an active response",
+    async () => {
+      root = realpathSync(mkdtempSync(join(tmpdir(), "fx-composer-interrupt-")));
+      const home = join(root, "home");
+      const workspace = join(root, "workspace");
+      const stderrPath = join(root, "stderr.log");
+      const tracePath = join(root, "trace.log");
+      const tapePath = join(root, "render.fxtape");
+      mkdirSync(join(home, ".fx"), { recursive: true });
+      mkdirSync(workspace, { recursive: true });
+      writeFileSync(join(home, ".fx", "settings.json"), "{}");
+
+      const held: HoldState = { started: false, cancelled: false, cancelCount: 0, released: false };
+      gateway = startFakeGateway([
+        () => heldUntilReleasedResponse(held),
+        fakeGatewayFinalText("COMPOSER_INTERRUPT_RECOVERED"),
+      ]);
+      session = await TmuxSession.create({
+        cwd: workspace,
+        stderrPath,
+        isolated: true,
+        env: {
+          HOME: home,
+          AI_GATEWAY_API_KEY: "fake-composer-interrupt-key",
+          VERCEL_OIDC_TOKEN: undefined,
+          FX_AUTO_UPGRADE: "0",
+          FX_GATEWAY_BASE_URL: gateway.baseUrl,
+          FX_GATEWAY_CHAT_URL: gateway.chatUrl,
+          FX_E2E_GATEWAY_CHAT_URL: gateway.chatUrl,
+          FX_MODEL: FAKE_GATEWAY_MODEL,
+          FX_TRACE_SCOPES: `${TRACE_SCOPES},input`,
+          FX_TRACE_LOG: tracePath,
+          FX_RECORD: tapePath,
+        },
+      });
+      await session.waitForComposer(TIMEOUT);
+      await session.sendText("Hold this response.");
+      await waitForCondition(() => held.started, "response start");
+      await session.sendLiteral("DISCARD_THIS_DRAFT");
+      await session.waitForText("DISCARD_THIS_DRAFT", TIMEOUT);
+
+      await session.sendKeys("C-c");
+      const cleared = (await session.capturePaneGrid()).join("\n");
+      expect(cleared).not.toContain("DISCARD_THIS_DRAFT");
+      expect(cleared).not.toContain("What can fx do differently?");
+      expect(held.cancelCount).toBe(0);
+      expect(readTrace(tracePath)).toContain("draft cleared reason=ctrl_c");
+      expect(readTrace(tracePath)).not.toContain("event=cancel_requested");
+      expect(session.isPaneAlive()).toBe(true);
+
+      await session.sendKeys("C-c");
+      await waitForCondition(() => held.cancelled, "second Control-C cancellation");
+      await session.waitForText("What can fx do differently?", TIMEOUT);
+      expect(held.cancelCount).toBe(1);
+      expect(session.isPaneAlive()).toBe(true);
+
+      await session.sendText("Continue after cancellation.");
+      await session.waitForText("COMPOSER_INTERRUPT_RECOVERED", TIMEOUT);
+      const scrollback = await session.captureFullScrollback();
+      expect(countOccurrences(scrollback, "What can fx do differently?")).toBe(1);
+      expect(scrollback).not.toContain("DISCARD_THIS_DRAFT");
+      expect(gateway.requests).toHaveLength(2);
+      expect(gateway.requests[1]!.body).not.toContain("DISCARD_THIS_DRAFT");
+      expect(gateway.requests[1]!.body).toContain("<turn_aborted>");
+      expect(readFileSync(stderrPath, "utf8")).toBe("");
+      const replay = Bun.spawnSync([join(import.meta.dir, "../../zig-out/bin/fx"), "replay", tapePath]);
+      expect(replay.exitCode).toBe(0);
+      expect(replay.stdout.toString()).toContain("COMPOSER_INTERRUPT_RECOVERED");
+    },
+    TIMEOUT * 2,
+  );
+
+  test(
     "immediate prompt after cancellation keeps thinking visible and remains cancellable",
     async () => {
       root = realpathSync(mkdtempSync(join(tmpdir(), "fx-cancel-next-prompt-")));


### PR DESCRIPTION
## Summary

- Clear composer text, pasted blocks, and image attachments on Ctrl+C while work is active without cancelling the turn or arming exit.
- Cancel active work on the next Ctrl+C with an empty composer, keeping fx open.