### PR TITLE
Preserve assistant paragraph indentation when wrapping

### DIFF
--- a/src/ui/render_engine/assistant_wrap.zig
+++ b/src/ui/render_engine/assistant_wrap.zig
@@ -812,8 +812,39 @@ fn assistantContinuation(text: []const u8, line_start: usize) ?AssistantContinua
         depth += 1;
         i = end;
     }
-    if (depth == 0) return null;
-    return .{ .blockquote = .{ .indent = indent, .depth = depth } };
+    if (depth > 0) return .{ .blockquote = .{ .indent = indent, .depth = depth } };
+    return if (proseIndent(text, line_start)) |width| .{ .list_indent = width } else null;
+}
+
+fn proseIndent(text: []const u8, line_start: usize) ?usize {
+    var i = line_start;
+    var width: usize = 0;
+    var line_end: ?usize = null;
+    while (i < text.len) {
+        switch (text[i]) {
+            ' ' => {
+                width += 1;
+                i += 1;
+            },
+            0x1b => {
+                // Bound control parsing to this logical line, including incomplete tails.
+                if (line_end == null) {
+                    var end = i;
+                    while (end < text.len and text[end] != '\r' and text[end] != '\n') : (end += 1) {}
+                    line_end = end;
+                }
+                const sequence_end = display_width.ansiSequenceEnd(text[0..line_end.?], i);
+                const seq = text[i..sequence_end];
+                if (seq.len < 3) return null;
+                const sgr = std.mem.startsWith(u8, seq, "\x1b[") and seq[seq.len - 1] == 'm';
+                if (!sgr and osc8Update(seq) == null) return null;
+                i = sequence_end;
+            },
+            0...8, 9...13, 14...26, 28...31, 127 => return null,
+            else => return if (width > 0) width else null,
+        }
+    }
+    return null;
 }
 
 fn definitionPrefixEnd(text: []const u8, start: usize) ?usize {
@@ -1017,6 +1048,56 @@ fn skipPacerDimReassertions(text: []const u8, start: usize) usize {
     var i = start;
     while (std.mem.startsWith(u8, text[i..], reassert)) : (i += reassert.len) {}
     return i;
+}
+
+test "wrapAssistantText preserves explicit paragraph indentation" {
+    const alloc = std.testing.allocator;
+    const out = try wrapAssistantText(alloc, "1. Heading\n   alpha beta gamma delta\n\n  alpha beta gamma delta\nalpha beta gamma delta", 16);
+    defer alloc.free(out);
+    try std.testing.expectEqualStrings(
+        "1. Heading\n   alpha beta\n   gamma delta\n\n  alpha beta\n  gamma delta\nalpha beta\ngamma delta",
+        out,
+    );
+}
+
+test "wrapAssistantText preserves paced paragraph indentation and links" {
+    const alloc = std.testing.allocator;
+    const prefix = "\x1b[1m \x1b[0m\x1b[1m  ";
+    const link = "\x1b]8;;https://example.com\x1b\\";
+    const close = "\x1b]8;;\x1b\\";
+    const out = try wrapAssistantText(alloc, prefix ++ link ++ "alpha beta gamma delta" ++ close ++ "\x1b[0m", 16);
+    defer alloc.free(out);
+    try std.testing.expectEqualStrings(prefix ++ link ++ "alpha beta\x1b[0m" ++ close ++ "\n   \x1b[1m" ++ link ++ "gamma delta" ++ close ++ "\x1b[0m", out);
+}
+
+test "paragraph indentation ignores blank incomplete and non-prose prefixes" {
+    for ([_][]const u8{ "   ", "   \nnext", "   \rnext", "  \ttext", "  \x1b[", "  \x1b[\ntext", "  \x1b]8;;unfinished", "  \x1b[Atext" }) |text| {
+        try std.testing.expectEqual(@as(?usize, null), proseIndent(text, 0));
+    }
+    try std.testing.expectEqual(@as(?usize, 3), proseIndent("\x1b[2m \x1b[0m  text", 0));
+    try std.testing.expectEqual(@as(?usize, 2), proseIndent(" \x1b]8;;https://example.com\x07 text", 0));
+}
+
+test "wrapAssistantText explicit indentation respects narrow widths and wide units" {
+    const alloc = std.testing.allocator;
+    const out = try wrapAssistantText(alloc, "   abcdef", 3);
+    defer alloc.free(out);
+    try std.testing.expectEqualStrings("   \nabc\ndef", out);
+    const wide = try wrapAssistantText(alloc, "  界界界", 4);
+    defer alloc.free(wide);
+    try std.testing.expectEqualStrings("  界\n  界\n  界", wide);
+}
+
+test "paragraph indentation preserves finalized source boundaries" {
+    const alloc = std.testing.allocator;
+    const text = "   alpha beta gamma delta\n  unfinished";
+    const partial = try wrapTranscriptAssistantTextWithFinalityInterruptible(alloc, text, 18, null);
+    defer alloc.free(partial.bytes);
+    const finished = try wrapTranscriptAssistantTextWithFinalityInterruptible(alloc, text ++ "\n", 18, null);
+    defer alloc.free(finished.bytes);
+    try std.testing.expectEqualStrings("     alpha beta\n     gamma delta\n", partial.bytes[0..partial.finalized_prefix_bytes]);
+    try std.testing.expectEqualStrings(partial.bytes, finished.bytes[0 .. finished.bytes.len - 1]);
+    try std.testing.expectEqual(finished.bytes.len, finished.finalized_prefix_bytes);
 }
 
 test "wrapAssistantText wraps plain ascii at cols" {

--- a/src/ui/render_engine/transcript_blocks.zig
+++ b/src/ui/render_engine/transcript_blocks.zig
@@ -4031,6 +4031,23 @@ test "renderEntriesToBytes reflows parser-rendered lists at paint-time cols" {
     }
 }
 
+test "renderEntriesToBytes preserves parser-rendered list paragraph indentation" {
+    const alloc = std.testing.allocator;
+    var processor = assistant_presentation.MarkdownProcessor{};
+    defer processor.deinit(alloc);
+    var source: std.ArrayList(u8) = .empty;
+    defer source.deinit(alloc);
+    try processor.push(alloc, "1. Heading\n   alpha beta gamma delta\n\n- Heading\n  alpha beta gamma delta\n", &source);
+    try processor.flush(alloc, &source);
+    var entries: std.ArrayList(TranscriptEntry) = .empty;
+    defer deinitTestEntries(&entries, alloc);
+    try appendAssistantTestEntry(&entries, alloc, 1, source.items);
+    const narrow = try renderEntriesToBytes(alloc, entries.items, 18, .{});
+    defer alloc.free(narrow);
+    try std.testing.expect(std.mem.find(u8, narrow, "     alpha beta\n     gamma delta") != null);
+    try std.testing.expect(std.mem.find(u8, narrow, "    alpha beta\n    gamma delta") != null);
+}
+
 test "renderEntriesToBytes reflows parser-rendered task lists at paint-time cols" {
     const alloc = std.testing.allocator;
     var processor = assistant_presentation.MarkdownProcessor{};

--- a/tests/e2e/tui-resize.test.ts
+++ b/tests/e2e/tui-resize.test.ts
@@ -2107,6 +2107,168 @@ describe.skipIf(SKIP)("tui: resize", () => {
   );
 
   test(
+    "list paragraph indentation survives streaming and resize from 167 to 72 columns",
+    async () => {
+      const root = realpathSync(
+        mkdtempSync(join(tmpdir(), "fx-resize-list-paragraph-")),
+      );
+      const home = join(root, "home");
+      const workspace = join(root, "workspace");
+      const stderrPath = join(root, "stderr.log");
+      const tracePath = join(root, "trace.log");
+      const tapePath = join(root, "session.fxtape");
+      tempDirs.push(root);
+      mkdirSync(join(home, ".fx"), { recursive: true });
+      mkdirSync(workspace, { recursive: true });
+      writeFileSync(stderrPath, "");
+
+      const paragraph =
+        "I recommend checking the dev channel every 60 seconds rather than the current 30 minutes. Leave stable-channel behavior unchanged. This detects published releases periodically, not instantly on a main merge.";
+      const source = [
+        "Recommended fix",
+        "",
+        "1. Continue polling while ready.",
+        `   ${paragraph}`,
+        "",
+        `2. ${paragraph}`,
+        "",
+        "- Bullet heading.",
+        `  ${paragraph}`,
+        "",
+        `- ${paragraph}`,
+        "",
+        "WRAP_REPRO_END",
+        "",
+      ].join("\n");
+      // Split both paragraph prefixes across deltas, including a spaces-only delta.
+      const chunks = [
+        "Recommended fix\n\n1. Continue polling while ready.\n ",
+        "  ",
+        paragraph.slice(0, 83),
+        `${paragraph.slice(83)}\n\n2. ${paragraph}\n\n- Bullet heading.\n `,
+        ` ${paragraph.slice(0, 83)}`,
+        `${paragraph.slice(83)}\n\n- ${paragraph}\n\nWRAP_REPRO_END\n`,
+      ];
+      expect(chunks.join("")).toBe(source);
+      const gateway = startFakeGateway([
+        fakeGatewaySse([
+          { type: "text-start", id: "list-paragraph" },
+          ...chunks.map((delta) => ({ type: "text-delta", id: "list-paragraph", delta })),
+          { type: "text-end", id: "list-paragraph" },
+          {
+            type: "finish",
+            finishReason: { unified: "stop", raw: "stop" },
+            usage: { inputTokens: { total: 1 }, outputTokens: { total: 200 } },
+          },
+        ]),
+      ]);
+      gateways.push(gateway);
+      session = await createResizeSession({
+        cmd: FX_BIN,
+        cwd: workspace,
+        env: {
+          HOME: home,
+          AI_GATEWAY_API_KEY: "fake-list-paragraph-key",
+          VERCEL_OIDC_TOKEN: undefined,
+          FX_GATEWAY_BASE_URL: gateway.baseUrl,
+          FX_GATEWAY_CHAT_URL: gateway.chatUrl,
+          FX_E2E_GATEWAY_CHAT_URL: gateway.chatUrl,
+          FX_MODEL: FAKE_GATEWAY_MODEL,
+          FX_AUTO_UPGRADE: "0",
+          FX_SOUND: "0",
+          FX_RECORD: tapePath,
+          FX_TRACE_LOG: tracePath,
+          FX_TRACE_SCOPES: "resize,frame_schedule,scroll",
+          NO_COLOR: "1",
+        },
+        width: 167,
+        height: 40,
+        stderrPath,
+        isolated: true,
+        remainOnExit: true,
+        minimumHistoryLines: MINIMUM_RESIZE_HISTORY_LINES,
+      });
+      const active = session;
+      await active.waitForComposer(10_000);
+      await active.sendText("render the list wrapping fixture");
+
+      const expectListParagraphs = async (cols: number) => {
+        await active.waitForStableScrollback((text) => text.includes("WRAP_REPRO_END"));
+        await active.waitForStableComposer();
+        const scrollback = (await active.captureFullScrollbackEscapes())
+          .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, "");
+        const lines = scrollback.split("\n");
+        const markers = [
+          "Recommended fix",
+          "1. Continue polling while ready.",
+          "2. I recommend checking",
+          "• Bullet heading.",
+          "• I recommend checking",
+          "WRAP_REPRO_END",
+        ];
+        const rows = semanticMarkerRows(scrollback, markers);
+        for (let index = 1; index < rows.length; index++) {
+          expect(rows[index]!).toBeGreaterThan(rows[index - 1]!);
+        }
+        const normalize = (text: string) => text.trim().replace(/\s+/g, " ");
+        expect(normalize(lines.slice(rows[0], rows[5]! + 1).join("\n")))
+          .toBe(normalize(source.replace(/^- /gm, "• ")));
+        expect(countOccurrences(scrollback, "I recommend checking")).toBe(4);
+
+        for (const [start, end, indent, marker] of [
+          [rows[1]! + 1, rows[2]!, 5, ""],
+          [rows[2]!, rows[3]!, 5, "2. "],
+          [rows[3]! + 1, rows[4]!, 4, ""],
+          [rows[4]!, rows[5]!, 4, "• "],
+        ] as const) {
+          const paragraphRows = lines.slice(start, end).filter((line) => line.trim() !== "");
+          expect(paragraphRows.length).toBeGreaterThan(1);
+          for (const [index, line] of paragraphRows.entries()) {
+            const expectedIndent = index === 0 && marker ? 2 : indent;
+            expect(line.length - line.trimStart().length).toBe(expectedIndent);
+            expect(line.length).toBeLessThanOrEqual(cols);
+          }
+          const text = paragraphRows.map((line) => line.trim());
+          expect(text[0]!.startsWith(marker)).toBe(true);
+          text[0] = text[0]!.slice(marker.length);
+          expect(text.join(" ")).toBe(paragraph);
+        }
+        const grid = await active.capturePaneGrid();
+        expect(grid.filter((line) => line.trim() === "┃")).toHaveLength(1);
+        expect(findFooter(grid)).not.toBeNull();
+        expect(active.paneStatus()).toEqual({ dead: false, status: null });
+        expectEmptyStderr(stderrPath);
+      };
+
+      await expectListParagraphs(167);
+      await active.resizeWindow(72, 40, 500);
+      await waitForTraceCount(tracePath, "settled_reset_committed", 1);
+      await expectListParagraphs(72);
+      await active.sendLiteralText("composer remains usable");
+      await active.waitForText("┃ composer remains usable");
+      await active.sendKeys("C-u");
+      await active.waitForStableComposer();
+      expect(gateway.requests).toHaveLength(1);
+      await active.sendText("/quit");
+      const exitDeadline = Date.now() + TIMEOUT;
+      while (!active.paneStatus().dead && Date.now() < exitDeadline) {
+        await Bun.sleep(25);
+      }
+      expect(active.paneStatus()).toEqual({ dead: true, status: 0 });
+      expectEmptyStderr(stderrPath);
+
+      const replay = Bun.spawnSync([FX_BIN, "replay", tapePath, "--json"], {
+        cwd: workspace,
+        env: { ...process.env, HOME: home, FX_SOUND: "0", FX_AUTO_UPGRADE: "0" },
+      });
+      expect(replay.exitCode).toBe(0);
+      expect(replay.stderr.toString()).toBe("");
+      expect(JSON.parse(replay.stdout.toString()).resize_count).toBe(1);
+    },
+    60_000,
+  );
+
+  test(
     "nested Markdown blockquote reflows across a live tmux shrink and grow",
     async () => {
       const root = realpathSync(


### PR DESCRIPTION
## Summary

- Keep indented assistant paragraphs aligned when they wrap, including paragraphs beneath numbered and bullet items and after terminal resizing.