### PR TITLE
Use Bun 1.4.2 for SDK WebAssembly checks

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.14"
+          bun-version: "1.4.2"
 
       - name: Build libfx artifacts
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.14"
+          bun-version: "1.4.2"
 
       - name: Build SDK artifacts
         run: |

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -213,6 +213,9 @@ processes maintain their own module caches.
 
 Node.js 20+ is supported. Browser WebAssembly requires a JSPI-capable browser.
 Some Node versions require `--experimental-wasm-jspi`.
+Bun 1.4.2 is the tested recommendation for Bun's WebAssembly backend.
+Bun 1.3.14 can crash when a hot WebAssembly loop resumes through JSPI during
+JIT tier-up.
 
 ## Interactive terminal
 

--- a/sdk/tests/test-node-wasm.mjs
+++ b/sdk/tests/test-node-wasm.mjs
@@ -14,6 +14,7 @@ const termScripts = [
   "test-term-workspace.mjs",
 ];
 const commands = [
+  [process.execPath, ["--experimental-wasm-jspi", fileURLToPath(new URL("test-wasm-jspi-tier-up.mjs", import.meta.url))]],
   [process.execPath, [fileURLToPath(new URL("test-core-output.mjs", import.meta.url))]],
   [process.execPath, ["--experimental-wasm-jspi", fileURLToPath(new URL("test-core-output-pressure.mjs", import.meta.url)), "wasm"]],
   [process.execPath, [fileURLToPath(new URL("test-wasm-memory.mjs", import.meta.url))]],

--- a/sdk/tests/test-wasm-jspi-tier-up.mjs
+++ b/sdk/tests/test-wasm-jspi-tier-up.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+import { strict as assert } from "node:assert";
+import { setImmediate } from "node:timers";
+
+// A hot Wasm loop must survive resumption across host tasks during JIT tier-up.
+// Bun 1.3.14 crashes here without any SDK, fetch, or instance teardown involved.
+// Fixture source (Zig 0.16, wasm32-freestanding, ReleaseSmall, no entry, rdynamic):
+// extern "host" fn next() i32;
+// export fn run() i32 {
+//     var sum: i32 = 0;
+//     for (0..100000) |_| sum +%= next();
+//     return sum;
+// }
+const module = await WebAssembly.compile(new Uint8Array([
+  0, 97, 115, 109, 1, 0, 0, 0, 1, 5, 1, 96, 0, 1, 127, 2,
+  13, 1, 4, 104, 111, 115, 116, 4, 110, 101, 120, 116, 0, 0, 3, 2,
+  1, 0, 4, 5, 1, 112, 1, 1, 1, 5, 3, 1, 0, 16, 6, 9,
+  1, 127, 1, 65, 128, 128, 192, 0, 11, 7, 16, 2, 6, 109, 101, 109,
+  111, 114, 121, 2, 0, 3, 114, 117, 110, 0, 1, 10, 49, 1, 47, 1,
+  2, 127, 65, 0, 33, 0, 65, 160, 141, 6, 33, 1, 2, 64, 3, 64,
+  32, 1, 69, 13, 1, 32, 1, 65, 127, 106, 33, 1, 16, 128, 128, 128,
+  128, 0, 32, 0, 106, 33, 0, 12, 0, 11, 11, 32, 0, 11,
+]));
+
+let calls = 0;
+let suspensions = 0;
+const instance = await WebAssembly.instantiate(module, {
+  host: {
+    next: new WebAssembly.Suspending(() => {
+      calls += 1;
+      if (calls % 32 !== 0) return 1;
+      suspensions += 1;
+      return new Promise((resolve) => setImmediate(() => resolve(1)));
+    }),
+  },
+});
+assert.equal(await WebAssembly.promising(instance.exports.run)(), 100_000);
+assert.equal(calls, 100_000);
+assert.equal(suspensions, 3125);
+console.log("Wasm JSPI tier-up passed: 100000 calls and 3125 task resumptions");


### PR DESCRIPTION
## Summary

- Run the SDK checks and libfx benchmarks on Bun 1.4.2 to avoid the 1.3.14 WebAssembly JSPI crash during JIT tier-up.
- Check hot-loop JSPI resumption in the Node and Bun lanes while preserving the existing benchmark workloads and counts.
- Recommend the tested Bun version for WebAssembly users.