### PR TITLE
Preserve credential storage failures in interactive status

### DIFF
--- a/src/core/app/app_auth_runtime.zig
+++ b/src/core/app/app_auth_runtime.zig
@@ -262,7 +262,7 @@ pub fn Runtime(comptime App: type) type {
             else
                 .gateway;
             const provider_inventory = if (comptime @hasDecl(@TypeOf(app.auth), "pickerView")) inventory: {
-                try app.auth.refreshSourceInventoryForLogout(app.alloc);
+                try app.auth.refreshSourceInventory(app.alloc);
                 break :inventory app.auth.pickerView().available_sources;
             } else @as(auth_runtime.SourceSet, .empty);
             const logout_provider = auth_transition.decideLogoutProvider(.{
@@ -2472,10 +2472,6 @@ const TestAuth = struct {
 
     fn openOnboardingPicker(self: *TestAuth, _: std.mem.Allocator) void {
         self.picker_opened = true;
-    }
-
-    fn refreshSourceInventoryForLogout(self: *TestAuth, _: std.mem.Allocator) !void {
-        self.source_inventory_refresh_count += 1;
     }
 
     fn beginSourceInventoryRefresh(

--- a/src/core/app/app_bootstrap_runtime.zig
+++ b/src/core/app/app_bootstrap_runtime.zig
@@ -209,6 +209,7 @@ pub fn Runtime(comptime App: type) type {
             app.auth.recordStartupStatus(
                 startup.stored_key_status,
                 startup.fx_login_status,
+                startup.credential_load_failure,
                 startup.credential_onboarding_skipped,
             );
             if (comptime @hasDecl(@TypeOf(app.auth), "refreshSourceInventory")) {

--- a/src/core/auth/auth_runtime.zig
+++ b/src/core/auth/auth_runtime.zig
@@ -41,11 +41,6 @@ const SourceProbeFn = *const fn (?*anyopaque, Allocator, credentials.Source) any
 const CredentialLoaderFn = *const fn (?*anyopaque, Allocator, credentials.Source) anyerror!?credentials.Credential;
 const StoredKeyStoreFn = *const fn (?*anyopaque, Allocator, []const u8) anyerror!void;
 
-const UnavailableSourcePolicy = enum {
-    fail,
-    omit,
-};
-
 const max_api_key_entry_bytes: usize = 8 * 1024;
 const max_api_key_mask_glyphs = provider_picker_catalog.max_key_mask_glyphs;
 const max_manual_code_mask_glyphs: usize = 32;
@@ -1919,10 +1914,6 @@ pub const Runtime = struct {
         try self.refreshSourceInventoryWithProbe(alloc, self, probeCredentialSource);
     }
 
-    pub fn refreshSourceInventoryForLogout(self: *Self, alloc: Allocator) !void {
-        try self.refreshSourceInventoryWithProbe(alloc, self, probeCredentialSourceForLogout);
-    }
-
     pub fn beginSourceInventoryRefresh(
         self: *Self,
         alloc: Allocator,
@@ -2002,14 +1993,18 @@ pub const Runtime = struct {
         self.source_inventory = inventory.available;
         self.unavailable_sources = inventory.unavailable;
         self.fx_login_session_available = inventory.available.contains(.fx_login);
+        if (!inventory.available.contains(.stored_key) and !inventory.unavailable.contains(.stored_key)) {
+            self.stored_key_status = .not_found;
+        }
+        if (!inventory.available.contains(.fx_login) and !inventory.unavailable.contains(.fx_login)) {
+            self.fx_login_status = .absent;
+        }
         if (self.credentialSource()) |source| {
             if (source != .host_managed and !inventory.unavailable.contains(source)) self.source_inventory.insert(source);
         } else if (self.credential_failure) |failure| {
             if (!inventory.available.contains(failure.source) and !inventory.unavailable.contains(failure.source)) {
                 debug_trace.logf("auth", "credential load failure cleared source={t} reason=source_absent", .{failure.source});
                 self.credential_failure = null;
-                if (failure.source == .stored_key) self.stored_key_status = .not_found;
-                if (failure.source == .fx_login) self.fx_login_status = .absent;
             }
         }
     }
@@ -2803,7 +2798,7 @@ pub const Runtime = struct {
         return self.reconcileAfterFxLoginLogoutWithDeps(
             alloc,
             self,
-            probeCredentialSourceForLogout,
+            probeCredentialSource,
             loadRuntimeCredentialSource,
         );
     }
@@ -2933,30 +2928,10 @@ test "host-managed runtime exposes authority without local credential state" {
 fn probeCredentialSource(raw_context: ?*anyopaque, _: Allocator, source: credentials.Source) !bool {
     const self: *Runtime = @ptrCast(@alignCast(raw_context.?));
     if (self.auth_mode == .host_managed) return false;
-    return sourcePresenceAvailable(credentials.sourcePresence(self.secret_store, source), .fail);
-}
-
-fn probeCredentialSourceForLogout(raw_context: ?*anyopaque, _: Allocator, source: credentials.Source) !bool {
-    const self: *Runtime = @ptrCast(@alignCast(raw_context.?));
-    if (self.auth_mode == .host_managed) return false;
-    const presence = credentials.sourcePresence(self.secret_store, source);
-    if (presence == .unavailable) {
-        debug_trace.logf("auth", "logout inventory omitted unavailable source={s}", .{@tagName(source)});
-    }
-    return sourcePresenceAvailable(presence, .omit);
-}
-
-fn sourcePresenceAvailable(
-    presence: host.SecretStorePresence,
-    unavailable_policy: UnavailableSourcePolicy,
-) error{CredentialStorageUnavailable}!bool {
-    return switch (presence) {
+    return switch (credentials.sourcePresence(self.secret_store, source)) {
         .present => true,
         .missing => false,
-        .unavailable => switch (unavailable_policy) {
-            .fail => error.CredentialStorageUnavailable,
-            .omit => false,
-        },
+        .unavailable => error.CredentialStorageUnavailable,
     };
 }
 
@@ -3610,6 +3585,43 @@ test "startup status and inventory preserve selected and host-managed failure se
     try std.testing.expect(hosted.statusSnapshotAt(100, .codex).missingHelp(.interactive) == null);
 }
 
+test "credential inventory retains startup failure while storage is unavailable" {
+    const alloc = std.testing.allocator;
+    var fixture: ApiKeySaveFixture = .{};
+    var runtime: Runtime = .{ .secret_store = fixture.secretStore() };
+    defer runtime.deinit(alloc);
+    runtime.recordStartupStatus(.unavailable, .not_attempted, .{
+        .source = .stored_key,
+        .err = error.StoredKeyUnreadable,
+    }, true);
+
+    try runtime.refreshSourceInventory(alloc);
+
+    try std.testing.expect(runtime.credential_failure != null);
+    try std.testing.expect(runtime.unavailable_sources.contains(.stored_key));
+    try std.testing.expect(!runtime.source_inventory.contains(.stored_key));
+    try std.testing.expectEqual(credentials.StoredKeyReadStatus.unavailable, runtime.stored_key_status);
+    try std.testing.expectEqual(@as(usize, 0), fixture.load_calls);
+}
+
+test "confirmed source removal clears stale store status after adoption and logout" {
+    const alloc = std.testing.allocator;
+    var runtime: Runtime = .{};
+    defer runtime.deinit(alloc);
+    runtime.recordStartupStatus(.unavailable, .not_attempted, .{
+        .source = .stored_key,
+        .err = error.StoredKeyUnreadable,
+    }, true);
+    var login = try makeTestCredential(alloc, "login-token", .fx_login, "team_1", null);
+    defer login.deinit(alloc);
+    _ = runtime.adoptCredential(alloc, &login);
+    runtime.applySourceInventory(.{ .available = SourceSet.initOne(.fx_login) });
+    var fixture: LogoutFixture = .{ .existing = .empty };
+    _ = try runtime.reconcileAfterFxLoginLogoutWithDeps(alloc, &fixture, LogoutFixture.probe, LogoutFixture.load);
+
+    try std.testing.expectEqualStrings(credentials.missing_interactive_credential_message, runtime.statusSnapshotAt(100, .gateway).missingHelp(.interactive).?);
+}
+
 test "auth status snapshot labels every credential source without exposing tokens" {
     const alloc = std.testing.allocator;
     const sources = [_]credentials.Source{
@@ -3736,16 +3748,6 @@ test "auth runtime detects only credential sources that exist" {
     try std.testing.expect(inventory.contains(.fx_login));
     try std.testing.expect(!inventory.contains(.vercel_oidc_token));
     try std.testing.expect(!inventory.contains(.stored_key));
-}
-
-test "credential inventory treats unavailable sources according to command policy" {
-    try std.testing.expect(try sourcePresenceAvailable(.present, .fail));
-    try std.testing.expect(!try sourcePresenceAvailable(.missing, .fail));
-    try std.testing.expectError(
-        error.CredentialStorageUnavailable,
-        sourcePresenceAvailable(.unavailable, .fail),
-    );
-    try std.testing.expect(!try sourcePresenceAvailable(.unavailable, .omit));
 }
 
 test "auth inventory skips unavailable sources and keeps later sources" {

--- a/src/core/auth/auth_runtime.zig
+++ b/src/core/auth/auth_runtime.zig
@@ -1750,7 +1750,7 @@ pub const Runtime = struct {
 
     pub fn modelCatalogAccess(self: *const Self) credentials.CatalogAccess {
         if (self.auth_mode == .host_managed) return .host_managed;
-        if (self.credential_failure) |failure| {
+        if (self.credentialFailure()) |failure| {
             return credentials.catalogAccessAfterRefreshFailure(failure.source);
         }
         return credentials.catalogAccessAt(self.selected_credential, io_mod.milliTimestamp());
@@ -1770,8 +1770,10 @@ pub const Runtime = struct {
         return true;
     }
 
+    /// Recovery and catalog access concern only the selected credential.
     pub fn credentialFailure(self: *const Self) ?CredentialFailure {
-        return self.credential_failure;
+        const failure = self.credential_failure orelse return null;
+        return if (self.credentialSource() == failure.source) failure else null;
     }
 
     pub fn credentialSource(self: *const Self) ?credentials.Source {
@@ -1819,6 +1821,12 @@ pub const Runtime = struct {
         const grok_connected = self.source_inventory.contains(.grok_subscription);
         const credential = self.selected_credential orelse return .{
             .required_source = requestedSource(provider, null),
+            .failure = if (self.credential_failure) |failure|
+                if (model_provider.authorizesCredential(provider, failure.source)) failure else null
+            else
+                null,
+            .stored_key_status = if (provider == .gateway) self.stored_key_status else .not_attempted,
+            .fx_login_status = if (provider == .gateway) self.fx_login_status else .not_attempted,
             .gateway_connected = gateway_connected,
             .chatgpt_connected = chatgpt_connected,
             .grok_connected = grok_connected,
@@ -1853,11 +1861,18 @@ pub const Runtime = struct {
         self: *Self,
         stored_key_status: credentials.StoredKeyReadStatus,
         fx_login_status: credentials.FxLoginReadStatus,
+        load_failure: ?credentials.LoadFailure,
         onboarding_skipped: bool,
     ) void {
         self.stored_key_status = stored_key_status;
         self.fx_login_status = fx_login_status;
         self.onboarding_skipped = onboarding_skipped;
+        if (self.auth_mode == .local and self.selected_credential == null) {
+            self.credential_failure = if (load_failure) |failure|
+                classifyCredentialFailure(failure.source, failure.err)
+            else
+                null;
+        }
     }
 
     pub fn beginProviderPreparation(self: *Self, alloc: Allocator, input: ProviderPreparationInput) !void {
@@ -1989,6 +2004,13 @@ pub const Runtime = struct {
         self.fx_login_session_available = inventory.available.contains(.fx_login);
         if (self.credentialSource()) |source| {
             if (source != .host_managed and !inventory.unavailable.contains(source)) self.source_inventory.insert(source);
+        } else if (self.credential_failure) |failure| {
+            if (!inventory.available.contains(failure.source) and !inventory.unavailable.contains(failure.source)) {
+                debug_trace.logf("auth", "credential load failure cleared source={t} reason=source_absent", .{failure.source});
+                self.credential_failure = null;
+                if (failure.source == .stored_key) self.stored_key_status = .not_found;
+                if (failure.source == .fx_login) self.fx_login_status = .absent;
+            }
         }
     }
 
@@ -3429,7 +3451,7 @@ test "auth runtime view preserves missing and loaded states" {
     var runtime: Runtime = .{};
     defer runtime.deinit(alloc);
 
-    runtime.recordStartupStatus(.unavailable, .unavailable, true);
+    runtime.recordStartupStatus(.unavailable, .unavailable, null, true);
     const missing = runtime.view();
     try std.testing.expect(missing.active_source == null);
     try std.testing.expect(missing.selected_team == null);
@@ -3495,6 +3517,97 @@ test "provider status snapshot preserves loaded and host-managed authority" {
     try std.testing.expectEqual(credentials.Source.host_managed, hosted.active_source.?);
     try std.testing.expect(hosted.required_source == null);
     try std.testing.expect(hosted.missingHelp(.interactive) == null);
+}
+
+test "startup credential failures reach only the matching provider status" {
+    for ([_]credentials.Source{ .stored_key, .fx_login, .chatgpt_subscription, .grok_subscription }) |source| {
+        const help = if (source == .stored_key)
+            credentials.unreadable_store_message
+        else
+            preparationFailureNotice(error.CredentialStorageUnavailable).?;
+        var runtime: Runtime = .{};
+        defer runtime.deinit(std.testing.allocator);
+        runtime.recordStartupStatus(
+            if (source == .stored_key) .unavailable else .not_attempted,
+            if (source == .fx_login) .unavailable else .not_attempted,
+            .{ .source = source, .err = error.CredentialStorageUnavailable },
+            true,
+        );
+
+        try std.testing.expect(runtime.credentialSource() == null);
+        try std.testing.expect(runtime.credentialFailure() == null);
+        try std.testing.expectEqual(credentials.CatalogPublicOnlyReason.no_credential, runtime.modelCatalogAccess().publicOnlyReason().?);
+        for ([_]model_provider.ProviderId{ .gateway, .codex, .grok }) |provider| {
+            const snapshot = runtime.statusSnapshotAt(100, provider);
+            if (model_provider.authorizesCredential(provider, source)) {
+                try std.testing.expectEqual(classifyCredentialFailure(source, error.CredentialStorageUnavailable), snapshot.failure.?);
+                try std.testing.expectEqualStrings(help, snapshot.missingHelp(.interactive).?);
+            } else {
+                try std.testing.expect(snapshot.failure == null);
+                try std.testing.expect(!std.mem.eql(u8, help, snapshot.missingHelp(.interactive).?));
+            }
+        }
+    }
+}
+
+test "startup credential failures clear after source removal or credential adoption" {
+    const alloc = std.testing.allocator;
+    for ([_]credentials.Source{ .stored_key, .fx_login, .chatgpt_subscription, .grok_subscription }) |source| {
+        var runtime: Runtime = .{};
+        defer runtime.deinit(alloc);
+        runtime.recordStartupStatus(
+            if (source == .stored_key) .unavailable else .not_attempted,
+            if (source == .fx_login) .unavailable else .not_attempted,
+            .{ .source = source, .err = error.CredentialStorageUnavailable },
+            true,
+        );
+        runtime.applySourceInventory(.{ .available = SourceSet.initOne(source) });
+        try std.testing.expect(runtime.credential_failure != null);
+        runtime.applySourceInventory(.{ .unavailable = SourceSet.initOne(source) });
+        try std.testing.expect(runtime.credential_failure != null);
+        runtime.applySourceInventory(.{});
+        try std.testing.expect(runtime.credential_failure == null);
+        try std.testing.expect(runtime.stored_key_status != .unavailable);
+        try std.testing.expect(runtime.fx_login_status != .unavailable);
+
+        runtime.recordStartupStatus(.not_attempted, .not_attempted, .{
+            .source = source,
+            .err = error.CredentialStorageUnavailable,
+        }, true);
+        var credential = try makeTestCredential(alloc, "replacement-token", .ai_gateway_api_key, null, null);
+        defer credential.deinit(alloc);
+        _ = runtime.adoptCredential(alloc, &credential);
+        try std.testing.expect(runtime.credential_failure == null);
+        try std.testing.expect(runtime.statusSnapshotAt(100, .gateway).missingHelp(.interactive) == null);
+    }
+}
+
+test "startup status and inventory preserve selected and host-managed failure semantics" {
+    const alloc = std.testing.allocator;
+    var runtime: Runtime = .{};
+    defer runtime.deinit(alloc);
+    var credential = try makeTestCredential(alloc, "selected-token", .fx_login, "team_1", null);
+    defer credential.deinit(alloc);
+    _ = runtime.adoptCredential(alloc, &credential);
+    const failure = classifyCredentialFailure(.fx_login, error.OAuthRequestFailed);
+    _ = runtime.recordCredentialFailure(failure);
+    runtime.recordStartupStatus(.not_attempted, .not_attempted, .{
+        .source = .grok_subscription,
+        .err = error.InvalidGrokAuthSession,
+    }, true);
+    runtime.applySourceInventory(.{});
+    try std.testing.expectEqual(failure, runtime.credentialFailure().?);
+    try std.testing.expectEqual(credentials.CatalogPublicOnlyReason.credential_refresh_failed, runtime.modelCatalogAccess().publicOnlyReason().?);
+
+    var hosted: Runtime = .{ .auth_mode = .host_managed };
+    defer hosted.deinit(alloc);
+    hosted.recordStartupStatus(.unavailable, .unavailable, .{
+        .source = .chatgpt_subscription,
+        .err = error.InvalidChatGptAuthSession,
+    }, true);
+    try std.testing.expect(hosted.credential_failure == null);
+    try std.testing.expectEqual(credentials.CatalogAccess.host_managed, hosted.modelCatalogAccess());
+    try std.testing.expect(hosted.statusSnapshotAt(100, .codex).missingHelp(.interactive) == null);
 }
 
 test "auth status snapshot labels every credential source without exposing tokens" {

--- a/src/core/auth/auth_transition.zig
+++ b/src/core/auth/auth_transition.zig
@@ -45,6 +45,7 @@ pub fn decideLogoutProvider(facts: LogoutFacts) model_provider.ProviderId {
     if (facts.requested) |provider| return provider;
     if (facts.selected == .grok or facts.active_source == .grok_subscription) return .grok;
     if (facts.selected == .codex or facts.active_source == .chatgpt_subscription) return .codex;
+    if (facts.active_source == .fx_login) return .gateway;
 
     const only_grok_login = facts.available_sources.contains(.grok_subscription) and
         !facts.available_sources.contains(.fx_login) and
@@ -96,6 +97,26 @@ test "logout fallback prefers Gateway then the remaining subscription" {
             if (provider == .codex) model_provider.ProviderId.grok else model_provider.ProviderId.codex,
             candidates[1].?,
         );
+    }
+}
+
+test "default logout honors an active fx login before other subscriptions" {
+    for ([_]model_provider.ProviderId{ .codex, .grok }) |other| {
+        var facts: LogoutFacts = .{
+            .requested = null,
+            .selected = .gateway,
+            .active_source = .fx_login,
+            .available_sources = .initOne(if (other == .codex) .chatgpt_subscription else .grok_subscription),
+        };
+        try std.testing.expectEqual(model_provider.ProviderId.gateway, decideLogoutProvider(facts));
+        facts.requested = other;
+        try std.testing.expectEqual(other, decideLogoutProvider(facts));
+        facts.requested = null;
+        facts.selected = other;
+        try std.testing.expectEqual(other, decideLogoutProvider(facts));
+        facts.selected = .gateway;
+        facts.active_source = .ai_gateway_api_key;
+        try std.testing.expectEqual(other, decideLogoutProvider(facts));
     }
 }
 

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -1398,6 +1398,40 @@ for (const gatewayState of ["absent", "rejected"] as const) {
   }, 60_000);
 }
 
+for (const otherProvider of ["codex", "grok"] as const) {
+  tmuxTest(`default logout preserves ${otherProvider} when active fx login becomes unreadable`, async () => {
+    home = mkdtempSync(join(tmpdir(), "fx-logout-active-unreadable-"));
+    stderrPath = join(home, "stderr.log");
+    writeFileSync(stderrPath, "");
+    gateway = startFakeGateway([]);
+    oauth = startFakeOAuth("unused-token");
+    writeSeededFxLogin(home, Date.now() + 3_600_000, oauth.issuerUrl, "team_fixture");
+    if (otherProvider === "codex") writeSeededChatGptLogin(home);
+    else writeSeededGrokLogin(home, "other-grok-token");
+    const otherPath = join(home, ".fx", otherProvider === "codex" ? "chatgpt-auth.json" : "grok-auth.json");
+    const otherCredential = readFileSync(otherPath, "utf8");
+    writeFileSync(join(home, ".fx", "settings.json"), JSON.stringify({ provider: "gateway", credential_source: "fx_login" }));
+    session = await startFx(home, stderrPath, gateway, oauth.issuerUrl, undefined, {
+      AI_GATEWAY_API_KEY: undefined,
+    });
+    await session.waitForComposer(TIMEOUT);
+    await session.sendText("/status");
+    await session.waitForText("auth=fx login", TIMEOUT);
+    const authPath = join(home, ".fx", "auth.json");
+    linkSync(authPath, join(home, "login.alias"));
+    await session.sendText("/logout");
+    const result = await session.waitForPane(
+      (pane) => pane.includes("Signed out of fx.") || pane.includes(`Signed out of ${otherProvider === "codex" ? "Codex" : "Grok"}.`),
+      TIMEOUT,
+    );
+    expect(result).toContain("Signed out of fx.");
+    expect(readFileSync(otherPath, "utf8")).toBe(otherCredential);
+    expect(existsSync(authPath)).toBe(false);
+    expect(gateway.requests).toHaveLength(0);
+    expect(readFileSync(stderrPath, "utf8")).toBe("");
+  }, TIMEOUT);
+}
+
 tmuxTest("provider recovery stays signed out when no replacement is connected", async () => {
   home = mkdtempSync(join(tmpdir(), "fx-logout-no-provider-"));
   stderrPath = join(home, "stderr.log");

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -1803,9 +1803,20 @@ tmuxTest(
         expect(response.error.message).toContain("Saved credential storage is unavailable");
         session = await startFx(home, stderrPath, gateway, oauth.issuerUrl, undefined, env);
         await session.waitForComposer(TIMEOUT);
+        await session.sendText("/status");
+        await session.waitForText("auth_help=", TIMEOUT);
+        expect(await session.captureFullScrollback()).toContain(
+          "auth_help=Saved credential storage is unavailable",
+        );
         await selectEnvKeyCredential(session);
         await session.sendText("Use the working Gateway account.");
         await session.waitForText(`GATEWAY_RECOVERED_${provider}`, TIMEOUT);
+        await session.sendText("/status");
+        await session.waitForText("auth=AI_GATEWAY_API_KEY", TIMEOUT);
+        const scrollback = await session.captureFullScrollback();
+        const recoveredStatus = scrollback.slice(scrollback.lastIndexOf("● Status:"));
+        expect(recoveredStatus).toContain("auth=AI_GATEWAY_API_KEY");
+        expect(recoveredStatus).not.toContain("auth_help=");
         expect(readFileSync(stderrPath, "utf8")).toBe("");
         await session.kill();
         session = null;

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -2870,6 +2870,36 @@ for (const [provider, help] of [
   }, TIMEOUT);
 }
 
+for (const provider of ["codex", "grok"] as const) {
+  tmuxTest(`/status retains ${provider} storage failure after unrelated logout`, async () => {
+    home = mkdtempSync(join(tmpdir(), "fx-status-logout-storage-"));
+    stderrPath = join(home, "stderr.log");
+    writeFileSync(stderrPath, "");
+    if (provider === "codex") writeSeededChatGptLogin(home);
+    else writeSeededGrokLogin(home, "unreadable-grok-token");
+    const credentialPath = join(home, ".fx", provider === "codex" ? "chatgpt-auth.json" : "grok-auth.json");
+    linkSync(credentialPath, join(home, "credential.alias"));
+    const settingsPath = join(home, ".fx", "settings.json");
+    const settings = JSON.stringify({ provider, models: { [provider]: "test-model" } });
+    writeFileSync(settingsPath, settings);
+    gateway = startFakeGateway([]);
+    session = await startFx(home, stderrPath, gateway, undefined, undefined, {
+      AI_GATEWAY_API_KEY: undefined,
+      FX_MODEL: undefined,
+    });
+    await session.waitForComposer(TIMEOUT);
+    await session.sendText("/logout vercel");
+    await session.waitForText("No fx login session found.", TIMEOUT);
+    await session.sendText("/status");
+    await session.waitForText("auth_help=", TIMEOUT);
+    expect(await session.captureFullScrollback()).toContain("auth_help=Saved credential storage is unavailable");
+    expect(existsSync(credentialPath)).toBe(true);
+    expect(readFileSync(settingsPath, "utf8")).toBe(settings);
+    expect(gateway.requests).toHaveLength(0);
+    expect(readFileSync(stderrPath, "utf8")).toBe("");
+  }, TIMEOUT);
+}
+
 async function startFxWithoutAuth(
   testHome: string,
   testStderrPath: string,


### PR DESCRIPTION
## Summary

- Report unavailable saved credential storage in interactive `/status` instead of missing-login guidance.
- Keep each reported failure scoped to its provider, including after an unrelated logout.
- Keep plain `/logout` on the active fx login when its saved storage becomes unreadable.
- Clear retained load failures after selecting a working credential.
- Clear stale storage warnings when the source is confirmed absent, including after credential changes and logout.
