### PR TITLE
Recover current-format session logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ fx session resume last
 fx session resume --id <id>
 ```
 
+If a saved conversation is damaged, run `fx session recover <id>` to copy its validated prefix into a new session. Recovery preserves checkpoint boundaries and referenced result files, leaves the original unchanged, and prints the new session ID. Records after the damaged boundary are not included, and recovery does not rerun commands. Healthy conversations can be resumed without recovery.
+
 Interactive terminal tabs show `fx v<version> | <folder>` using the running binary's version and current workspace folder name, for example `fx v0.0.7 | fx`. Renaming a session or switching models leaves the title unchanged. Resuming from another folder uses that folder's name. Exiting clears the fx-owned title. Noninteractive commands do not emit terminal-title controls.
 
 Run `/feedback` to open the feedback form at `fx.sh/feedback`. It does not create a diagnostic or change the clipboard.

--- a/src/core/cli/cli_surface.zig
+++ b/src/core/cli/cli_surface.zig
@@ -2911,7 +2911,7 @@ fn writeLookupFailure(
         error.SessionRecoveryRequiresCurrentSchema => {
             try writeStderr(
                 deps,
-                "fx session: recovery only applies to current schema-v3 sessions; migrate legacy sessions first\n",
+                "fx session: recovery supports conversation logs and schema-v3 event logs; migrate snapshot sessions first\n",
             );
         },
         error.SessionRecoveryUnsupportedSchema => {
@@ -3042,7 +3042,7 @@ fn lookupFailureMessage(err: anyerror) ?[]const u8 {
         error.LegacySessionMigrationFailed, error.LegacySessionChanged => "migration did not complete; the original session remains authoritative",
         error.LegacySessionMigrationIndeterminate => "migration outcome is indeterminate and will be resolved by the next exact writable load",
         error.SessionRecoveryNotNeeded => "recovery was refused because the session has a valid commit boundary; resume it normally",
-        error.SessionRecoveryRequiresCurrentSchema => "recovery only applies to current schema-v3 sessions; migrate legacy sessions first",
+        error.SessionRecoveryRequiresCurrentSchema => "recovery supports conversation logs and schema-v3 event logs; migrate snapshot sessions first",
         error.SessionRecoveryUnsupportedSchema => "recovery is unavailable for this unsupported session version",
         error.SessionRecoveryBoundaryInvalid => "no exact trustworthy recovery boundary was found; the source was left unchanged",
         error.SessionRecoveryIndeterminate => "the recovery copy could not be confirmed; the source was left unchanged",

--- a/src/core/session/session_log.zig
+++ b/src/core/session/session_log.zig
@@ -898,6 +898,9 @@ pub fn find_conversation_recovery_boundary(
     }
     var boundary: ConversationRecoveryBoundary = .{};
     var offset: u64 = 0;
+    var coverage_offset: u64 = 0;
+    var coverage_seq: u64 = 0;
+    var coverage_progress: ConversationProgress = .{};
     scan: while (offset < length) {
         const line = session_replay.readLineAt(alloc, file, offset, length) catch |err| switch (err) {
             error.TruncatedEventFrame, error.EventFrameTooLarge => break,
@@ -914,6 +917,21 @@ pub fn find_conversation_recovery_boundary(
             .latest_checkpoint_coverage = state.latest_checkpoint_coverage,
             .pending_tool_calls = state.pending_tool_calls.items,
         }, decoded.value) catch break;
+        if (decoded.value.event == .context_checkpoint) {
+            const coverage = decoded.value.event.context_checkpoint.covers_through_seq;
+            // Coverage is monotone, so historical cuts need only one extra scan.
+            while (coverage_seq < coverage) {
+                const covered = (try session_replay.readLineAt(alloc, file, coverage_offset, offset)) orelse
+                    return error.SessionRecoveryBoundaryInvalid;
+                defer alloc.free(covered.bytes);
+                var frame = try session_event.decodeConversationFrame(alloc, covered.bytes);
+                defer frame.deinit();
+                try coverage_progress.observe(frame.value.seq, frame.value.event, null);
+                coverage_seq = frame.value.seq;
+                coverage_offset = covered.next_offset;
+            }
+            if (coverage_progress.pending != 0) break :scan;
+        }
         state.applyReplayedEvent(decoded.value.seq, decoded.value.event) catch |err| switch (err) {
             error.InvalidConversationFrame => break :scan,
             else => return err,
@@ -1037,6 +1055,37 @@ test "conversation recovery boundary validates prefix and never edits source" {
     try std.testing.expectError(error.SessionRecoveryBoundaryInvalid, find_conversation_recovery_boundary(alloc, &dir));
 }
 
+test "conversation recovery rejects checkpoint cuts inside tool batches" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var dir = io_mod.VerifiedDir{ .dir = tmp.dir };
+    const prefix =
+        "{\"schema_version\":1,\"seq\":1,\"timestamp_ms\":1,\"event\":{\"user\":{\"text\":\"request\"}}}\n" ++
+        "{\"schema_version\":1,\"seq\":2,\"timestamp_ms\":1,\"event\":{\"tool_call\":{\"call_id\":\"one\",\"tool_name\":\"shell\",\"arguments_json\":\"{}\"}}}\n" ++
+        "{\"schema_version\":1,\"seq\":3,\"timestamp_ms\":1,\"event\":{\"tool_call\":{\"call_id\":\"two\",\"tool_name\":\"shell\",\"arguments_json\":\"{}\"}}}\n" ++
+        "{\"schema_version\":1,\"seq\":4,\"timestamp_ms\":1,\"event\":{\"tool_result\":{\"call_id\":\"one\",\"tool_name\":\"shell\",\"status\":\"success\",\"artifact_ref\":\"one.txt\",\"stored_bytes\":0,\"completeness\":\"complete\"}}}\n" ++
+        "{\"schema_version\":1,\"seq\":5,\"timestamp_ms\":1,\"event\":{\"tool_result\":{\"call_id\":\"two\",\"tool_name\":\"shell\",\"status\":\"success\",\"artifact_ref\":\"two.txt\",\"stored_bytes\":0,\"completeness\":\"complete\"}}}\n" ++
+        "{\"schema_version\":1,\"seq\":6,\"timestamp_ms\":1,\"event\":{\"turn_completed\":{}}}\n";
+    for ([_]u64{ 1, 2, 3, 4, 5, 6 }) |coverage| {
+        for ([_][]const u8{ "", "invalid\n" }) |tail| {
+            const bytes = try std.fmt.allocPrint(alloc, "{s}{{\"schema_version\":1,\"seq\":7,\"timestamp_ms\":1,\"event\":{{\"context_checkpoint\":{{\"covers_through_seq\":{d},\"summary\":\"checkpoint\"}}}}}}\n{s}", .{ prefix, coverage, tail });
+            defer alloc.free(bytes);
+            try tmp.dir.writeFile(std.testing.io, .{ .sub_path = events_file, .data = bytes, .flags = .{ .permissions = private_file_permissions } });
+            if (coverage >= 2 and coverage <= 4) {
+                const boundary = try find_conversation_recovery_boundary(alloc, &dir);
+                try std.testing.expectEqual(prefix.len, boundary.bytes);
+                try std.testing.expectEqual(@as(u64, 6), boundary.seq);
+            } else if (tail.len == 0) {
+                try std.testing.expectError(error.SessionRecoveryNotNeeded, find_conversation_recovery_boundary(alloc, &dir));
+            } else {
+                const boundary = try find_conversation_recovery_boundary(alloc, &dir);
+                try std.testing.expectEqual(bytes.len - tail.len, boundary.bytes);
+            }
+        }
+    }
+}
+
 test "conversation recovery allocation failures do not become corruption" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -1044,12 +1093,13 @@ test "conversation recovery allocation failures do not become corruption" {
     try tmp.dir.writeFile(std.testing.io, .{ .sub_path = events_file, .flags = .{ .permissions = private_file_permissions }, .data = "{\"schema_version\":1,\"seq\":1,\"timestamp_ms\":1,\"event\":{\"user\":{\"text\":\"fact\"}}}\n" ++
         "{\"schema_version\":1,\"seq\":2,\"timestamp_ms\":1,\"event\":{\"assistant\":{\"text\":\"saved\"}}}\n" ++
         "{\"schema_version\":1,\"seq\":3,\"timestamp_ms\":1,\"event\":{\"turn_completed\":{}}}\n" ++
-        "{\"schema_version\":1,\"seq\":4,\"timestamp_ms\":1,\"event\":{\"user\":{\"text\":\"pending\"}}}\n" ++
-        "{\"schema_version\":1,\"seq\":5,\"timestamp_ms\":1,\"event\":{\"tool_call\":{\"call_id\":\"call1\",\"tool_name\":\"shell\",\"arguments_json\":\"{}\"}}}\ninvalid\n" });
+        "{\"schema_version\":1,\"seq\":4,\"timestamp_ms\":1,\"event\":{\"context_checkpoint\":{\"covers_through_seq\":1,\"summary\":\"retained fact\"}}}\n" ++
+        "{\"schema_version\":1,\"seq\":5,\"timestamp_ms\":1,\"event\":{\"user\":{\"text\":\"pending\"}}}\n" ++
+        "{\"schema_version\":1,\"seq\":6,\"timestamp_ms\":1,\"event\":{\"tool_call\":{\"call_id\":\"call1\",\"tool_name\":\"shell\",\"arguments_json\":\"{}\"}}}\ninvalid\n" });
     try std.testing.checkAllAllocationFailures(std.testing.allocator, struct {
         fn check(alloc: Allocator, source: *io_mod.VerifiedDir) !void {
             const boundary = try find_conversation_recovery_boundary(alloc, source);
-            try std.testing.expectEqual(@as(u64, 3), boundary.seq);
+            try std.testing.expectEqual(@as(u64, 4), boundary.seq);
         }
     }.check, .{&dir});
 }

--- a/src/core/session/session_log.zig
+++ b/src/core/session/session_log.zig
@@ -741,6 +741,15 @@ fn loadConversationStateIfPresent(
     dir: *io_mod.VerifiedDir,
     expected_session_id: []const u8,
 ) !?session_codec.DurableSessionState {
+    return load_conversation_state_at_boundary(alloc, dir, expected_session_id, null);
+}
+
+fn load_conversation_state_at_boundary(
+    alloc: Allocator,
+    dir: *io_mod.VerifiedDir,
+    expected_session_id: []const u8,
+    recovery: ?ConversationRecoveryBoundary,
+) !?session_codec.DurableSessionState {
     const metadata_bytes = readManagedFileAlloc(
         alloc,
         dir,
@@ -753,7 +762,10 @@ fn loadConversationStateIfPresent(
     defer alloc.free(metadata_bytes);
     var probe = std.json.parseFromSlice(std.json.Value, alloc, metadata_bytes, .{
         .parse_numbers = false,
-    }) catch return null;
+    }) catch |err| switch (err) {
+        error.OutOfMemory => return err,
+        else => return null,
+    };
     defer probe.deinit();
     const object = if (probe.value == .object) probe.value.object else return null;
     const version_value = object.get("schema_version") orelse return null;
@@ -773,10 +785,15 @@ fn loadConversationStateIfPresent(
     var conversation_seq: u64 = 0;
     var open_work_id: ?[]u8 = null;
     defer if (open_work_id) |work_id| alloc.free(work_id);
-    const history = try replayConversationHistory(alloc, event_file, &conversation_seq, &open_work_id);
+    const length = if (recovery) |boundary| boundary.bytes else try event_file.length(io_mod.getIo());
+    const history = try replayConversationHistory(alloc, event_file, length, &conversation_seq, &open_work_id);
     errdefer session.freeHistoryTurnSlice(alloc, history);
-    try restoreContextResultBodies(alloc, dir, history);
-    const last_work_id = if (latestConversationWorkId(history)) |work_id|
+    if (recovery == null) try restoreContextResultBodies(alloc, dir, history);
+    const latest_work_id = if (recovery != null and recovery.?.turn_open and open_work_id != null)
+        open_work_id
+    else
+        latestConversationWorkId(history);
+    const last_work_id = if (latest_work_id) |work_id|
         try alloc.dupe(u8, work_id)
     else
         null;
@@ -789,7 +806,10 @@ fn loadConversationStateIfPresent(
     errdefer if (usage) |*snapshot| snapshot.deinit(alloc);
     var permission_state = try loadConversationPermissionState(alloc, dir);
     errdefer permission_state.deinit(alloc);
-    var recovery_checkpoint = try loadConversationRecoveryCheckpoint(alloc, dir, conversation_seq);
+    var recovery_checkpoint = if (recovery == null)
+        try loadConversationRecoveryCheckpoint(alloc, dir, conversation_seq)
+    else
+        null;
     errdefer if (recovery_checkpoint) |*checkpoint| checkpoint.deinit(alloc);
     if (recovery_checkpoint) |*checkpoint| {
         if (checkpoint.user.work_id == null) {
@@ -852,6 +872,209 @@ pub fn hasConversationMetadata(
     const bytes = (try readConversationMetadataBytes(alloc, dir)) orelse return false;
     defer alloc.free(bytes);
     return isConversationMetadata(alloc, bytes);
+}
+
+pub const ConversationRecoveryBoundary = struct {
+    bytes: u64 = 0,
+    seq: u64 = 0,
+    timestamp_ms: i64 = 0,
+    turn_open: bool = false,
+};
+
+/// Reads only. The existing transition validator remains the record authority.
+pub fn find_conversation_recovery_boundary(
+    alloc: Allocator,
+    dir: *io_mod.VerifiedDir,
+) !ConversationRecoveryBoundary {
+    var reader = try ConversationHistoryReader.init(alloc, dir);
+    defer reader.deinit();
+    const file = reader.file;
+    const length = reader.length;
+    reader.length = 0;
+    var state = ConversationWriter{ .alloc = alloc, .file = file };
+    defer {
+        state.clearPendingToolCalls();
+        state.pending_tool_calls.deinit(alloc);
+    }
+    var boundary: ConversationRecoveryBoundary = .{};
+    var offset: u64 = 0;
+    scan: while (offset < length) {
+        const line = session_replay.readLineAt(alloc, file, offset, length) catch |err| switch (err) {
+            error.TruncatedEventFrame, error.EventFrameTooLarge => break,
+            else => return err,
+        } orelse break;
+        defer alloc.free(line.bytes);
+        var decoded = session_event.decodeConversationFrame(alloc, line.bytes) catch |err| switch (err) {
+            error.InvalidConversationFrame => break,
+            else => return err,
+        };
+        defer decoded.deinit();
+        session_event.validateConversationTransition(.{
+            .last_seq = state.last_seq,
+            .latest_checkpoint_coverage = state.latest_checkpoint_coverage,
+            .pending_tool_calls = state.pending_tool_calls.items,
+        }, decoded.value) catch break;
+        state.applyReplayedEvent(decoded.value.seq, decoded.value.event) catch |err| switch (err) {
+            error.InvalidConversationFrame => break :scan,
+            else => return err,
+        };
+        // A valid frame must also be replayable before it can extend the copy.
+        reader.length = line.next_offset;
+        if (reader.next() catch |err| switch (err) {
+            error.InvalidConversationFrame, error.ConversationSizeOverflow => break :scan,
+            else => return err,
+        }) |turn| session.freeHistoryTurn(alloc, turn);
+        offset = line.next_offset;
+        if (!state.turn_open or
+            (decoded.value.event == .context_checkpoint and state.pending_tool_calls.items.len == 0))
+        {
+            boundary = .{
+                .bytes = offset,
+                .seq = state.last_seq,
+                .timestamp_ms = decoded.value.timestamp_ms,
+                .turn_open = state.turn_open,
+            };
+        }
+    }
+    if (offset == length and boundary.bytes == length) return error.SessionRecoveryNotNeeded;
+    if (boundary.bytes == 0) return error.SessionRecoveryBoundaryInvalid;
+    debug_trace.logf("session", "event=conversation_recovery_boundary source_bytes={d} retained_bytes={d} through_seq={d}", .{ length, boundary.bytes, boundary.seq });
+    return boundary;
+}
+
+/// Caller owns the returned complete archive, with a checkpointed open turn
+/// explicitly interrupted rather than scheduling its abandoned continuation.
+pub fn load_conversation_recovery_state(
+    alloc: Allocator,
+    dir: *io_mod.VerifiedDir,
+    session_id: []const u8,
+    boundary: ConversationRecoveryBoundary,
+) !session_codec.DurableSessionState {
+    const loaded = load_conversation_state_at_boundary(alloc, dir, session_id, boundary) catch |err| switch (err) {
+        error.InvalidSessionMetadata, error.InvalidSessionFormat => return error.SessionRecoveryBoundaryInvalid,
+        else => return err,
+    };
+    var state = loaded orelse return error.SessionRecoveryBoundaryInvalid;
+    errdefer state.deinit(alloc);
+    const file = try openManagedFile(dir, events_file, .read_only);
+    defer file.close(io_mod.getIo());
+    const archive = try load_conversation_archive_from_file(alloc, file, boundary.bytes, boundary.turn_open);
+    session.freeHistoryTurnSlice(alloc, state.history);
+    state.history = archive;
+    state.context_history_start = latestConversationCheckpointIndex(archive);
+    return state;
+}
+
+/// Installs exact validated records in an unpublished target; never edits source.
+pub fn copy_conversation_recovery_prefix(
+    alloc: Allocator,
+    source: *io_mod.VerifiedDir,
+    target: *io_mod.VerifiedDir,
+    boundary: ConversationRecoveryBoundary,
+) !void {
+    const input = try openManagedFile(source, events_file, .read_only);
+    defer input.close(io_mod.getIo());
+    const output = try openManagedFile(target, events_file, .read_write);
+    defer output.close(io_mod.getIo());
+    var buffer: [8192]u8 = undefined;
+    var offset: u64 = 0;
+    while (offset < boundary.bytes) {
+        const count: usize = @intCast(@min(buffer.len, boundary.bytes - offset));
+        if (try input.readPositionalAll(io_mod.getIo(), buffer[0..count], offset) != count)
+            return error.SessionRecoveryBoundaryInvalid;
+        try output.writePositionalAll(io_mod.getIo(), buffer[0..count], offset);
+        offset += count;
+    }
+    if (boundary.turn_open) {
+        const interrupted = try session_event.encodeConversationFrame(alloc, .{
+            .seq = try std.math.add(u64, boundary.seq, 1),
+            .timestamp_ms = boundary.timestamp_ms,
+            .event = .{ .interrupted = .{ .reason = .failed } },
+        });
+        defer alloc.free(interrupted);
+        try output.writePositionalAll(io_mod.getIo(), interrupted, offset);
+        offset = try std.math.add(u64, offset, interrupted.len);
+    }
+    try output.setLength(io_mod.getIo(), offset);
+    try output.sync(io_mod.getIo());
+    debug_trace.logf("session", "event=conversation_recovery_prefix bytes={d} through_seq={d} interrupted={}", .{ boundary.bytes, boundary.seq, boundary.turn_open });
+}
+
+test "conversation recovery boundary validates prefix and never edits source" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var dir = io_mod.VerifiedDir{ .dir = tmp.dir };
+    const prefix =
+        "{\"schema_version\":1,\"seq\":1,\"timestamp_ms\":1,\"event\":{\"user\":{\"text\":\"fact\"}}}\n" ++
+        "{\"schema_version\":1,\"seq\":2,\"timestamp_ms\":1,\"event\":{\"assistant\":{\"text\":\"saved\"}}}\n" ++
+        "{\"schema_version\":1,\"seq\":3,\"timestamp_ms\":1,\"event\":{\"turn_completed\":{}}}\n";
+    const suffixes = [_][]const u8{
+        "{",
+        "invalid\n",
+        "{\"schema_version\":1,\"seq\":99,\"timestamp_ms\":1,\"event\":{\"user\":{\"text\":\"wrong sequence\"}}}\n",
+        "{\"schema_version\":1,\"seq\":4,\"timestamp_ms\":1,\"event\":{\"context_checkpoint\":{\"covers_through_seq\":9,\"summary\":\"invalid coverage\"}}}\n",
+        "{\"schema_version\":1,\"seq\":4,\"timestamp_ms\":1,\"event\":{\"user\":{\"text\":\"unfinished batch\"}}}\n" ++
+            "{\"schema_version\":1,\"seq\":5,\"timestamp_ms\":1,\"event\":{\"tool_call\":{\"call_id\":\"one\",\"tool_name\":\"shell\",\"arguments_json\":\"{}\"}}}\n" ++
+            "{\"schema_version\":1,\"seq\":6,\"timestamp_ms\":1,\"event\":{\"tool_call\":{\"call_id\":\"two\",\"tool_name\":\"shell\",\"arguments_json\":\"{}\"}}}\n" ++
+            "{\"schema_version\":1,\"seq\":7,\"timestamp_ms\":1,\"event\":{\"interrupted\":{\"reason\":\"failed\"}}}\ninvalid\n",
+    };
+    for (suffixes) |suffix| {
+        const bytes = try std.mem.concat(alloc, u8, &.{ prefix, suffix });
+        defer alloc.free(bytes);
+        try tmp.dir.writeFile(std.testing.io, .{ .sub_path = events_file, .data = bytes, .flags = .{ .permissions = private_file_permissions } });
+        const boundary = try find_conversation_recovery_boundary(alloc, &dir);
+        try std.testing.expectEqual(prefix.len, boundary.bytes);
+        try std.testing.expectEqual(@as(u64, 3), boundary.seq);
+        try std.testing.expect(!boundary.turn_open);
+        const actual = try readManagedFileAlloc(alloc, &dir, events_file, bytes.len);
+        defer alloc.free(actual);
+        try std.testing.expectEqualStrings(bytes, actual);
+    }
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = events_file, .data = prefix, .flags = .{ .permissions = private_file_permissions } });
+    try std.testing.expectError(error.SessionRecoveryNotNeeded, find_conversation_recovery_boundary(alloc, &dir));
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = events_file, .data = "invalid\n", .flags = .{ .permissions = private_file_permissions } });
+    try std.testing.expectError(error.SessionRecoveryBoundaryInvalid, find_conversation_recovery_boundary(alloc, &dir));
+}
+
+test "conversation recovery allocation failures do not become corruption" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var dir = io_mod.VerifiedDir{ .dir = tmp.dir };
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = events_file, .flags = .{ .permissions = private_file_permissions }, .data = "{\"schema_version\":1,\"seq\":1,\"timestamp_ms\":1,\"event\":{\"user\":{\"text\":\"fact\"}}}\n" ++
+        "{\"schema_version\":1,\"seq\":2,\"timestamp_ms\":1,\"event\":{\"assistant\":{\"text\":\"saved\"}}}\n" ++
+        "{\"schema_version\":1,\"seq\":3,\"timestamp_ms\":1,\"event\":{\"turn_completed\":{}}}\n" ++
+        "{\"schema_version\":1,\"seq\":4,\"timestamp_ms\":1,\"event\":{\"user\":{\"text\":\"pending\"}}}\n" ++
+        "{\"schema_version\":1,\"seq\":5,\"timestamp_ms\":1,\"event\":{\"tool_call\":{\"call_id\":\"call1\",\"tool_name\":\"shell\",\"arguments_json\":\"{}\"}}}\ninvalid\n" });
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, struct {
+        fn check(alloc: Allocator, source: *io_mod.VerifiedDir) !void {
+            const boundary = try find_conversation_recovery_boundary(alloc, source);
+            try std.testing.expectEqual(@as(u64, 3), boundary.seq);
+        }
+    }.check, .{&dir});
+}
+
+test "conversation recovery state preserves allocation errors and contains invalid metadata" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var dir = io_mod.VerifiedDir{ .dir = tmp.dir };
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = manifest_file, .flags = .{ .permissions = private_file_permissions }, .data = "{\"schema_version\":4,\"id\":\"recovery-source\",\"created_at_ms\":1,\"updated_at_ms\":1,\"origin_workspace_root\":\"/tmp\",\"workspace_root\":\"/tmp\",\"conversation_language\":\"en\",\"provider\":\"gateway\",\"model\":\"test/model\",\"effort\":\"auto\",\"fast_mode\":false,\"title\":null,\"subagent_child\":false}" });
+    const prefix =
+        "{\"schema_version\":1,\"seq\":1,\"timestamp_ms\":1,\"event\":{\"user\":{\"text\":\"fact\"}}}\n" ++
+        "{\"schema_version\":1,\"seq\":2,\"timestamp_ms\":1,\"event\":{\"assistant\":{\"text\":\"saved\"}}}\n" ++
+        "{\"schema_version\":1,\"seq\":3,\"timestamp_ms\":1,\"event\":{\"turn_completed\":{}}}\n";
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = events_file, .flags = .{ .permissions = private_file_permissions }, .data = prefix ++ "invalid\n" });
+    const boundary = try find_conversation_recovery_boundary(alloc, &dir);
+    try std.testing.expectError(error.SessionRecoveryBoundaryInvalid, load_conversation_recovery_state(alloc, &dir, "wrong-id", boundary));
+    try std.testing.checkAllAllocationFailures(alloc, struct {
+        fn check(a: Allocator, source: *io_mod.VerifiedDir, cut: ConversationRecoveryBoundary) !void {
+            var state = try load_conversation_recovery_state(a, source, "recovery-source", cut);
+            defer state.deinit(a);
+            try std.testing.expectEqual(@as(usize, 1), state.history.len);
+            try std.testing.expect(state.recovery_checkpoint == null);
+        }
+    }.check, .{ &dir, boundary });
 }
 
 /// Reads and validates current metadata once. The caller owns the decoded value.
@@ -946,10 +1169,10 @@ fn openConversationWritableSession(
 fn replayConversationHistory(
     alloc: Allocator,
     file: std.Io.File,
+    length: u64,
     conversation_seq: *u64,
     open_work_id: *?[]u8,
 ) ![]session.HistoryTurn {
-    const length = try file.length(io_mod.getIo());
     const window = try findConversationReplayWindow(alloc, file, length);
     conversation_seq.* = window.last_complete_seq;
     var offset = window.offset;
@@ -1139,6 +1362,15 @@ pub fn loadConversationArchive(
     var file = try openManagedFile(dir, events_file, .read_only);
     defer file.close(io_mod.getIo());
     const length = try file.length(io_mod.getIo());
+    return load_conversation_archive_from_file(alloc, file, length, false);
+}
+
+fn load_conversation_archive_from_file(
+    alloc: Allocator,
+    file: std.Io.File,
+    length: u64,
+    close_open_turn: bool,
+) ![]session.HistoryTurn {
     var offset: u64 = 0;
     var turns: std.ArrayList(session.HistoryTurn) = .empty;
     errdefer {
@@ -1201,6 +1433,11 @@ pub fn loadConversationArchive(
             if (turn != .compacted_summary) raw_turn_count += 1;
         }
         offset = line.next_offset;
+    }
+    if (close_open_turn and builder.user != null) {
+        const completed = try builder.finishInterrupted(.{ .reason = .failed });
+        errdefer session.freeHistoryTurn(alloc, completed);
+        try turns.append(alloc, completed);
     }
     return turns.toOwnedSlice(alloc);
 }

--- a/src/core/session/session_store.zig
+++ b/src/core/session/session_store.zig
@@ -24,6 +24,7 @@ const session_projection = @import("session_projection.zig");
 const session_display_metadata = @import("session_display_metadata.zig");
 const session_usage = @import("session_usage.zig");
 const session_usage_sidecar = @import("session_usage_sidecar.zig");
+const subagent_child_state = @import("../subagent/child_state.zig");
 const Allocator = std.mem.Allocator;
 
 const authority_module = @import("session_authority.zig");
@@ -3192,9 +3193,8 @@ pub const Store = struct {
         };
     }
 
-    /// Creates a new conversation session from the exact validated manifest
-    /// boundary of a source whose commit watermark is corrupt. The source is
-    /// locked for the read and is never modified.
+    /// Copies a validated conversation prefix or legacy manifest boundary to a
+    /// new session. The source is locked for the read and is never modified.
     pub fn recoverSessionCopy(
         self: Store,
         alloc: Allocator,
@@ -3208,71 +3208,86 @@ pub const Store = struct {
             options.session_lock_deadline_ms,
         );
         defer source.deinit(alloc);
-        const authority = try classifyAuthority(
-            alloc,
-            &source.dir,
-            session_id,
-        );
-        if (authority != .schema_v3) {
-            return error.SessionRecoveryRequiresCurrentSchema;
-        }
-        var manifest_file = openSessionFile(
-            &source.dir,
-            "session.json",
-            .read_only,
-        ) catch return error.SessionRecoveryBoundaryInvalid;
-        defer manifest_file.close(io_mod.getIo());
-        const manifest_stat = try manifest_file.stat(io_mod.getIo());
-        if (manifest_stat.size > session_projection.manifest_max_bytes) {
-            return error.SessionRecoveryBoundaryInvalid;
-        }
-        const manifest_bytes = readExactLegacyFile(
-            alloc,
-            &manifest_file,
-            manifest_stat.size,
-        ) catch |err| switch (err) {
-            error.OutOfMemory => return error.OutOfMemory,
-            else => return error.SessionRecoveryBoundaryInvalid,
+        var metadata = session_log.readConversationMetadata(alloc, &source.dir) catch |err| switch (err) {
+            error.InvalidSessionMetadata, error.InvalidSessionFormat => return error.SessionRecoveryBoundaryInvalid,
+            else => return err,
         };
-        defer alloc.free(manifest_bytes);
-        const manifest_schema = authority_module.manifestSchemaVersion(
-            alloc,
-            manifest_bytes,
-        ) catch |err| switch (err) {
-            error.OutOfMemory => return error.OutOfMemory,
-            else => return error.SessionRecoveryBoundaryInvalid,
-        };
-        if (manifest_schema != 3) {
-            return error.SessionRecoveryUnsupportedSchema;
-        }
+        defer if (metadata) |*current| current.deinit();
+        var current_boundary: ?session_log.ConversationRecoveryBoundary = null;
+        var recovered = recovery_state: {
+            if (metadata) |current| {
+                if (!std.mem.eql(u8, current.value.id, session_id)) return error.SessionRecoveryBoundaryInvalid;
+                if (current.value.subagent_child) return error.SessionNotFound;
+                current_boundary = try session_log.find_conversation_recovery_boundary(alloc, &source.dir);
+                break :recovery_state try session_log.load_conversation_recovery_state(alloc, &source.dir, session_id, current_boundary.?);
+            }
+            const authority = try classifyAuthority(
+                alloc,
+                &source.dir,
+                session_id,
+            );
+            if (authority != .schema_v3) {
+                return error.SessionRecoveryRequiresCurrentSchema;
+            }
+            var manifest_file = openSessionFile(
+                &source.dir,
+                "session.json",
+                .read_only,
+            ) catch return error.SessionRecoveryBoundaryInvalid;
+            defer manifest_file.close(io_mod.getIo());
+            const manifest_stat = try manifest_file.stat(io_mod.getIo());
+            if (manifest_stat.size > session_projection.manifest_max_bytes) {
+                return error.SessionRecoveryBoundaryInvalid;
+            }
+            const manifest_bytes = readExactLegacyFile(
+                alloc,
+                &manifest_file,
+                manifest_stat.size,
+            ) catch |err| switch (err) {
+                error.OutOfMemory => return error.OutOfMemory,
+                else => return error.SessionRecoveryBoundaryInvalid,
+            };
+            defer alloc.free(manifest_bytes);
+            const manifest_schema = authority_module.manifestSchemaVersion(
+                alloc,
+                manifest_bytes,
+            ) catch |err| switch (err) {
+                error.OutOfMemory => return error.OutOfMemory,
+                else => return error.SessionRecoveryBoundaryInvalid,
+            };
+            if (manifest_schema != 3) {
+                return error.SessionRecoveryUnsupportedSchema;
+            }
 
-        var manifest = session_projection.decodeManifest(alloc, manifest_bytes) catch |err| switch (err) {
-            error.OutOfMemory => return error.OutOfMemory,
-            else => return error.SessionRecoveryBoundaryInvalid,
+            var manifest = session_projection.decodeManifest(alloc, manifest_bytes) catch |err| switch (err) {
+                error.OutOfMemory => return error.OutOfMemory,
+                else => return error.SessionRecoveryBoundaryInvalid,
+            };
+            defer manifest.deinit(alloc);
+            if (!std.mem.eql(u8, manifest.id, session_id)) return error.SessionRecoveryBoundaryInvalid;
+            var events = openSessionFile(&source.dir, "events.jsonl", .read_only) catch
+                return error.SessionRecoveryBoundaryInvalid;
+            defer events.close(io_mod.getIo());
+            var imported = session_replay.replayCommittedPrefix(
+                alloc,
+                events,
+                manifest.log_generation,
+                manifest.last_event_seq,
+                manifest.event_log_bytes,
+            ) catch |err| switch (err) {
+                error.OutOfMemory => return error.OutOfMemory,
+                error.UnsupportedSessionSchema => return error.SessionRecoveryUnsupportedSchema,
+                else => return error.SessionRecoveryBoundaryInvalid,
+            };
+            var imported_owned = true;
+            defer if (imported_owned) imported.deinit(alloc);
+            if (!session_projection.stateMatchesManifest(imported.state, manifest)) {
+                return error.SessionRecoveryBoundaryInvalid;
+            }
+            const recovered_state = imported.takeState();
+            imported_owned = false;
+            break :recovery_state recovered_state;
         };
-        defer manifest.deinit(alloc);
-        if (!std.mem.eql(u8, manifest.id, session_id)) return error.SessionRecoveryBoundaryInvalid;
-        var events = openSessionFile(&source.dir, "events.jsonl", .read_only) catch
-            return error.SessionRecoveryBoundaryInvalid;
-        defer events.close(io_mod.getIo());
-        var imported = session_replay.replayCommittedPrefix(
-            alloc,
-            events,
-            manifest.log_generation,
-            manifest.last_event_seq,
-            manifest.event_log_bytes,
-        ) catch |err| switch (err) {
-            error.OutOfMemory => return error.OutOfMemory,
-            error.UnsupportedSessionSchema => return error.SessionRecoveryUnsupportedSchema,
-            else => return error.SessionRecoveryBoundaryInvalid,
-        };
-        var imported_owned = true;
-        defer if (imported_owned) imported.deinit(alloc);
-        if (!session_projection.stateMatchesManifest(imported.state, manifest)) {
-            return error.SessionRecoveryBoundaryInvalid;
-        }
-        var recovered = imported.takeState();
-        imported_owned = false;
         defer recovered.deinit(alloc);
         try resolveSessionSnapshotLocators(
             alloc,
@@ -3293,6 +3308,9 @@ pub const Store = struct {
             .read_only,
         );
         defer source_children.deinit();
+        if (try subagent_child_state.capabilityHasManagedChildMarker(alloc, &source_children)) {
+            return error.SessionNotFound;
+        }
 
         const source_id = try alloc.dupe(u8, recovered.id);
         errdefer alloc.free(source_id);
@@ -3339,6 +3357,13 @@ pub const Store = struct {
             target_owned = false;
         };
 
+        if (recovered.usage == null) {
+            if (target.state.usage) |usage| {
+                // Keep the normal new-session default when optional usage is absent.
+                recovered.usage = try session_usage.dupeSnapshotOwned(alloc, usage);
+            }
+        }
+
         const staged_target_dir = try sessionDirPath(
             alloc,
             staging_root.display_root,
@@ -3379,6 +3404,10 @@ pub const Store = struct {
             target.child_capability orelse
                 return error.SessionChildStoreFailed,
         );
+        if (current_boundary) |boundary| {
+            try session_log.copy_conversation_recovery_prefix(alloc, &source.dir, &target.log.dir, boundary);
+            if (metadata.?.value.title) |title| _ = try target.renameConversation(alloc, title);
+        }
         if (!try session_log.durableStatesEqual(target.state, recovered)) {
             const disposition = discardRecoveryStagedSession(
                 &staging_root,
@@ -3420,13 +3449,7 @@ pub const Store = struct {
         target.deinit(alloc);
         target_owned = false;
 
-        var verified = self.resumeExactForWrite(
-            alloc,
-            recovered_id,
-            recovered.workspace_root,
-            false,
-            .{ .log = options },
-        ) catch |err| {
+        var verified = self.loadReadOnly(alloc, recovered_id) catch |err| {
             debug_trace.logf(
                 "session",
                 "event=session_recovery_target_indeterminate target={s} verify_err={s}",
@@ -3440,7 +3463,7 @@ pub const Store = struct {
             };
         };
         defer verified.deinit(alloc);
-        if (!try session_log.durableStatesEqual(verified.state, recovered)) {
+        if (!try session_log.durableStatesEqual(verified, recovered)) {
             return .{
                 .source_session_id = source_id,
                 .recovered_session_id = recovered_id,

--- a/src/core/session/session_store.zig
+++ b/src/core/session/session_store.zig
@@ -3665,10 +3665,10 @@ fn copyRecoveredCommandReplay(
                 alloc,
                 target,
                 descriptor,
-            ) catch return error.SessionRecoveryBoundaryInvalid;
+            ) catch |err| return recoveryArtifactReadError(err);
             defer reader.deinit();
-            while (reader.nextByte() catch
-                return error.SessionRecoveryBoundaryInvalid) |_|
+            while (reader.nextByte() catch |err|
+                return recoveryArtifactReadError(err)) |_|
             {}
             return !authenticated;
         },
@@ -3752,7 +3752,7 @@ fn copyRecoveredManagedChild(
         const read_len = source_file.readRangeInto(
             offset,
             buffer[0..chunk_len],
-        ) catch return error.SessionRecoveryBoundaryInvalid;
+        ) catch |err| return recoveryArtifactReadError(err);
         if (read_len == 0) return error.SessionRecoveryBoundaryInvalid;
         source_hasher.update(buffer[0..read_len]);
         try target_file.writeAll(buffer[0..read_len]);
@@ -3796,7 +3796,7 @@ fn managedFileDigest(
         const read_len = file.readRangeInto(
             offset,
             buffer[0..chunk_len],
-        ) catch return error.SessionRecoveryBoundaryInvalid;
+        ) catch |err| return recoveryArtifactReadError(err);
         if (read_len == 0) return error.SessionRecoveryBoundaryInvalid;
         hasher.update(buffer[0..read_len]);
         offset = std.math.add(u64, offset, read_len) catch
@@ -3805,6 +3805,34 @@ fn managedFileDigest(
     var digest: [32]u8 = undefined;
     hasher.final(&digest);
     return digest;
+}
+
+fn recoveryArtifactReadError(err: anyerror) anyerror {
+    return switch (err) {
+        error.FileNotFound,
+        error.InvalidReplayHeader,
+        error.ReplaySizeMismatch,
+        error.ReplayTooLarge,
+        error.ReplayOffsetTooLarge,
+        error.UnexpectedEndOfReplay,
+        error.EndOfStream,
+        error.TruncatedReplayFrame,
+        error.InvalidReplayStream,
+        error.EmptyReplayFrame,
+        error.ReplayFrameTooLarge,
+        error.Overflow,
+        => error.SessionRecoveryBoundaryInvalid,
+        else => err,
+    };
+}
+
+test "recovery artifact errors distinguish damaged bytes from operational failures" {
+    for ([_]anyerror{ error.FileNotFound, error.InvalidReplayHeader, error.ReplaySizeMismatch, error.ReplayTooLarge, error.ReplayOffsetTooLarge, error.UnexpectedEndOfReplay, error.EndOfStream, error.TruncatedReplayFrame, error.InvalidReplayStream, error.EmptyReplayFrame, error.ReplayFrameTooLarge, error.Overflow }) |err| {
+        try std.testing.expectEqual(error.SessionRecoveryBoundaryInvalid, recoveryArtifactReadError(err));
+    }
+    for ([_]anyerror{ error.OutOfMemory, error.ReadFailed, error.AccessDenied, error.Canceled, error.Unseekable, error.Unexpected, error.SystemResources }) |err| {
+        try std.testing.expectEqual(err, recoveryArtifactReadError(err));
+    }
 }
 
 fn validateRecoveredManagedChildDigest(
@@ -5794,6 +5822,39 @@ test "doctor ignores legacy task records" {
         }
     }
     try std.testing.expect(!found);
+}
+
+test "recovery command replay allocation failures propagate without changing source" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(std.testing.io, "source");
+    try tmp.dir.createDirPath(std.testing.io, "target");
+    const source_path = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "source");
+    defer alloc.free(source_path);
+    const target_path = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "target");
+    defer alloc.free(target_path);
+    var source = try session_child_store.SessionChildCapability.initLegacyRoute(alloc, source_path, .command_artifacts, .writable);
+    defer source.deinit();
+    var target = try session_child_store.SessionChildCapability.initLegacyRoute(alloc, target_path, .command_artifacts, .writable);
+    defer target.deinit();
+    const capture = try command_replay_store.Capture.create(alloc, 1024, &source);
+    defer alloc.destroy(capture);
+    defer capture.discard(alloc);
+    capture.appendAccepted(alloc, .stdout, "retained command bytes");
+    const replay = capture.retain(alloc) orelse return error.TestExpectedReplay;
+    try std.testing.expect(replay == .available);
+    var source_file = try source.openFileReadOnly(alloc, .command_artifacts, replay.available.handle);
+    defer source_file.deinit();
+    const before = try managedFileDigest(&source_file, replay.available.framed_bytes);
+    try std.testing.checkAllAllocationFailures(alloc, struct {
+        fn check(test_alloc: Allocator, input: *session_child_store.SessionChildCapability, output: *session_child_store.SessionChildCapability, value: core_types.CommandOutputReplay) !void {
+            // Each failure run starts from the same absent-target state.
+            defer output.delete(.command_artifacts, value.available.handle) catch {};
+            try std.testing.expect(!try copyRecoveredCommandReplay(test_alloc, input, output, value));
+        }
+    }.check, .{ &source, &target, replay });
+    try std.testing.expectEqual(before, try managedFileDigest(&source_file, replay.available.framed_bytes));
 }
 
 test "recovery authenticates content-addressed command artifacts" {

--- a/src/core/subagent/child_state.zig
+++ b/src/core/subagent/child_state.zig
@@ -545,7 +545,7 @@ pub fn hasManagedChildMarker(
     return capabilityHasManagedChildMarker(alloc, &capability);
 }
 
-fn capabilityHasManagedChildMarker(
+pub fn capabilityHasManagedChildMarker(
     alloc: Allocator,
     capability: *session_child_store.SessionChildCapability,
 ) !bool {

--- a/tests/e2e/session-recovery.test.ts
+++ b/tests/e2e/session-recovery.test.ts
@@ -237,6 +237,55 @@ describe("session recovery", () => {
     }, TIMEOUT);
   }
 
+  for (const tail of ["", "invalid tail\n"]) {
+    test(`current recovery excludes checkpoint splitting a call/result pair with tail=${tail.length > 0}`, async () => {
+      const fixture = createFixture("fx-session-current-cut-");
+      const responses = [fakeShellRun("cut-call", "printf 'CUT_RESULT_619\\n'"), fakeGatewayFinalText("CUT_SAVED")];
+      const gateway = startFakeGateway(responses);
+      try {
+        const created = await runFx(["ask", "--json", "--full-access", "Save one result."], {
+          cwd: fixture.workspace, env: gatewayEnv(fixture, gateway), timeoutMs: TIMEOUT,
+        });
+        expect(created.code).toBe(0);
+        const id = JSON.parse(created.stdout).session_id;
+        const source = join(fixture.home, ".fx", "sessions", id);
+        const eventPath = join(source, "events.jsonl");
+        const prefix = readFileSync(eventPath, "utf8");
+        const records = prefix.trimEnd().split("\n").map(JSON.parse);
+        const callSeq = records.find((record) => record.event.tool_call).seq;
+        appendFileSync(eventPath, JSON.stringify({ schema_version: 1, seq: records.at(-1).seq + 1, timestamp_ms: Date.now(), event: {
+          context_checkpoint: { covers_through_seq: callSeq, summary: "INVALID_SPLIT_CHECKPOINT" },
+        } }) + "\n" + tail);
+        const before = savedFileHashes(source);
+        const recovered = await runFx(["session", "recover", id, "--json"], {
+          cwd: fixture.workspace, env: gatewayEnv(fixture, gateway), timeoutMs: TIMEOUT,
+        });
+        expect(recovered.code).toBe(0);
+        expect(recovered.stderr).toBe("");
+        const result = JSON.parse(recovered.stdout);
+        expect(result.status).toBe("recovered");
+        const target = join(fixture.home, ".fx", "sessions", result.recovered_id);
+        expect(readFileSync(join(target, "events.jsonl"), "utf8")).toBe(prefix);
+        expect(savedFileHashes(source)).toEqual(before);
+        const inspected = await runFx(["session", "--id", result.recovered_id, "--json"], {
+          cwd: fixture.workspace, env: gatewayEnv(fixture, gateway), timeoutMs: TIMEOUT,
+        });
+        expect(inspected.code).toBe(0);
+        expect(inspected.stderr).toBe("");
+        expect(inspected.stdout).toContain("CUT_SAVED");
+        responses.push(fakeGatewayFinalText("CUT_CONTINUED"));
+        const continued = await continueSession(fixture, gateway, result.recovered_id);
+        expect(continued.code).toBe(0);
+        expect(JSON.parse(continued.stdout).output).toBe("CUT_CONTINUED");
+        expect(gateway.requests).toHaveLength(3);
+        expect(savedFileHashes(source)).toEqual(before);
+      } finally {
+        gateway.stop();
+        rmSync(fixture.root, { recursive: true, force: true });
+      }
+    }, TIMEOUT);
+  }
+
   for (const damage of ["metadata", "private-child", "private-marker", "first-record", "missing-result", "changed-result"] as const) {
     test(`current conversation recovery refuses ${damage} without publishing a copy`, async () => {
       const fixture = createFixture("fx-session-current-refusal-");

--- a/tests/e2e/session-recovery.test.ts
+++ b/tests/e2e/session-recovery.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
 import {
   appendFileSync,
+  existsSync,
   mkdtempSync,
   mkdirSync,
   readFileSync,
@@ -15,12 +17,30 @@ import { runFx } from "../evals/eval-helpers";
 import {
   FAKE_GATEWAY_MODEL,
   fakeGatewayFinalText,
+  fakeGatewayToolCall,
+  fakeShellRun,
   startFakeGateway,
   TmuxSession,
   tmuxAvailable,
 } from "./tmux-helpers";
 
 const TIMEOUT = 30_000;
+
+function savedFileHashes(root: string): Record<string, string> {
+  const hashes: Record<string, string> = {};
+  function visit(directory: string, prefix = "") {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      if (entry.name === "session.lock") continue;
+      const relative = join(prefix, entry.name);
+      if (entry.isDirectory()) visit(join(directory, entry.name), relative);
+      else hashes[relative] = createHash("sha256")
+        .update(readFileSync(join(directory, entry.name)))
+        .digest("hex");
+    }
+  }
+  visit(root);
+  return hashes;
+}
 
 function createFixture(prefix: string) {
   const root = mkdtempSync(join(tmpdir(), prefix));
@@ -91,6 +111,190 @@ async function continueSession(
 }
 
 describe("session recovery", () => {
+  test("healthy current conversation needs no recovery or migration", async () => {
+    const fixture = createFixture("fx-session-current-healthy-");
+    const gateway = startFakeGateway([fakeGatewayFinalText("SAVED_HEALTHY")]);
+    try {
+      const id = await createSavedSession(fixture, gateway);
+      const source = join(fixture.home, ".fx", "sessions", id);
+      const before = savedFileHashes(source);
+      const result = await runFx(["session", "recover", id, "--json"], {
+        cwd: fixture.workspace, env: gatewayEnv(fixture, gateway), timeoutMs: TIMEOUT,
+      });
+      expect(result.code).toBe(1);
+      expect(result.stderr).toBe("");
+      expect(JSON.parse(result.stdout).code).toBe("SessionRecoveryNotNeeded");
+      expect(savedFileHashes(source)).toEqual(before);
+      expect(readdirSync(join(fixture.home, ".fx", "sessions"))).toEqual([id]);
+      expect(gateway.requests).toHaveLength(1);
+    } finally {
+      gateway.stop();
+      rmSync(fixture.root, { recursive: true, force: true });
+    }
+  }, TIMEOUT);
+
+  for (const { checkpointedTurn, missingUsage, fullCoverage } of [
+    { checkpointedTurn: false, missingUsage: false, fullCoverage: false },
+    { checkpointedTurn: true, missingUsage: false, fullCoverage: false },
+    { checkpointedTurn: false, missingUsage: true, fullCoverage: false },
+    { checkpointedTurn: false, missingUsage: false, fullCoverage: true },
+  ]) {
+    test(`current conversation recovery preserves exact checkpoints and artifacts with open=${checkpointedTurn} missing usage=${missingUsage} full coverage=${fullCoverage}`, async () => {
+      const fixture = createFixture("fx-session-current-copy-");
+      const responses = [
+        fakeShellRun("saved-effect", "printf 'ONCE_RECOVERY_731\\n' >> effect.log; printf 'RESULT_RECOVERY_982\\n'"),
+        fakeGatewayFinalText("WORK_SAVED"),
+      ];
+      const gateway = startFakeGateway(responses);
+      try {
+        const created = await runFx(["ask", "--json", "--full-access", "Save one command result."], {
+          cwd: fixture.workspace, env: gatewayEnv(fixture, gateway), timeoutMs: TIMEOUT,
+        });
+        expect(created.code).toBe(0);
+        const id = JSON.parse(created.stdout).session_id;
+        const source = join(fixture.home, ".fx", "sessions", id);
+        const eventPath = join(source, "events.jsonl");
+        const metadataPath = join(source, "session.json");
+        const metadata = JSON.parse(readFileSync(metadataPath, "utf8"));
+        metadata.title = "Recovered work keeps its chosen title";
+        writeFileSync(metadataPath, JSON.stringify(metadata), { mode: 0o600 });
+        if (missingUsage) rmSync(join(source, "usage-v2.json"));
+        const records = readFileSync(eventPath, "utf8").trimEnd().split("\n").map(JSON.parse);
+        if (fullCoverage) records[0].event.user.work_id = "covered-recovery-work";
+        const stored = records.find((record) => record.event.tool_result).event.tool_result;
+        const coverage = fullCoverage ? records[records.length - 1].seq : 1;
+        const append = (event: object) => records.push({
+          schema_version: 1, seq: records.length + 1, timestamp_ms: Date.now(), event,
+        });
+        append({ context_checkpoint: { covers_through_seq: coverage, summary: "<context_handoff>Saved command completed.</context_handoff>" } });
+        append({ context_checkpoint: { covers_through_seq: coverage, summary: "<context_handoff>Retain the completed command and its result.</context_handoff>" } });
+        if (checkpointedTurn) {
+          append({ user: { text: "Keep the already completed stored read.", work_id: "checkpointed-recovery-work" } });
+          append({ tool_call: { call_id: "checkpointed-read", tool_name: "read_tool_result", arguments_json: JSON.stringify({ handle: stored.artifact_ref }) } });
+          append({ tool_result: { ...stored, call_id: "checkpointed-read", tool_name: "read_tool_result" } });
+          append({ context_checkpoint: { covers_through_seq: 1, summary: "<context_handoff>Checkpointed read is already complete.</context_handoff>" } });
+        }
+        const prefix = records.map((record) => JSON.stringify(record)).join("\n") + "\n";
+        writeFileSync(eventPath, prefix + "invalid CORRUPT_TAIL_MUST_NOT_REPLAY\n", { mode: 0o600 });
+        const before = savedFileHashes(source);
+        const recovered = await runFx(["session", "recover", id, "--json"], {
+          cwd: fixture.workspace, env: gatewayEnv(fixture, gateway), timeoutMs: TIMEOUT,
+        });
+        expect(recovered.code).toBe(0);
+        expect(recovered.stderr).toBe("");
+        const result = JSON.parse(recovered.stdout);
+        expect(result).toMatchObject({ kind: "session_recovery", source_id: id, status: "recovered" });
+        expect(result.recovered_id).not.toBe(id);
+        expect(gateway.requests).toHaveLength(2);
+        expect(savedFileHashes(source)).toEqual(before);
+        const target = join(fixture.home, ".fx", "sessions", result.recovered_id);
+        expect(JSON.parse(readFileSync(join(target, "session.json"), "utf8")).title).toBe(metadata.title);
+        const targetEvents = readFileSync(join(target, "events.jsonl"), "utf8");
+        expect(targetEvents.startsWith(prefix)).toBe(true);
+        expect(targetEvents).not.toContain("CORRUPT_TAIL_MUST_NOT_REPLAY");
+        const suffix = targetEvents.slice(prefix.length);
+        if (checkpointedTurn) expect(JSON.parse(suffix).event).toEqual({ interrupted: expect.objectContaining({ reason: "failed" }) });
+        else expect(suffix).toBe("");
+        for (const [path, digest] of Object.entries(before)) {
+          if (path.startsWith("tool-results/") || path.startsWith("logs/commands/")) {
+            expect(savedFileHashes(target)[path]).toBe(digest);
+          }
+        }
+
+        responses.push(
+          fakeGatewayToolCall("read-recovered", "read_tool_result", { request: { handle: stored.artifact_ref, query: "RESULT_RECOVERY_982" } }),
+          fakeGatewayFinalText("RECOVERED_CONTINUATION_SAVED"),
+        );
+        const tracePath = join(fixture.root, "continue.trace.log");
+        const continued = await runFx(["ask", "--json", "--full-access", "--resume-id", result.recovered_id, "Read the retained result. Do not repeat completed commands."], {
+          cwd: fixture.workspace,
+          env: { ...gatewayEnv(fixture, gateway), FX_TRACE_LOG: tracePath, FX_TRACE_SCOPES: "tool,session,agent" },
+          timeoutMs: TIMEOUT,
+        });
+        expect(continued.code).toBe(0);
+        expect(JSON.parse(continued.stdout)).toMatchObject({ output: "RECOVERED_CONTINUATION_SAVED", tool_calls: [{ name: "read_tool_result", status: "success" }] });
+        expect(gateway.requests).toHaveLength(4);
+        const executionStarts = readFileSync(tracePath, "utf8").split("\n")
+          .filter((line) => line.includes("[tool] event=execution_start "));
+        expect(executionStarts).toHaveLength(1);
+        expect(executionStarts[0]).toContain("call_id=read-recovered name=read_tool_result");
+        const after = readFileSync(join(target, "events.jsonl"), "utf8").trimEnd().split("\n").map(JSON.parse);
+        const readResult = after.find((record) => record.event.tool_result?.call_id === "read-recovered").event.tool_result;
+        expect(readResult.status).toBe("success");
+        expect(readFileSync(join(target, "tool-results", readResult.artifact_ref), "utf8")).toContain("RESULT_RECOVERY_982");
+        expect(readFileSync(join(fixture.workspace, "effect.log"), "utf8")).toBe("ONCE_RECOVERY_731\n");
+        expect(savedFileHashes(source)).toEqual(before);
+        const inspected = await runFx(["session", "--id", result.recovered_id, "--json"], {
+          cwd: fixture.workspace, env: gatewayEnv(fixture, gateway), timeoutMs: TIMEOUT,
+        });
+        expect(inspected.code).toBe(0);
+        expect(inspected.stderr).toBe("");
+        expect(inspected.stdout).toContain("RECOVERED_CONTINUATION_SAVED");
+      } finally {
+        gateway.stop();
+        rmSync(fixture.root, { recursive: true, force: true });
+      }
+    }, TIMEOUT);
+  }
+
+  for (const damage of ["metadata", "private-child", "private-marker", "first-record", "missing-result", "changed-result"] as const) {
+    test(`current conversation recovery refuses ${damage} without publishing a copy`, async () => {
+      const fixture = createFixture("fx-session-current-refusal-");
+      const gateway = startFakeGateway([
+        fakeShellRun("retained-result", "printf 'REQUIRED_RESULT_619\\n'"),
+        fakeGatewayFinalText("RESULT_SAVED"),
+      ]);
+      try {
+        const created = await runFx(["ask", "--json", "--full-access", "Save a result."], {
+          cwd: fixture.workspace, env: gatewayEnv(fixture, gateway), timeoutMs: TIMEOUT,
+        });
+        expect(created.code).toBe(0);
+        const id = JSON.parse(created.stdout).session_id;
+        const source = join(fixture.home, ".fx", "sessions", id);
+        const eventPath = join(source, "events.jsonl");
+        const committed = readFileSync(eventPath, "utf8");
+        if (damage === "metadata" || damage === "private-child") {
+          const metadataPath = join(source, "session.json");
+          const metadata = JSON.parse(readFileSync(metadataPath, "utf8"));
+          if (damage === "metadata") metadata.id = "different-session";
+          else metadata.subagent_child = true;
+          writeFileSync(metadataPath, JSON.stringify(metadata), { mode: 0o600 });
+        } else if (damage === "private-marker") {
+          mkdirSync(join(source, "subagent"), { recursive: true, mode: 0o700 });
+          writeFileSync(join(source, "subagent", "owner.json"), "{}", { mode: 0o600 });
+          appendFileSync(eventPath, "invalid tail\n");
+        } else if (damage === "first-record") {
+          writeFileSync(eventPath, "[" + committed.slice(1), { mode: 0o600 });
+        } else {
+          appendFileSync(eventPath, "invalid tail\n");
+          const record = committed.trimEnd().split("\n").map(JSON.parse)
+            .find((frame) => frame.event.tool_result).event.tool_result;
+          const artifactPath = join(source, "tool-results", record.artifact_ref);
+          if (damage === "missing-result") rmSync(artifactPath);
+          else {
+            const bytes = readFileSync(artifactPath);
+            bytes[0] ^= 1;
+            writeFileSync(artifactPath, bytes);
+          }
+        }
+        const before = savedFileHashes(source);
+        const result = await runFx(["session", "recover", id, "--json"], {
+          cwd: fixture.workspace, env: gatewayEnv(fixture, gateway), timeoutMs: TIMEOUT,
+        });
+        expect(result.code).toBe(1);
+        expect(result.stderr).toBe("");
+        expect(JSON.parse(result.stdout).code).toBe(damage === "private-child" || damage === "private-marker" ? "SessionNotFound" : "SessionRecoveryBoundaryInvalid");
+        expect(savedFileHashes(source)).toEqual(before);
+        const sessionRoot = join(fixture.home, ".fx", "sessions");
+        expect(readdirSync(sessionRoot).filter((name) => existsSync(join(sessionRoot, name, "session.json")))).toEqual([id]);
+        expect(gateway.requests).toHaveLength(2);
+      } finally {
+        gateway.stop();
+        rmSync(fixture.root, { recursive: true, force: true });
+      }
+    }, TIMEOUT);
+  }
+
   test.skipIf(!tmuxAvailable())("resume picker discovers a checkpoint from an unfinished first turn", async () => {
     const fixture = createFixture("fx-session-first-checkpoint-");
     const gateway = startFakeGateway([


### PR DESCRIPTION
## Summary

- Recover damaged current-format conversations into a separate saved session.
- Leave the original session unchanged.
- Preserve exact checkpoint coverage and stored tool-result and command-replay files.
- Keep user-chosen session titles in recovered copies.
- Mark checkpointed unfinished turns as interrupted without rerunning commands.
- Report when a healthy conversation does not need recovery.
- Return structured recovery errors for malformed metadata or missing required artifacts.
- Keep private child sessions out of standalone recovery.
- Recover sessions with missing optional usage data or fully summarized work history.
- Recover up to the last valid prefix when a checkpoint splits a tool-call batch.
- Keep storage and memory failures distinct from corrupt session data.
