### PR TITLE
Preserve native assistant message boundaries

### DIFF
--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -2579,7 +2579,6 @@ fn materializeConfirmedProviderTools(
         within_turn_suffix,
         null,
         novel_calls,
-        completion.assistant_phase,
         try deps.agent_stream_provider.projectReplay(arena, if (completion.provider_state_json) |parts| .{ .source = selection, .parts_json = parts } else null, novel_calls, false, true),
     );
     var batch: runtime_tool_batch.StepBatchState = .{};
@@ -7957,7 +7956,6 @@ fn processQueuedPromptLoop(
             &within_turn_suffix,
             if (terminal_provider_completion) null else completion.content,
             effective_tool_calls,
-            completion.assistant_phase,
             if (terminal_provider_completion or filtered_provider_calls.removed > 0)
                 try deps.agent_stream_provider.projectReplay(arena, provider_replay, effective_tool_calls, !terminal_provider_completion, true)
             else

--- a/src/core/agent/runtime/tool_batch.zig
+++ b/src/core/agent/runtime/tool_batch.zig
@@ -46,14 +46,12 @@ pub fn appendAssistantToolCallStep(
     within_turn_suffix: *std.ArrayList(ChatMessage),
     content: ?[]const u8,
     tool_calls: []const ToolCall,
-    assistant_phase: ?types.AssistantMessagePhase,
     provider_replay: ?types.ProviderReplay,
 ) !void {
     try within_turn_suffix.append(arena, .{
         .role = .assistant,
         .content = content,
         .tool_calls = tool_calls,
-        .assistant_phase = assistant_phase,
         .provider_replay = provider_replay,
     });
 }
@@ -556,7 +554,7 @@ test "drained batch feedback follows all tool results and keeps its source call"
         .{ .id = "call_second", .name = "run_command", .arguments_json = "{}" },
     };
 
-    try appendAssistantToolCallStep(alloc, &suffix, null, &calls, .commentary, null);
+    try appendAssistantToolCallStep(alloc, &suffix, null, &calls, null);
     try appendToolResultContent(
         alloc,
         &suffix,
@@ -587,10 +585,6 @@ test "drained batch feedback follows all tool results and keeps its source call"
 
     try std.testing.expectEqual(@as(usize, 4), suffix.items.len);
     try std.testing.expectEqual(.assistant, suffix.items[0].role);
-    try std.testing.expectEqual(
-        types.AssistantMessagePhase.commentary,
-        suffix.items[0].assistant_phase.?,
-    );
     try std.testing.expectEqual(.tool, suffix.items[1].role);
     try std.testing.expectEqual(.tool, suffix.items[2].role);
     try std.testing.expectEqual(.user, suffix.items[3].role);

--- a/src/core/shared/types.zig
+++ b/src/core/shared/types.zig
@@ -1136,11 +1136,6 @@ pub fn freeProviderReplay(alloc: std.mem.Allocator, value: ProviderReplay) void 
     alloc.free(value.parts_json);
 }
 
-/// Provider-returned phase for stateless assistant-message replay.
-pub const AssistantMessagePhase = enum {
-    commentary,
-    final_answer,
-};
 pub const ChatMessage = struct {
     role: ChatRole,
     content: ?[]const u8 = null,
@@ -1149,8 +1144,6 @@ pub const ChatMessage = struct {
     tool_name: ?[]const u8 = null,
     tool_calls: []const ToolCall = &.{},
     provider_replay: ?ProviderReplay = null,
-    /// Borrowed phase metadata for the same current-turn continuation.
-    assistant_phase: ?AssistantMessagePhase = null,
     tool_result_status: ?PersistedToolStatus = null,
     tool_result_memory: ?ToolResultMemory = null,
     permission_feedback: bool = false,
@@ -1170,7 +1163,6 @@ pub fn projectProviderReplay(
         if (replay.matches(source)) continue;
         if (projected == null) projected = try alloc.dupe(ChatMessage, messages);
         projected.?[index].provider_replay = null;
-        projected.?[index].assistant_phase = null;
     }
     return projected;
 }
@@ -1291,7 +1283,6 @@ pub const ProviderFailureCause = enum {
 pub const ModelCompletion = struct {
     content: ?[]const u8 = null,
     tool_calls: []const ToolCall = &.{},
-    assistant_phase: ?AssistantMessagePhase = null,
     generation_id: ?[]const u8 = null,
     billing: ?ProviderBilling = null,
     /// Gateway generation or resolved-model metadata was malformed or conflicting.

--- a/src/gateway/responses_protocol.zig
+++ b/src/gateway/responses_protocol.zig
@@ -784,7 +784,6 @@ const TextUpdate = struct {
 
 const TextPart = struct {
     kind: TextKind,
-    item_id_hash: ?[TextDigest.digest_length]u8 = null,
     received_bytes: usize = 0,
     digest: TextDigest = .init(.{}),
     finalized: bool = false,
@@ -1151,11 +1150,6 @@ pub const Reducer = struct {
         if (!entry.found_existing) entry.value_ptr.* = .{ .kind = update.kind };
         const part = entry.value_ptr;
         if (part.kind != update.kind) return error.ResponsesTextConflict;
-        if (update.item_id_hash) |id| {
-            if (part.item_id_hash) |prior| {
-                if (!std.mem.eql(u8, &id, &prior)) return error.ResponsesTextConflict;
-            } else part.item_id_hash = id;
-        }
         const suffix = switch (update.mode) {
             .final => try part.final_suffix(update.text),
             .delta => blk: {

--- a/src/gateway/responses_protocol.zig
+++ b/src/gateway/responses_protocol.zig
@@ -98,11 +98,15 @@ pub fn writeInput(
                 try writer.writeAll("]}");
             },
             .assistant => {
-                var assistant_phase = message.assistant_phase;
+                var legacy_phase: ?AssistantMessagePhase = null;
+                var span_end: ?usize = null;
+                const content = message.content orelse "";
                 if (message.provider_replay) |replay| {
                     const state_json = replay.parts_json;
-                    var state = std.json.parseFromSlice(std.json.Value, scratch_alloc, state_json, .{}) catch
-                        return error.InvalidProviderState;
+                    var state = std.json.parseFromSlice(std.json.Value, scratch_alloc, state_json, .{}) catch |err| switch (err) {
+                        error.OutOfMemory => return error.OutOfMemory,
+                        else => return error.InvalidProviderState,
+                    };
                     defer state.deinit();
                     if (state.value != .array) return error.InvalidProviderState;
                     for (state.value.array.items) |item| {
@@ -110,9 +114,22 @@ pub fn writeInput(
                         const kind = item.object.get("type") orelse return error.InvalidProviderState;
                         if (kind != .string) return error.InvalidProviderState;
                         if (std.mem.eql(u8, kind.string, "message")) {
-                            const phase = assistantMessagePhase(item.object) orelse return error.InvalidProviderState;
-                            if (assistant_phase) |prior| if (prior != phase) return error.InvalidProviderState;
-                            assistant_phase = phase;
+                            const phase = assistantMessagePhase(item.object) catch return error.InvalidProviderState;
+                            if (item.object.contains("offset") or item.object.contains("length")) {
+                                if (legacy_phase != null) return error.InvalidProviderState;
+                                const offset = replay_index(item.object, "offset") orelse return error.InvalidProviderState;
+                                const length = replay_index(item.object, "length") orelse return error.InvalidProviderState;
+                                if (offset > content.len or length == 0 or length > content.len - offset) return error.InvalidProviderState;
+                                if (span_end) |end| {
+                                    if (offset < end or !std.mem.eql(u8, content[end..offset], "\n\n")) return error.InvalidProviderState;
+                                } else if (offset != 0) return error.InvalidProviderState;
+                                try write_assistant_text(writer, &first, content[offset..][0..length], phase);
+                                span_end = offset + length;
+                            } else {
+                                if (span_end != null or phase == null) return error.InvalidProviderState;
+                                if (legacy_phase) |prior| if (prior != phase.?) return error.InvalidProviderState;
+                                legacy_phase = phase;
+                            }
                             continue;
                         }
                         if (!std.mem.eql(u8, kind.string, "reasoning")) return error.InvalidProviderState;
@@ -120,17 +137,11 @@ pub fn writeInput(
                         try std.json.Stringify.value(item, .{}, writer);
                     }
                 }
-                if (message.content) |content| if (content.len > 0) {
-                    try writeComma(writer, &first);
-                    try writer.writeAll("{\"type\":\"message\",\"role\":\"assistant\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"text\":");
-                    try std.json.Stringify.value(content, .{}, writer);
-                    try writer.writeAll(",\"annotations\":[]}]");
-                    if (assistant_phase) |phase| {
-                        try writer.writeAll(",\"phase\":");
-                        try std.json.Stringify.value(@tagName(phase), .{}, writer);
-                    }
-                    try writer.writeByte('}');
-                };
+                if (span_end) |end| {
+                    // Capture can end inside the separator before the next message.
+                    const tail = content[end..];
+                    if (tail.len > 2 or !std.mem.startsWith(u8, "\n\n", tail)) return error.InvalidProviderState;
+                } else if (content.len > 0) try write_assistant_text(writer, &first, content, legacy_phase);
                 for (message.tool_calls) |call| {
                     try writeComma(writer, &first);
                     try writer.writeAll("{\"type\":\"function_call\",\"call_id\":");
@@ -176,6 +187,24 @@ pub fn writeInput(
             },
         }
     }
+}
+
+fn replay_index(fields: std.json.ObjectMap, name: []const u8) ?usize {
+    const value = fields.get(name) orelse return null;
+    if (value != .integer) return null;
+    return std.math.cast(usize, value.integer);
+}
+
+fn write_assistant_text(writer: *std.Io.Writer, first: *bool, content: []const u8, phase: ?AssistantMessagePhase) !void {
+    try writeComma(writer, first);
+    try writer.writeAll("{\"type\":\"message\",\"role\":\"assistant\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"text\":");
+    try std.json.Stringify.value(content, .{}, writer);
+    try writer.writeAll(",\"annotations\":[]}]");
+    if (phase) |value| {
+        try writer.writeAll(",\"phase\":");
+        try std.json.Stringify.value(@tagName(value), .{}, writer);
+    }
+    try writer.writeByte('}');
 }
 
 test "Responses request projects long call ids with matching outputs" {
@@ -285,7 +314,7 @@ test "Responses request preserves assistant commentary phase" {
             .role = .assistant,
             .content = "I will inspect the file first.",
             .tool_calls = &calls,
-            .assistant_phase = .commentary,
+            .provider_replay = .{ .source = .{ .provider = .codex, .model = "fixture-model" }, .parts_json = "[{\"type\":\"message\",\"phase\":\"commentary\"}]" },
         },
         .{
             .role = .tool,
@@ -788,34 +817,30 @@ fn text_identity(fields: std.json.ObjectMap, name: []const u8) !?[TextDigest.dig
     return digest;
 }
 
-const AssistantPhaseAccumulator = union(enum) {
-    empty,
-    value: types.AssistantMessagePhase,
-    conflicting,
+const AssistantMessagePhase = enum { commentary, final_answer };
 
-    fn observe(self: *AssistantPhaseAccumulator, candidate: ?types.AssistantMessagePhase) void {
-        const phase = candidate orelse return;
-        self.* = switch (self.*) {
-            .empty => .{ .value = phase },
-            .value => |current| if (current == phase) .{ .value = current } else .conflicting,
-            .conflicting => .conflicting,
-        };
-    }
-
-    fn resolved(self: AssistantPhaseAccumulator) ?types.AssistantMessagePhase {
-        return switch (self) {
-            .value => |phase| phase,
-            .empty, .conflicting => null,
-        };
-    }
-};
-
-fn assistantMessagePhase(fields: std.json.ObjectMap) ?types.AssistantMessagePhase {
-    const raw = stringField(fields, "phase") orelse return null;
-    return std.meta.stringToEnum(types.AssistantMessagePhase, raw);
+fn assistantMessagePhase(fields: std.json.ObjectMap) !?AssistantMessagePhase {
+    const raw = fields.get("phase") orelse return null;
+    if (raw == .null) return null;
+    if (raw != .string) return error.InvalidEvent;
+    return std.meta.stringToEnum(AssistantMessagePhase, raw.string);
 }
 
 pub const Reducer = struct {
+    const MessageItem = struct {
+        output_index: i64,
+        id_hash: ?[TextDigest.digest_length]u8,
+        phase: ?AssistantMessagePhase,
+        offset: usize = 0,
+        length: usize = 0,
+
+        fn replay_json(self: MessageItem, buffer: []u8) ![]const u8 {
+            var out: std.Io.Writer = .fixed(buffer);
+            try std.json.Stringify.value(.{ .type = "message", .offset = self.offset, .length = self.length, .phase = self.phase }, .{ .emit_null_optional_fields = false }, &out);
+            return out.buffered();
+        }
+    };
+
     const ReasoningItem = struct {
         output_index: i64,
         id_hash: ?[TextDigest.digest_length]u8,
@@ -823,6 +848,7 @@ pub const Reducer = struct {
     };
 
     content: std.ArrayList(u8) = .empty,
+    message_items: std.ArrayList(MessageItem) = .empty,
     reasoning_items: std.ArrayList(ReasoningItem) = .empty,
     reasoning_bytes: usize = 0,
     tools: std.ArrayList(ToolAccumulator) = .empty,
@@ -833,7 +859,6 @@ pub const Reducer = struct {
     text_parts: std.AutoHashMapUnmanaged(TextKey, TextPart) = .empty,
     last_text_key: ?TextKey = null,
     text_bytes: usize = 0,
-    assistant_phase: AssistantPhaseAccumulator = .empty,
     event_count: usize = 0,
     aggregate_bytes: usize = 0,
 
@@ -843,6 +868,7 @@ pub const Reducer = struct {
 
     pub fn deinit(self: *Reducer, alloc: std.mem.Allocator) void {
         self.content.deinit(alloc);
+        self.message_items.deinit(alloc);
         self.text_parts.deinit(alloc);
         for (self.reasoning_items.items) |item| if (item.json) |json| alloc.free(json);
         self.reasoning_items.deinit(alloc);
@@ -907,7 +933,7 @@ pub const Reducer = struct {
             } else if (std.mem.eql(u8, item_type, "reasoning")) {
                 try self.reconcile_reasoning(alloc, output_index, item.object, .identity, limits);
             } else if (std.mem.eql(u8, item_type, "message")) {
-                self.assistant_phase.observe(assistantMessagePhase(item.object));
+                _ = try self.reconcile_message(alloc, output_index, try text_identity(item.object, "id"), try assistantMessagePhase(item.object), limits);
             }
         } else if (std.mem.eql(u8, event_type, "response.output_text.delta") or
             std.mem.eql(u8, event_type, "response.refusal.delta"))
@@ -965,7 +991,6 @@ pub const Reducer = struct {
             } else if (std.mem.eql(u8, item_type, "reasoning")) {
                 try self.reconcile_reasoning(alloc, output_index, item.object, .completed, limits);
             } else if (std.mem.eql(u8, item_type, "message")) {
-                self.assistant_phase.observe(assistantMessagePhase(item.object));
                 try self.finalize_text_message(alloc, output_index, item.object, callbacks, cancel_flag, content_capture_limit, limits);
             }
         } else if (std.mem.eql(u8, event_type, "response.completed") or
@@ -986,7 +1011,6 @@ pub const Reducer = struct {
                     } else if (std.mem.eql(u8, item_type, "reasoning")) {
                         try self.reconcile_reasoning(alloc, index, item.object, .completed, limits);
                     } else if (std.mem.eql(u8, item_type, "message")) {
-                        self.assistant_phase.observe(assistantMessagePhase(item.object));
                         try self.finalize_text_message(alloc, index, item.object, callbacks, cancel_flag, content_capture_limit, limits);
                     }
                 }
@@ -1060,6 +1084,33 @@ pub const Reducer = struct {
         self.reasoning_bytes = total;
     }
 
+    fn reconcile_message(self: *Reducer, alloc: std.mem.Allocator, output_index: i64, id_hash: ?[TextDigest.digest_length]u8, phase: ?AssistantMessagePhase, limits: StreamLimits) !*MessageItem {
+        var low: usize = 0;
+        var high = self.message_items.items.len;
+        while (low < high) {
+            const middle = low + (high - low) / 2;
+            if (self.message_items.items[middle].output_index < output_index) low = middle + 1 else high = middle;
+        }
+        if (id_hash) |id| for (self.message_items.items) |prior| {
+            const prior_id = prior.id_hash orelse continue;
+            const same_id = std.mem.eql(u8, &prior_id, &id);
+            if (prior.output_index == output_index and !same_id) return error.ResponsesTextConflict;
+            if (prior.output_index != output_index and same_id) return error.ResponsesTextConflict;
+        };
+        if (low < self.message_items.items.len and self.message_items.items[low].output_index == output_index) {
+            const prior = &self.message_items.items[low];
+            if (phase) |value| {
+                if (prior.phase) |old| if (old != value) return error.ResponsesTextConflict;
+                prior.phase = value;
+            }
+            if (id_hash != null) prior.id_hash = id_hash;
+            return prior;
+        }
+        if (self.message_items.items.len >= limits.events) return error.ResourceLimitExceeded;
+        try self.message_items.insert(alloc, low, .{ .output_index = output_index, .id_hash = id_hash, .phase = phase });
+        return &self.message_items.items[low];
+    }
+
     fn accept_text(
         self: *Reducer,
         alloc: std.mem.Allocator,
@@ -1068,6 +1119,7 @@ pub const Reducer = struct {
         capture_limit: ?usize,
         limits: StreamLimits,
     ) !void {
+        const message = try self.reconcile_message(alloc, update.key.output_index, update.item_id_hash, null, limits);
         if (self.text_parts.count() >= limits.events and !self.text_parts.contains(update.key)) return error.ResourceLimitExceeded;
         const entry = try self.text_parts.getOrPut(alloc, update.key);
         if (!entry.found_existing) entry.value_ptr.* = .{ .kind = update.kind };
@@ -1087,12 +1139,19 @@ pub const Reducer = struct {
         };
         if (suffix.len != 0) {
             if (self.last_text_key) |last| if (update.key.precedes(last)) return error.ResponsesTextConflict;
-            const total = try checkedAccumulatedSize(self.text_bytes, suffix.len, limits.aggregate_bytes);
+            const boundary = if (self.last_text_key) |last| last.output_index != update.key.output_index else false;
+            const with_boundary = try checkedAccumulatedSize(self.text_bytes, if (boundary) 2 else 0, limits.aggregate_bytes);
+            const total = try checkedAccumulatedSize(with_boundary, suffix.len, limits.aggregate_bytes);
+            if (boundary) try appendCaptured(alloc, &self.content, "\n\n", capture_limit);
+            const before = self.content.items.len;
             try appendCaptured(alloc, &self.content, suffix, capture_limit);
+            if (message.length == 0) message.offset = before;
+            message.length += self.content.items.len - before;
             part.digest.update(suffix);
             part.received_bytes += suffix.len; // Bounded by the aggregate total above.
             self.text_bytes = total;
             self.last_text_key = update.key;
+            if (boundary) callbacks.on_content(callbacks.context, "\n\n");
         }
         if (update.mode == .final) part.finalized = true;
         if (suffix.len != 0) callbacks.on_content(callbacks.context, suffix);
@@ -1130,6 +1189,7 @@ pub const Reducer = struct {
         capture_limit: ?usize,
         limits: StreamLimits,
     ) !void {
+        _ = try self.reconcile_message(alloc, output_index, try text_identity(fields, "id"), try assistantMessagePhase(fields), limits);
         const parts = fields.get("content") orelse return error.InvalidEvent;
         if (parts != .array) return error.InvalidEvent;
         const identity = try text_identity(fields, "id");
@@ -1175,35 +1235,28 @@ pub const Reducer = struct {
             null;
         if (owned_content != null) self.content = .empty;
         errdefer if (owned_content) |value| alloc.free(value);
-        const phase_json: ?[]const u8 = if (self.assistant_phase.resolved()) |phase|
-            switch (phase) {
-                .commentary => "{\"type\":\"message\",\"phase\":\"commentary\"}",
-                .final_answer => "{\"type\":\"message\",\"phase\":\"final_answer\"}",
-            }
-        else
-            null;
-        const owned_provider_state = if (self.reasoning_bytes > 0 or phase_json != null) state: {
-            var size = self.reasoning_bytes;
-            if (phase_json) |phase| size = try checkedAccumulatedSize(size, phase.len + @as(usize, if (size == 0) 2 else 1), limits.provider_state_bytes);
-            _ = try checkedAccumulatedSize(0, size, limits.provider_state_bytes);
+        const owned_provider_state = state: {
             var out: std.Io.Writer.Allocating = .init(alloc);
             defer out.deinit();
-            try out.ensureTotalCapacity(size);
-            try out.writer.writeByte('[');
-            var first = true;
-            for (self.reasoning_items.items) |item| {
+            var reasoning_index: usize = 0;
+            for (self.message_items.items) |message| {
                 if (cancel_flag.load(.seq_cst)) return error.Cancelled;
-                const json = item.json orelse continue;
-                try writeComma(&out.writer, &first);
-                try out.writer.writeAll(json);
+                while (reasoning_index < self.reasoning_items.items.len and self.reasoning_items.items[reasoning_index].output_index <= message.output_index) : (reasoning_index += 1) {
+                    if (self.reasoning_items.items[reasoning_index].json) |json| try append_replay_item(&out, json, limits.provider_state_bytes);
+                }
+                if (message.length == 0) continue;
+                if (self.message_items.items.len == 1 and message.phase == null) continue;
+                var buffer: [160]u8 = undefined;
+                try append_replay_item(&out, try message.replay_json(&buffer), limits.provider_state_bytes);
             }
-            if (phase_json) |phase| {
-                try writeComma(&out.writer, &first);
-                try out.writer.writeAll(phase);
+            for (self.reasoning_items.items[reasoning_index..]) |item| {
+                if (cancel_flag.load(.seq_cst)) return error.Cancelled;
+                if (item.json) |json| try append_replay_item(&out, json, limits.provider_state_bytes);
             }
+            if (out.written().len == 0) break :state null;
             try out.writer.writeByte(']');
             break :state try out.toOwnedSlice();
-        } else null;
+        };
         errdefer if (owned_provider_state) |value| alloc.free(value);
         const owned_tools: []types.ToolCall = if (self.tools.items.len > 0)
             try alloc.alloc(types.ToolCall, self.tools.items.len)
@@ -1236,7 +1289,6 @@ pub const Reducer = struct {
         return .{
             .content = owned_content,
             .tool_calls = owned_tools,
-            .assistant_phase = self.assistant_phase.resolved(),
             .generation_id = generation_id,
             .provider_state_json = owned_provider_state,
             .finish_reason = self.finish_reason orelse if (owned_tools.len > 0) .tool_calls else .stop,
@@ -1244,6 +1296,14 @@ pub const Reducer = struct {
         };
     }
 };
+
+fn append_replay_item(out: *std.Io.Writer.Allocating, json: []const u8, maximum: usize) !void {
+    const item_size = try checkedAccumulatedSize(json.len, 2, maximum);
+    _ = try checkedAccumulatedSize(out.written().len, item_size, maximum);
+    try out.ensureUnusedCapacity(item_size);
+    try out.writer.writeByte(if (out.written().len == 0) '[' else ',');
+    try out.writer.writeAll(json);
+}
 
 const ToolRecordTest = struct {
     alloc: std.mem.Allocator,
@@ -1281,6 +1341,35 @@ const ToolRecordTest = struct {
     fn ignore(_: *anyopaque, _: []const u8) void {}
 };
 
+test "Responses message replay preserves separate commentary and final text" {
+    var stream = ToolRecordTest.init(std.testing.allocator);
+    defer stream.deinit();
+    try stream.apply(
+        \\{"type":"response.completed","response":{"status":"completed","output":[{"type":"message","id":"msg_progress","phase":"commentary","content":[{"type":"output_text","text":"Checking."}]},{"type":"message","id":"msg_final","phase":"final_answer","content":[{"type":"output_text","text":"42"}]}]}}
+    );
+    const completion = try stream.finish();
+    defer stream.freeCompletion(completion);
+    try std.testing.expectEqualStrings("Checking.\n\n42", completion.content.?);
+    var out: std.Io.Writer.Allocating = .init(stream.alloc);
+    defer out.deinit();
+    const messages = [_]types.ChatMessage{.{
+        .role = .assistant,
+        .content = completion.content,
+        .provider_replay = .{ .source = .{ .provider = .codex, .model = "fixture-model" }, .parts_json = completion.provider_state_json orelse "[]" },
+    }};
+    try out.writer.writeByte('[');
+    try writeInput(&out.writer, stream.alloc, &messages, null, .{ .tool_calls = 4, .tool_identity_bytes = 1024, .tool_arguments_bytes = 4096, .provider_state_bytes = 4096 }, .{});
+    try out.writer.writeByte(']');
+    const parsed = try std.json.parseFromSlice(std.json.Value, stream.alloc, out.written(), .{});
+    defer parsed.deinit();
+    const items = parsed.value.array.items;
+    try std.testing.expectEqual(@as(usize, 2), items.len);
+    try std.testing.expectEqualStrings("commentary", items[0].object.get("phase").?.string);
+    try std.testing.expectEqualStrings("Checking.", items[0].object.get("content").?.array.items[0].object.get("text").?.string);
+    try std.testing.expectEqualStrings("final_answer", items[1].object.get("phase").?.string);
+    try std.testing.expectEqualStrings("42", items[1].object.get("content").?.array.items[0].object.get("text").?.string);
+}
+
 test "Responses reasoning replay retains terminal-only context" {
     var stream = ToolRecordTest.init(std.testing.allocator);
     defer stream.deinit();
@@ -1288,6 +1377,123 @@ test "Responses reasoning replay retains terminal-only context" {
     const completion = try stream.finish();
     defer stream.freeCompletion(completion);
     try std.testing.expectEqualStrings("[{\"id\":\"rs_1\",\"type\":\"reasoning\",\"summary\":[],\"encrypted_content\":\"opaque\"}]", completion.provider_state_json orelse "");
+}
+
+test "Responses message replay rejects ambiguous or invalid spans" {
+    const cases = [_][]const u8{
+        \\[{"type":"message","offset":-1,"length":1}]
+        ,
+        \\[{"type":"message","offset":0,"length":6}]
+        ,
+        \\[{"type":"message","offset":6,"length":1}]
+        ,
+        \\[{"type":"message","offset":0,"length":0}]
+        ,
+        \\[{"type":"message","offset":0}]
+        ,
+        \\[{"type":"message","length":1}]
+        ,
+        \\[{"type":"message","offset":"0","length":1}]
+        ,
+        \\[{"type":"message","offset":0,"length":1,"phase":42}]
+        ,
+        \\[{"type":"message","offset":1,"length":4}]
+        ,
+        \\[{"type":"message","offset":0,"length":4},{"type":"message","offset":3,"length":2}]
+        ,
+        \\[{"type":"message","offset":0,"length":1},{"type":"message","offset":4,"length":1}]
+        ,
+        \\[{"type":"message","offset":0,"length":1}]
+        ,
+        \\[{"type":"message","phase":"commentary"},{"type":"message","offset":0,"length":5}]
+        ,
+        \\[{"type":"message","offset":0,"length":5},{"type":"message","phase":"commentary"}]
+        ,
+    };
+    for (cases) |parts_json| {
+        var out: std.Io.Writer.Allocating = .init(std.testing.allocator);
+        defer out.deinit();
+        const messages = [_]types.ChatMessage{.{ .role = .assistant, .content = "a\n\nbc", .provider_replay = .{ .source = .{ .provider = .codex, .model = "fixture-model" }, .parts_json = parts_json } }};
+        try std.testing.expectError(error.InvalidProviderState, ImageInputTest.write(std.testing.allocator, &out.writer, &messages, null));
+    }
+}
+
+test "Responses message replay excludes separators and uncaptured bytes" {
+    for (0..6) |capture_limit| {
+        var stream = TextRecordTest.init(std.testing.allocator);
+        defer stream.deinit();
+        stream.capture_limit = capture_limit;
+        try stream.delta(0, 0, "a");
+        try stream.apply(
+            \\{"type":"response.output_item.done","output_index":0,"item":{"type":"message","id":"first","phase":"commentary","content":[{"type":"output_text","text":"a"}]}}
+        );
+        try stream.apply(
+            \\{"type":"response.completed","response":{"status":"completed","output":[{"type":"message","id":"first","phase":"commentary","content":[{"type":"output_text","text":"a"}]},{"type":"message","content":[]},{"type":"message","id":"last","phase":"final_answer","content":[{"type":"output_text","text":"bc"}]}]}}
+        );
+        try stream.expect_emitted("a\n\nbc");
+        var result = stream_provider.Result{ .completed = .{ .completion = try stream.reducer.finish(stream.alloc, &stream.cancelled, stream.limits), .ownership = .owned } };
+        defer result.deinit(stream.alloc);
+        const completion = result.completed.completion;
+        try std.testing.expectEqualStrings("a\n\nbc"[0..capture_limit], completion.content orelse "");
+        const messages = [_]types.ChatMessage{.{ .role = .assistant, .content = completion.content, .provider_replay = if (completion.provider_state_json) |parts| .{ .source = .{ .provider = .codex, .model = "fixture-model" }, .parts_json = parts } else null }};
+        var out: std.Io.Writer.Allocating = .init(stream.alloc);
+        defer out.deinit();
+        try ImageInputTest.write(stream.alloc, &out.writer, &messages, null);
+        const parsed = try std.json.parseFromSlice(std.json.Value, stream.alloc, out.written(), .{});
+        defer parsed.deinit();
+        const items = parsed.value.array.items;
+        try std.testing.expectEqual(@as(usize, if (capture_limit == 0) 0 else if (capture_limit <= 3) 1 else 2), items.len);
+        if (items.len > 0) {
+            try std.testing.expectEqualStrings("a", items[0].object.get("content").?.array.items[0].object.get("text").?.string);
+            try std.testing.expectEqualStrings("commentary", items[0].object.get("phase").?.string);
+        }
+        if (items.len > 1) {
+            try std.testing.expectEqualStrings("bc"[0 .. capture_limit - 3], items[1].object.get("content").?.array.items[0].object.get("text").?.string);
+            try std.testing.expectEqualStrings("final_answer", items[1].object.get("phase").?.string);
+        }
+    }
+}
+
+test "Responses message replay binds item identity before text and across content parts" {
+    for ([_][]const u8{
+        \\{"type":"response.output_text.delta","output_index":0,"item_id":"changed","delta":"bad"}
+        ,
+        \\{"type":"response.output_text.delta","output_index":1,"item_id":"original","delta":"bad"}
+        ,
+        \\{"type":"response.output_item.done","output_index":0,"item":{"type":"message","id":"changed","content":[]}}
+        ,
+    }) |event| {
+        var stream = TextRecordTest.init(std.testing.allocator);
+        defer stream.deinit();
+        try stream.apply(
+            \\{"type":"response.output_item.added","output_index":0,"item":{"type":"message","id":"original","phase":"commentary"}}
+        );
+        try std.testing.expectError(error.ResponsesTextConflict, stream.apply(event));
+        try stream.expect_emitted("");
+    }
+    var stream = TextRecordTest.init(std.testing.allocator);
+    defer stream.deinit();
+    try stream.apply(
+        \\{"type":"response.output_text.delta","output_index":0,"content_index":0,"item_id":"original","delta":"a"}
+    );
+    try std.testing.expectError(error.ResponsesTextConflict, stream.apply(
+        \\{"type":"response.output_text.delta","output_index":0,"content_index":1,"item_id":"changed","delta":"b"}
+    ));
+    try stream.expect_emitted("a");
+}
+
+test "Responses message replay releases request scratch on allocation failure" {
+    const Probe = struct {
+        fn run(alloc: std.mem.Allocator) !void {
+            const messages = [_]types.ChatMessage{.{ .role = .assistant, .content = "a\n\nb", .provider_replay = .{ .source = .{ .provider = .codex, .model = "fixture-model" }, .parts_json = "[{\"type\":\"message\",\"offset\":0,\"length\":1},{\"type\":\"message\",\"offset\":3,\"length\":1}]" } }};
+            // Output storage is separate from the scratch allocator under test.
+            var wire: std.Io.Writer.Allocating = .init(std.testing.allocator);
+            defer wire.deinit();
+            try ImageInputTest.write(alloc, &wire.writer, &messages, null);
+            try std.testing.expect(std.mem.find(u8, wire.written(), "phase") == null);
+        }
+    };
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, Probe.run, .{});
 }
 
 test "Responses reasoning replay retains terminal enrichment without duplicates" {
@@ -1395,12 +1601,13 @@ test "Responses reasoning replay counts unique bytes and phase at the exact boun
         defer stream.freeCompletion(completion);
         try std.testing.expectEqualStrings(state, completion.provider_state_json.?);
     }
-    const phase = "{\"type\":\"message\",\"phase\":\"commentary\"}";
+    const phase = "{\"type\":\"message\",\"offset\":0,\"length\":1,\"phase\":\"commentary\"}";
     for ([_]usize{ state.len + phase.len + 1, state.len + phase.len }) |limit| {
         var stream = ToolRecordTest.init(std.testing.allocator);
         defer stream.deinit();
         try stream.apply(event);
         try stream.apply("{\"type\":\"response.output_item.added\",\"output_index\":1,\"item\":{\"type\":\"message\",\"phase\":\"commentary\"}}");
+        try stream.apply("{\"type\":\"response.output_text.delta\",\"output_index\":1,\"delta\":\"x\"}");
         try stream.apply(ToolRecordTest.terminal);
         var bounds = ToolRecordTest.limits;
         bounds.provider_state_bytes = limit;
@@ -1443,7 +1650,7 @@ test "Responses text finalization preserves mixed streamed and final-only items"
     try stream.apply(ToolRecordTest.terminal);
     const completion = try stream.finish();
     defer stream.freeCompletion(completion);
-    try std.testing.expectEqualStrings("COMMENTARY_ITEM\nFINAL_ANSWER_ITEM", completion.content.?);
+    try std.testing.expectEqualStrings("COMMENTARY_ITEM\n\n\nFINAL_ANSWER_ITEM", completion.content.?);
 }
 
 const TextRecordTest = struct {
@@ -1531,7 +1738,7 @@ test "Responses text finalization reads terminal-only messages and streamed refu
     defer stream.deinit();
     try stream.apply("{\"type\":\"response.refusal.delta\",\"output_index\":0,\"delta\":\"No\"}");
     try stream.apply("{\"type\":\"response.completed\",\"response\":{\"status\":\"completed\",\"output\":[{\"type\":\"message\",\"content\":[{\"type\":\"refusal\",\"refusal\":\"No.\"}]},{\"type\":\"message\",\"content\":[{\"type\":\"output_text\",\"text\":\" Alternative.\"}]}]}}");
-    try stream.finish("No. Alternative.");
+    try stream.finish("No.\n\n Alternative.");
 }
 
 test "Responses text finalization retains item text when the terminal envelope is empty" {
@@ -1590,7 +1797,7 @@ test "Responses text finalization preserves append order and bounded sparse inde
     try stream.final(99_999_999, 99_999_999, "b");
     try stream.final(0, 0, "a");
     try std.testing.expectError(error.ResponsesTextConflict, stream.final(1, 0, "late"));
-    try stream.expect_emitted("ab");
+    try stream.expect_emitted("a\n\nb");
 
     var bounded = TextRecordTest.init(std.testing.allocator);
     defer bounded.deinit();
@@ -1633,7 +1840,7 @@ test "Responses text finalization releases state on allocation failure" {
             try stream.apply("{\"type\":\"response.output_text.delta\",\"delta\":\"a\"}");
             try stream.apply("{\"type\":\"response.output_text.done\",\"text\":\"ab\"}");
             try stream.apply("{\"type\":\"response.output_text.done\",\"output_index\":1,\"text\":\"cd\"}");
-            try stream.finish("abcd");
+            try stream.finish("ab\n\ncd");
         }
     };
     try std.testing.checkAllAllocationFailures(std.testing.allocator, Probe.run, .{});
@@ -1642,11 +1849,13 @@ test "Responses text finalization releases state on allocation failure" {
 test "Responses text finalization fuzzes chunking and capture boundaries" {
     const Probe = struct {
         fn run(_: void, smith: *std.testing.Smith) !void {
-            var buffer: [260]u8 = undefined;
+            var buffer: [262]u8 = undefined;
             const len: usize = @intCast(smith.slice(buffer[0..256]));
             for (buffer[0..len]) |*byte| byte.* = 32 + byte.* % 95;
             const split = if (len == 0) 0 else buffer[0] % (len + 1);
-            @memcpy(buffer[len..][0..4], "tail");
+            const separator: []const u8 = if (len == 0) "" else "\n\n";
+            @memcpy(buffer[len..][0..separator.len], separator);
+            @memcpy(buffer[len + separator.len ..][0..4], "tail");
             var stream = TextRecordTest.init(std.testing.allocator);
             defer stream.deinit();
             stream.capture_limit = if (len == 0) 0 else buffer[0] % 17;
@@ -1654,7 +1863,7 @@ test "Responses text finalization fuzzes chunking and capture boundaries" {
             try stream.final(0, 0, buffer[0..len]);
             try stream.final(0, 0, buffer[0..len]);
             try stream.final(1, 0, "tail");
-            try stream.finish(buffer[0 .. len + 4]);
+            try stream.finish(buffer[0 .. len + separator.len + 4]);
         }
     };
     try std.testing.fuzz({}, Probe.run, .{ .corpus = &.{ "", "a", "two chunks", "capture limit is not receipt progress" } });
@@ -1673,11 +1882,9 @@ test "Responses captures assistant commentary phase" {
     const completion = try stream.finish();
     defer stream.freeCompletion(completion);
 
-    try std.testing.expectEqual(
-        types.AssistantMessagePhase.commentary,
-        completion.assistant_phase.?,
-    );
-    try std.testing.expectEqualStrings("[{\"type\":\"message\",\"phase\":\"commentary\"}]", completion.provider_state_json.?);
+    const replay = try std.json.parseFromSlice(std.json.Value, stream.alloc, completion.provider_state_json.?, .{});
+    defer replay.deinit();
+    try std.testing.expectEqualStrings("commentary", replay.value.array.items[0].object.get("phase").?.string);
 }
 
 test "Responses captures assistant phase from terminal output" {
@@ -1689,13 +1896,12 @@ test "Responses captures assistant phase from terminal output" {
     const completion = try stream.finish();
     defer stream.freeCompletion(completion);
 
-    try std.testing.expectEqual(
-        types.AssistantMessagePhase.final_answer,
-        completion.assistant_phase.?,
-    );
+    const replay = try std.json.parseFromSlice(std.json.Value, stream.alloc, completion.provider_state_json.?, .{});
+    defer replay.deinit();
+    try std.testing.expectEqualStrings("final_answer", replay.value.array.items[0].object.get("phase").?.string);
 }
 
-test "Responses ignores unknown and conflicting assistant phases" {
+test "Responses omits unknown phases and rejects contradictory phases within one message" {
     var unknown = ToolRecordTest.init(std.testing.allocator);
     defer unknown.deinit();
     try unknown.apply(
@@ -1704,20 +1910,16 @@ test "Responses ignores unknown and conflicting assistant phases" {
     try unknown.apply(ToolRecordTest.terminal);
     const unknown_completion = try unknown.finish();
     defer unknown.freeCompletion(unknown_completion);
-    try std.testing.expect(unknown_completion.assistant_phase == null);
+    try std.testing.expect(unknown_completion.provider_state_json == null);
 
     var conflicting = ToolRecordTest.init(std.testing.allocator);
     defer conflicting.deinit();
     try conflicting.apply(
         "{\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"message\",\"phase\":\"commentary\"}}",
     );
-    try conflicting.apply(
+    try std.testing.expectError(error.ResponsesTextConflict, conflicting.apply(
         "{\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"message\",\"phase\":\"final_answer\",\"content\":[]}}",
-    );
-    try conflicting.apply(ToolRecordTest.terminal);
-    const conflicting_completion = try conflicting.finish();
-    defer conflicting.freeCompletion(conflicting_completion);
-    try std.testing.expect(conflicting_completion.assistant_phase == null);
+    ));
 }
 
 test "Responses rejects conflicting completed tool records" {

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -4560,6 +4560,75 @@ for (const scenario of ["replace", "conflict", "invalid-index"] as const) {
   }, 60_000);
 }
 
+test("native assistant messages keep their boundaries and phases through tools and resume", async () => {
+  for (const provider of ["codex", "grok"] as const) {
+    const profile = mkdtempSync(join(tmpdir(), "fx-message-replay-"));
+    const testGateway = startFakeGateway([]);
+    const model = "fixture-model";
+    const message = (id: string, phase: string, text: string) => ({ type: "message", id, role: "assistant", status: "completed", phase, content: [{ type: "output_text", text, annotations: [] }] });
+    const progress = message("msg_progress", "commentary", "Checking the file.");
+    const progressTwo = message("msg_progress_two", "commentary", "Reading its contents.");
+    const answer = message("msg_answer", "final_answer", "The value is 42.");
+    const reasoning = { type: "reasoning", id: "rs_messages", summary: [], encrypted_content: "MESSAGE_REPLAY_CONTEXT" };
+    const call = { type: "function_call", id: "fc_messages", call_id: "call_messages", name: "read_file", arguments: JSON.stringify({ path: "notes.txt" }) };
+    const responses = [fakeGatewaySse([
+      { type: "response.output_item.added", output_index: 0, item: { ...progress, content: [] } },
+      { type: "response.output_text.delta", output_index: 0, content_index: 0, item_id: progress.id, delta: "Checking " },
+      { type: "response.output_text.delta", output_index: 0, content_index: 0, item_id: progress.id, delta: "the file." },
+      { type: "response.output_item.done", output_index: 0, item: progress },
+      { type: "response.output_item.added", output_index: 3, item: { ...call, arguments: "" } },
+      { type: "response.completed", response: { status: "completed", output: [progress, reasoning, progressTwo, call] } },
+    ]), fakeGatewaySse([
+      { type: "response.completed", response: { status: "completed", output: [message("msg_result", "commentary", "Read complete."), answer] } },
+    ]), fakeGatewaySse([
+      { type: "response.completed", response: { status: "completed", output: [message("msg_resume", "final_answer", "Still 42.")] } },
+    ])];
+    const direct = provider === "codex" ? startFakeCodexToolLoop({ responses, model }) : startFakeGrokToolLoop({ responses, model });
+    try {
+      if (provider === "codex") writeSeededChatGptLogin(profile, direct.accessToken);
+      else writeSeededGrokLogin(profile, direct.accessToken);
+      writeFileSync(join(profile, ".fx", "settings.json"), JSON.stringify({ provider, [provider + "_model"]: model }), { mode: 0o600 });
+      writeFileSync(join(profile, "notes.txt"), "42\n");
+      const env = {
+        HOME: profile, AI_GATEWAY_API_KEY: "fixture", VERCEL_OIDC_TOKEN: undefined, FX_MODEL: undefined,
+        FX_DISABLE_KEYCHAIN: "1", FX_AUTO_UPGRADE: "0", FX_SOUND: "0",
+        FX_GATEWAY_BASE_URL: testGateway.baseUrl, FX_E2E_GATEWAY_MODELS_URL: testGateway.baseUrl + "/coding-agent/v1/models",
+        FX_E2E_OPENAI_CODEX_RESPONSES_URL: direct.responsesUrl, FX_E2E_OPENAI_CODEX_MODELS_URL: direct.modelsUrl,
+        FX_E2E_XAI_GROK_RESPONSES_URL: direct.responsesUrl, FX_E2E_XAI_GROK_MODELS_URL: direct.modelsUrl,
+        FX_E2E_XAI_GROK_MODALITIES_URL: "modalitiesUrl" in direct ? direct.modalitiesUrl : undefined,
+      };
+      const first = await runFx(["ask", "--json", "--auto", "Read notes.txt and report the value."], { cwd: profile, env, timeoutMs: TIMEOUT });
+      expect(first.code, first.stdout + first.stderr).toBe(0);
+      const result = JSON.parse(first.stdout);
+      expect(result.output).toBe("Checking the file.\n\nReading its contents.\n\nRead complete.\n\nThe value is 42.");
+      expect(direct.bodies).toHaveLength(2);
+      const resumed = await runFx(["ask", "--json", "--auto", "--resume-id", result.session_id, "What was the value?"], { cwd: profile, env, timeoutMs: TIMEOUT });
+      expect(resumed.code, resumed.stdout + resumed.stderr).toBe(0);
+      expect(JSON.parse(resumed.stdout).output).toBe("Still 42.");
+      expect(direct.bodies).toHaveLength(3);
+      for (const [index, body] of direct.bodies.slice(1).entries()) {
+        const input = JSON.parse(body).input;
+        const messages = input.filter((item: { role?: string }) => item.role === "assistant");
+        expect(messages.map((item: { phase?: string; content: Array<{ text: string }> }) => ({ phase: item.phase, text: item.content.map((part) => part.text).join("") }))).toEqual([
+          { phase: "commentary", text: "Checking the file." },
+          { phase: "commentary", text: "Reading its contents." },
+          ...(index === 1 ? [{ phase: "commentary", text: "Read complete." }, { phase: "final_answer", text: "The value is 42." }] : []),
+        ]);
+        expect(input.filter((item: { type?: string }) => item.type === "reasoning")).toEqual([reasoning]);
+        const calls = input.filter((item: { type?: string }) => item.type === "function_call");
+        const outputs = input.filter((item: { type?: string }) => item.type === "function_call_output");
+        expect(calls.map((item: { call_id: string }) => item.call_id)).toEqual(["call_messages"]);
+        expect(outputs.map((item: { call_id: string }) => item.call_id)).toEqual(["call_messages"]);
+        expect(outputs[0].output).toContain("42");
+      }
+      expect(testGateway.requests).toHaveLength(0);
+    } finally {
+      direct.stop(); testGateway.stop();
+      rmSync(profile, { recursive: true, force: true });
+    }
+  }
+}, 60_000);
+
 test("native reasoning snapshots survive tools and saved resume exactly once", async () => {
   for (const provider of ["codex", "grok"] as const) for (const shape of ["both", "terminal-only", "enriched", "conflict", "identity-conflict"] as const) {
     const conflict = shape === "conflict" || shape === "identity-conflict";
@@ -4710,6 +4779,7 @@ test("provider SSE framing preserves saved and resumed answers", async () => {
 
 test("direct providers reconcile final text before saving or releasing tools", async () => {
   const prefix = "COMMENTARY_ITEM\n", answer = "FINAL_ANSWER_ITEM";
+  const display = prefix + "\n\n" + answer;
   for (const provider of ["codex", "grok"] as const) for (const mode of ["streamed", "final-only", "mixed", "terminal-only", "conflict"]) {
     const profile = mkdtempSync(join(tmpdir(), "fx-response-text-"));
     const model = "fixture-model";
@@ -4765,17 +4835,17 @@ test("direct providers reconcile final text before saving or releasing tools", a
       } else {
         expect(first.code, first.stdout + first.stderr).toBe(0);
         expect(first.stderr).toBe("");
-        expect(output.output).toBe(prefix + answer);
-        expect(output.final_output).toBe(prefix + answer);
+        expect(output.output).toBe(display);
+        expect(output.final_output).toBe(display);
         const detail = await runFx(["session", "--json", "--id", output.session_id], { cwd: profile, env });
         expect(detail.code).toBe(0);
-        expect(JSON.parse(detail.stdout).history[0].assistant).toBe(prefix + answer);
+        expect(JSON.parse(detail.stdout).history[0].assistant).toBe(display);
         const resumed = await runFx(["ask", "--json", "--auto", "--resume-id", output.session_id, "Recall the prior answer."], { cwd: profile, env, timeoutMs: TIMEOUT });
         expect(resumed.code, resumed.stdout + resumed.stderr).toBe(0);
         expect(resumed.stderr).toBe("");
         expect(direct.bodies).toHaveLength(2);
         const replay = JSON.parse(direct.bodies[1]).input.filter((entry: { role?: string }) => entry.role === "assistant");
-        expect(replay.some((entry: { content: Array<{ text?: string }> }) => entry.content.some(part => part.text === prefix + answer))).toBe(true);
+        expect(replay.map((entry: { content: Array<{ text?: string }> }) => entry.content.map(part => part.text).join(""))).toEqual([prefix, answer]);
       }
       expect(gateway.requests).toHaveLength(0);
     } finally {


### PR DESCRIPTION
## Summary

- Preserve separate assistant messages and their phases through native tool continuation and session resume.
- Separate native assistant messages into paragraphs instead of joining their text.
- Reject conflicting message identities, phases, and invalid replay ranges.
- Continue reading saved sessions with legacy phase-only replay metadata.
