### PR TITLE
Preserve selected authentication source in ask errors

### DIFF
--- a/src/core/auth/auth_runtime.zig
+++ b/src/core/auth/auth_runtime.zig
@@ -318,11 +318,33 @@ fn prepareResolvedCredential(
     return credential;
 }
 
-fn requestedSource(
+pub fn requestedSource(
     provider: model_provider.ProviderId,
     preferred: ?credentials.Source,
 ) ?credentials.Source {
-    return if (provider == .gateway) preferred else provider_catalog.find(provider).login_source;
+    if (provider != .gateway) return provider_catalog.find(provider).login_source;
+    return if (model_provider.authorizesCredential(provider, preferred)) preferred else null;
+}
+
+test "requested credential source follows provider authority" {
+    const cases = [_]struct {
+        provider: model_provider.ProviderId,
+        preferred: ?credentials.Source,
+        required: ?credentials.Source,
+    }{
+        .{ .provider = .gateway, .preferred = null, .required = null },
+        .{ .provider = .gateway, .preferred = .fx_login, .required = .fx_login },
+        .{ .provider = .gateway, .preferred = .stored_key, .required = .stored_key },
+        .{ .provider = .gateway, .preferred = .ai_gateway_api_key, .required = .ai_gateway_api_key },
+        .{ .provider = .gateway, .preferred = .vercel_oidc_token, .required = .vercel_oidc_token },
+        .{ .provider = .gateway, .preferred = .chatgpt_subscription, .required = null },
+        .{ .provider = .gateway, .preferred = .grok_subscription, .required = null },
+        .{ .provider = .codex, .preferred = .fx_login, .required = .chatgpt_subscription },
+        .{ .provider = .grok, .preferred = .fx_login, .required = .grok_subscription },
+    };
+    for (cases) |case| {
+        try std.testing.expectEqual(case.required, requestedSource(case.provider, case.preferred));
+    }
 }
 
 pub fn preparationError(failure: CredentialFailure) ?CredentialPreparationError {
@@ -1517,14 +1539,7 @@ pub fn loadStatusSnapshotForProvider(
         };
     }
     return .{
-        .required_source = if (provider == .codex)
-            .chatgpt_subscription
-        else if (provider == .grok)
-            .grok_subscription
-        else if (provider == .gateway and !model_provider.authorizesCredential(.gateway, preferred))
-            null
-        else
-            preferred,
+        .required_source = if (provider) |selected_provider| requestedSource(selected_provider, preferred) else preferred,
         .stored_key_status = resolution.stored_key_status,
         .fx_login_status = resolution.fx_login_status,
         .failure = if (resolution.failure) |failure| classifyCredentialFailure(failure.source, failure.err) else null,

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -1406,13 +1406,12 @@ fn missingCredentialResult(
     alloc: Allocator,
     options: RunOptions,
     provider: model_provider.ProviderId,
+    preferred: ?credentials.Source,
 ) !PromptRunResult {
-    const message = if (provider == .codex)
-        credentials.missing_chatgpt_credential_message
-    else if (provider == .grok)
-        credentials.missing_grok_credential_message
-    else
-        credentials.missing_credential_message;
+    const status = auth_runtime.StatusSnapshot{
+        .required_source = auth_runtime.requestedSource(provider, preferred),
+    };
+    const message = status.missingHelp(.cli).?;
     try options.deps.write_stderr(options.deps.stderr_ctx, "fx ask: ");
     try options.deps.write_stderr(options.deps.stderr_ctx, message);
     try options.deps.write_stderr(options.deps.stderr_ctx, "\n");
@@ -1484,7 +1483,7 @@ fn runPromptInternal(alloc: Allocator, prompt: []const u8, permission_override: 
         if (startup.credential_load_failure) |failure| {
             if (auth_runtime.preparationError(auth_runtime.classifyCredentialFailure(failure.source, failure.err))) |err| return err;
         }
-        return missingCredentialResult(alloc, options, startup.provider);
+        return missingCredentialResult(alloc, options, startup.provider, startup.credential_source_preference);
     }
 
     var owned_resumed_model: ?[]u8 = null;
@@ -1595,15 +1594,16 @@ fn runPromptInternal(alloc: Allocator, prompt: []const u8, permission_override: 
         const credential: *const credentials.Credential = if (startup_credential_is_final)
             &startup.credential.?
         else routed: {
+            const preferred_source = if (ctx.provider == .gateway) startup.credential_source_preference else null;
             routed_credential = try auth_runtime.prepareCredential(
                 alloc,
                 cfg.gateway_provider.oauth_transport,
                 cfg.secret_store,
                 ctx.provider,
-                if (ctx.provider == .gateway) startup.credential_source_preference else null,
+                preferred_source,
             );
             if (routed_credential == null) {
-                return missingCredentialResult(alloc, options, ctx.provider);
+                return missingCredentialResult(alloc, options, ctx.provider, preferred_source);
             }
             break :routed &routed_credential.?;
         };

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -749,9 +749,7 @@ describe("cli: status", () => {
           const ask = await runFx(["ask", "--json", "--no-save", "Say hello."], options);
           expect(ask.code).toBe(1);
           expect(JSON.parse(ask.stdout).error).toBe("MissingCredentials");
-          expect(ask.stderr).toContain(
-            scenario.provider === "gateway" ? MISSING_AUTH_MESSAGE : scenario.help,
-          );
+          expect(ask.stderr).toContain(scenario.help);
           expect(readFileSync(settingsPath, "utf8")).toBe(settings);
         } finally {
           rmSync(root, { recursive: true, force: true });
@@ -760,6 +758,71 @@ describe("cli: status", () => {
       TIMEOUT,
     );
   }
+
+  test("fresh and resumed asks retain an unavailable exact login with an environment key", async () => {
+    const root = mkdtempSync(join(tmpdir(), "fx-ask-exact-source-"));
+    const gateway = startFakeGateway([
+      fakeGatewayFinalText("SESSION_SEEDED"),
+      fakeGatewayFinalText("AUTOMATIC_KEY_WORKS"),
+    ]);
+    try {
+      const home = join(root, "home");
+      const workspace = join(root, "workspace");
+      mkdirSync(join(home, ".fx"), { recursive: true });
+      mkdirSync(workspace);
+      const settingsPath = join(home, ".fx", "settings.json");
+      const settings = { provider: "gateway", models: { gateway: FAKE_GATEWAY_MODEL } };
+      writeFileSync(settingsPath, JSON.stringify(settings));
+      const options = {
+        cwd: realpathSync(workspace),
+        env: {
+          HOME: realpathSync(home),
+          AI_GATEWAY_API_KEY: "exact-source-control-key",
+          VERCEL_OIDC_TOKEN: undefined,
+          FX_MODEL: undefined,
+          FX_DISABLE_KEYCHAIN: "1",
+          FX_GATEWAY_BASE_URL: gateway.baseUrl,
+          FX_GATEWAY_CHAT_URL: gateway.chatUrl,
+          FX_E2E_GATEWAY_MODELS_URL: `${gateway.baseUrl}/coding-agent/v1/models`,
+        },
+      };
+      const seeded = await runFx(["ask", "--json", "Create a short greeting."], options);
+      expect(seeded.code).toBe(0);
+      const sessionId = JSON.parse(seeded.stdout).session_id;
+      expect(sessionId.length).toBeGreaterThan(0);
+      expect(gateway.requests).toHaveLength(1);
+
+      const pinned = JSON.stringify({ ...settings, credential_source: "fx_login" });
+      writeFileSync(settingsPath, pinned);
+      const status = await runFx(["status", "--json"], options);
+      const help = JSON.parse(status.stdout).auth_help;
+      expect(help).toContain("fx login is selected but unavailable");
+      for (const resumed of [false, true]) {
+        for (const json of [false, true]) {
+          const result = await runFx([
+            "ask", ...(json ? ["--json"] : []),
+            ...(resumed ? ["--resume-id", sessionId] : ["--no-save"]),
+            "Continue with a greeting.",
+          ], options);
+          expect(result.code).toBe(1);
+          expect(result.stderr).toContain(help);
+          expect(result.stderr).not.toContain("set AI_GATEWAY_API_KEY");
+          if (json) expect(JSON.parse(result.stdout).error).toBe("MissingCredentials");
+          expect(readFileSync(settingsPath, "utf8")).toBe(pinned);
+          expect(gateway.requests).toHaveLength(1);
+        }
+      }
+
+      writeFileSync(settingsPath, JSON.stringify(settings));
+      const automatic = await runFx(["ask", "--json", "--no-save", "Give a greeting."], options);
+      expect(automatic.code).toBe(0);
+      expect(JSON.parse(automatic.stdout).output).toContain("AUTOMATIC_KEY_WORKS");
+      expect(gateway.requests).toHaveLength(2);
+    } finally {
+      gateway.stop();
+      rmSync(root, { recursive: true, force: true });
+    }
+  }, TIMEOUT);
 
   test(
     "status and doctor share fx login source, team, and refreshability",


### PR DESCRIPTION
## Summary

- Report a missing selected fx login in fresh and resumed `fx ask` calls, so the error no longer recommends an excluded API key.
