### PR TITLE
Fix skill status presentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Skills are advertised in a stable catalog sized to the selected model's context 
 
 Explicit `$skill-name` mentions load the selected instructions before the model starts work. The `skill` tool accepts an advertised `location` and an optional relative `resource`, returning the complete document or a visible failure. Omitting `resource` or passing an empty string reads `SKILL.md`. File and tool-result limits still apply, and an explicit `skill_chunk_bytes` limit blocks a complete read that would exceed it. Existing named, offset-based calls remain supported.
 
-In the interactive shell, explicitly requested skills show a named load summary before the assistant replies. These automatic loads are not counted as tool calls; a loaded status confirms prepared instructions, not that the model followed them.
+In the interactive shell, explicitly requested skills show a named load summary before the assistant replies. Full failure details are available in Ctrl+O. These automatic loads are not counted as tool calls; a loaded status confirms prepared instructions, not that the model followed them.
 
 ## Documentation
 

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -4271,6 +4271,12 @@ fn processQueuedPromptInner(
         if (explicit_section.?.notice) |notice| try deps.pushContextNotice(notice);
         if (explicit_section.?.diagnostic_notice) |notice| try deps.pushContextNotice(notice);
         if (deps.push_interactive_notice) |push_notice| {
+            if (explicit_section.?.load_details) |details| try push_notice(deps.ctx, .{
+                .topic = "skills",
+                .tone = .warning,
+                .body = details,
+                .visibility = .full_only,
+            });
             if (explicit_section.?.load_notice) |notice| try push_notice(deps.ctx, notice);
         }
     }

--- a/src/core/skills/skill_invocation.zig
+++ b/src/core/skills/skill_invocation.zig
@@ -188,12 +188,14 @@ pub const ExplicitPromptSection = struct {
     notice: ?[]u8 = null,
     diagnostic_notice: ?[]u8 = null,
     load_notice: ?types.SemanticNotice = null,
+    load_details: ?[]u8 = null,
 
     pub fn deinit(self: *ExplicitPromptSection, alloc: Allocator) void {
         alloc.free(self.text);
         if (self.notice) |notice| alloc.free(notice);
         if (self.diagnostic_notice) |notice| alloc.free(notice);
         if (self.load_notice) |notice| types.freeSemanticNotice(alloc, notice);
+        if (self.load_details) |details| alloc.free(details);
         self.* = .{ .text = &.{} };
     }
 };
@@ -222,6 +224,8 @@ pub fn buildExplicitPromptSection(
     defer diagnostic_notices.deinit();
     var load_rows: std.Io.Writer.Allocating = .init(alloc);
     defer load_rows.deinit();
+    var load_details: std.Io.Writer.Allocating = .init(alloc);
+    defer load_details.deinit();
     var loaded: usize = 0;
 
     try out.writer.writeAll(
@@ -239,6 +243,7 @@ pub fn buildExplicitPromptSection(
                 &notices.writer,
                 &diagnostic_notices,
                 &load_rows.writer,
+                &load_details.writer,
                 catalog,
                 binding.name,
                 binding.path,
@@ -253,7 +258,9 @@ pub fn buildExplicitPromptSection(
                 defer alloc.free(failure);
                 try out.writer.writeAll(failure);
                 try out.writer.writeByte('\n');
-                try appendExplicitLoadRow(alloc, &load_rows.writer, name, failure);
+                try appendExplicitLoadRow(alloc, &load_rows.writer, name, "ambiguous name");
+                try appendExplicitLoadRow(alloc, &load_details.writer, name, failure);
+                try load_details.writer.writeByte('\n');
             },
         }
     }
@@ -262,8 +269,10 @@ pub fn buildExplicitPromptSection(
     const summary = if (failed == 0)
         try std.fmt.allocPrint(alloc, "{d} requested skill{s} loaded{s}", .{ loaded, if (loaded == 1) "" else "s", load_rows.written() })
     else
-        try std.fmt.allocPrint(alloc, "Requested skills · {d} loaded · {d} failed{s}", .{ loaded, failed, load_rows.written() });
+        try std.fmt.allocPrint(alloc, "Requested skills · {d} loaded · {d} failed (ctrl o for details){s}", .{ loaded, failed, load_rows.written() });
     errdefer alloc.free(summary);
+    const details = if (load_details.written().len > 0) try load_details.toOwnedSlice() else null;
+    errdefer if (details) |value| alloc.free(value);
 
     const text = try out.toOwnedSlice();
     errdefer alloc.free(text);
@@ -275,12 +284,16 @@ pub fn buildExplicitPromptSection(
         .notice = notice,
         .diagnostic_notice = diagnostic_notice,
         .load_notice = .{ .topic = "", .tone = if (failed == 0) .neutral else .warning, .body = summary },
+        .load_details = details,
     };
 }
 
 fn appendExplicitLoadRow(alloc: Allocator, out: *std.Io.Writer, name: []const u8, failure: ?[]const u8) !void {
     const row = if (failure) |detail|
-        try std.fmt.allocPrint(alloc, "Could not load {s}: {s}", .{ name, detail })
+        if (detail.len > 0)
+            try std.fmt.allocPrint(alloc, "Could not load {s}: {s}", .{ name, detail })
+        else
+            try std.fmt.allocPrint(alloc, "Could not load {s}", .{name})
     else
         try std.fmt.allocPrint(alloc, "Loaded skill {s}", .{name});
     defer alloc.free(row);
@@ -304,6 +317,13 @@ test "explicit skill requests report ambiguous names without selecting a source"
     try expectContains(section.load_notice.?.body, "Requested skills · 0 loaded · 1 failed");
     try expectContains(section.load_notice.?.body, "Could not load review:");
     try expectNotContains(section.load_notice.?.body, "Loaded skill review");
+    try expectContains(section.load_notice.?.body, "ambiguous name");
+    try expectNotContains(section.load_notice.?.body, "/workspace/review");
+    try expectNotContains(section.load_notice.?.body, "/global/review");
+    try expectContains(section.load_notice.?.body, "ctrl o");
+    try expectContains(section.load_details.?, "/workspace/review");
+    try expectContains(section.load_details.?, "/global/review");
+    try std.testing.expect(section.notice == null);
 }
 
 test "explicit skills include complete instructions beyond the default chunk" {
@@ -322,6 +342,7 @@ test "explicit skills include complete instructions beyond the default chunk" {
     try std.testing.expect(std.mem.find(u8, section.text, "BEGIN INSTRUCTIONS") != null);
     try std.testing.expect(std.mem.find(u8, section.text, "COMPLETE TAIL") != null);
     try std.testing.expectEqualStrings("1 requested skill loaded\n└ Loaded skill workflow", section.load_notice.?.body);
+    try std.testing.expect(section.load_details == null);
     const bindings = [_]ExplicitBinding{ .{ .name = "workflow", .path = path }, .{ .name = "workflow", .path = path } };
     var repeated = try buildExplicitPromptSection(alloc, .{ .skills = &skills }, "$workflow $workflow", &bindings, .{}, null);
     defer repeated.deinit(alloc);
@@ -348,8 +369,9 @@ test "explicit load summary reports a missing bound skill without success" {
     var section = try buildExplicitPromptSection(alloc, .{ .skills = &.{} }, "Use the selected workflow", &.{.{ .name = "missing-workflow", .path = "/unavailable/workflow" }}, .{}, null);
     defer section.deinit(alloc);
     try expectContains(section.load_notice.?.body, "Requested skills · 0 loaded · 1 failed");
-    try expectContains(section.load_notice.?.body, "Could not load missing-workflow:");
-    try expectContains(section.load_notice.?.body, "not found at advertised location");
+    try expectContains(section.load_notice.?.body, "Could not load missing-workflow");
+    try expectNotContains(section.load_notice.?.body, "/unavailable/workflow");
+    try expectContains(section.load_details.?, "not found at advertised location");
     try expectNotContains(section.text, "<skill_content");
 }
 
@@ -555,6 +577,7 @@ fn appendExplicitSkill(
     notices: *std.Io.Writer,
     diagnostic_notices: *std.Io.Writer.Allocating,
     load_rows: *std.Io.Writer,
+    load_details: *std.Io.Writer,
     catalog: Catalog,
     name: []const u8,
     location: []const u8,
@@ -581,7 +604,11 @@ fn appendExplicitSkill(
         .loaded => |output| if (output.complete) null else "Complete instructions were not loaded.",
         .failure => |output| output.model_output,
     };
-    try appendExplicitLoadRow(alloc, load_rows, name, failure);
+    if (failure) |detail| {
+        try appendExplicitLoadRow(alloc, load_details, name, detail);
+        try load_details.writeByte('\n');
+    }
+    try appendExplicitLoadRow(alloc, load_rows, name, if (failure != null) "" else null);
     return failure == null;
 }
 
@@ -2037,7 +2064,8 @@ test "explicit invocation reports user byte ceilings without partial success" {
     try expectNotContains(explicit.text, "TAIL MUST WAIT");
     try std.testing.expect(explicit.notice != null);
     try expectContains(explicit.load_notice.?.body, "0 loaded · 1 failed");
-    try expectContains(explicit.load_notice.?.body, "Could not load workflow:");
+    try expectContains(explicit.load_notice.?.body, "Could not load workflow");
+    try expectContains(explicit.load_details.?, "skill_chunk_bytes");
     try expectNotContains(explicit.load_notice.?.body, "Loaded skill workflow");
 
     var fuzzy = try buildExplicitPromptSection(alloc, catalog, "please improve this workflow", &.{}, limits, null);

--- a/src/ui/render_engine/transcript_blocks.zig
+++ b/src/ui/render_engine/transcript_blocks.zig
@@ -1429,6 +1429,8 @@ fn noticeLabelStyle(styles: Styles, tone: types.NoticeTone) []const u8 {
 
 fn noticeContinuationIndent(text: []const u8, cursor: usize, cols: u16) usize {
     if (cols <= 2 or cursor >= text.len) return 0;
+    const line_start = cursor > 0 and (text[cursor - 1] == '\n' or text[cursor - 1] == '\r');
+    if (line_start and (std.mem.startsWith(u8, text[cursor..], "├ ") or std.mem.startsWith(u8, text[cursor..], "└ "))) return 0;
     if (text[cursor] == '\n' or text[cursor] == '\r') return 2;
     const unit = display_width.displayUnitAt(text, cursor);
     return if (unit.cell_width <= cols - 2) 2 else 0;
@@ -2849,6 +2851,33 @@ test "background semantic notices render one topic for launch and failure" {
         try std.testing.expect(std.mem.find(u8, rendered, "System: Background") == null);
         try std.testing.expect(std.mem.find(u8, rendered, "Background: Background") == null);
     }
+}
+
+test "semantic notice tree branches align with the header while wrapped prose stays indented" {
+    const alloc = std.testing.allocator;
+    const cases = [_]struct { body: []const u8, cols: u16, expected: []const u8 }{
+        .{ .body = "2 skills loaded\n├ Loaded alpha\n└ Loaded beta", .cols = 40, .expected = "● 2 skills loaded\n├ Loaded alpha\n└ Loaded beta" },
+        .{ .body = "Ready\n└ alpha beta gamma", .cols = 12, .expected = "● Ready\n└ alpha beta\n  gamma" },
+        .{ .body = "alpha └ beta", .cols = 8, .expected = "● alpha\n  └ beta" },
+        .{ .body = "Ready\nordinary prose", .cols = 40, .expected = "● Ready\n  ordinary prose" },
+    };
+    for (cases) |case| {
+        const rendered = try renderSemanticNotice(alloc, .{ .topic = "", .tone = .neutral, .body = case.body }, .{}, case.cols);
+        defer alloc.free(rendered);
+        try std.testing.expectEqualStrings(case.expected, rendered);
+    }
+    const styled = try renderSemanticNotice(alloc, .{
+        .topic = "",
+        .tone = .neutral,
+        .body = cases[0].body,
+    }, .{ .system_notice_text_style = "\x1b[37m", .reset_style = "\x1b[0m" }, 40);
+    defer alloc.free(styled);
+    var grid = try vt_emulator.Grid.init(alloc, 40, 4);
+    defer grid.deinit();
+    try grid.feed(styled);
+    try std.testing.expectEqual(@as(u21, '●'), grid.cellAt(1, 1).?.codepoint);
+    try std.testing.expectEqual(@as(u21, '├'), grid.cellAt(2, 1).?.codepoint);
+    try std.testing.expectEqual(@as(u21, '└'), grid.cellAt(3, 1).?.codepoint);
 }
 
 test "semantic notice wraps words paths UTF-8 and explicit newlines without truncation" {

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -782,6 +782,8 @@ describe("gateway stream lifecycle", () => {
       expect(first).toContain("2 requested skills loaded");
       expect(first).toContain("Loaded skill status-first");
       expect(first).toContain("Loaded skill status-second");
+      expect(first).toMatch(/^├ Loaded skill status-first$/m);
+      expect(first).toMatch(/^└ Loaded skill status-second$/m);
       expect(first.indexOf("2 requested skills loaded")).toBeLessThan(first.indexOf("STATUS_FIRST_COMPLETE"));
       expect(first).not.toContain("tool call");
       await tui.resizeWindow(48, 36);
@@ -791,10 +793,16 @@ describe("gateway stream lifecycle", () => {
       expect(mixed.replace(/\s+/g, " ")).toContain("Requested skills · 1 loaded · 1 failed");
       expect(mixed).toContain("Could not load status-duplicate");
       expect(mixed).toContain("ambiguous");
+      expect(mixed).toMatch(/^└ Could not load status-duplicate/m);
+      expect(mixed.replace(/\s+/g, " ")).toContain("ctrl o");
+      expect(mixed).not.toContain("duplicate-a");
+      expect(mixed).not.toContain("duplicate-b");
       expect(mixed).not.toContain("Loaded skill status-duplicate");
       expect(mixed).not.toContain("tool call");
       await tui.sendKeys("C-o");
       await tui.waitForText("Could not load status-duplicate", 5_000);
+      const details = await tui.waitForText("duplicate-a", 5_000);
+      expect(details).toContain("duplicate-b");
       await tui.sendKeys("C-o");
       await tui.waitForComposer(5_000);
       expect(gateway.requests).toHaveLength(2);


### PR DESCRIPTION
## Summary

- Align skill status branches with the heading while preserving wrapped-text indentation.
- Keep inline failure rows short and show complete diagnostics in Ctrl+O.
