### PR TITLE
Restore reliable session continuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ fx session resume last
 fx session resume --id <id>
 ```
 
+`fx -c` also resumes the latest session for the current workspace. It skips unrelated current-format conversation histories during selection and attempts safe recovery of the selected session after an interrupted migration. A busy or unrecoverable selected session produces an error rather than opening an older conversation.
+
+Older sessions that saved Vercel connection settings can be opened through `-r`, `/resume`, `-c`, or an exact ID. Migration preserves their model settings and keeps unfinished responses as interrupted history, without replaying old requests or restoring saved credential references.
+
 If a saved conversation is damaged, run `fx session recover <id>` to copy its validated prefix into a new session. Recovery preserves checkpoint boundaries and referenced result files, leaves the original unchanged, and prints the new session ID. Records after the damaged boundary are not included, and recovery does not rerun commands. Healthy conversations can be resumed without recovery.
 
 Interactive terminal tabs show `fx v<version> | <folder>` using the running binary's version and current workspace folder name, for example `fx v0.0.7 | fx`. Renaming a session or switching models leaves the title unchanged. Resuming from another folder uses that folder's name. Exiting clears the fx-owned title. Noninteractive commands do not emit terminal-title controls.

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -3119,6 +3119,7 @@ fn shouldRejectRecoveryAuthority(
     source: ?types.CredentialSource,
     account_id: ?[]const u8,
 ) bool {
+    if (checkpoint.disposition == .history_only) return true;
     const provider_may_have_received_request = checkpoint.outstanding_reservation or
         checkpoint.consumed_provider_attempts > 0;
     return provider_may_have_received_request and !recoveryCredentialAuthorityMatches(
@@ -3192,6 +3193,9 @@ test "potentially sent recovery rejects missing or changed credential authority"
         .chatgpt_subscription,
         "acct_1",
     ));
+    legacy.disposition = .history_only;
+    try std.testing.expect(shouldRejectRecoveryAuthority(legacy, .chatgpt_subscription, "acct_1"));
+    try std.testing.expect(shouldRejectRecoveryAuthority(legacy, null, null));
 }
 
 fn checkpointCause(

--- a/src/core/app/app_entry_runtime.zig
+++ b/src/core/app/app_entry_runtime.zig
@@ -270,7 +270,7 @@ fn runInteractiveWithDeps(comptime App: type, comptime cooperative: bool, alloc:
             error.SessionAuthorityBoundaryUnavailable,
             error.SessionCommitBoundaryUnavailable,
             => {
-                writeStderr(deps, "fx: this session is being updated; wait a moment and retry\n");
+                writeStderr(deps, "fx: a saved session has an unfinished update that could not be recovered; run `fx doctor` to identify the affected session\n");
                 return .{ .exit = 1 };
             },
             error.OneOffSessionNotResumable => {
@@ -1280,11 +1280,11 @@ test "app entry maps unavailable session state to one expected startup failure" 
         },
         .{
             .init_error = error.SessionAuthorityBoundaryUnavailable,
-            .message = "fx: this session is being updated; wait a moment and retry\n",
+            .message = "fx: a saved session has an unfinished update that could not be recovered; run `fx doctor` to identify the affected session\n",
         },
         .{
             .init_error = error.SessionCommitBoundaryUnavailable,
-            .message = "fx: this session is being updated; wait a moment and retry\n",
+            .message = "fx: a saved session has an unfinished update that could not be recovered; run `fx doctor` to identify the affected session\n",
         },
         .{
             .init_error = error.OneOffSessionNotResumable,

--- a/src/core/session/session_codec.zig
+++ b/src/core/session/session_codec.zig
@@ -33,6 +33,64 @@ pub const DurableSessionPreferences = struct {
     }
 };
 
+/// Decodes persisted preferences; the caller owns the returned model.
+pub fn parse_preferences(alloc: Allocator, value: std.json.Value) !DurableSessionPreferences {
+    const raw = try requireObject(value);
+    const legacy = raw.contains("connection_id") or raw.contains("model_id");
+    const object = if (legacy)
+        try exactObject(value, &.{ "connection_id", "model_id", "effort", "fast_mode" })
+    else if (raw.contains("provider"))
+        try exactObject(value, &.{ "provider", "model", "effort", "fast_mode" })
+    else
+        try exactObject(value, &.{ "model", "effort", "fast_mode" });
+    const provider: model_provider.ProviderId = if (legacy) blk: {
+        if (!std.mem.eql(u8, try requireString(object, "connection_id"), "vercel")) return error.InvalidDurableField;
+        break :blk .gateway;
+    } else if (object.contains("provider"))
+        model_provider.parse(try requireString(object, "provider")) orelse return error.InvalidDurableField
+    else
+        .gateway;
+    const model = try requireString(object, if (legacy) "model_id" else "model");
+    try validateModel(model);
+    const effort = types.ReasoningEffort.parse(try requireString(object, "effort")) orelse return error.InvalidDurableField;
+    const fast_mode = try requireBool(object, "fast_mode");
+    return .{ .provider = provider, .model = try alloc.dupe(u8, model), .effort = effort, .fast_mode = fast_mode };
+}
+
+test "legacy connection preferences decode through the shared state codec" {
+    const alloc = std.testing.allocator;
+    const state_json = "{\"id\":\"legacy\",\"origin_workspace_root\":\"/workspace\",\"workspace_root\":\"/workspace\",\"created_at_ms\":1,\"updated_at_ms\":2,\"conversation_language\":\"en\",\"preferences\":{\"connection_id\":\"vercel\",\"model_id\":\"test/model\",\"effort\":\"high\",\"fast_mode\":true},\"history\":[],\"total_input_tokens\":0,\"total_output_tokens\":0}";
+    try std.testing.checkAllAllocationFailures(alloc, struct {
+        fn check(a: Allocator, bytes: []const u8) !void {
+            var source = std.Io.Reader.fixed(bytes);
+            var state = try decodeState(a, &source, .{});
+            defer state.deinit(a);
+            try std.testing.expectEqual(model_provider.ProviderId.gateway, state.preferences.provider);
+            try std.testing.expectEqualStrings("test/model", state.preferences.model);
+            try std.testing.expectEqualStrings("high", state.preferences.effort.label());
+            try std.testing.expect(state.preferences.fast_mode);
+        }
+    }.check, .{state_json});
+}
+
+test "legacy connection preferences reject unknown identities and mixed fields" {
+    const alloc = std.testing.allocator;
+    for ([_][]const u8{
+        "{\"connection_id\":\"custom\",\"model_id\":\"test\",\"effort\":\"auto\",\"fast_mode\":false}",
+        "{\"connection_id\":\"vercel\",\"model_id\":\"test\",\"model\":\"other\",\"effort\":\"auto\",\"fast_mode\":false}",
+        "{\"connection_id\":\"vercel\",\"model_id\":\"test\",\"provider\":\"codex\",\"effort\":\"auto\",\"fast_mode\":false}",
+        "{\"connection_id\":\"vercel\",\"model_id\":\"\",\"effort\":\"auto\",\"fast_mode\":false}",
+    }) |bytes| {
+        var parsed = try std.json.parseFromSlice(std.json.Value, alloc, bytes, .{});
+        defer parsed.deinit();
+        if (parse_preferences(alloc, parsed.value)) |value| {
+            var owned = value;
+            owned.deinit(alloc);
+            return error.TestUnexpectedResult;
+        } else |err| try std.testing.expect(err == error.InvalidSessionFormat or err == error.InvalidDurableField);
+    }
+}
+
 pub const RecoveryToolState = enum {
     none,
     proven_unexecuted,
@@ -63,6 +121,7 @@ pub const TurnAuthority = struct {
 
 pub const RecoveryCheckpoint = struct {
     version: u8 = 2,
+    disposition: enum { continuable, history_only } = .continuable,
     turn_id: u64,
     user: session.UserTurn,
     assistant_source: []u8,
@@ -105,6 +164,7 @@ pub const RecoveryCheckpoint = struct {
         const authority = try self.authority.dupe(alloc);
         return .{
             .version = self.version,
+            .disposition = self.disposition,
             .turn_id = self.turn_id,
             .user = user,
             .assistant_source = assistant_source,
@@ -159,6 +219,20 @@ pub const DurableSessionState = struct {
         if (self.usage) |*usage| usage.deinit(alloc);
         if (self.recovery_checkpoint) |*checkpoint| checkpoint.deinit(alloc);
         self.* = undefined;
+    }
+
+    /// Retains legacy recovery evidence without granting permission to replay its route.
+    pub fn archive_legacy_recovery(self: *DurableSessionState, alloc: Allocator) !bool {
+        const checkpoint = if (self.recovery_checkpoint) |*value| value else return false;
+        if (checkpoint.disposition != .history_only) return false;
+        const turn = try session.dupeHistoryTurn(alloc, checkpoint.interruptedTurn());
+        errdefer session.freeHistoryTurn(alloc, turn);
+        const len = try std.math.add(usize, self.history.len, 1);
+        self.history = try alloc.realloc(self.history, len);
+        self.history[len - 1] = turn;
+        checkpoint.deinit(alloc);
+        self.recovery_checkpoint = null;
+        return true;
     }
 
     pub fn dupe(self: DurableSessionState, alloc: Allocator) !DurableSessionState {
@@ -930,6 +1004,7 @@ fn parsePermissionState(
 }
 
 pub fn writeRecoveryCheckpoint(writer: *std.Io.Writer, checkpoint: RecoveryCheckpoint) !void {
+    if (checkpoint.disposition == .history_only) return error.InvalidDurableField;
     try writer.print("{{\"version\":{d},\"turn_id\":{d},\"user\":", .{
         checkpoint.version,
         checkpoint.turn_id,
@@ -996,25 +1071,19 @@ fn decodeStateImpl(alloc: Allocator, source: *std.Io.Reader, limits: DecodeLimit
     const conversation_language = try parseConversationLanguage(language_raw);
 
     try expectKey(&json_reader, alloc, "preferences");
-    try expectToken(try json_reader.next(), .object_begin);
-    try expectKey(&json_reader, alloc, "model");
-    const model = try readStringOwned(&json_reader, alloc, 1024);
-    errdefer alloc.free(model);
-    try expectKey(&json_reader, alloc, "effort");
-    const effort_raw = try readStringOwned(&json_reader, alloc, types.ReasoningEffort.max_name_bytes);
-    defer alloc.free(effort_raw);
-    const effort = types.ReasoningEffort.parse(effort_raw) orelse
-        return error.InvalidDurableField;
-    try expectKey(&json_reader, alloc, "fast_mode");
-    const fast_mode = try readBool(&json_reader);
-    var provider: model_provider.ProviderId = .gateway;
-    if (try json_reader.peekNextTokenType() != .object_end) {
-        try expectKey(&json_reader, alloc, "provider");
-        const provider_raw = try readStringOwned(&json_reader, alloc, 16);
-        defer alloc.free(provider_raw);
-        provider = model_provider.parse(provider_raw) orelse return error.InvalidDurableField;
-    }
-    try expectToken(try json_reader.next(), .object_end);
+    var preferences = preferences: {
+        var buffer: [8 * 1024]u8 = undefined;
+        var fixed = std.heap.FixedBufferAllocator.init(&buffer);
+        const value = std.json.Value.jsonParse(fixed.allocator(), &json_reader, .{
+            .max_value_len = 1024,
+            .allocate = .alloc_always,
+        }) catch |err| switch (err) {
+            error.OutOfMemory => return error.InvalidSessionFormat,
+            else => return err,
+        };
+        break :preferences try parse_preferences(alloc, value);
+    };
+    errdefer preferences.deinit(alloc);
 
     try expectKey(&json_reader, alloc, "history");
     try expectToken(try json_reader.next(), .array_begin);
@@ -1128,12 +1197,7 @@ fn decodeStateImpl(alloc: Allocator, source: *std.Io.Reader, limits: DecodeLimit
         .created_at_ms = created_at_ms,
         .updated_at_ms = updated_at_ms,
         .conversation_language = conversation_language,
-        .preferences = .{
-            .provider = provider,
-            .model = model,
-            .effort = effort,
-            .fast_mode = fast_mode,
-        },
+        .preferences = preferences,
         .history = owned_history,
         .context_history_start = context_history_start,
         .total_input_tokens = total_input_tokens,
@@ -1151,7 +1215,17 @@ fn decodeStateImpl(alloc: Allocator, source: *std.Io.Reader, limits: DecodeLimit
 pub fn parseRecoveryCheckpoint(alloc: Allocator, value: std.json.Value) !RecoveryCheckpoint {
     const raw_object = try requireObject(value);
     const version = try requireU64(raw_object, "version");
-    const object = switch (version) {
+    const legacy_route = raw_object.contains("route_identity");
+    const object = if (legacy_route) legacy: {
+        try validate_legacy_recovery_route(raw_object.get("route_identity").?, version);
+        const delivery = try requireString(raw_object, "delivery");
+        if (!std.mem.eql(u8, delivery, "possibly_sent") and !std.mem.eql(u8, delivery, "definitely_unsent")) return error.InvalidDurableField;
+        break :legacy try exactObject(value, &.{
+            "version",                    "route_identity",          "delivery",   "turn_id",     "user",                "assistant_source", "execution",
+            "cause",                      "action",                  "tool_state", "route_model", "requested_fast_mode", "fast_mode",        "max_provider_attempts",
+            "consumed_provider_attempts", "outstanding_reservation",
+        });
+    } else switch (version) {
         1 => if (raw_object.get("route_provider") != null)
             try exactObject(value, &.{
                 "version",             "turn_id",   "user",                  "assistant_source",           "execution",
@@ -1177,7 +1251,10 @@ pub fn parseRecoveryCheckpoint(alloc: Allocator, value: std.json.Value) !Recover
     errdefer alloc.free(assistant_source);
     const execution = try parseExecutionMemory(alloc, object.get("execution") orelse return error.InvalidSessionFormat);
     errdefer session.freeExecutionMemory(alloc, execution);
-    const authority = if (version == 1) legacy: {
+    const authority = if (legacy_route) TurnAuthority{
+        .provider = .gateway,
+        .model = try parseDurableBytes(alloc, object.get("route_model") orelse return error.InvalidSessionFormat),
+    } else if (version == 1) legacy: {
         const model = try parseDurableBytes(alloc, object.get("route_model") orelse return error.InvalidSessionFormat);
         break :legacy TurnAuthority{
             .provider = if (object.get("route_provider")) |provider_value| blk: {
@@ -1197,6 +1274,7 @@ pub fn parseRecoveryCheckpoint(alloc: Allocator, value: std.json.Value) !Recover
         return error.InvalidDurableField;
     return .{
         .version = 2,
+        .disposition = if (legacy_route) .history_only else .continuable,
         .turn_id = try requireU64(object, "turn_id"),
         .user = user,
         .assistant_source = assistant_source,
@@ -1214,6 +1292,77 @@ pub fn parseRecoveryCheckpoint(alloc: Allocator, value: std.json.Value) !Recover
         .consumed_provider_attempts = consumed_provider_attempts,
         .outstanding_reservation = try requireBool(object, "outstanding_reservation"),
     };
+}
+
+test "legacy route checkpoints retain history without resumable authority" {
+    const alloc = std.testing.allocator;
+    const routes = [_][]const u8{
+        "{\"connection_id\":\"vercel\",\"adapter_kind\":\"vercel_ai_gateway\",\"permission_review_model_id\":\"review\"}",
+        "{\"connection_id\":\"vercel\",\"adapter_kind\":\"vercel_ai_gateway\",\"permission_review_model_id\":\"review\",\"vision_model_id\":\"vision\",\"subagent_model_id\":\"child\"}",
+        "{\"version\":1,\"connection_id\":\"vercel\",\"adapter_kind\":\"vercel_ai_gateway\",\"endpoint\":\"https://unused.invalid\",\"protocol\":\"vercel_ai_gateway\",\"credential_ref\":\"unused\",\"permission_review_model_id\":\"review\",\"vision_model_id\":\"vision\",\"subagent_model_id\":\"child\"}",
+    };
+    const fields = "\"turn_id\":1,\"user\":{\"text\":\"saved request\",\"images\":[]},\"assistant_source\":\"saved partial\",\"execution\":{\"schema_version\":3,\"tool_steps\":[],\"files\":[]},\"cause\":\"response_interrupted\",\"action\":\"continuing_response\",\"tool_state\":\"uncertain\",\"route_model\":\"test/model\",\"requested_fast_mode\":false,\"fast_mode\":false,\"max_provider_attempts\":3,\"consumed_provider_attempts\":0,\"outstanding_reservation\":false}";
+    for (routes, 2..) |route, version| {
+        for ([_][]const u8{ "possibly_sent", "definitely_unsent" }) |delivery| {
+            const bytes = try std.fmt.allocPrint(alloc, "{{\"version\":{d},\"route_identity\":{s},\"delivery\":\"{s}\",{s}", .{ version, route, delivery, fields });
+            defer alloc.free(bytes);
+            var parsed = try std.json.parseFromSlice(std.json.Value, alloc, bytes, .{});
+            defer parsed.deinit();
+            var checkpoint = try parseRecoveryCheckpoint(alloc, parsed.value);
+            defer checkpoint.deinit(alloc);
+            try std.testing.expectEqual(.history_only, checkpoint.disposition);
+            try std.testing.expect(checkpoint.authority.credential_source == null);
+            try std.testing.expect(checkpoint.authority.credential_identity == null);
+            var out: std.Io.Writer.Allocating = .init(alloc);
+            defer out.deinit();
+            try std.testing.expectError(error.InvalidDurableField, writeRecoveryCheckpoint(&out.writer, checkpoint));
+            try std.testing.expectEqual(@as(usize, 0), out.written().len);
+            const borrowed = DurableSessionState{
+                .id = @constCast("legacy"),
+                .origin_workspace_root = @constCast("/workspace"),
+                .workspace_root = @constCast("/workspace"),
+                .created_at_ms = 1,
+                .updated_at_ms = 2,
+                .conversation_language = .literal("en"),
+                .preferences = .{ .model = @constCast("test/model"), .effort = .auto, .fast_mode = false },
+                .history = &.{},
+                .total_input_tokens = 0,
+                .total_output_tokens = 0,
+                .recovery_checkpoint = checkpoint,
+            };
+            try std.testing.checkAllAllocationFailures(alloc, struct {
+                fn check(a: Allocator, original: DurableSessionState) !void {
+                    var state = try original.dupe(a);
+                    defer state.deinit(a);
+                    try std.testing.expect(try state.archive_legacy_recovery(a));
+                    try std.testing.expect(!(try state.archive_legacy_recovery(a)));
+                    try std.testing.expect(state.recovery_checkpoint == null);
+                    try std.testing.expectEqual(@as(usize, 1), state.history.len);
+                    try std.testing.expectEqualStrings("saved request", state.history[0].interrupted.user.text);
+                    try std.testing.expectEqualStrings("saved partial", state.history[0].interrupted.assistant.?);
+                }
+            }.check, .{borrowed});
+        }
+    }
+}
+
+fn validate_legacy_recovery_route(value: std.json.Value, version: u64) !void {
+    const object = switch (version) {
+        2 => try exactObject(value, &.{ "connection_id", "adapter_kind", "permission_review_model_id" }),
+        3 => try exactObject(value, &.{ "connection_id", "adapter_kind", "permission_review_model_id", "vision_model_id", "subagent_model_id" }),
+        4 => try exactObject(value, &.{ "version", "connection_id", "adapter_kind", "endpoint", "protocol", "credential_ref", "permission_review_model_id", "vision_model_id", "subagent_model_id" }),
+        else => return error.InvalidDurableField,
+    };
+    if (!std.mem.eql(u8, try requireString(object, "connection_id"), "vercel") or
+        !std.mem.eql(u8, try requireString(object, "adapter_kind"), "vercel_ai_gateway")) return error.InvalidDurableField;
+    if (version == 4 and (try requireU64(object, "version") != 1 or
+        !std.mem.eql(u8, try requireString(object, "protocol"), "vercel_ai_gateway"))) return error.InvalidDurableField;
+    var fields = object.iterator();
+    while (fields.next()) |field| {
+        if (std.mem.eql(u8, field.key_ptr.*, "version")) continue;
+        if (field.value_ptr.* != .string or field.value_ptr.string.len > 4096 or
+            !std.unicode.utf8ValidateSlice(field.value_ptr.string)) return error.InvalidDurableField;
+    }
 }
 
 fn parseTurnAuthority(alloc: Allocator, value: std.json.Value) !TurnAuthority {

--- a/src/core/session/session_discovery.zig
+++ b/src/core/session/session_discovery.zig
@@ -399,6 +399,76 @@ fn classifyConversationCandidate(
     };
 }
 
+/// Reads only the facts needed for writable latest selection. Caller owns the candidate.
+pub fn writable_conversation_candidate(
+    alloc: Allocator,
+    session_dir: *io_mod.VerifiedDir,
+    session_id: []const u8,
+    metadata: session_codec.SessionMetadata,
+    workspace_root: []const u8,
+) !WritableCandidate {
+    if (!std.mem.eql(u8, metadata.id, session_id)) return error.InvalidSessionFormat;
+    var updated_at_ms = metadata.updated_at_ms;
+    if (std.mem.eql(u8, metadata.workspace_root, workspace_root)) {
+        const path_stat = try session_dir.dir.statFile(io_mod.getIo(), "events.jsonl", .{ .follow_symlinks = false });
+        if (path_stat.kind != .file or path_stat.nlink != 1) return error.SessionPathUnsafe;
+        var file = try openSessionFile(session_dir, "events.jsonl", .read_only);
+        defer file.close(io_mod.getIo());
+        const stat = try file.stat(io_mod.getIo());
+        var offset: u64 = 0;
+        while (offset < stat.size) {
+            const line = session_replay.readLineAt(alloc, file, offset, stat.size) catch |err| switch (err) {
+                error.TruncatedEventFrame => break,
+                else => return err,
+            } orelse break;
+            defer alloc.free(line.bytes);
+            var decoded = try session_event.decodeConversationFrame(alloc, line.bytes);
+            defer decoded.deinit();
+            switch (decoded.value.event) {
+                .turn_completed, .interrupted, .context_checkpoint => {
+                    updated_at_ms = @max(updated_at_ms, std.math.cast(
+                        i64,
+                        @divFloor(stat.mtime.nanoseconds, std.time.ns_per_ms),
+                    ) orelse std.math.maxInt(i64));
+                    break;
+                },
+                else => {},
+            }
+            offset = line.next_offset;
+        }
+    }
+    return dupeWritableCandidate(alloc, metadata.id, metadata.workspace_root, updated_at_ms, .conversation, .current);
+}
+
+/// Identifies a fenced candidate without recovering it. Caller owns the candidate.
+pub fn fenced_legacy_writable_candidate(
+    alloc: Allocator,
+    session_dir: *io_mod.VerifiedDir,
+    session_id: []const u8,
+    fallback_workspace: []const u8,
+) !WritableCandidate {
+    const name: []const u8 = if (try entryExistsRelative(session_dir, "session.legacy.json")) "session.legacy.json" else "session.json";
+    const path_stat = try session_dir.dir.statFile(io_mod.getIo(), name, .{ .follow_symlinks = false });
+    if (path_stat.kind != .file or path_stat.nlink != 1) return error.SessionPathUnsafe;
+    var file = try openSessionFile(session_dir, name, .read_only);
+    defer file.close(io_mod.getIo());
+    const stat = try file.stat(io_mod.getIo());
+    if (stat.size > automatic_legacy_max_bytes) return error.LegacySessionTooLarge;
+    var buffer: [16 * 1024]u8 = undefined;
+    var reader = file.readerStreaming(io_mod.getIo(), &buffer);
+    var summary = try readLegacySummary(alloc, &reader.interface, null);
+    defer summary.deinit(alloc);
+    if (!std.mem.eql(u8, summary.id, session_id)) return error.InvalidSessionFormat;
+    return dupeWritableCandidate(
+        alloc,
+        summary.id,
+        summary.workspace_root orelse fallback_workspace,
+        summary.updated_at_ms,
+        candidateStorageForLegacy(summary.schema_version),
+        .stale,
+    );
+}
+
 /// Builds a read-only candidate from a schema-v3 manifest, validating the
 /// authority marker, manifest identity, and projection freshness.
 /// Fails with `error.InvalidSessionFormat` / `error.UnsupportedSessionSchema` on mismatch.

--- a/src/core/session/session_event.zig
+++ b/src/core/session/session_event.zig
@@ -1877,23 +1877,9 @@ fn readFrameLine(alloc: Allocator, source: *std.Io.Reader) ![]u8 {
 }
 
 fn parsePreferences(alloc: Allocator, value: std.json.Value) !session_codec.DurableSessionPreferences {
-    const raw_object = try requireObject(value);
-    const object = if (raw_object.get("provider") != null)
-        try exactObject(value, &.{ "provider", "model", "effort", "fast_mode" })
-    else
-        try exactObject(value, &.{ "model", "effort", "fast_mode" });
-    const model = try dupeString(alloc, object, "model");
-    errdefer alloc.free(model);
-    return .{
-        .provider = if (object.get("provider")) |provider_value| blk: {
-            if (provider_value != .string) return error.InvalidEventFrame;
-            break :blk model_provider.parse(provider_value.string) orelse return error.InvalidEventFrame;
-        } else .gateway,
-        .model = model,
-        .effort = types.ReasoningEffort.parse(
-            try requireString(object, "effort"),
-        ) orelse return error.InvalidEventFrame,
-        .fast_mode = try requireBool(object, "fast_mode"),
+    return session_codec.parse_preferences(alloc, value) catch |err| switch (err) {
+        error.OutOfMemory => return err,
+        else => return error.InvalidEventFrame,
     };
 }
 

--- a/src/core/session/session_log.zig
+++ b/src/core/session/session_log.zig
@@ -2880,6 +2880,9 @@ fn importLegacySnapshotStateWithOps(
     if (migrated_permissions) |permissions| import_state.permission_state = permissions;
     var converted = try import_state.dupe(alloc);
     errdefer converted.deinit(alloc);
+    if (try converted.archive_legacy_recovery(alloc)) {
+        debug_trace.logf("session", "legacy recovery archived session_id={s} reason=unverifiable_route_authority", .{converted.id});
+    }
     const discarded = try discardEmptyLegacyFileEvidence(alloc, converted.history);
     if (discarded > 0) debug_trace.logf("session", "legacy import discarded file evidence count={d} reason=empty_path", .{discarded});
     try projectConversationSnapshotLocators(alloc, converted.history);

--- a/src/core/session/session_migration.zig
+++ b/src/core/session/session_migration.zig
@@ -222,6 +222,9 @@ pub fn loadSchemaV3ReadOnly(
     {
         return error.InvalidSessionFormat;
     }
+    if (try replayed.state.archive_legacy_recovery(alloc)) {
+        @import("../shared/debug_trace.zig").logf("session", "legacy recovery archived session_id={s} reason=unverifiable_route_authority", .{session_id});
+    }
     const state = replayed.takeState();
     return .{
         .state = state,
@@ -351,6 +354,46 @@ fn loadMigrationPreferences(
         .effort = detailed.settings.effort orelse .auto,
         .fast_mode = detailed.settings.fast_mode orelse false,
     };
+}
+
+test "schema v3 import archives legacy recovery with allocation failure cleanup" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var dir = io_mod.VerifiedDir{ .dir = try tmp.dir.openDir(std.testing.io, ".", .{}) };
+    defer dir.close();
+    const generation = [_]u8{1} ** 16;
+    const started = try session_event.encodeLegacyFixtureFrame(alloc, .{
+        .log_generation = generation,
+        .seq = 1,
+        .event_id = [_]u8{1} ** 16,
+        .timestamp_ms = 10,
+        .event = .{ .session_started = .{
+            .id = @constCast("legacy-recovery"),
+            .created_at_ms = 10,
+            .origin_workspace_root = @constCast("/workspace"),
+            .workspace_root = @constCast("/workspace"),
+            .conversation_language = .literal("en"),
+            .preferences = .{ .model = @constCast("test/model"), .effort = .auto, .fast_mode = false },
+        } },
+    });
+    defer alloc.free(started);
+    const recovery = "{\"schema_version\":1,\"log_generation\":\"01010101010101010101010101010101\",\"seq\":2,\"event_id\":\"02020202020202020202020202020202\",\"timestamp_ms\":20,\"kind\":\"recovery_checkpoint_set\",\"payload\":{\"checkpoint\":{\"version\":2,\"route_identity\":{\"connection_id\":\"vercel\",\"adapter_kind\":\"vercel_ai_gateway\",\"permission_review_model_id\":\"review\"},\"delivery\":\"possibly_sent\",\"turn_id\":1,\"user\":{\"text\":\"saved request\",\"images\":[]},\"assistant_source\":\"saved partial\",\"execution\":{\"schema_version\":3,\"tool_steps\":[],\"files\":[]},\"cause\":\"response_interrupted\",\"action\":\"continuing_response\",\"tool_state\":\"uncertain\",\"route_model\":\"test/model\",\"requested_fast_mode\":false,\"fast_mode\":false,\"max_provider_attempts\":3,\"consumed_provider_attempts\":0,\"outstanding_reservation\":false}}}\n";
+    const events = try std.mem.concat(alloc, u8, &.{ started, recovery });
+    defer alloc.free(events);
+    try dir.dir.writeFile(std.testing.io, .{ .sub_path = "events.jsonl", .data = events });
+    const watermark = try std.fmt.allocPrint(alloc, "{{\"schema_version\":1,\"session_id\":\"legacy-recovery\",\"log_generation\":\"01010101010101010101010101010101\",\"through_seq\":2,\"through_event_id\":\"02020202020202020202020202020202\",\"through_event_log_bytes\":{d}}}", .{events.len});
+    defer alloc.free(watermark);
+    try dir.dir.writeFile(std.testing.io, .{ .sub_path = "commit.01010101010101010101010101010101.json", .data = watermark });
+    try std.testing.checkAllAllocationFailures(alloc, struct {
+        fn check(a: Allocator, source: *io_mod.VerifiedDir) !void {
+            var imported = try loadSchemaV3ReadOnly(a, source, "legacy-recovery");
+            defer imported.deinit(a);
+            try std.testing.expect(imported.state.recovery_checkpoint == null);
+            try std.testing.expectEqual(@as(usize, 1), imported.state.history.len);
+            try std.testing.expectEqualStrings("saved partial", imported.state.history[0].interrupted.assistant.?);
+        }
+    }.check, .{&dir});
 }
 
 test "schema v3 import follows the committed watermark beyond a stale manifest" {

--- a/src/core/session/session_projection.zig
+++ b/src/core/session/session_projection.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
 const session = @import("session.zig");
 const session_codec = @import("session_codec.zig");
-const model_provider = @import("../config/model_provider.zig");
 const session_event = @import("session_event.zig");
 const types = @import("../shared/types.zig");
 
@@ -487,22 +486,9 @@ fn writePreferences(
 }
 
 fn parsePreferences(alloc: Allocator, value: std.json.Value) !session_codec.DurableSessionPreferences {
-    const raw_object = if (value == .object) value.object else return error.InvalidManifest;
-    const object = if (raw_object.get("provider") != null)
-        try exactObject(value, &.{ "provider", "model", "effort", "fast_mode" })
-    else
-        try exactObject(value, &.{ "model", "effort", "fast_mode" });
-    const model = try dupeString(alloc, object, "model");
-    errdefer alloc.free(model);
-    return .{
-        .provider = if (object.get("provider")) |provider_value| blk: {
-            if (provider_value != .string) return error.InvalidManifest;
-            break :blk model_provider.parse(provider_value.string) orelse return error.InvalidManifest;
-        } else .gateway,
-        .model = model,
-        .effort = types.ReasoningEffort.parse(try requireString(object, "effort")) orelse
-            return error.InvalidManifest,
-        .fast_mode = try requireBool(object, "fast_mode"),
+    return session_codec.parse_preferences(alloc, value) catch |err| switch (err) {
+        error.OutOfMemory => return err,
+        else => return error.InvalidManifest,
     };
 }
 
@@ -530,12 +516,6 @@ fn requireString(object: std.json.ObjectMap, key: []const u8) ![]const u8 {
 
 fn dupeString(alloc: Allocator, object: std.json.ObjectMap, key: []const u8) ![]u8 {
     return try alloc.dupe(u8, try requireString(object, key));
-}
-
-fn requireBool(object: std.json.ObjectMap, key: []const u8) !bool {
-    const value = object.get(key) orelse return error.InvalidManifest;
-    if (value != .bool) return error.InvalidManifest;
-    return value.bool;
 }
 
 fn requireI64(object: std.json.ObjectMap, key: []const u8) !i64 {

--- a/src/core/session/session_store.zig
+++ b/src/core/session/session_store.zig
@@ -2689,6 +2689,18 @@ pub const Store = struct {
         return loaded;
     }
 
+    fn only_unpublished_lock(session_dir: *io_mod.VerifiedDir) !bool {
+        var dir = try session_dir.dir.openDir(io_mod.getIo(), ".", .{ .iterate = true });
+        defer dir.close(io_mod.getIo());
+        var entries = dir.iterate();
+        while (try entries.next(io_mod.getIo())) |entry| {
+            if (entry.kind != .file or !std.mem.eql(u8, entry.name, "session.lock")) return false;
+            const stat = try dir.statFile(io_mod.getIo(), entry.name, .{ .follow_symlinks = false });
+            if (stat.kind != .file or stat.size != 0 or stat.nlink != 1) return false;
+        }
+        return true;
+    }
+
     fn selectWritableLastId(
         self: Store,
         alloc: Allocator,
@@ -2720,7 +2732,7 @@ pub const Store = struct {
                     err,
                 );
                 return err;
-            };
+            } orelse continue;
             if (!std.mem.eql(u8, candidate.workspace_root, workspace_root)) {
                 logDiscovery(
                     .workspace_writable_last,
@@ -2771,13 +2783,13 @@ pub const Store = struct {
         session_id: []const u8,
         workspace_root: []const u8,
         _: ResumeOptions,
-    ) !WritableCandidate {
+    ) !?WritableCandidate {
         var session_dir = try self.openSessionDir(session_id);
         defer session_dir.close();
         if (try session_log.readConversationMetadata(alloc, &session_dir)) |value| {
             var metadata = value;
             defer metadata.deinit();
-            return discovery.writable_conversation_candidate(
+            return try discovery.writable_conversation_candidate(
                 alloc,
                 &session_dir,
                 session_id,
@@ -2786,7 +2798,7 @@ pub const Store = struct {
             );
         }
         if (try authority_module.entryExistsRelative(&session_dir, "authority.pending.json")) {
-            return discovery.fenced_legacy_writable_candidate(
+            return try discovery.fenced_legacy_writable_candidate(
                 alloc,
                 &session_dir,
                 session_id,
@@ -2795,13 +2807,16 @@ pub const Store = struct {
         }
         return switch (try classifyAuthority(alloc, &session_dir, session_id)) {
             .legacy => {
-                var candidate = try classifyLegacyCandidate(
+                var candidate = classifyLegacyCandidate(
                     alloc,
                     &session_dir,
                     session_id,
-                );
+                ) catch |err| {
+                    if (err == error.FileNotFound and try only_unpublished_lock(&session_dir)) return null;
+                    return err;
+                };
                 defer candidate.deinit(alloc);
-                return dupeWritableCandidate(
+                return try dupeWritableCandidate(
                     alloc,
                     candidate.summary.id,
                     candidate.summary.workspace_root orelse self.workspace_root,
@@ -2821,7 +2836,7 @@ pub const Store = struct {
                     projected = candidate_value;
                     const candidate = projected.?;
                     if (candidate.projection_state == .current) {
-                        return dupeWritableCandidate(
+                        return try dupeWritableCandidate(
                             alloc,
                             candidate.summary.id,
                             candidate.summary.workspace_root.?,
@@ -2849,7 +2864,7 @@ pub const Store = struct {
                         candidate.summary.workspace_root.?,
                         workspace_root,
                     )) return err;
-                    return dupeWritableCandidate(
+                    return try dupeWritableCandidate(
                         alloc,
                         candidate.summary.id,
                         candidate.summary.workspace_root.?,
@@ -2859,7 +2874,7 @@ pub const Store = struct {
                     );
                 };
                 defer source.deinit(alloc);
-                return dupeWritableCandidate(
+                return try dupeWritableCandidate(
                     alloc,
                     source.state.id,
                     source.state.workspace_root,
@@ -6491,6 +6506,28 @@ test "classifies conversation and legacy candidates" {
     );
 }
 
+test "writable last skips only unpublished lock directories" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var ctx = try initTempStore(alloc, &tmp);
+    defer ctx.deinit(alloc);
+    try createHistoryPageFixture(alloc, ctx.store, "local", ctx.workspace, 1, "saved");
+    try ctx.store.canonical_root.sessions.?.dir.createDir(std.testing.io, "empty", .fromMode(0o700));
+    try ctx.store.canonical_root.sessions.?.dir.createDir(std.testing.io, "lock-only", .fromMode(0o700));
+    try writeFixtureEntry(alloc, ctx.store, "lock-only", "session.lock", "");
+    {
+        var resumed = try ctx.store.resumeTargetForWrite(alloc, .last, ctx.workspace, .{});
+        defer resumed.deinit(alloc);
+        try std.testing.expectEqualStrings("local", resumed.active_id);
+    }
+    try writeFixtureEntry(alloc, ctx.store, "lock-only", "events.jsonl", "unidentified saved data\n");
+    try std.testing.expectError(error.FileNotFound, ctx.store.resumeTargetForWrite(alloc, .last, ctx.workspace, .{}));
+    const retained = try readFixtureFile(alloc, ctx.store, "lock-only", "events.jsonl", 1024);
+    defer alloc.free(retained);
+    try std.testing.expectEqualStrings("unidentified saved data\n", retained);
+}
+
 test "writable last ignores unrelated conversation history" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
@@ -6600,7 +6637,7 @@ test "writable last preserves conversation recency and allocation cleanup" {
         defer dir.close();
         var reference = try classifyReadOnlyCandidate(alloc, &dir, id);
         defer reference.deinit(alloc);
-        var candidate = try ctx.store.resolveWritableCandidate(alloc, id, ctx.workspace, .{});
+        var candidate = (try ctx.store.resolveWritableCandidate(alloc, id, ctx.workspace, .{})).?;
         defer candidate.deinit(alloc);
         try std.testing.expectEqual(reference.summary.updated_at_ms, candidate.updated_at_ms);
         try std.testing.expectEqualStrings(reference.summary.workspace_root.?, candidate.workspace_root);

--- a/src/core/session/session_store.zig
+++ b/src/core/session/session_store.zig
@@ -1179,13 +1179,16 @@ pub const Store = struct {
             options,
         ) orelse return session_log.failLoadedWritableSession(error.NoSavedSessions);
         defer alloc.free(selected);
-        var loaded = try self.resumeExactForWrite(
+        var loaded = self.resumeExactForWrite(
             alloc,
             selected,
             workspace_root,
             false,
             options,
-        );
+        ) catch |err| {
+            logDiscoveryError(.workspace_writable_last, selected, null, null, err);
+            return err;
+        };
         errdefer loaded.deinit(alloc);
         return loaded;
     }
@@ -2708,21 +2711,15 @@ pub const Store = struct {
                 entry.name,
                 workspace_root,
                 options,
-            ) catch |err| switch (err) {
-                error.OutOfMemory,
-                error.SessionAuthorityBoundaryUnavailable,
-                error.SessionCommitBoundaryUnavailable,
-                => return err,
-                else => {
-                    logDiscoveryError(
-                        .workspace_writable_last,
-                        entry.name,
-                        null,
-                        null,
-                        err,
-                    );
-                    return err;
-                },
+            ) catch |err| {
+                logDiscoveryError(
+                    .workspace_writable_last,
+                    entry.name,
+                    null,
+                    null,
+                    err,
+                );
+                return err;
             };
             if (!std.mem.eql(u8, candidate.workspace_root, workspace_root)) {
                 logDiscovery(
@@ -2777,20 +2774,23 @@ pub const Store = struct {
     ) !WritableCandidate {
         var session_dir = try self.openSessionDir(session_id);
         defer session_dir.close();
-        if (try session_log.hasConversationMetadata(alloc, &session_dir)) {
-            var candidate = try classifyReadOnlyCandidate(
+        if (try session_log.readConversationMetadata(alloc, &session_dir)) |value| {
+            var metadata = value;
+            defer metadata.deinit();
+            return discovery.writable_conversation_candidate(
                 alloc,
                 &session_dir,
                 session_id,
+                metadata.value,
+                workspace_root,
             );
-            defer candidate.deinit(alloc);
-            return dupeWritableCandidate(
+        }
+        if (try authority_module.entryExistsRelative(&session_dir, "authority.pending.json")) {
+            return discovery.fenced_legacy_writable_candidate(
                 alloc,
-                candidate.summary.id,
-                candidate.summary.workspace_root orelse self.workspace_root,
-                candidate.summary.updated_at_ms,
-                candidate.storage,
-                candidate.projection_state,
+                &session_dir,
+                session_id,
+                self.workspace_root,
             );
         }
         return switch (try classifyAuthority(alloc, &session_dir, session_id)) {
@@ -6489,6 +6489,130 @@ test "classifies conversation and legacy candidates" {
         CandidateStorage.legacy_v2,
         legacy_candidate.storage,
     );
+}
+
+test "writable last ignores unrelated conversation history" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var ctx = try initTempStore(alloc, &tmp);
+    defer ctx.deinit(alloc);
+    try createHistoryPageFixture(alloc, ctx.store, "local", ctx.workspace, 1, "local-turn");
+    var foreign_state = try testDurableState(alloc, "foreign", "/foreign-workspace");
+    defer foreign_state.deinit(alloc);
+    var foreign = try ctx.store.startWritableSession(alloc, foreign_state);
+    foreign.deinit(alloc);
+    var foreign_dir = try ctx.store.openSessionDir("foreign");
+    defer foreign_dir.close();
+    var metadata = (try session_log.readConversationMetadata(alloc, &foreign_dir)).?;
+    defer metadata.deinit();
+    try std.testing.expectEqualStrings("/foreign-workspace", metadata.value.workspace_root);
+    try writeFixtureEntry(alloc, ctx.store, "foreign", "events.jsonl", "unreadable foreign history\n");
+
+    var resumed = try ctx.store.resumeTargetForWrite(alloc, .last, ctx.workspace, .{});
+    defer resumed.deinit(alloc);
+    try std.testing.expectEqualStrings("local", resumed.active_id);
+    try std.testing.expectEqualStrings("local-turn-0", resumed.state.history[0].assistant.user.text);
+    const unchanged = try readFixtureFile(alloc, ctx.store, "foreign", "events.jsonl", 1024);
+    defer alloc.free(unchanged);
+    try std.testing.expectEqualStrings("unreadable foreign history\n", unchanged);
+}
+
+test "writable last ignores an unrelated legacy authority fence" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var ctx = try initTempStore(alloc, &tmp);
+    defer ctx.deinit(alloc);
+    try writeLegacyFixture(alloc, ctx.store, "local", ctx.workspace, 10);
+    try writeLegacyFixture(alloc, ctx.store, "foreign-fenced", "/foreign-workspace", 20);
+    try writeFixtureEntry(alloc, ctx.store, "foreign-fenced", "authority.pending.json", "pending");
+
+    var resumed = try ctx.store.resumeTargetForWrite(alloc, .last, ctx.workspace, .{});
+    defer resumed.deinit(alloc);
+    try std.testing.expectEqualStrings("local", resumed.active_id);
+    const unchanged = try readFixtureFile(alloc, ctx.store, "foreign-fenced", "authority.pending.json", 1024);
+    defer alloc.free(unchanged);
+    try std.testing.expectEqualStrings("pending", unchanged);
+}
+
+test "writable last reaches selected legacy authority recovery" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var ctx = try initTempStore(alloc, &tmp);
+    defer ctx.deinit(alloc);
+    try writeLegacyFixture(alloc, ctx.store, "older", ctx.workspace, 10);
+    try writeLegacyFixture(alloc, ctx.store, "recover-latest", ctx.workspace, 20);
+    const stable = try readFixtureFile(alloc, ctx.store, "recover-latest", "session.json", 4096);
+    defer alloc.free(stable);
+    try writeFixtureEntry(alloc, ctx.store, "recover-latest", "session.legacy.json", stable);
+    try writeFixtureEntry(alloc, ctx.store, "recover-latest", "authority.pending.json", "pending");
+    try writeFixtureEntry(alloc, ctx.store, "recover-latest", "session.json", "interrupted replacement");
+
+    var resumed = try ctx.store.resumeTargetForWrite(alloc, .last, ctx.workspace, .{});
+    defer resumed.deinit(alloc);
+    try std.testing.expectEqualStrings("recover-latest", resumed.active_id);
+    var dir = try ctx.store.openSessionDir("recover-latest");
+    defer dir.close();
+    try requireAuthorityFenceAbsent(alloc, &dir, "recover-latest");
+}
+
+test "writable last only inspects the history needed for ranking" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var ctx = try initTempStore(alloc, &tmp);
+    defer ctx.deinit(alloc);
+    try createHistoryPageFixture(alloc, ctx.store, "older-prefix", ctx.workspace, 1, "older");
+    const prefix = try readFixtureFile(alloc, ctx.store, "older-prefix", "events.jsonl", 64 * 1024);
+    defer alloc.free(prefix);
+    const with_suffix = try std.mem.concat(alloc, u8, &.{ prefix, "unreadable suffix\n" });
+    defer alloc.free(with_suffix);
+    try writeFixtureEntry(alloc, ctx.store, "older-prefix", "events.jsonl", with_suffix);
+    var selected = try testDurableState(alloc, "newest", ctx.workspace);
+    defer selected.deinit(alloc);
+    selected.updated_at_ms = std.math.maxInt(i64);
+    var writable = try ctx.store.startWritableSession(alloc, selected);
+    writable.deinit(alloc);
+
+    var resumed = try ctx.store.resumeTargetForWrite(alloc, .last, ctx.workspace, .{});
+    defer resumed.deinit(alloc);
+    try std.testing.expectEqualStrings("newest", resumed.active_id);
+    const unchanged = try readFixtureFile(alloc, ctx.store, "older-prefix", "events.jsonl", 64 * 1024);
+    defer alloc.free(unchanged);
+    try std.testing.expectEqualStrings(with_suffix, unchanged);
+}
+
+test "writable last preserves conversation recency and allocation cleanup" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var ctx = try initTempStore(alloc, &tmp);
+    defer ctx.deinit(alloc);
+    const user = "{\"schema_version\":1,\"seq\":1,\"timestamp_ms\":20,\"event\":{\"user\":{\"text\":\"unfinished\"}}}\n";
+    const checkpoint = "{\"schema_version\":1,\"seq\":2,\"timestamp_ms\":21,\"event\":{\"context_checkpoint\":{\"covers_through_seq\":1,\"summary\":\"saved context\"}}}\n";
+    for ([_][]const u8{ "empty", "unfinished", "completed", "checkpoint" }) |id| {
+        try createHistoryPageFixture(alloc, ctx.store, id, ctx.workspace, if (std.mem.eql(u8, id, "completed")) 1 else 0, "turn");
+        if (std.mem.eql(u8, id, "unfinished")) try writeFixtureEntry(alloc, ctx.store, id, "events.jsonl", user);
+        if (std.mem.eql(u8, id, "checkpoint")) try writeFixtureEntry(alloc, ctx.store, id, "events.jsonl", user ++ checkpoint);
+        var dir = try ctx.store.openSessionDir(id);
+        defer dir.close();
+        var reference = try classifyReadOnlyCandidate(alloc, &dir, id);
+        defer reference.deinit(alloc);
+        var candidate = try ctx.store.resolveWritableCandidate(alloc, id, ctx.workspace, .{});
+        defer candidate.deinit(alloc);
+        try std.testing.expectEqual(reference.summary.updated_at_ms, candidate.updated_at_ms);
+        try std.testing.expectEqualStrings(reference.summary.workspace_root.?, candidate.workspace_root);
+        var metadata = (try session_log.readConversationMetadata(alloc, &dir)).?;
+        defer metadata.deinit();
+        try std.testing.checkAllAllocationFailures(alloc, struct {
+            fn check(a: Allocator, d: *io_mod.VerifiedDir, m: session_codec.SessionMetadata) !void {
+                var value = try discovery.writable_conversation_candidate(a, d, m.id, m, m.workspace_root);
+                defer value.deinit(a);
+            }
+        }.check, .{ &dir, metadata.value });
+    }
 }
 
 test "writable last returns busy for the selected target" {

--- a/tests/e2e/session-recovery.test.ts
+++ b/tests/e2e/session-recovery.test.ts
@@ -572,6 +572,9 @@ describe("session recovery", () => {
     try {
       const id = await createSavedSession(fixture, gateway);
       const sessions = join(fixture.home, ".fx", "sessions");
+      const unpublished = join(sessions, "unpublished");
+      mkdirSync(unpublished, { mode: 0o700 });
+      writeFileSync(join(unpublished, "session.lock"), "", { mode: 0o600 });
       const metadata = JSON.parse(readFileSync(join(sessions, id, "session.json"), "utf8"));
       const foreign = join(sessions, "foreign-history");
       mkdirSync(foreign, { mode: 0o700 });

--- a/tests/e2e/session-recovery.test.ts
+++ b/tests/e2e/session-recovery.test.ts
@@ -217,7 +217,7 @@ function createLegacySession(fixture: ReturnType<typeof createFixture>, version:
     schema_version: 1, title: LEGACY_TITLE, preview: null, origin_workspace_root: fixture.workspace,
   });
   writeFileSync(join(fixture.home, ".fx", "settings.json"), JSON.stringify({
-    model: "anthropic/claude-sonnet-4.6", effort: "low", fast_mode: false, auto_upgrade: false,
+    model: "workspace/default", effort: "low", fast_mode: false, auto_upgrade: false,
   }), { mode: 0o600 });
   return { id, source, watermarkPath };
 }

--- a/tests/e2e/session-recovery.test.ts
+++ b/tests/e2e/session-recovery.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
   appendFileSync,
   existsSync,
+  lstatSync,
   mkdtempSync,
   mkdirSync,
   readFileSync,
@@ -13,7 +15,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { runFx } from "../evals/eval-helpers";
+import { FX_BIN, runFx } from "../evals/eval-helpers";
 import {
   FAKE_GATEWAY_MODEL,
   fakeGatewayFinalText,
@@ -108,6 +110,172 @@ async function continueSession(
       timeoutMs: TIMEOUT,
     },
   );
+}
+
+const LEGACY_TITLE = "Synthetic legacy recovery conversation";
+const LEGACY_ANSWER = "LEGACY_COMMITTED_ANSWER";
+const LEGACY_PARTIAL = "LEGACY_PARTIAL_EVIDENCE";
+const LEGACY_TOOL_CALL_ID = "legacy-recorded-read";
+const LEGACY_TOOL_EVIDENCE = "LEGACY_TOOL_EVIDENCE";
+const LEGACY_GATEWAY_OPTIONS = {
+  models: [{
+    id: FAKE_GATEWAY_MODEL,
+    type: "language",
+    tags: ["reasoning", "tool-use"],
+    reasoning_options: [{ type: "effort", values: ["low", "high"] }],
+    fast_options: [{ type: "toggle" }],
+  }],
+};
+
+// Entirely synthetic schema-v3 data: no copied sessions, credentials, or child markers.
+function createLegacySession(fixture: ReturnType<typeof createFixture>, version: 2 | 3 | 4) {
+  const id = `synthetic-legacy-v${version}`;
+  const source = join(fixture.home, ".fx", "sessions", id);
+  mkdirSync(source, { recursive: true, mode: 0o700 });
+  const generation = "01".repeat(16);
+  const authority = "03".repeat(16);
+  const preferences = {
+    connection_id: "vercel", model_id: FAKE_GATEWAY_MODEL, effort: "high", fast_mode: true,
+  };
+  const execution = { schema_version: 4, tool_steps: [], files: [] };
+  const checkpointExecution = {
+    ...execution,
+    tool_steps: [{
+      assistant: null,
+      tool_calls: [{
+        id: LEGACY_TOOL_CALL_ID, name: "read_file",
+        arguments_json: JSON.stringify({ path: "synthetic-recorded-read.txt" }), provider_result: null,
+      }],
+      tool_results: [{
+        tool_call_id: LEGACY_TOOL_CALL_ID, tool_name: "read_file", status: "success",
+        output: LEGACY_TOOL_EVIDENCE, output_handle: null, preview: null,
+        output_bytes: Buffer.byteLength(LEGACY_TOOL_EVIDENCE),
+        stored_output_bytes: Buffer.byteLength(LEGACY_TOOL_EVIDENCE),
+        truncated: false, provider_native: false, created_at_ms: 25, permission_feedback: [],
+        committed_file_presentation: null, command_output_replay: null,
+        command_process_presentation: null, terminal_action_presentation: null,
+      }],
+    }],
+  };
+  const route = {
+    connection_id: "vercel", adapter_kind: "vercel_ai_gateway", permission_review_model_id: "",
+    ...(version >= 3 ? { vision_model_id: "", subagent_model_id: "" } : {}),
+    ...(version === 4 ? {
+      version: 1, endpoint: "https://legacy-route.invalid", protocol: "vercel_ai_gateway",
+      credential_ref: "synthetic-unusable-credential",
+    } : {}),
+  };
+  const records = [
+    { kind: "session_started", payload: {
+      id, created_at_ms: 10, origin_workspace_root: fixture.workspace,
+      workspace_root: fixture.workspace, conversation_language: "en", preferences,
+    } },
+    { kind: "history_turn_committed", payload: {
+      conversation_language: "en", total_input_tokens: 0, total_output_tokens: 0,
+      turn: { kind: "assistant", user: { text: LEGACY_TITLE, images: [] }, assistant: LEGACY_ANSWER, execution },
+    } },
+    { kind: "recovery_checkpoint_set", payload: { checkpoint: {
+      version, route_identity: route, delivery: "possibly_sent", turn_id: 2,
+      user: { text: "An interrupted synthetic request", images: [] },
+      assistant_source: LEGACY_PARTIAL, execution: checkpointExecution, cause: "response_interrupted",
+      action: "continuing_response", tool_state: "confirmed", route_model: FAKE_GATEWAY_MODEL,
+      requested_fast_mode: true, fast_mode: true, max_provider_attempts: 3,
+      consumed_provider_attempts: 1, outstanding_reservation: false,
+    } } },
+  ].map((record, index) => ({
+    schema_version: 1, log_generation: generation, seq: index + 1,
+    event_id: (index + 1).toString(16).padStart(2, "0").repeat(16),
+    timestamp_ms: (index + 1) * 10, ...record,
+  }));
+  const lines = records.map((record) => JSON.stringify(record) + "\n");
+  const events = lines.join("");
+  const writeJson = (name: string, value: object) => writeFileSync(
+    join(source, name), JSON.stringify(value) + "\n", { mode: 0o600 },
+  );
+  writeFileSync(join(source, "events.jsonl"), events, { mode: 0o600 });
+  writeJson("authority.json", {
+    schema_version: 1, storage_format: "event_log_v1", session_id: id,
+    authority_id: authority, source: "native_create",
+  });
+  writeJson("session.json", {
+    schema_version: 3, storage_format: "event_log_v1", id, authority_id: authority,
+    log_generation: generation, created_at_ms: 10, updated_at_ms: 30,
+    origin_workspace_root: fixture.workspace, workspace_root: fixture.workspace,
+    conversation_language: "en", history_len: 1, total_input_tokens: 0, total_output_tokens: 0,
+    last_event_seq: records.length, event_log_bytes: Buffer.byteLength(events),
+    event_log_stat_fingerprint: "00".repeat(32), generation_base_seq: 1,
+    generation_base_bytes: Buffer.byteLength(lines[0]!), checkpoint_seq: null,
+    checkpoint_sha256: null, preferences,
+  });
+  const watermarkPath = join(source, `commit.${generation}.json`);
+  writeJson(`commit.${generation}.json`, {
+    schema_version: 1, session_id: id, log_generation: generation,
+    through_seq: records.length, through_event_id: records.at(-1)!.event_id,
+    through_event_log_bytes: Buffer.byteLength(events),
+  });
+  writeJson("display.json", {
+    schema_version: 1, title: LEGACY_TITLE, preview: null, origin_workspace_root: fixture.workspace,
+  });
+  writeFileSync(join(fixture.home, ".fx", "settings.json"), JSON.stringify({
+    model: "anthropic/claude-sonnet-4.6", effort: "low", fast_mode: false, auto_upgrade: false,
+  }), { mode: 0o600 });
+  return { id, source, watermarkPath };
+}
+
+function legacyGatewayEnv(
+  fixture: ReturnType<typeof createFixture>,
+  gateway: ReturnType<typeof startFakeGateway>,
+) {
+  return {
+    ...gatewayEnv(fixture, gateway), FX_MODEL: undefined, FX_EFFORT: undefined,
+    FX_FAST_MODE: undefined, FX_E2E_GATEWAY_MODELS_URL: `${gateway.baseUrl}/coding-agent/v1/models`,
+    FX_TRACE_LOG: join(fixture.root, "legacy.trace.log"), FX_TRACE_SCOPES: "tool,session,agent",
+  };
+}
+
+function expectLegacyArchive(source: string) {
+  const events = readFileSync(join(source, "events.jsonl"), "utf8");
+  const records = events.trimEnd().split("\n").map(JSON.parse);
+  const archived = records.filter((record) => record.event.interrupted?.partial_text === LEGACY_PARTIAL);
+  expect(archived).toHaveLength(1);
+  expect(archived[0].event.interrupted.reason).toBe("failed");
+  const calls = records.filter((record) => record.event.tool_call?.call_id === LEGACY_TOOL_CALL_ID);
+  expect(calls).toHaveLength(1);
+  expect(calls[0].event.tool_call).toMatchObject({
+    tool_name: "read_file", arguments_json: JSON.stringify({ path: "synthetic-recorded-read.txt" }),
+  });
+  const results = records.filter((record) => record.event.tool_result?.call_id === LEGACY_TOOL_CALL_ID);
+  expect(results).toHaveLength(1);
+  const result = results[0].event.tool_result;
+  // Imported inline output has exact retained bytes, but legacy completeness is not trusted.
+  expect(result).toMatchObject({
+    tool_name: "read_file", status: "success", completeness: "partial",
+    output_bytes: Buffer.byteLength(LEGACY_TOOL_EVIDENCE),
+    stored_bytes: Buffer.byteLength(LEGACY_TOOL_EVIDENCE), preview: LEGACY_TOOL_EVIDENCE,
+  });
+  expect(readFileSync(join(source, "tool-results", result.artifact_ref), "utf8")).toBe(LEGACY_TOOL_EVIDENCE);
+  expect(events.split(LEGACY_PARTIAL)).toHaveLength(2);
+  expect(events).toContain(LEGACY_ANSWER);
+  expect(events).not.toContain("route_identity");
+  expect(existsSync(join(source, "recovery.json"))).toBe(false);
+  expect(existsSync(join(source, "subagent", "owner.json"))).toBe(false);
+  const metadata = JSON.parse(readFileSync(join(source, "session.json"), "utf8"));
+  expect(metadata).toMatchObject({
+    schema_version: 4, provider: "gateway", model: FAKE_GATEWAY_MODEL, effort: "high", fast_mode: true,
+  });
+  expect(metadata.subagent_child).not.toBe(true);
+}
+
+function expectLegacyRequest(request: { body: string; headers: Headers }) {
+  expect(request.headers.get("ai-language-model-id")).toBe(FAKE_GATEWAY_MODEL);
+  expect(JSON.parse(request.body)).toMatchObject({
+    reasoning: "high", providerOptions: { gateway: { speed: "fast" } },
+  });
+  expect(request.body).toContain(LEGACY_ANSWER);
+  expect(request.body).toContain(LEGACY_TOOL_EVIDENCE);
+  expect(request.body.split(LEGACY_PARTIAL)).toHaveLength(2);
+  expect(request.body).not.toContain("synthetic-unusable-credential");
+  expect(request.body).not.toContain("legacy-route.invalid");
 }
 
 describe("session recovery", () => {
@@ -393,6 +561,330 @@ describe("session recovery", () => {
       rmSync(fixture.root, { recursive: true, force: true });
     }
   }, TIMEOUT);
+
+  test.skipIf(!tmuxAvailable())("continue ignores unrelated history and unfinished migration", async () => {
+    const fixture = createFixture("fx-continue-isolated-discovery-");
+    const gateway = startFakeGateway([
+      fakeGatewayFinalText("LOCAL_HISTORY_KEPT"),
+      fakeGatewayFinalText("CONTINUE_DISCOVERY_OK"),
+    ]);
+    let tui: TmuxSession | null = null;
+    try {
+      const id = await createSavedSession(fixture, gateway);
+      const sessions = join(fixture.home, ".fx", "sessions");
+      const metadata = JSON.parse(readFileSync(join(sessions, id, "session.json"), "utf8"));
+      const foreign = join(sessions, "foreign-history");
+      mkdirSync(foreign, { mode: 0o700 });
+      writeFileSync(join(foreign, "session.json"), JSON.stringify({
+        ...metadata, id: "foreign-history", workspace_root: "/another-workspace",
+      }), { mode: 0o600 });
+      writeFileSync(join(foreign, "events.jsonl"), "UNRELATED_UNREADABLE_HISTORY\n", { mode: 0o600 });
+      const fenced = join(sessions, "foreign-fenced");
+      mkdirSync(fenced, { mode: 0o700 });
+      writeFileSync(join(fenced, "session.json"), JSON.stringify({
+        schema_version: 1, id: "foreign-fenced", created_at_ms: 1,
+        updated_at_ms: Date.now(), workspace_root: "/another-workspace",
+        conversation_language: "en", history_len: 0, history: [],
+      }), { mode: 0o600 });
+      writeFileSync(join(fenced, "authority.pending.json"), "pending", { mode: 0o600 });
+      const foreignBefore = savedFileHashes(foreign);
+      const fencedBefore = savedFileHashes(fenced);
+      const stderrPath = join(fixture.root, "continue.stderr");
+      tui = await TmuxSession.create({
+        cmd: `${JSON.stringify(FX_BIN)} -c`,
+        cwd: fixture.workspace, env: gatewayEnv(fixture, gateway), stderrPath,
+      });
+      await tui.waitForComposer(TIMEOUT);
+      await tui.waitForText("LOCAL_HISTORY_KEPT", TIMEOUT);
+      await tui.sendText("Continue the same conversation.");
+      await tui.waitForText("CONTINUE_DISCOVERY_OK", TIMEOUT);
+      await tui.waitForComposer(TIMEOUT);
+      await tui.sendText("/quit");
+      expect(await tui.waitForSessionEnd(TIMEOUT)).toBe(true);
+      expect(readFileSync(stderrPath, "utf8")).toBe("");
+      expect(gateway.requests).toHaveLength(2);
+      expect(gateway.requests[1]!.body).toContain("LOCAL_HISTORY_KEPT");
+      expect(readFileSync(join(sessions, id, "events.jsonl"), "utf8")).toContain("CONTINUE_DISCOVERY_OK");
+      expect(savedFileHashes(foreign)).toEqual(foreignBefore);
+      expect(savedFileHashes(fenced)).toEqual(fencedBefore);
+    } finally {
+      await tui?.kill();
+      gateway.stop();
+      rmSync(fixture.root, { recursive: true, force: true });
+    }
+  }, TIMEOUT);
+
+  for (const { version, entry } of [
+    { version: 2, entry: "-r" },
+    { version: 3, entry: "/resume" },
+    { version: 4, entry: "--resume id" },
+  ] as const) {
+    test.skipIf(!tmuxAvailable())(`legacy v${version} checkpoint resumes through ${entry} and survives close/reopen`, async () => {
+      const fixture = createFixture("fx-legacy-resume-flow-");
+      const legacy = createLegacySession(fixture, version);
+      const gateway = startFakeGateway([
+        fakeGatewayFinalText("LEGACY_CONTINUE_SAVED"),
+        fakeGatewayFinalText("LEGACY_EXACT_REOPEN_SAVED"),
+      ], LEGACY_GATEWAY_OPTIONS);
+      let tui: TmuxSession | null = null;
+      try {
+        const before = savedFileHashes(legacy.source);
+        const inspected = await runFx(["session", "--id", legacy.id, "--json"], {
+          cwd: fixture.workspace, env: legacyGatewayEnv(fixture, gateway), timeoutMs: TIMEOUT,
+        });
+        expect(inspected.code).toBe(0);
+        expect(inspected.stderr).toBe("");
+        expect(inspected.stdout).toContain(LEGACY_ANSWER);
+        expect(savedFileHashes(legacy.source)).toEqual(before);
+        expect(gateway.requests).toHaveLength(0);
+
+        const sessionsRoot = join(fixture.home, ".fx", "sessions");
+        const sessionEntries = () => readdirSync(sessionsRoot).filter((name) => name !== ".resume-catalog").sort();
+        const expectedSessionIds = [legacy.id];
+        let blankSessionDir: string | null = null;
+        expect(sessionEntries()).toEqual(expectedSessionIds);
+        const initialArgs = entry === "/resume" ? [] : entry === "-r" ? ["-r"] : ["--resume", legacy.id];
+        for (const [index, args] of [initialArgs, ["-c"], ["--resume", legacy.id]].entries()) {
+          const stderrPath = join(fixture.root, `legacy-${index}.stderr`);
+          tui = await TmuxSession.create({
+            cmd: [FX_BIN, ...args].map((arg) => JSON.stringify(arg)).join(" "),
+            cwd: fixture.workspace, env: legacyGatewayEnv(fixture, gateway), stderrPath,
+          });
+          if (index === 0 && entry !== "--resume id") {
+            if (entry === "/resume") {
+              await tui.waitForComposer(TIMEOUT);
+              const created = sessionEntries().filter((name) => !expectedSessionIds.includes(name));
+              expect(created).toHaveLength(1);
+              const blankId = created[0]!;
+              blankSessionDir = join(sessionsRoot, blankId);
+              expect(lstatSync(blankSessionDir).isDirectory()).toBe(true);
+              const blankMetadata = JSON.parse(readFileSync(join(blankSessionDir, "session.json"), "utf8"));
+              expect(blankMetadata).toMatchObject({ schema_version: 4, id: blankId, workspace_root: fixture.workspace });
+              expect(blankMetadata.subagent_child).not.toBe(true);
+              expect(readFileSync(join(blankSessionDir, "events.jsonl"), "utf8")).toBe("");
+              expect(existsSync(join(blankSessionDir, "recovery.json"))).toBe(false);
+              expectedSessionIds.push(blankId);
+              expectedSessionIds.sort();
+              expect(sessionEntries()).toEqual(expectedSessionIds);
+              await tui.sendText("/resume");
+            }
+            await tui.waitForText(LEGACY_TITLE, TIMEOUT);
+            expect(savedFileHashes(legacy.source)).toEqual(before);
+            expect(gateway.requests).toHaveLength(0);
+            await tui.sendKeys("Enter");
+          }
+          await tui.waitForText(LEGACY_PARTIAL, TIMEOUT);
+          await tui.waitForComposer(TIMEOUT);
+          const scrollback = await tui.captureFullScrollbackEscapes();
+          expect(scrollback).toContain(LEGACY_ANSWER);
+          expect(scrollback.split(LEGACY_PARTIAL)).toHaveLength(2);
+          expectLegacyArchive(legacy.source);
+          expect(gateway.requests).toHaveLength(Math.max(0, index - 1));
+          expect(gateway.classifierRequests).toHaveLength(0);
+
+          // First close without a prompt; reopening must not resurrect recovery work.
+          if (index > 0) {
+            const reply = index === 1 ? "LEGACY_CONTINUE_SAVED" : "LEGACY_EXACT_REOPEN_SAVED";
+            await tui.sendText(`Continue the migrated conversation after reopen ${index}.`);
+            await tui.waitForText(reply, TIMEOUT);
+            await tui.waitForComposer(TIMEOUT);
+            await tui.waitForPane(() => readFileSync(join(legacy.source, "events.jsonl"), "utf8").includes(reply), TIMEOUT);
+            expect(gateway.requests).toHaveLength(index);
+            expectLegacyRequest(gateway.requests[index - 1]!);
+            expectLegacyArchive(legacy.source);
+          }
+          await tui.sendText("/quit");
+          expect(await tui.waitForSessionEnd(TIMEOUT)).toBe(true);
+          expect(readFileSync(stderrPath, "utf8")).toBe("");
+          expect(gateway.requests).toHaveLength(index);
+          expect(gateway.classifierRequests).toHaveLength(0);
+          expect(sessionEntries()).toEqual(expectedSessionIds);
+          if (blankSessionDir) expect(readFileSync(join(blankSessionDir, "events.jsonl"), "utf8")).toBe("");
+          await tui.kill();
+          tui = null;
+        }
+        expect(readFileSync(join(fixture.root, "legacy.trace.log"), "utf8"))
+          .not.toContain("[tool] event=execution_start ");
+        expect(sessionEntries()).toEqual(expectedSessionIds);
+      } finally {
+        await tui?.kill();
+        gateway.stop();
+        rmSync(fixture.root, { recursive: true, force: true });
+      }
+    }, TIMEOUT * 3);
+  }
+
+  test("legacy ask resume fails closed at a bad watermark then preserves archived evidence on retry", async () => {
+    const fixture = createFixture("fx-legacy-ask-recovery-");
+    const legacy = createLegacySession(fixture, 4);
+    const gateway = startFakeGateway([
+      fakeGatewayFinalText("LEGACY_ASK_SAVED"),
+      fakeGatewayFinalText("LEGACY_ASK_REOPEN_SAVED"),
+    ], LEGACY_GATEWAY_OPTIONS);
+    try {
+      const watermark = readFileSync(legacy.watermarkPath, "utf8");
+      writeFileSync(legacy.watermarkPath, JSON.stringify({
+        ...JSON.parse(watermark), through_event_log_bytes: Buffer.byteLength(readFileSync(join(legacy.source, "events.jsonl"))) - 1,
+      }));
+      const before = savedFileHashes(legacy.source);
+      const failed = await runFx(["ask", "--json", "--auto", "--resume-id", legacy.id, "Do not run with invalid history."], {
+        cwd: fixture.workspace, env: legacyGatewayEnv(fixture, gateway), timeoutMs: TIMEOUT,
+      });
+      expect(failed.timedOut).toBe(false);
+      expect(failed.code).toBe(1);
+      expect(gateway.requests).toHaveLength(0);
+      expect(gateway.classifierRequests).toHaveLength(0);
+      expect(savedFileHashes(legacy.source)).toEqual(before);
+      expect(readdirSync(join(fixture.home, ".fx", "sessions"))).toEqual([legacy.id]);
+      writeFileSync(legacy.watermarkPath, watermark);
+
+      for (const [index, args] of [["--resume-id", legacy.id], ["--resume", "last"]].entries()) {
+        const result = await runFx(["ask", "--json", "--auto", ...args, "Continue the synthetic saved conversation."], {
+          cwd: fixture.workspace, env: legacyGatewayEnv(fixture, gateway), timeoutMs: TIMEOUT,
+        });
+        expect(result.code).toBe(0);
+        expect(result.stderr).toBe("");
+        expect(JSON.parse(result.stdout)).toMatchObject({
+          session_id: legacy.id, model: FAKE_GATEWAY_MODEL, tool_calls: [],
+          output: index === 0 ? "LEGACY_ASK_SAVED" : "LEGACY_ASK_REOPEN_SAVED",
+        });
+        expect(gateway.requests).toHaveLength(index + 1);
+        expectLegacyRequest(gateway.requests[index]!);
+        expectLegacyArchive(legacy.source);
+      }
+      expect(gateway.requests[1]!.body).toContain("LEGACY_ASK_SAVED");
+      expect(readFileSync(join(fixture.root, "legacy.trace.log"), "utf8"))
+        .not.toContain("[tool] event=execution_start ");
+    } finally {
+      gateway.stop();
+      rmSync(fixture.root, { recursive: true, force: true });
+    }
+  }, TIMEOUT * 2);
+
+  for (const kind of ["recovery_checkpoint_cleared", "history_turn_committed"] as const) {
+    test(`legacy ask resume does not resurrect a checkpoint superseded by ${kind}`, async () => {
+      const fixture = createFixture("fx-legacy-checkpoint-superseded-");
+      const legacy = createLegacySession(fixture, 4);
+      const gateway = startFakeGateway([fakeGatewayFinalText("SUPERSESSION_ASK_SAVED")], LEGACY_GATEWAY_OPTIONS);
+      try {
+        const eventsPath = join(legacy.source, "events.jsonl");
+        const events = readFileSync(eventsPath, "utf8");
+        const records = events.trimEnd().split("\n").map(JSON.parse);
+        const watermark = JSON.parse(readFileSync(legacy.watermarkPath, "utf8"));
+        const supersedingAnswer = "LEGACY_SUPERSEDING_ANSWER";
+        const event = {
+          schema_version: 1, log_generation: watermark.log_generation,
+          seq: watermark.through_seq + 1, event_id: "04".repeat(16), timestamp_ms: 40, kind,
+          payload: kind === "recovery_checkpoint_cleared" ? {} : {
+            ...records[1].payload,
+            turn: {
+              ...records[1].payload.turn,
+              user: records[2].payload.checkpoint.user,
+              assistant: supersedingAnswer,
+            },
+          },
+        };
+        const appended = JSON.stringify(event) + "\n";
+        appendFileSync(eventsPath, appended);
+        // Leave the derived manifest stale; the committed watermark owns the replay boundary.
+        writeFileSync(legacy.watermarkPath, JSON.stringify({
+          ...watermark, through_seq: event.seq, through_event_id: event.event_id,
+          through_event_log_bytes: Buffer.byteLength(events + appended),
+        }) + "\n");
+
+        expect(gateway.requests).toHaveLength(0);
+        const prompt = "Continue after the superseding legacy event.";
+        const result = await runFx(["ask", "--json", "--auto", "--resume-id", legacy.id, prompt], {
+          cwd: fixture.workspace, env: legacyGatewayEnv(fixture, gateway), timeoutMs: TIMEOUT,
+        });
+        expect(result.code).toBe(0);
+        expect(result.stderr).toBe("");
+        expect(JSON.parse(result.stdout)).toMatchObject({
+          session_id: legacy.id, output: "SUPERSESSION_ASK_SAVED", tool_calls: [],
+        });
+        expect(gateway.requests).toHaveLength(1);
+        expect(gateway.classifierRequests).toHaveLength(0);
+        const request = gateway.requests[0]!.body;
+        expect(request).toContain(prompt);
+        expect(request).toContain(LEGACY_ANSWER);
+        expect(request).not.toContain(LEGACY_PARTIAL);
+        expect(request).not.toContain(LEGACY_TOOL_EVIDENCE);
+        const migrated = readFileSync(eventsPath, "utf8");
+        expect(migrated).toContain(LEGACY_ANSWER);
+        expect(migrated).toContain("SUPERSESSION_ASK_SAVED");
+        expect(migrated).not.toContain(LEGACY_PARTIAL);
+        expect(migrated).not.toContain(LEGACY_TOOL_CALL_ID);
+        expect(migrated).not.toContain(LEGACY_TOOL_EVIDENCE);
+        expect(migrated.trimEnd().split("\n").map(JSON.parse).filter((record) => record.event.interrupted))
+          .toHaveLength(0);
+        if (kind === "history_turn_committed") {
+          expect(request).toContain(supersedingAnswer);
+          expect(migrated).toContain(supersedingAnswer);
+        }
+        expect(existsSync(join(legacy.source, "recovery.json"))).toBe(false);
+        expect(readFileSync(join(fixture.root, "legacy.trace.log"), "utf8"))
+          .not.toContain("[tool] event=execution_start ");
+      } finally {
+        gateway.stop();
+        rmSync(fixture.root, { recursive: true, force: true });
+      }
+    }, TIMEOUT);
+  }
+
+  for (const { target, fileName, fenced } of [
+    { target: "event log", fileName: "events.jsonl", fenced: false },
+    { target: "fenced legacy snapshot", fileName: "session.legacy.json", fenced: true },
+  ]) {
+    test.skipIf(process.platform === "win32")(`ask resume last rejects a FIFO ${target} promptly without writes`, async () => {
+      const fixture = createFixture("fx-session-fifo-");
+      const gateway = startFakeGateway([fakeGatewayFinalText("FIFO_SOURCE_SAVED")]);
+      try {
+        const id = fenced ? "fenced-legacy-fifo" : await createSavedSession(fixture, gateway);
+        const source = join(fixture.home, ".fx", "sessions", id);
+        if (fenced) {
+          mkdirSync(source, { recursive: true, mode: 0o700 });
+          const snapshot = JSON.stringify({
+            schema_version: 1, id, created_at_ms: 1, updated_at_ms: Date.now(),
+            workspace_root: fixture.workspace, conversation_language: "en", history_len: 0, history: [],
+          });
+          writeFileSync(join(source, "session.json"), snapshot, { mode: 0o600 });
+          writeFileSync(join(source, "session.legacy.json"), snapshot, { mode: 0o600 });
+          writeFileSync(join(source, "authority.pending.json"), "pending", { mode: 0o600 });
+        }
+        const fifoPath = join(source, fileName);
+        const before = savedFileHashes(source);
+        delete before[fileName];
+        rmSync(fifoPath);
+        execFileSync("mkfifo", ["-m", "600", fifoPath]);
+        const fifoBefore = lstatSync(fifoPath);
+        expect(fifoBefore.isFIFO()).toBe(true);
+        const namesBefore = readdirSync(source, { recursive: true }).sort();
+        const result = await runFx(["ask", "--json", "--auto", "--resume", "last", "Never open the FIFO."], {
+          cwd: fixture.workspace, env: gatewayEnv(fixture, gateway), timeoutMs: 5_000,
+        });
+        expect(result.timedOut).toBe(false);
+        expect(result.killSent).toBe(false);
+        expect(result.code).toBe(1);
+        expect(result.elapsedMs).toBeLessThan(5_000);
+        expect(result.stdout + result.stderr).toContain("SessionPathUnsafe");
+        expect(gateway.requests).toHaveLength(fenced ? 0 : 1);
+        expect(gateway.classifierRequests).toHaveLength(0);
+        expect(readdirSync(source, { recursive: true }).sort()).toEqual(namesBefore);
+        const fifoAfter = lstatSync(fifoPath);
+        expect(fifoAfter.isFIFO()).toBe(true);
+        expect([fifoAfter.ino, fifoAfter.size, fifoAfter.mtimeMs, fifoAfter.ctimeMs])
+          .toEqual([fifoBefore.ino, fifoBefore.size, fifoBefore.mtimeMs, fifoBefore.ctimeMs]);
+        // Never hash/read the FIFO: retain the regular-file and directory evidence separately.
+        for (const [path, digest] of Object.entries(before)) {
+          expect(createHash("sha256").update(readFileSync(join(source, path))).digest("hex")).toBe(digest);
+        }
+        expect(readdirSync(join(fixture.home, ".fx", "sessions"))).toEqual([id]);
+      } finally {
+        gateway.stop();
+        rmSync(fixture.root, { recursive: true, force: true });
+      }
+    }, TIMEOUT);
+  }
 
   test("latest resume discovers and repairs a partial final JSONL record", async () => {
     const fixture = createFixture("fx-session-partial-record-");


### PR DESCRIPTION
## Summary

- Resume older connection-based sessions through the picker, continue shortcut, exact ID, and noninteractive requests while preserving model settings.
- Keep unfinished legacy responses and recorded tool results as interrupted history without replaying saved requests or restoring credential references.
- Avoid reading unrelated current-format conversation histories when selecting the latest workspace session.
- Recover the selected session after an interrupted legacy migration without falling back to older work.
- Ignore empty session directories left behind before a conversation was saved.
- Report unrecoverable updates instead of asking users to wait for an update that may no longer be running.