### PR TITLE
Preserve native output and reject conflicting records

### DIFF
--- a/src/gateway/responses_protocol.zig
+++ b/src/gateway/responses_protocol.zig
@@ -915,6 +915,7 @@ pub const Reducer = struct {
             if (item != .object) return false;
             const item_type = stringField(item.object, "type") orelse return false;
             if (std.mem.eql(u8, item_type, "function_call")) {
+                try self.check_output_kind(output_index, .function_call);
                 const call_id = stringField(item.object, "call_id") orelse return false;
                 const name = stringField(item.object, "name") orelse return false;
                 if (findTool(self.tools.items, output_index) == null) {
@@ -936,6 +937,8 @@ pub const Reducer = struct {
                 try self.reconcile_reasoning(alloc, output_index, item.object, .identity, limits);
             } else if (std.mem.eql(u8, item_type, "message")) {
                 _ = try self.reconcile_message(alloc, output_index, try text_identity(item.object, "id"), try assistantMessagePhase(item.object), limits);
+            } else {
+                try self.check_output_kind(output_index, .unknown);
             }
         } else if (std.mem.eql(u8, event_type, "response.output_text.delta") or
             std.mem.eql(u8, event_type, "response.refusal.delta"))
@@ -965,12 +968,15 @@ pub const Reducer = struct {
         } else if (std.mem.eql(u8, event_type, "response.reasoning_summary_text.delta") or
             std.mem.eql(u8, event_type, "response.reasoning_text.delta"))
         {
+            if (try optional_index(parsed.value.object, "output_index")) |index| try self.check_output_kind(index, .reasoning);
             const delta = stringField(parsed.value.object, "delta") orelse return false;
             if (callbacks.on_reasoning) |callback| callback(callbacks.context, delta);
         } else if (std.mem.eql(u8, event_type, "response.reasoning_summary_part.done")) {
+            if (try optional_index(parsed.value.object, "output_index")) |index| try self.check_output_kind(index, .reasoning);
             if (callbacks.on_reasoning) |callback| callback(callbacks.context, "\n\n");
         } else if (std.mem.eql(u8, event_type, "response.function_call_arguments.delta")) {
             const output_index = try optional_index(parsed.value.object, "output_index") orelse return false;
+            try self.check_output_kind(output_index, .function_call);
             const delta = stringField(parsed.value.object, "delta") orelse return false;
             const index = findTool(self.tools.items, output_index) orelse return false;
             try self.tools.items[index].reconcileIdentity(alloc, parsed.value.object, "item_id", limits);
@@ -979,6 +985,7 @@ pub const Reducer = struct {
             if (callbacks.on_tool_input) |callback| callback(callbacks.context, delta);
         } else if (std.mem.eql(u8, event_type, "response.function_call_arguments.done")) {
             const output_index = try optional_index(parsed.value.object, "output_index") orelse return false;
+            try self.check_output_kind(output_index, .function_call);
             const arguments = stringField(parsed.value.object, "arguments") orelse return error.InvalidEvent;
             const index = findTool(self.tools.items, output_index) orelse return error.ResponsesToolCallConflict;
             try self.tools.items[index].reconcileIdentity(alloc, parsed.value.object, "item_id", limits);
@@ -994,6 +1001,8 @@ pub const Reducer = struct {
                 try self.reconcile_reasoning(alloc, output_index, item.object, .completed, limits);
             } else if (std.mem.eql(u8, item_type, "message")) {
                 try self.finalize_text_message(alloc, output_index, item.object, callbacks, cancel_flag, content_capture_limit, limits);
+            } else {
+                try self.check_output_kind(output_index, .unknown);
             }
         } else if (std.mem.eql(u8, event_type, "response.completed") or
             std.mem.eql(u8, event_type, "response.done") or
@@ -1003,10 +1012,11 @@ pub const Reducer = struct {
             const response_value = parsed.value.object.get("response") orelse return error.InvalidEvent;
             if (response_value != .object) return error.InvalidEvent;
             const status = try terminal_status(event_type, response_value.object);
+            const output = response_value.object.get("output") orelse .null;
             if (status == .failed) {
                 const failure = response_value.object.get("error");
                 try self.accept_failure(alloc, if (failure != null and failure.? == .object) failure.?.object else .{});
-            } else if (response_value.object.get("output")) |output| {
+            } else if (output != .null) {
                 if (output != .array) return error.InvalidEvent;
                 for (output.array.items, 0..) |item, output_index| {
                     if (cancel_flag.load(.seq_cst)) return error.Cancelled;
@@ -1019,6 +1029,8 @@ pub const Reducer = struct {
                         try self.reconcile_reasoning(alloc, index, item.object, .completed, limits);
                     } else if (std.mem.eql(u8, item_type, "message")) {
                         try self.finalize_text_message(alloc, index, item.object, callbacks, cancel_flag, content_capture_limit, limits);
+                    } else {
+                        try self.check_output_kind(index, .unknown);
                     }
                 }
             }
@@ -1044,7 +1056,18 @@ pub const Reducer = struct {
         return false;
     }
 
+    fn check_output_kind(self: *const Reducer, output_index: i64, kind: enum { function_call, reasoning, message, unknown }) error{ResponsesOutputItemConflict}!void {
+        if (kind != .function_call and findTool(self.tools.items, output_index) != null) return error.ResponsesOutputItemConflict;
+        if (kind != .reasoning) for (self.reasoning_items.items) |item| {
+            if (item.output_index == output_index) return error.ResponsesOutputItemConflict;
+        };
+        if (kind != .message) for (self.message_items.items) |item| {
+            if (item.output_index == output_index) return error.ResponsesOutputItemConflict;
+        };
+    }
+
     fn reconcile_reasoning(self: *Reducer, alloc: std.mem.Allocator, output_index: i64, fields: std.json.ObjectMap, evidence: enum { identity, completed }, limits: StreamLimits) !void {
+        try self.check_output_kind(output_index, .reasoning);
         const id_hash = try text_identity(fields, "id");
         var low: usize = 0;
         var high = self.reasoning_items.items.len;
@@ -1085,7 +1108,6 @@ pub const Reducer = struct {
             if (id_hash != null) prior.id_hash = id_hash;
             prior.json = json;
         } else {
-            if (id_hash == null and json == null) return;
             if (self.reasoning_items.items.len >= limits.events) return error.ResourceLimitExceeded;
             try self.reasoning_items.insert(alloc, low, .{ .output_index = output_index, .id_hash = id_hash, .json = json });
         }
@@ -1093,6 +1115,7 @@ pub const Reducer = struct {
     }
 
     fn reconcile_message(self: *Reducer, alloc: std.mem.Allocator, output_index: i64, id_hash: ?[TextDigest.digest_length]u8, phase: ?AssistantMessagePhase, limits: StreamLimits) !*MessageItem {
+        try self.check_output_kind(output_index, .message);
         var low: usize = 0;
         var high = self.message_items.items.len;
         while (low < high) {
@@ -1231,6 +1254,7 @@ pub const Reducer = struct {
         callbacks: StreamCallbacks,
         limits: StreamLimits,
     ) !void {
+        try self.check_output_kind(output_index, .function_call);
         const index = findTool(self.tools.items, output_index) orelse return error.ResponsesToolCallConflict;
         const tool = &self.tools.items[index];
         try tool.reconcileIdentity(alloc, fields, "id", limits);
@@ -1365,6 +1389,134 @@ const ToolRecordTest = struct {
 
     fn ignore(_: *anyopaque, _: []const u8) void {}
 };
+
+test "Responses absent final snapshot preserves completed stream evidence" {
+    for ([_][]const u8{ "", ",\"output\":[]", ",\"output\":null" }) |snapshot| {
+        var stream = ToolRecordTest.init(std.testing.allocator);
+        defer stream.deinit();
+        try stream.apply(
+            \\{"type":"response.output_item.done","output_index":0,"item":{"type":"message","id":"msg_done","phase":"final_answer","content":[{"type":"output_text","text":"Completed answer."}]}}
+        );
+        const terminal = try std.fmt.allocPrint(stream.alloc, "{{\"type\":\"response.completed\",\"response\":{{\"status\":\"completed\"{s}}}}}", .{snapshot});
+        defer stream.alloc.free(terminal);
+        try stream.apply(terminal);
+        const completion = try stream.finish();
+        defer stream.freeCompletion(completion);
+        try std.testing.expectEqualStrings("Completed answer.", completion.content.?);
+        try std.testing.expectEqual(types.ProviderFinishReason.stop, completion.finish_reason.?);
+        try std.testing.expect(completion.provider_state_json != null);
+    }
+}
+
+test "Responses output slot cannot change kind before completion" {
+    const conflicts = [_][]const u8{
+        \\{"type":"response.output_item.done","output_index":0,"item":{"type":"message","id":"msg_replacement","content":[{"type":"output_text","text":"conflicting text"}]}}
+        ,
+        \\{"type":"response.completed","response":{"status":"completed","output":[{"type":"message","id":"msg_replacement","content":[{"type":"output_text","text":"conflicting text"}]}]}}
+        ,
+    };
+    for (conflicts) |event| {
+        var stream = TextRecordTest.init(std.testing.allocator);
+        defer stream.deinit();
+        try stream.apply(
+            \\{"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","id":"fc_original","call_id":"call_original","name":"read_file","arguments":"{}"}}
+        );
+        try std.testing.expectError(error.ResponsesOutputItemConflict, stream.apply(event));
+        try stream.expect_emitted("");
+        try std.testing.expectError(error.StreamIncomplete, stream.reducer.finish(stream.alloc, &stream.cancelled, stream.limits));
+    }
+}
+
+test "Responses output kinds remain exclusive across item event stages" {
+    const items = [_][]const u8{
+        \\{"type":"message","content":[]}
+        ,
+        \\{"type":"reasoning"}
+        ,
+        \\{"type":"function_call","id":"fc","call_id":"call","name":"read_file","arguments":"{}"}
+        ,
+        \\{"type":"future_item"}
+        ,
+    };
+    for (items[0..3], 0..) |initial, from| {
+        for (items, 0..) |replacement, to| {
+            for ([_][]const u8{ "response.output_item.added", "response.output_item.done", "response.completed" }) |stage| {
+                var stream = ToolRecordTest.init(std.testing.allocator);
+                defer stream.deinit();
+                const start = try std.fmt.allocPrint(stream.alloc, "{{\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{s}}}", .{initial});
+                defer stream.alloc.free(start);
+                try stream.apply(start);
+                const event = if (std.mem.eql(u8, stage, "response.completed"))
+                    try std.fmt.allocPrint(stream.alloc, "{{\"type\":\"response.completed\",\"response\":{{\"status\":\"completed\",\"output\":[{s}]}}}}", .{replacement})
+                else
+                    try std.fmt.allocPrint(stream.alloc, "{{\"type\":\"{s}\",\"output_index\":0,\"item\":{s}}}", .{ stage, replacement });
+                defer stream.alloc.free(event);
+                if (from == to) {
+                    try stream.apply(event);
+                    try stream.apply(ToolRecordTest.terminal);
+                    const completion = try stream.finish();
+                    defer stream.freeCompletion(completion);
+                } else {
+                    try std.testing.expectError(error.ResponsesOutputItemConflict, stream.apply(event));
+                    try std.testing.expectError(error.StreamIncomplete, stream.finish());
+                }
+            }
+        }
+    }
+}
+
+test "Responses typed deltas cannot target a different owned kind" {
+    const cases = [_]struct { start: []const u8, event: []const u8 }{
+        .{ .start = ToolRecordTest.start, .event = "{\"type\":\"response.output_text.delta\",\"output_index\":0,\"delta\":\"wrong\"}" },
+        .{ .start = ToolRecordTest.start, .event = "{\"type\":\"response.refusal.done\",\"output_index\":0,\"refusal\":\"wrong\"}" },
+        .{ .start = ToolRecordTest.start, .event = "{\"type\":\"response.reasoning_summary_text.delta\",\"output_index\":0,\"delta\":\"wrong\"}" },
+        .{ .start = "{\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"message\"}}", .event = "{\"type\":\"response.function_call_arguments.delta\",\"output_index\":0,\"delta\":\"{}\"}" },
+        .{ .start = "{\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"reasoning\"}}", .event = "{\"type\":\"response.function_call_arguments.done\",\"output_index\":0,\"arguments\":\"{}\"}" },
+    };
+    for (cases) |case| {
+        var stream = TextRecordTest.init(std.testing.allocator);
+        defer stream.deinit();
+        try stream.apply(case.start);
+        try std.testing.expectError(error.ResponsesOutputItemConflict, stream.apply(case.event));
+        try stream.expect_emitted("");
+    }
+}
+
+test "Responses non-null snapshot shapes remain invalid" {
+    for ([_][]const u8{ "{}", "false", "0", "\"invalid\"" }) |snapshot| {
+        var stream = ToolRecordTest.init(std.testing.allocator);
+        defer stream.deinit();
+        const event = try std.fmt.allocPrint(stream.alloc, "{{\"type\":\"response.completed\",\"response\":{{\"status\":\"completed\",\"output\":{s}}}}}", .{snapshot});
+        defer stream.alloc.free(event);
+        try std.testing.expectError(error.InvalidEvent, stream.apply(event));
+        try std.testing.expectError(error.StreamIncomplete, stream.finish());
+    }
+}
+
+test "Responses null snapshot preserves separate item kinds without extra replay" {
+    const Probe = struct {
+        fn run(alloc: std.mem.Allocator) !void {
+            var stream = ToolRecordTest.init(alloc);
+            defer stream.deinit();
+            try stream.apply("{\"type\":\"response.output_item.added\",\"output_index\":1,\"item\":{\"type\":\"reasoning\"}}");
+            try stream.apply(ToolRecordTest.start);
+            try stream.apply(ToolRecordTest.finalized);
+            const reasoning = "{\"type\":\"response.output_item.done\",\"output_index\":1,\"item\":{\"type\":\"reasoning\",\"encrypted_content\":\"retained\"}}";
+            try stream.apply(reasoning);
+            try stream.apply(reasoning);
+            try stream.apply("{\"type\":\"response.output_text.delta\",\"output_index\":2,\"delta\":\"done\"}");
+            try stream.apply("{\"type\":\"response.output_item.done\",\"output_index\":3,\"item\":{\"type\":\"future_item\"}}");
+            try stream.apply("{\"type\":\"response.completed\",\"response\":{\"status\":\"completed\",\"output\":null}}");
+            const completion = try stream.finish();
+            defer stream.freeCompletion(completion);
+            try std.testing.expectEqualStrings("done", completion.content.?);
+            try std.testing.expectEqual(@as(usize, 1), completion.tool_calls.len);
+            try std.testing.expectEqual(types.ProviderFinishReason.tool_calls, completion.finish_reason.?);
+            try std.testing.expectEqualStrings("[{\"type\":\"reasoning\",\"encrypted_content\":\"retained\"}]", completion.provider_state_json.?);
+        }
+    };
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, Probe.run, .{});
+}
 
 test "Responses message replay preserves separate commentary and final text" {
     var stream = ToolRecordTest.init(std.testing.allocator);
@@ -1759,7 +1911,7 @@ test "Responses terminal failure retains progress without final-only output" {
     var stream = TextRecordTest.init(std.testing.allocator);
     defer stream.deinit();
     try stream.delta(0, 0, "partial");
-    try stream.apply(ToolRecordTest.start);
+    try stream.apply("{\"type\":\"response.output_item.added\",\"output_index\":1,\"item\":{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"call_1\",\"name\":\"write_file\",\"arguments\":\"\"}}");
     try stream.apply("{\"type\":\"response.failed\",\"response\":{\"error\":{\"code\":\"server_error\",\"message\":\"retry\"},\"output\":[{\"type\":\"message\",\"content\":[{\"type\":\"output_text\",\"text\":\"must not publish\"}]}]}}");
     try stream.expect_emitted("partial");
     const completion = try stream.reducer.finish(stream.alloc, &stream.cancelled, stream.limits);
@@ -2258,7 +2410,7 @@ fn expectToolFinalizationAllocations(alloc: std.mem.Allocator) !void {
     try stream.apply("{\"type\":\"response.function_call_arguments.delta\",\"output_index\":0,\"delta\":\"discarded preview\"}");
     try stream.apply(ToolRecordTest.finalized);
     try stream.apply("{\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"id\":\"fc_1\",\"arguments\":\" {\\\"path\\\":\\\"preview.txt\\\"} \"}}");
-    try stream.apply("{\"type\":\"response.output_text.delta\",\"delta\":\"finished\"}");
+    try stream.apply("{\"type\":\"response.output_text.delta\",\"output_index\":1,\"delta\":\"finished\"}");
     try stream.apply("{\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"status\":\"completed\"}}");
     const completion = try stream.finish();
     defer stream.freeCompletion(completion);

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -4700,6 +4700,92 @@ test("native reasoning snapshots survive tools and saved resume exactly once", a
   }
 }, 60_000);
 
+test("native final snapshots preserve completed items and reject conflicting kinds", async () => {
+  for (const provider of ["codex", "grok"] as const) for (const shape of ["null", "empty", "kind-at-item", "kind-at-terminal"] as const) {
+    const conflict = shape.startsWith("kind-");
+    const profile = mkdtempSync(join(tmpdir(), "fx-output-consistency-"));
+    const gateway = startFakeGateway([]);
+    const model = "fixture-model";
+    const reasoning = { type: "reasoning", id: "rs_snapshot", summary: [], encrypted_content: "SNAPSHOT_REASONING" };
+    const message = (id: string, text: string, phase: string) => ({ type: "message", id, role: "assistant", status: "completed", phase, content: [{ type: "output_text", text, annotations: [] }] });
+    const progress = message("msg_progress", "Inspecting.", "commentary");
+    const call = { type: "function_call", id: "fc_snapshot", call_id: "call_snapshot", name: "read_file", arguments: JSON.stringify({ path: "notes.txt" }) };
+    const replacement = message("msg_replacement", "CONFLICTING_TEXT", "final_answer");
+    const events: object[] = [
+      { type: "response.output_item.done", output_index: 0, item: reasoning },
+      { type: "response.output_item.done", output_index: 1, item: progress },
+      { type: "response.output_item.added", output_index: 2, item: { ...call, arguments: "" } },
+      { type: "response.function_call_arguments.done", output_index: 2, item_id: call.id, arguments: call.arguments },
+      { type: "response.output_item.done", output_index: 2, item: shape === "kind-at-item" ? replacement : call },
+      { type: "response.completed", response: { status: "completed", output: shape === "kind-at-terminal" ? [reasoning, progress, replacement] : shape === "empty" ? [] : null } },
+    ];
+    const answer = (text: string) => fakeGatewaySse([
+      { type: "response.output_item.done", output_index: 0, item: message("msg_answer", text, "final_answer") },
+      { type: "response.completed", response: { status: "completed", output: null } },
+    ]);
+    const responses = [fakeGatewaySse(events), answer("SNAPSHOT_OK"), answer("RESUMED_OK")];
+    const direct = provider === "codex" ? startFakeCodexToolLoop({ model, responses }) : startFakeGrokToolLoop({ model, responses });
+    try {
+      if (provider === "codex") writeSeededChatGptLogin(profile, direct.accessToken);
+      else writeSeededGrokLogin(profile, direct.accessToken);
+      writeFileSync(join(profile, ".fx", "settings.json"), JSON.stringify({ provider, [provider + "_model"]: model }), { mode: 0o600 });
+      writeFileSync(join(profile, "notes.txt"), "SNAPSHOT_READ_RESULT\n");
+      const tracePath = join(profile, "trace.log");
+      const env = {
+        HOME: profile, AI_GATEWAY_API_KEY: "fixture", VERCEL_OIDC_TOKEN: undefined, FX_MODEL: undefined,
+        FX_DISABLE_KEYCHAIN: "1", FX_AUTO_UPGRADE: "0", FX_SOUND: "0", FX_TRACE_LOG: tracePath, FX_TRACE_SCOPES: "agent,gateway,tool",
+        FX_GATEWAY_BASE_URL: gateway.baseUrl, FX_E2E_GATEWAY_MODELS_URL: gateway.baseUrl + "/coding-agent/v1/models",
+        FX_E2E_OPENAI_CODEX_RESPONSES_URL: direct.responsesUrl, FX_E2E_OPENAI_CODEX_MODELS_URL: direct.modelsUrl,
+        FX_E2E_XAI_GROK_RESPONSES_URL: direct.responsesUrl, FX_E2E_XAI_GROK_MODELS_URL: direct.modelsUrl,
+        FX_E2E_XAI_GROK_MODALITIES_URL: "modalitiesUrl" in direct ? direct.modalitiesUrl : undefined,
+      };
+      const first = await runFx(["ask", "--json", "--auto", "Read notes.txt and report the result."], { cwd: profile, env, timeoutMs: TIMEOUT });
+      expect(first.code, provider + "/" + shape + ": " + first.stdout + first.stderr).toBe(conflict ? 1 : 0);
+      expect(first.signal).toBeNull();
+      const result = JSON.parse(first.stdout);
+      expect(direct.bodies).toHaveLength(conflict ? 1 : 2);
+      const trace = readFileSync(tracePath, "utf8");
+      if (conflict) {
+        expect(result.error).toBe("ResponsesOutputItemConflict");
+        expect(result.tool_calls).toEqual([]);
+        expect(trace).not.toContain("after_tool_execution");
+        expect(result.output).not.toContain("CONFLICTING_TEXT");
+      } else {
+        expect(result.output).toBe("Inspecting.\n\nSNAPSHOT_OK");
+        expect(result.tool_calls).toEqual([{ name: "read_file", status: "success" }]);
+        expect(trace).toContain("after_tool_execution");
+      }
+      const detail = await runFx(["session", "--json", "--id", result.session_id], { cwd: profile, env });
+      expect(detail.code).toBe(0);
+      const history = JSON.parse(detail.stdout).history;
+      expect(history).toHaveLength(1);
+      expect(history[0].kind).toBe(conflict ? "interrupted" : "assistant");
+      expect(history[0].execution?.tool_steps ?? []).toHaveLength(conflict ? 0 : 1);
+      const resumed = await runFx(["ask", "--json", "--auto", "--resume-id", result.session_id, "Continue without tools."], { cwd: profile, env, timeoutMs: TIMEOUT });
+      expect(resumed.code, resumed.stdout + resumed.stderr).toBe(0);
+      expect(resumed.stderr).toBe("");
+      expect(JSON.parse(resumed.stdout).output).toBe(conflict ? "SNAPSHOT_OK" : "RESUMED_OK");
+      expect(direct.bodies).toHaveLength(conflict ? 2 : 3);
+      for (const body of direct.bodies.slice(1)) {
+        const input = JSON.parse(body).input;
+        const calls = input.filter((item: { type?: string }) => item.type === "function_call");
+        const outputs = input.filter((item: { type?: string }) => item.type === "function_call_output");
+        expect(calls.map((item: { call_id: string }) => item.call_id)).toEqual(conflict ? [] : ["call_snapshot"]);
+        expect(outputs).toHaveLength(conflict ? 0 : 1);
+        if (!conflict) {
+          expect(outputs[0].output).toContain("SNAPSHOT_READ_RESULT");
+          expect(input.filter((item: { type?: string }) => item.type === "reasoning")).toEqual([reasoning]);
+          expect(input.find((item: { phase?: string }) => item.phase === "commentary").content[0].text).toBe("Inspecting.");
+        }
+      }
+      expect(gateway.requests).toHaveLength(0);
+    } finally {
+      direct.stop(); gateway.stop();
+      rmSync(profile, { recursive: true, force: true });
+    }
+  }
+}, 60_000);
+
 test("native terminal outcomes preserve recovery and incomplete warnings", async () => {
   for (const provider of ["gateway", "codex", "grok"] as const) for (const mode of ["transient", "partial", "tool", "rejected", "rejected-partial", "length", "length-with-status"]) {
     const native = provider !== "gateway";


### PR DESCRIPTION
## Summary

- Complete native turns with null final output snapshots while retaining streamed replies and replay context.
- Reject conflicting output-item types before tool execution instead of keeping stale calls.
