### PR TITLE
Prepare authentication before manual compaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Run `/feedback` to open the feedback form at `fx.sh/feedback`. It does not creat
 
 Run `/trace` to create a private Markdown diagnostic with logs, session context, runtime state, permissions, and recent activity. On macOS, fx copies the `.md` file to the clipboard; on other platforms, it saves the file and prints its path. Review and redact the trace before sharing it.
 
-fx automatically summarizes a long session into a fresh context window when the active model request reaches 80% of its usable input capacity, then continues the same turn. Run `/compact` to create the same durable handoff immediately and wait for your next prompt.
+fx automatically summarizes a long session into a fresh context window when the active model request reaches 80% of its usable input capacity, then continues the same turn. Run `/compact` to create the same durable handoff immediately and wait for your next prompt. Manual compaction refreshes the selected login when needed; Ctrl+C cancels preparation. If authentication fails, the chat stays open and unchanged so you can reconnect and retry `/compact`.
 
 Compaction handoffs remain internal context for the model. Resuming a session and opening its full transcript show the conversation and tool activity, not internal summaries or operation ledgers.
 

--- a/src/core/app/app_auth_runtime.zig
+++ b/src/core/app/app_auth_runtime.zig
@@ -1860,9 +1860,9 @@ pub fn Runtime(comptime App: type) type {
                 app.auth.recordCredentialFailure(failure)
             else
                 true;
-            if (!first_observation) return false;
-
-            const recovery = try credentialRecoveryText(app.alloc, failure);
+            const for_compaction = if (comptime @hasField(App, "submission")) app.submission.compaction_pending else false;
+            if (!first_observation and !for_compaction) return false;
+            const recovery = try credentialRecoveryText(app.alloc, failure, for_compaction);
             defer app.alloc.free(recovery);
             try app.writeDomainNotice(.{
                 .topic = "auth",
@@ -1876,8 +1876,20 @@ pub fn Runtime(comptime App: type) type {
         fn credentialRecoveryText(
             alloc: std.mem.Allocator,
             failure: auth_runtime.CredentialFailure,
+            for_compaction: bool,
         ) ![]u8 {
             const source_label = credentials.sourceLabel(failure.source);
+            if (for_compaction) {
+                const reason = if (auth_runtime.preparationError(failure)) |err|
+                    auth_runtime.preparationFailureNotice(err).?
+                else
+                    "Sign-in expired.";
+                return std.fmt.allocPrint(
+                    alloc,
+                    "{s}: {s} Your conversation is unchanged. Check /status and repair authentication with /provider, then run /compact again.",
+                    .{ source_label, reason },
+                );
+            }
             return switch (failure.reason) {
                 .invalid_credential => std.fmt.allocPrint(
                     alloc,
@@ -3355,6 +3367,20 @@ test "prompt credential refresh allows only OutOfMemory to escape" {
     try std.testing.expect(!app.shell.render_requests.footer_requested);
     try std.testing.expectEqual(@as(usize, 0), app.auth.source_inventory_refresh_count);
     try std.testing.expect(!app.auth.picker_opened);
+}
+
+test "manual compaction credential failure guidance does not promise a saved prompt" {
+    const alloc = std.testing.allocator;
+    const failure = auth_runtime.classifyCredentialFailure(.fx_login, error.CredentialRefreshUnavailable);
+    const manual = try Runtime(TestApp).credentialRecoveryText(alloc, failure, true);
+    defer alloc.free(manual);
+    try std.testing.expect(std.mem.find(u8, manual, "Your conversation is unchanged.") != null);
+    try std.testing.expect(std.mem.find(u8, manual, "/compact again") != null);
+    try std.testing.expect(std.mem.find(u8, manual, "Your prompt is saved.") == null);
+    const prompt = try Runtime(TestApp).credentialRecoveryText(alloc, failure, false);
+    defer alloc.free(prompt);
+    try std.testing.expect(std.mem.find(u8, prompt, "Your prompt is saved.") != null);
+    try std.testing.expect(std.mem.find(u8, prompt, "/compact") == null);
 }
 
 test "prompt credential refresh falls back when its task cannot start" {

--- a/src/core/app/app_commands.zig
+++ b/src/core/app/app_commands.zig
@@ -1932,29 +1932,8 @@ pub fn Handlers(comptime App: type) type {
 
         fn commandCompactHistory(ctx: *anyopaque) !void {
             const app: *App = @ptrCast(@alignCast(ctx));
-            if (comptime @hasDecl(App, "enqueueContextCompaction")) {
-                if (!app.hasContextToCompact()) {
-                    try app.writeDomainNotice(.{
-                        .topic = "context",
-                        .tone = .neutral,
-                        .body = "No context to compact.",
-                    }, true);
-                    return;
-                }
-                if (try app.enqueueContextCompaction()) {
-                    try app.writeDomainNotice(.{
-                        .topic = "context",
-                        .tone = .neutral,
-                        .body = "Compaction queued.",
-                    }, true);
-                } else {
-                    try app.writeDomainNotice(.{
-                        .topic = "context",
-                        .tone = .warning,
-                        .body = "Wait for the active work to finish before compacting context.",
-                    }, true);
-                }
-                return;
+            if (comptime @hasDecl(App, "request_context_compaction")) {
+                return app.request_context_compaction();
             }
             try app.writeDomainNotice(.{
                 .topic = "context",

--- a/src/core/app/input_submit_runtime.zig
+++ b/src/core/app/input_submit_runtime.zig
@@ -80,6 +80,7 @@ pub const PendingSkillRefresh = enum {
 pub const State = struct {
     pending: ?PendingSubmission = null,
     retry_after_auth: bool = false,
+    compaction_pending: bool = false,
 };
 
 fn buildPendingPromptDraft(
@@ -132,6 +133,72 @@ fn buildPendingPromptDraft(
 
 pub fn SubmitRuntime(comptime App: type) type {
     return struct {
+        pub fn request_context_compaction(app: *App) !void {
+            if (app.submission.compaction_pending) return;
+            if (!app.hasContextToCompact()) {
+                try app.writeDomainNotice(.{ .topic = "context", .tone = .neutral, .body = "No context to compact." }, true);
+                return;
+            }
+            if (app.submission.pending != null or app.worker.isProcessing() or
+                app.worker.queuedPromptCount() > 0 or app.worker.contextCompactionStatus() != .idle)
+            {
+                try app.writeDomainNotice(.{ .topic = "context", .tone = .warning, .body = "Wait for the active work to finish before compacting context." }, true);
+                return;
+            }
+            app.submission.compaction_pending = true;
+            errdefer clear_context_compaction(app, "notice_failed");
+            collect_context_compaction(app);
+            if (app.submission.compaction_pending) {
+                debug_trace.logf("input", "manual_compaction_auth_pending", .{});
+                try app.writeDomainNotice(.{ .topic = "context", .tone = .neutral, .body = "Preparing authentication for compaction. Press Ctrl+C to cancel." }, true);
+            }
+        }
+
+        fn collect_context_compaction(app: *App) void {
+            if (comptime !@hasDecl(App, "enqueueContextCompaction")) return;
+            if (!app.submission.compaction_pending) return;
+            admit_context_compaction(app) catch |err| {
+                clear_context_compaction(app, "admission_failed");
+                app.submission.retry_after_auth = false;
+                debug_trace.logf("input", "manual compaction admission failed err={s}", .{@errorName(err)});
+                var buffer: [256]u8 = undefined;
+                const body = std.fmt.bufPrint(&buffer, "Compaction was not started ({s}). Your conversation is unchanged. Check authentication and try /compact again.", .{@errorName(err)}) catch "Compaction was not started. Your conversation is unchanged. Try /compact again.";
+                app.writeDomainNotice(.{ .topic = "context", .tone = .@"error", .body = body }, true) catch |notice_err| {
+                    debug_trace.logf("input", "manual compaction failure notice failed err={s}", .{@errorName(notice_err)});
+                };
+            };
+        }
+
+        fn admit_context_compaction(app: *App) !void {
+            switch (try App.collectPendingPromptCredential(app)) {
+                .pending => return,
+                .rejected => {
+                    clear_context_compaction(app, "auth_rejected");
+                    app.submission.retry_after_auth = false;
+                    return;
+                },
+                .current => {},
+            }
+            app.submission.compaction_pending = false;
+            const queued = try app.enqueueContextCompaction();
+            app.writeDomainNotice(.{
+                .topic = "context",
+                .tone = if (queued) .neutral else .warning,
+                .body = if (queued) "Compaction queued." else "Wait for the active work to finish before compacting context.",
+            }, true) catch |err| {
+                debug_trace.logf("input", "manual compaction admission notice failed queued={} err={s}", .{ queued, @errorName(err) });
+            };
+        }
+
+        fn clear_context_compaction(app: *App, reason: []const u8) void {
+            if (!app.submission.compaction_pending) return;
+            app.submission.compaction_pending = false;
+            debug_trace.logf("input", "manual compaction intent cleared reason={s}", .{reason});
+            if (comptime @hasField(App, "auth")) {
+                if (comptime @hasDecl(@TypeOf(app.auth), "cancelPromptCredentialRefresh")) app.auth.cancelPromptCredentialRefresh();
+            }
+        }
+
         pub fn requestPromptRetryAfterAuth(app: *App) void {
             app.submission.retry_after_auth = true;
         }
@@ -235,6 +302,7 @@ pub fn SubmitRuntime(comptime App: type) type {
 
         pub fn collectPendingSubmissionFacts(app: *App) void {
             if (comptime !@hasField(App, "submission")) return;
+            collect_context_compaction(app);
             var pending = if (app.submission.pending) |*value| value else return;
             if (pending.phase == .awaiting_adoption) {
                 adoptPendingSubmission(app) catch |err| {
@@ -352,6 +420,14 @@ pub fn SubmitRuntime(comptime App: type) type {
 
         pub fn cancelPendingSubmission(app: *App) bool {
             if (comptime !@hasField(App, "submission")) return false;
+            if (app.submission.compaction_pending) {
+                clear_context_compaction(app, "cancelled");
+                app.writeDomainNotice(.{ .topic = "context", .tone = .neutral, .body = "Context compaction cancelled." }, true) catch |err| {
+                    debug_trace.logf("input", "manual compaction cancellation notice failed err={s}", .{@errorName(err)});
+                };
+                app.shell.render_requests.request(.footer);
+                return true;
+            }
             const pending = app.submission.pending orelse return false;
             if (pending.phase == .queued) {
                 if (comptime !@hasDecl(@TypeOf(app.worker), "removeQueuedPrompt")) {
@@ -395,6 +471,7 @@ pub fn SubmitRuntime(comptime App: type) type {
         }
 
         pub fn clearPendingSubmission(app: *App, reason: []const u8) void {
+            if (comptime @hasField(App, "submission")) clear_context_compaction(app, reason);
             const snapshot_cleanup: PendingSnapshotCleanup = if (transferPendingImageSnapshotsToComposerHistory(app))
                 .preserve
             else
@@ -403,6 +480,7 @@ pub fn SubmitRuntime(comptime App: type) type {
         }
 
         pub fn clearPendingSubmissionForSessionTransition(app: *App) void {
+            if (comptime @hasField(App, "submission")) clear_context_compaction(app, "session_transition");
             if (comptime @hasField(App, "auth")) {
                 if (comptime @hasDecl(@TypeOf(app.auth), "cancelProviderPreparation")) _ = app.auth.cancelProviderPreparation();
             }
@@ -545,6 +623,7 @@ pub fn SubmitRuntime(comptime App: type) type {
 
         pub fn submit(app: *App, max_prompt_history: usize) !void {
             if (comptime @hasField(App, "submission")) {
+                if (app.submission.compaction_pending and !pendingAuthRoutesLocalCommand(app)) return;
                 if (app.submission.pending) |pending| {
                     const route_local_command = pending.phase == .awaiting_auth and
                         pendingAuthRoutesLocalCommand(app);
@@ -2132,6 +2211,160 @@ test "pending draft construction frees every partial allocation" {
         checkPendingDraftConstructionAllocationFailure,
         .{},
     );
+}
+
+const CompactionAdmissionFake = struct {
+    alloc: std.mem.Allocator = std.testing.allocator,
+    submission: State = .{},
+    has_context: bool = true,
+    readiness: enum { pending, current, rejected } = .pending,
+    readiness_error: ?anyerror = null,
+    enqueue_error: ?anyerror = null,
+    credential_checks: usize = 0,
+    enqueue_count: usize = 0,
+    notice_error: bool = false,
+    notice_count: usize = 0,
+    notices: std.ArrayList(u8) = .empty,
+    auth: struct {
+        cancelled: usize = 0,
+        pub fn cancelPromptCredentialRefresh(self: *@This()) void {
+            self.cancelled += 1;
+        }
+    } = .{},
+    shell: struct { render_requests: @import("../../ui/render_request.zig").RenderRequestState = .{} } = .{},
+    worker: struct {
+        busy: bool = false,
+        queued: usize = 0,
+        status: worker_runtime.ContextCompactionStatus = .idle,
+        released_holds: usize = 0,
+        pub fn isProcessing(self: *@This()) bool {
+            return self.busy;
+        }
+        pub fn queuedPromptCount(self: *@This()) usize {
+            return self.queued;
+        }
+        pub fn contextCompactionStatus(self: *@This()) worker_runtime.ContextCompactionStatus {
+            return self.status;
+        }
+        pub fn releaseTurnStartHold(self: *@This()) void {
+            self.released_holds += 1;
+        }
+        pub fn clearQueuedPrompts(self: *@This(), _: std.mem.Allocator, _: []const types.ImageAttachment) void {
+            self.queued = 0;
+        }
+    } = .{},
+
+    fn deinit(self: *CompactionAdmissionFake) void {
+        SubmitRuntime(CompactionAdmissionFake).clear_context_compaction(self, "test_cleanup");
+        self.notices.deinit(self.alloc);
+    }
+    pub fn hasContextToCompact(self: *CompactionAdmissionFake) bool {
+        return self.has_context;
+    }
+    pub fn collectPendingPromptCredential(self: *CompactionAdmissionFake) !@TypeOf(self.readiness) {
+        self.credential_checks += 1;
+        if (self.readiness_error) |err| return err;
+        return self.readiness;
+    }
+    pub fn enqueueContextCompaction(self: *CompactionAdmissionFake) !bool {
+        if (self.enqueue_error) |err| return err;
+        self.enqueue_count += 1;
+        return true;
+    }
+    pub fn writeDomainNotice(self: *CompactionAdmissionFake, notice: types.SemanticNotice, _: bool) !void {
+        self.notice_count += 1;
+        if (self.notice_error) return error.OutOfMemory;
+        try self.notices.appendSlice(self.alloc, notice.body);
+    }
+};
+
+test "manual compaction admission waits for authentication and enqueues once" {
+    var app: CompactionAdmissionFake = .{};
+    defer app.deinit();
+    const Runtime = SubmitRuntime(CompactionAdmissionFake);
+    try Runtime.request_context_compaction(&app);
+    try Runtime.request_context_compaction(&app);
+    try std.testing.expect(app.submission.compaction_pending);
+    try std.testing.expectEqual(@as(usize, 1), app.credential_checks);
+    try std.testing.expectEqual(@as(usize, 0), app.enqueue_count);
+    app.readiness = .current;
+    Runtime.collect_context_compaction(&app);
+    Runtime.collect_context_compaction(&app);
+    try std.testing.expect(!app.submission.compaction_pending);
+    try std.testing.expectEqual(@as(usize, 1), app.enqueue_count);
+    try std.testing.expectEqual(@as(usize, 0), app.auth.cancelled);
+}
+
+test "manual compaction empty and busy admission does not prepare authentication" {
+    for (0..4) |case| {
+        var app: CompactionAdmissionFake = .{};
+        defer app.deinit();
+        switch (case) {
+            0 => app.has_context = false,
+            1 => app.worker.busy = true,
+            2 => app.worker.queued = 1,
+            3 => app.worker.status = .queued,
+            else => unreachable,
+        }
+        try SubmitRuntime(CompactionAdmissionFake).request_context_compaction(&app);
+        try std.testing.expect(!app.submission.compaction_pending);
+        try std.testing.expectEqual(@as(usize, 0), app.credential_checks);
+        try std.testing.expectEqual(@as(usize, 0), app.enqueue_count);
+    }
+}
+
+test "manual compaction rejected authentication cannot submit a draft later" {
+    var app: CompactionAdmissionFake = .{ .readiness = .rejected };
+    defer app.deinit();
+    app.submission.retry_after_auth = true;
+    try SubmitRuntime(CompactionAdmissionFake).request_context_compaction(&app);
+    try std.testing.expect(!app.submission.compaction_pending);
+    try std.testing.expect(!app.submission.retry_after_auth);
+    app.readiness = .current;
+    SubmitRuntime(CompactionAdmissionFake).collect_context_compaction(&app);
+    try std.testing.expectEqual(@as(usize, 0), app.enqueue_count);
+}
+
+test "manual compaction admission errors stay local and release pending ownership" {
+    for ([_]bool{ false, true }) |after_readiness| {
+        var app: CompactionAdmissionFake = .{ .readiness = .current };
+        defer app.deinit();
+        if (after_readiness) app.enqueue_error = error.MissingApiKey else app.readiness_error = error.OutOfMemory;
+        try SubmitRuntime(CompactionAdmissionFake).request_context_compaction(&app);
+        try std.testing.expect(!app.submission.compaction_pending);
+        try std.testing.expectEqual(@as(usize, 0), app.enqueue_count);
+        try std.testing.expect(std.mem.find(u8, app.notices.items, "Your conversation is unchanged.") != null);
+    }
+}
+
+test "manual compaction queued work is not reported unstarted after a notice failure" {
+    var app: CompactionAdmissionFake = .{ .readiness = .current, .notice_error = true };
+    defer app.deinit();
+    try SubmitRuntime(CompactionAdmissionFake).request_context_compaction(&app);
+    try std.testing.expectEqual(@as(usize, 1), app.enqueue_count);
+    try std.testing.expectEqual(@as(usize, 1), app.notice_count);
+    try std.testing.expect(!app.submission.compaction_pending);
+}
+
+test "manual compaction cancellation and transition clearing prevent late enqueue" {
+    for (0..3) |boundary| {
+        var app: CompactionAdmissionFake = .{};
+        defer app.deinit();
+        const Runtime = SubmitRuntime(CompactionAdmissionFake);
+        try Runtime.request_context_compaction(&app);
+        switch (boundary) {
+            0 => try std.testing.expect(Runtime.cancelPendingSubmission(&app)),
+            1 => Runtime.clearPendingSubmissionForSessionTransition(&app),
+            2 => Runtime.clearPendingSubmission(&app, "shutdown"),
+            else => unreachable,
+        }
+        Runtime.clearPendingSubmission(&app, "repeated_cleanup");
+        app.readiness = .current;
+        Runtime.collect_context_compaction(&app);
+        try std.testing.expectEqual(@as(usize, 1), app.auth.cancelled);
+        try std.testing.expectEqual(@as(usize, 0), app.enqueue_count);
+        try std.testing.expectEqual(@as(usize, 0), app.worker.released_holds);
+    }
 }
 
 const PendingLifecycleFake = struct {

--- a/src/main.zig
+++ b/src/main.zig
@@ -1473,6 +1473,10 @@ const App = struct {
         };
     }
 
+    pub fn request_context_compaction(self: *App) !void {
+        try InputSubmitRuntime.request_context_compaction(self);
+    }
+
     pub fn enqueueContextCompaction(self: *App) !bool {
         if (self.worker.isProcessing() or self.worker.queuedPromptCount() > 0) return false;
         const selection = self.provider_selection.selection();
@@ -4151,6 +4155,7 @@ test {
     _ = @import("core/app/app_commands.zig");
     _ = @import("core/app/app_entry_runtime.zig");
     _ = @import("core/app/app_input_runtime.zig");
+    _ = input_submit_runtime;
     _ = @import("core/app/app_lifecycle.zig");
     _ = @import("core/app/model_cache_runtime.zig");
     _ = @import("core/app/usage_dashboard_runtime.zig");

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -6243,6 +6243,132 @@ tmuxTest(
 );
 
 tmuxTest(
+  "manual compaction refreshes the selected login without losing the draft",
+  async () => {
+    home = mkdtempSync(join(tmpdir(), "fx-compact-auth-refresh-"));
+    stderrPath = join(home, "stderr.log");
+    const tracePath = join(home, "trace.log");
+    writeFileSync(stderrPath, "");
+    gateway = startFakeGateway([
+      fakeGatewayFinalText("COMPACT_AUTH_FIRST_REPLY"),
+      fakeGatewayFinalText("COMPACT_AUTH_SECOND_REPLY"),
+      fakeGatewayFinalText("The conversation established COMPACT_AUTH_FIRST and COMPACT_AUTH_SECOND."),
+      fakeGatewayFinalText("COMPACT_AUTH_CONTINUED"),
+    ]);
+    oauth = startFakeOAuth(ACQUIRED_LOGIN_TOKEN, undefined, 3600, Number.POSITIVE_INFINITY, { tokenDelayMs: 2_000 });
+    const expiresAt = Date.now() + 80_000;
+    writeSeededFxLogin(home, expiresAt, oauth.issuerUrl, "team_123");
+    session = await startFx(home, stderrPath, gateway, oauth.issuerUrl, tracePath, {
+      AI_GATEWAY_API_KEY: undefined,
+      FX_TRACE_SCOPES: "auth,input,worker,context_compaction,session",
+    }, home);
+    await session.waitForComposer(TIMEOUT);
+    await session.sendText("Remember COMPACT_AUTH_FIRST.");
+    await session.waitForText("COMPACT_AUTH_FIRST_REPLY", TIMEOUT);
+    await session.sendText("Remember COMPACT_AUTH_SECOND.");
+    await session.waitForText("COMPACT_AUTH_SECOND_REPLY", TIMEOUT);
+    expect(gateway.requests).toHaveLength(2);
+    expect(oauth.requests.filter((request) => request.path === "/oauth/token")).toHaveLength(0);
+    await Bun.sleep(Math.max(0, expiresAt - 60_000 + 100 - Date.now()));
+    await session.sendText("/status");
+    await session.waitForText("auth_expired=true", TIMEOUT);
+    await session.sendText("/compact");
+    await waitForTrace(tracePath, "manual_compaction_auth_pending", TIMEOUT);
+    expect(gateway.requests).toHaveLength(2);
+    await session.sendText("/compact");
+    await session.sendLiteral("PRESERVE_COMPACTION_DRAFT");
+    await session.waitForText("PRESERVE_COMPACTION_DRAFT", 1_000);
+    await session.waitForText("Context compacted.", TIMEOUT);
+    expect(await session.captureFullScrollback()).toContain("PRESERVE_COMPACTION_DRAFT");
+    expect(oauth.requests.filter((request) => request.grantType === "refresh_token")).toHaveLength(1);
+    expect(gateway.requests).toHaveLength(3);
+    expect(gateway.requests[2].headers.get("authorization")).toBe(`Bearer ${ACQUIRED_LOGIN_TOKEN}`);
+    expect(JSON.parse(gateway.requests[2].body).tools ?? []).toHaveLength(0);
+    const sessionIds = readdirSync(join(home, ".fx", "sessions")).filter((id) => existsSync(join(home!, ".fx", "sessions", id, "session.json")));
+    expect(sessionIds).toHaveLength(1);
+    const historyPath = join(home, ".fx", "sessions", sessionIds[0], "events.jsonl");
+    const records = readFileSync(historyPath, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+    expect(records.filter((record) => record.event.context_checkpoint)).toHaveLength(1);
+    await session.sendKeys("C-u");
+    await session.sendText("Continue after the manual compaction.");
+    await session.waitForText("COMPACT_AUTH_CONTINUED", TIMEOUT);
+    expect(gateway.requests).toHaveLength(4);
+    await session.sendText("/quit");
+    await session.waitForSessionEnd(TIMEOUT);
+    expect(readFileSync(stderrPath, "utf8")).toBe("");
+    const trace = readFileSync(tracePath, "utf8");
+    for (const secret of [LOGIN_TOKEN, ACQUIRED_LOGIN_TOKEN, "seeded-refresh-token", "acquired-refresh-token"]) expect(trace).not.toContain(secret);
+  },
+  90_000,
+);
+
+for (const outcome of ["failure", "cancel"] as const) {
+  tmuxTest(`manual compaction auth ${outcome} preserves the session and accepts a later prompt`, async () => {
+    home = mkdtempSync(join(tmpdir(), `fx-compact-auth-${outcome}-`));
+    stderrPath = join(home, "stderr.log");
+    const tracePath = join(home, "trace.log");
+    writeFileSync(stderrPath, "");
+    gateway = startFakeGateway([
+      fakeGatewayFinalText("AUTH_BOUNDARY_FIRST_REPLY"),
+      fakeGatewayFinalText("AUTH_BOUNDARY_SECOND_REPLY"),
+      fakeGatewayFinalText("AUTH_BOUNDARY_RECOVERED"),
+    ]);
+    oauth = startFakeOAuth(outcome === "failure" ? null : ACQUIRED_LOGIN_TOKEN, undefined, 3600, Number.POSITIVE_INFINITY, {
+      tokenDelayMs: outcome === "cancel" ? 10_000 : 1_000,
+    });
+    const expiresAt = Date.now() + 80_000;
+    writeSeededFxLogin(home, expiresAt, oauth.issuerUrl, "team_123");
+    writeFileSync(join(home, ".fx", "settings.json"), JSON.stringify({ credential_source: "fx_login" }));
+    session = await startFx(home, stderrPath, gateway, oauth.issuerUrl, tracePath, {
+      FX_TRACE_SCOPES: "auth,input,worker,context_compaction,session",
+    }, home);
+    await session.waitForComposer(TIMEOUT);
+    await session.sendText("Remember AUTH_BOUNDARY_FIRST.");
+    await session.waitForText("AUTH_BOUNDARY_FIRST_REPLY", TIMEOUT);
+    await session.sendText("Remember AUTH_BOUNDARY_SECOND.");
+    await session.waitForText("AUTH_BOUNDARY_SECOND_REPLY", TIMEOUT);
+    const sessionIds = readdirSync(join(home, ".fx", "sessions")).filter((id) => existsSync(join(home!, ".fx", "sessions", id, "session.json")));
+    expect(sessionIds).toHaveLength(1);
+    const historyPath = join(home, ".fx", "sessions", sessionIds[0], "events.jsonl");
+    const before = readFileSync(historyPath, "utf8");
+    expect(gateway.requests).toHaveLength(2);
+    expect(gateway.requests[0].headers.get("authorization")).toBe(`Bearer ${LOGIN_TOKEN}`);
+    expect(oauth.requests.filter((request) => request.path === "/oauth/token")).toHaveLength(0);
+    await Bun.sleep(Math.max(0, expiresAt - 60_000 + 100 - Date.now()));
+    await session.sendText("/compact");
+    await waitForTrace(tracePath, "manual_compaction_auth_pending", TIMEOUT);
+    await session.sendLiteral("DRAFT_DURING_AUTH_BOUNDARY");
+    await session.waitForText("DRAFT_DURING_AUTH_BOUNDARY", 1_000);
+    if (outcome === "cancel") {
+      await session.sendKeys("C-c");
+      await session.waitForText("Context compaction cancelled.", 3_000);
+    } else {
+      await session.waitForText("Your conversation is unchanged.", TIMEOUT);
+      const scrollback = await session.captureFullScrollback();
+      expect(scrollback).toContain("/compact again");
+      expect(scrollback).not.toContain("Your prompt is saved.");
+    }
+    expect(await session.captureFullScrollback()).toContain("DRAFT_DURING_AUTH_BOUNDARY");
+    expect(readFileSync(historyPath, "utf8")).toBe(before);
+    expect(gateway.requests).toHaveLength(2);
+    await session.sendKeys("C-u");
+    await selectEnvKeyCredential(session);
+    expect(gateway.requests).toHaveLength(2);
+    await session.sendText("Continue the original conversation without tools.");
+    await session.waitForText("AUTH_BOUNDARY_RECOVERED", TIMEOUT);
+    expect(gateway.requests).toHaveLength(3);
+    expect(gateway.requests[2].headers.get("authorization")).toBe(`Bearer ${ENV_TOKEN}`);
+    expect(readFileSync(historyPath, "utf8")).not.toContain('"context_checkpoint"');
+    await session.sendText("/quit");
+    await session.waitForSessionEnd(TIMEOUT);
+    expect(readFileSync(stderrPath, "utf8")).toBe("");
+    const trace = readFileSync(tracePath, "utf8");
+    expect(trace).not.toContain("context_compaction_enqueue");
+    for (const secret of [LOGIN_TOKEN, ACQUIRED_LOGIN_TOKEN, ENV_TOKEN, "seeded-refresh-token", "acquired-refresh-token"]) expect(trace).not.toContain(secret);
+  }, 90_000);
+}
+
+tmuxTest(
   "expired selected login preserves the prompt and avoids Gateway before explicit recovery",
   async () => {
     home = mkdtempSync(join(tmpdir(), "fx-tui-auth-source-failure-"));


### PR DESCRIPTION
## Summary

- Refresh the selected login before starting manual compaction.
- Keep the chat open and show recovery guidance when authentication fails.
- Keep the composer responsive and preserve typed drafts during preparation.
- Let Ctrl+C cancel preparation without changing the conversation.
- Coalesce repeated `/compact` requests while authentication is pending.
- Discard pending preparation when changing sessions or quitting.
