### PR TITLE
Speed up repeated session continuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ fx session resume --id <id>
 
 `fx -c` also resumes the latest session for the current workspace. It skips unrelated current-format conversation histories during selection and attempts safe recovery of the selected session after an interrupted migration. A busy or unrecoverable selected session produces an error rather than opening an older conversation.
 
+Repeated continuation reuses validated summaries of unchanged older sessions instead of replaying their histories during selection. The first scan, or a scan after those session files change, can take longer. Opening the resume picker preserves these cached summaries.
+
 Older sessions that saved Vercel connection settings can be opened through `-r`, `/resume`, `-c`, or an exact ID. Migration preserves their model settings and keeps unfinished responses as interrupted history, without replaying old requests or restoring saved credential references.
 
 If a saved conversation is damaged, run `fx session recover <id>` to copy its validated prefix into a new session. Recovery preserves checkpoint boundaries and referenced result files, leaves the original unchanged, and prints the new session ID. Records after the damaged boundary are not included, and recovery does not rerun commands. Healthy conversations can be resumed without recovery.

--- a/src/core/session/session_catalog_cache.zig
+++ b/src/core/session/session_catalog_cache.zig
@@ -9,20 +9,42 @@ const summary_codec = @import("session_summary_codec.zig");
 
 const Allocator = std.mem.Allocator;
 const Sha256 = std.crypto.hash.sha2.Sha256;
-const magic = "fx-resume-catalog-v1\n";
+// Disposable v4 proofs bind replay and the legacy route gates to one stat window.
+const magic = "fx-resume-catalog-v4\n";
 const file_name = ".resume-catalog";
-const max_bytes = 64 * 1024 * 1024;
-const max_records = 100_000;
+pub const max_bytes = 64 * 1024 * 1024;
+pub const max_records = 100_000;
 const Fingerprint = [Sha256.digest_length]u8;
+const Generation = @import("session_event.zig").Identifier;
 
 pub const Entry = struct {
     fingerprint: ?Fingerprint,
-    value: union(enum) { visible: session_store.SessionSummary, excluded: []u8 },
+    value: union(enum) { visible: session_store.SessionSummary, excluded: []u8, legacy_ranking: LegacyRanking },
+
+    /// Caller owns both strings; this is ranking evidence, never picker visibility.
+    pub const LegacyRanking = struct {
+        id: []u8,
+        workspace_root: []u8,
+        updated_at_ms: i64,
+        generation: Generation,
+
+        pub fn clone(alloc: Allocator, id_value: []const u8, workspace_root: []const u8, updated_at_ms: i64, generation: Generation) !LegacyRanking {
+            const owned_id = try alloc.dupe(u8, id_value);
+            errdefer alloc.free(owned_id);
+            return .{ .id = owned_id, .workspace_root = try alloc.dupe(u8, workspace_root), .updated_at_ms = updated_at_ms, .generation = generation };
+        }
+
+        fn deinit(self: *LegacyRanking, alloc: Allocator) void {
+            alloc.free(self.id);
+            alloc.free(self.workspace_root);
+        }
+    };
 
     fn id(self: Entry) []const u8 {
         return switch (self.value) {
             .visible => |summary| summary.id,
             .excluded => |name| name,
+            .legacy_ranking => |ranking| ranking.id,
         };
     }
 
@@ -30,6 +52,7 @@ pub const Entry = struct {
         switch (self.value) {
             .visible => |*summary| summary.deinit(alloc),
             .excluded => |name| alloc.free(name),
+            .legacy_ranking => |*ranking| ranking.deinit(alloc),
         }
         self.* = undefined;
     }
@@ -82,13 +105,22 @@ const Summary = struct {
     }
 };
 
-const Row = struct { id: []const u8, fingerprint: []const u8, summary: ?Summary };
+const Row = struct {
+    id: []const u8,
+    fingerprint: []const u8,
+    value: union(enum) {
+        visible: Summary,
+        excluded: void,
+        legacy_ranking: struct { workspace_root: []const u8, updated_at_ms: i64, generation: Generation },
+    },
+};
 
 /// Owns parsed cache bytes. Reused entries are separately owned by the caller.
 pub const Loaded = struct {
     bytes: ?[]u8 = null,
     parsed: ?std.json.Parsed([]Row) = null,
     index: std.StringHashMapUnmanaged(usize) = .empty,
+    picker_count: usize = 0,
 
     pub fn deinit(self: *Loaded, alloc: Allocator) void {
         self.index.deinit(alloc);
@@ -98,13 +130,17 @@ pub const Loaded = struct {
     }
 
     pub fn count(self: *const Loaded) usize {
-        return self.index.count();
+        return self.picker_count;
+    }
+    pub fn rankingCount(self: *const Loaded) usize {
+        return self.index.count() - self.picker_count;
     }
     pub fn present(self: *const Loaded) bool {
         return self.parsed != null;
     }
     pub fn contains(self: *const Loaded, id: []const u8) bool {
-        return self.index.contains(id);
+        const position = self.index.get(id) orelse return false;
+        return self.parsed.?.value[position].value != .legacy_ranking;
     }
 
     pub fn load(alloc: Allocator, dir: ?io_mod.VerifiedDir, cancelled: ?*const std.atomic.Value(bool)) !Loaded {
@@ -145,13 +181,21 @@ pub const Loaded = struct {
         var index: std.StringHashMapUnmanaged(usize) = .empty;
         errdefer index.deinit(alloc);
         try index.ensureTotalCapacity(alloc, @intCast(parsed.value.len));
+        var picker_count: usize = 0;
         for (parsed.value, 0..) |row, i| {
             if (cancelled) |stop| if (stop.load(.acquire)) return error.Cancelled;
             try session_layout.validateSessionId(row.id);
             if (row.fingerprint.len != 64) return error.InvalidCatalogCache;
             var fingerprint_bytes: Fingerprint = undefined;
             _ = std.fmt.hexToBytes(&fingerprint_bytes, row.fingerprint) catch return error.InvalidCatalogCache;
-            if (row.summary) |summary| {
+            if (row.value != .legacy_ranking) picker_count += 1;
+            if (row.value == .legacy_ranking) {
+                const ranking = row.value.legacy_ranking;
+                try @import("session_store_paths.zig").validateWorkspaceRoot(ranking.workspace_root);
+                if (ranking.updated_at_ms < 0) return error.InvalidCatalogCache;
+            }
+            if (row.value == .visible) {
+                const summary = row.value.visible;
                 if (summary.created_at_ms < 0 or summary.updated_at_ms < summary.created_at_ms) return error.InvalidCatalogCache;
                 if (summary.history_len == 0 and !summary.has_checkpoint) return error.InvalidCatalogCache;
                 _ = try session.ConversationLanguage.fromSlice(summary.language);
@@ -169,22 +213,44 @@ pub const Loaded = struct {
             if (entry.found_existing) return error.InvalidCatalogCache;
             entry.value_ptr.* = i;
         }
-        return .{ .bytes = bytes, .parsed = parsed, .index = index };
+        return .{ .bytes = bytes, .parsed = parsed, .index = index, .picker_count = picker_count };
     }
 
     pub fn reuse(self: *const Loaded, alloc: Allocator, id: []const u8, fingerprint_value: Fingerprint) !?Entry {
         const position = self.index.get(id) orelse return null;
         const row = self.parsed.?.value[position];
-        const hex = std.fmt.bytesToHex(fingerprint_value, .lower);
-        if (!std.mem.eql(u8, row.fingerprint, &hex)) return null;
+        if (row.value == .legacy_ranking or !matches(row, fingerprint_value)) return null;
         return try cloneRow(alloc, row, fingerprint_value);
     }
 
+    /// Generation from a successful replay observation, not a caller-selected source.
+    pub fn rankingGeneration(self: *const Loaded, id: []const u8) ?Generation {
+        const position = self.index.get(id) orelse return null;
+        return switch (self.parsed.?.value[position].value) {
+            .legacy_ranking => |ranking| ranking.generation,
+            .visible, .excluded => null,
+        };
+    }
+
+    /// Returns an independently owned ranking observation, never a picker row.
+    pub fn reuseRanking(self: *const Loaded, alloc: Allocator, id: []const u8, fingerprint_value: Fingerprint) !?Entry {
+        const position = self.index.get(id) orelse return null;
+        const row = self.parsed.?.value[position];
+        if (row.value != .legacy_ranking or !matches(row, fingerprint_value)) return null;
+        return try cloneRow(alloc, row, fingerprint_value);
+    }
+
+    fn matches(row: Row, value: Fingerprint) bool {
+        const hex = std.fmt.bytesToHex(value, .lower);
+        return std.mem.eql(u8, row.fingerprint, &hex);
+    }
+
     fn cloneRow(alloc: Allocator, row: Row, value: Fingerprint) !Entry {
-        return .{ .fingerprint = value, .value = if (row.summary) |summary|
-            .{ .visible = try summary.clone(alloc, row.id) }
-        else
-            .{ .excluded = try alloc.dupe(u8, row.id) } };
+        return .{ .fingerprint = value, .value = switch (row.value) {
+            .visible => |summary| .{ .visible = try summary.clone(alloc, row.id) },
+            .excluded => .{ .excluded = try alloc.dupe(u8, row.id) },
+            .legacy_ranking => |ranking| .{ .legacy_ranking = try Entry.LegacyRanking.clone(alloc, row.id, ranking.workspace_root, ranking.updated_at_ms, ranking.generation) },
+        } };
     }
 };
 
@@ -202,35 +268,70 @@ pub const Writer = struct {
     }
 
     pub fn save(self: *Writer, alloc: Allocator, entries: []const Entry, cancelled: *const std.atomic.Value(bool)) !void {
+        return self.saveKind(alloc, entries, .picker, cancelled);
+    }
+
+    /// Replaces complete-scan ranking observations, preserving valid picker rows.
+    pub fn saveRanking(self: *Writer, alloc: Allocator, entries: []const Entry, cancelled: *const std.atomic.Value(bool)) !void {
+        return self.saveKind(alloc, entries, .ranking, cancelled);
+    }
+
+    const Purpose = enum { picker, ranking };
+
+    fn saveKind(self: *Writer, alloc: Allocator, entries: []const Entry, purpose: Purpose, cancelled: *const std.atomic.Value(bool)) !void {
+        if (cancelled.load(.acquire)) return error.Cancelled;
+        if (entries.len > max_records) return error.CatalogCacheTooLarge;
+        var previous = try Loaded.load(alloc, self.dir, cancelled);
+        defer previous.deinit(alloc);
+        var replaced: std.StringHashMapUnmanaged(void) = .empty;
+        defer replaced.deinit(alloc);
         var payload: std.Io.Writer.Allocating = .init(alloc);
         defer payload.deinit();
-        try payload.writer.writeByte('[');
+        payload.writer.writeByte('[') catch return error.OutOfMemory;
         var written: usize = 0;
         for (entries) |*entry| {
             if (cancelled.load(.acquire)) return error.Cancelled;
             const value = entry.fingerprint orelse continue;
-            if (written == max_records) return error.CatalogCacheTooLarge;
-            if (written != 0) try payload.writer.writeByte(',');
+            if ((entry.value == .legacy_ranking) != (purpose == .ranking)) return error.InvalidCatalogCache;
+            try replaced.put(alloc, entry.id(), {});
             const hex = std.fmt.bytesToHex(value, .lower);
-            try std.json.Stringify.value(Row{ .id = entry.id(), .fingerprint = &hex, .summary = switch (entry.value) {
-                .visible => |*summary| Summary.from(summary),
-                .excluded => null,
-            } }, .{}, &payload.writer);
-            written += 1;
-            if (payload.written().len > max_bytes - magic.len - Sha256.digest_length - 1) return error.CatalogCacheTooLarge;
+            try writeRow(&payload, &written, .{ .id = entry.id(), .fingerprint = &hex, .value = switch (entry.value) {
+                .visible => |*summary| .{ .visible = Summary.from(summary) },
+                .excluded => .excluded,
+                .legacy_ranking => |ranking| .{ .legacy_ranking = .{ .workspace_root = ranking.workspace_root, .updated_at_ms = ranking.updated_at_ms, .generation = ranking.generation } },
+            } });
         }
-        try payload.writer.writeByte(']');
+        if (previous.parsed) |parsed| for (parsed.value) |row| {
+            if (cancelled.load(.acquire)) return error.Cancelled;
+            if ((row.value == .legacy_ranking) == (purpose == .ranking) or replaced.contains(row.id)) continue;
+            // Legacy picker observations have no fingerprint and must not erase ranking rows.
+            const current = (if (row.value == .legacy_ranking)
+                rankingFingerprint(self.dir.dir, row.id, row.value.legacy_ranking.generation)
+            else
+                fingerprint(self.dir.dir, row.id)) catch null;
+            if (current) |stamp| if (Loaded.matches(row, stamp)) try writeRow(&payload, &written, row);
+        };
+        payload.writer.writeByte(']') catch return error.OutOfMemory;
         if (cancelled.load(.acquire)) return error.Cancelled;
         var digest: Fingerprint = undefined;
         Sha256.hash(payload.written(), &digest, .{});
         var out: std.Io.Writer.Allocating = .init(alloc);
         defer out.deinit();
-        try out.writer.writeAll(magic);
-        try out.writer.writeAll(&digest);
-        try out.writer.writeAll(payload.written());
+        out.writer.writeAll(magic) catch return error.OutOfMemory;
+        out.writer.writeAll(&digest) catch return error.OutOfMemory;
+        out.writer.writeAll(payload.written()) catch return error.OutOfMemory;
         try io_mod.durableReplaceVerified(alloc, &self.dir, file_name, out.written());
     }
 };
+
+fn writeRow(payload: *std.Io.Writer.Allocating, written: *usize, row: Row) !void {
+    if (written.* == max_records) return error.CatalogCacheTooLarge;
+    if (written.* != 0) payload.writer.writeByte(',') catch return error.OutOfMemory;
+    // This writer is memory-only: WriteFailed means allocation exhaustion.
+    std.json.Stringify.value(row, .{}, &payload.writer) catch return error.OutOfMemory;
+    written.* += 1;
+    if (payload.written().len > max_bytes - magic.len - Sha256.digest_length - 1) return error.CatalogCacheTooLarge;
+}
 
 /// Stats are freshness evidence only. Cache misses still use canonical discovery and admission.
 pub fn fingerprint(dir: std.Io.Dir, id: []const u8) !?Fingerprint {
@@ -266,6 +367,94 @@ pub fn fingerprint(dir: std.Io.Dir, id: []const u8) !?Fingerprint {
     var value: Fingerprint = undefined;
     digest.final(&value);
     return value;
+}
+
+const watermark_name_len = "commit.".len + 32 + ".json".len;
+
+/// Observes only the active-generation watermark used by the v3 importer, plus
+/// fixed source inputs. Superseded watermarks never govern that committed prefix.
+pub fn rankingFingerprint(root: std.Io.Dir, id: []const u8, generation: Generation) !?Fingerprint {
+    try session_layout.validateSessionId(id);
+    var dir = try root.openDir(io_mod.getIo(), id, .{ .follow_symlinks = false });
+    defer dir.close(io_mod.getIo());
+    return rankingFingerprintForOpenSession(root, id, dir, generation);
+}
+
+/// Binds the observation to the same directory handle used by canonical replay.
+/// Replacement of that directory disables publication of the old handle's result.
+pub fn rankingFingerprintForOpenSession(root: std.Io.Dir, id: []const u8, session_dir: std.Io.Dir, generation: Generation) !?Fingerprint {
+    try session_layout.validateSessionId(id);
+    const before = (try statOptional(root, id)) orelse return null;
+    if (before.kind != .directory) return null;
+    var dir = try session_dir.openDir(io_mod.getIo(), ".", .{ .follow_symlinks = false });
+    defer dir.close(io_mod.getIo());
+    if (!sameStat(before, try dir.stat(io_mod.getIo()))) return null;
+    var hash = Sha256.init(.{});
+    addStat(&hash, before);
+    try addDevice(&hash, dir, ".");
+    for ([_][]const u8{ "session.json", "events.jsonl", "authority.json", "authority.pending.json", "commit.pending.json", "session.legacy.json", "checkpoint.json" }) |name| {
+        if (!try addRankingFile(&hash, dir, name)) return null;
+    }
+    var watermark_buffer: [watermark_name_len]u8 = undefined;
+    const watermark = try std.fmt.bufPrint(&watermark_buffer, "commit.{s}.json", .{std.fmt.bytesToHex(generation, .lower)});
+    if (!try addRankingFile(&hash, dir, watermark)) return null;
+    if (try statOptional(dir, "subagent")) |child_stat| {
+        if (child_stat.kind != .directory) return null;
+        hash.update(&.{1});
+        addStat(&hash, child_stat);
+        try addDevice(&hash, dir, "subagent");
+        var child = try dir.openDir(io_mod.getIo(), "subagent", .{ .follow_symlinks = false });
+        defer child.close(io_mod.getIo());
+        if (!sameStat(child_stat, try child.stat(io_mod.getIo()))) return null;
+        for ([_][]const u8{ "owner.json", "control.json" }) |name| if (!try addRankingFile(&hash, child, name)) return null;
+        if (!sameStat(child_stat, (try statOptional(dir, "subagent")) orelse return null)) return null;
+    } else hash.update(&.{0});
+    if (!sameStat(before, try dir.stat(io_mod.getIo())) or !sameStat(before, (try statOptional(root, id)) orelse return null)) return null;
+    var result: Fingerprint = undefined;
+    hash.final(&result);
+    return result;
+}
+
+fn addRankingFile(hash: *Sha256, dir: std.Io.Dir, name: []const u8) !bool {
+    hash.update(name);
+    hash.update(&.{0});
+    if (try statOptional(dir, name)) |stat| {
+        if (stat.kind != .file or stat.nlink != 1) return false;
+        hash.update(&.{1});
+        addStat(hash, stat);
+        try addDevice(hash, dir, name);
+    } else hash.update(&.{0});
+    return true;
+}
+
+// std.Io.File.Stat omits device identity. Match the authority reader's native
+// no-follow observation; unsupported targets cannot produce ranking cache hits.
+fn addDevice(hash: *Sha256, dir: std.Io.Dir, name: []const u8) !void {
+    var buffer: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const path = try std.fmt.bufPrintZ(&buffer, "{s}", .{name});
+    const device: u64 = switch (@import("builtin").os.tag) {
+        .linux => blk: {
+            const linux = std.os.linux;
+            var stat: linux.Statx = std.mem.zeroes(linux.Statx);
+            while (true) switch (linux.errno(linux.statx(dir.handle, path, linux.AT.SYMLINK_NOFOLLOW, linux.STATX.BASIC_STATS, &stat))) {
+                .SUCCESS => break :blk (@as(u64, stat.dev_major) << 32) | stat.dev_minor,
+                .INTR => continue,
+                else => return error.RankingFingerprintUnavailable,
+            };
+        },
+        .macos => blk: {
+            var stat: std.c.Stat = undefined;
+            while (true) switch (std.c.errno(std.c.fstatat(dir.handle, path, &stat, std.c.AT.SYMLINK_NOFOLLOW))) {
+                .SUCCESS => break :blk @intCast(stat.dev),
+                .INTR => continue,
+                else => return error.RankingFingerprintUnavailable,
+            };
+        },
+        else => return error.RankingFingerprintUnavailable,
+    };
+    var bytes: [8]u8 = undefined;
+    std.mem.writeInt(u64, &bytes, device, .little);
+    hash.update(&bytes);
 }
 
 fn statOptional(dir: std.Io.Dir, path: []const u8) !?std.Io.File.Stat {
@@ -348,6 +537,231 @@ test "catalog cache corruption and duplicate identifiers require rebuilding" {
     var corrupt = try Loaded.load(alloc, writer.dir, null);
     defer corrupt.deinit(alloc);
     try std.testing.expect(!corrupt.present());
+}
+
+fn rankingTestSource(dir: std.Io.Dir, id: []const u8) !void {
+    try dir.createDir(io_mod.getIo(), id, .fromMode(0o700));
+    var child = try dir.openDir(io_mod.getIo(), id, .{});
+    defer child.close(io_mod.getIo());
+    for ([_][]const u8{ "session.json", "events.jsonl", "authority.json", "commit.11111111111111111111111111111111.json" }) |name| {
+        var file = try child.createFile(io_mod.getIo(), name, .{ .permissions = .fromMode(0o600) });
+        defer file.close(io_mod.getIo());
+        try file.writeStreamingAll(io_mod.getIo(), "{}\n");
+    }
+}
+
+test "catalog ranking rows roundtrip isolate kinds and survive picker publication" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try rankingTestSource(tmp.dir, "legacy");
+    try rankingTestSource(tmp.dir, "picker");
+    var writer = Writer{ .dir = .{ .dir = try tmp.dir.openDir(std.testing.io, ".", .{ .iterate = true }) } };
+    defer writer.deinit();
+    const stamp = (try rankingFingerprint(tmp.dir, "legacy", @splat(0x11))).?;
+    const ranking = Entry{ .fingerprint = stamp, .value = .{ .legacy_ranking = .{ .id = @constCast("legacy"), .workspace_root = @constCast("/workspace"), .updated_at_ms = 20, .generation = @splat(0x11) } } };
+    const picker = Entry{ .fingerprint = try fingerprint(tmp.dir, "picker"), .value = .{ .excluded = @constCast("picker") } };
+    const legacy_picker = Entry{ .fingerprint = null, .value = .{ .excluded = @constCast("legacy") } };
+    var stop = std.atomic.Value(bool).init(false);
+    try writer.saveRanking(alloc, &.{ranking}, &stop);
+    try writer.save(alloc, &.{ picker, legacy_picker }, &stop);
+    try writer.saveRanking(alloc, &.{ranking}, &stop);
+    var loaded = try Loaded.load(alloc, writer.dir, null);
+    defer loaded.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 1), loaded.count());
+    try std.testing.expectEqual(@as(usize, 1), loaded.rankingCount());
+    try std.testing.expect(!loaded.contains("legacy"));
+    try std.testing.expect(loaded.contains("picker"));
+    try std.testing.expect((try loaded.reuse(alloc, "legacy", stamp)) == null);
+    try std.testing.expect((try loaded.reuseRanking(alloc, "picker", picker.fingerprint.?)) == null);
+    try std.testing.expect((try loaded.reuseRanking(alloc, "legacy", @splat(0))) == null);
+    var reused = (try loaded.reuseRanking(alloc, "legacy", stamp)).?;
+    defer reused.deinit(alloc);
+    try std.testing.expectEqualStrings("legacy", reused.value.legacy_ranking.id);
+    try std.testing.expectEqualStrings("/workspace", reused.value.legacy_ranking.workspace_root);
+    try std.testing.expectEqual(@as(i64, 20), reused.value.legacy_ranking.updated_at_ms);
+
+    // A newly migrated, cacheable picker row supersedes its old ranking row.
+    const migrated = Entry{ .fingerprint = try fingerprint(tmp.dir, "legacy"), .value = .{ .excluded = @constCast("legacy") } };
+    try writer.save(alloc, &.{ picker, migrated }, &stop);
+    var replaced = try Loaded.load(alloc, writer.dir, null);
+    defer replaced.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 2), replaced.count());
+    try std.testing.expectEqual(@as(usize, 0), replaced.rankingCount());
+}
+
+test "catalog ranking fingerprint detects in-place authority and active watermark inputs" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try rankingTestSource(tmp.dir, "legacy");
+    var dir = try tmp.dir.openDir(std.testing.io, "legacy", .{});
+    defer dir.close(std.testing.io);
+    for ([_][]const u8{ "authority.pending.json", "commit.pending.json", "session.legacy.json", "checkpoint.json" }) |name| {
+        var file = try dir.createFile(std.testing.io, name, .{});
+        file.close(std.testing.io);
+    }
+    for ([_][]const u8{ "session.json", "events.jsonl", "authority.json", "authority.pending.json", "commit.pending.json", "session.legacy.json", "checkpoint.json", "commit.11111111111111111111111111111111.json" }) |name| {
+        const before = (try rankingFingerprint(tmp.dir, "legacy", @splat(0x11))).?;
+        const parent = try dir.stat(std.testing.io);
+        var file = try dir.openFile(std.testing.io, name, .{ .mode = .read_write });
+        defer file.close(std.testing.io);
+        io_mod.sleep(2 * std.time.ns_per_ms);
+        try file.writePositionalAll(std.testing.io, "bad", 0);
+        try std.testing.expect(sameStat(parent, try dir.stat(std.testing.io)));
+        try std.testing.expect(!std.mem.eql(u8, &before, &(try rankingFingerprint(tmp.dir, "legacy", @splat(0x11))).?));
+    }
+    const before = (try rankingFingerprint(tmp.dir, "legacy", @splat(0x11))).?;
+    try dir.deleteFile(std.testing.io, "authority.pending.json");
+    try std.testing.expect(!std.mem.eql(u8, &before, &(try rankingFingerprint(tmp.dir, "legacy", @splat(0x11))).?));
+    var unknown = try dir.createFile(std.testing.io, "commit.unknown.json", .{});
+    defer unknown.close(std.testing.io);
+    const with_obsolete = (try rankingFingerprint(tmp.dir, "legacy", @splat(0x11))).?;
+    try unknown.writeStreamingAll(std.testing.io, "not an active watermark");
+    try std.testing.expectEqual(with_obsolete, (try rankingFingerprint(tmp.dir, "legacy", @splat(0x11))).?);
+}
+
+test "catalog ranking fingerprint rejects active symlinks and replaced directories" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try rankingTestSource(tmp.dir, "legacy");
+    var original = try tmp.dir.openDir(std.testing.io, "legacy", .{});
+    defer original.close(std.testing.io);
+    try tmp.dir.rename("legacy", tmp.dir, "old", std.testing.io);
+    try rankingTestSource(tmp.dir, "legacy");
+    try std.testing.expect((try rankingFingerprintForOpenSession(tmp.dir, "legacy", original, @splat(0x11))) == null);
+    var dir = try tmp.dir.openDir(std.testing.io, "legacy", .{});
+    defer dir.close(std.testing.io);
+    try dir.symLink(std.testing.io, "events.jsonl", "authority.pending.json", .{});
+    try std.testing.expect((try rankingFingerprint(tmp.dir, "legacy", @splat(0x11))) == null);
+    try dir.deleteFile(std.testing.io, "authority.pending.json");
+    try dir.deleteFile(std.testing.io, "commit.11111111111111111111111111111111.json");
+    try dir.symLink(std.testing.io, "events.jsonl", "commit.11111111111111111111111111111111.json", .{});
+    try std.testing.expect((try rankingFingerprint(tmp.dir, "legacy", @splat(0x11))) == null);
+}
+
+test "catalog ranking cache tolerates thousands of obsolete watermarks and binds generation" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try rankingTestSource(tmp.dir, "legacy");
+    var dir = try tmp.dir.openDir(std.testing.io, "legacy", .{});
+    defer dir.close(std.testing.io);
+    var name_buffer: [watermark_name_len]u8 = undefined;
+    for (0..1536) |index| {
+        const name = try std.fmt.bufPrint(&name_buffer, "commit.{x:0>32}.json", .{index});
+        var file = try dir.createFile(std.testing.io, name, .{});
+        defer file.close(std.testing.io);
+        try file.writeStreamingAll(std.testing.io, "obsolete invalid JSON");
+    }
+    const generation: Generation = @splat(0x11);
+    const stamp = (try rankingFingerprint(tmp.dir, "legacy", generation)).?;
+    var writer = Writer{ .dir = .{ .dir = try tmp.dir.openDir(std.testing.io, ".", .{}) } };
+    defer writer.deinit();
+    const ranking = Entry{ .fingerprint = stamp, .value = .{ .legacy_ranking = .{ .id = @constCast("legacy"), .workspace_root = @constCast("/workspace"), .updated_at_ms = 20, .generation = generation } } };
+    var stop = std.atomic.Value(bool).init(false);
+    try writer.saveRanking(alloc, &.{ranking}, &stop);
+    try writer.save(alloc, &.{}, &stop);
+    var loaded = try Loaded.load(alloc, writer.dir, null);
+    defer loaded.deinit(alloc);
+    try std.testing.expectEqual(generation, loaded.rankingGeneration("legacy").?);
+    var reused = (try loaded.reuseRanking(alloc, "legacy", (try rankingFingerprint(tmp.dir, "legacy", generation)).?)).?;
+    defer reused.deinit(alloc);
+    try std.testing.expectEqual(generation, reused.value.legacy_ranking.generation);
+    const other = (try rankingFingerprint(tmp.dir, "legacy", @splat(0x22))).?;
+    try std.testing.expect((try loaded.reuseRanking(alloc, "legacy", other)) == null);
+    var events = try dir.openFile(std.testing.io, "events.jsonl", .{ .mode = .read_write });
+    defer events.close(std.testing.io);
+    try events.writePositionalAll(std.testing.io, "new generation", 0);
+    const changed = (try rankingFingerprint(tmp.dir, "legacy", generation)).?;
+    try std.testing.expect((try loaded.reuseRanking(alloc, "legacy", changed)) == null);
+}
+
+test "catalog ranking invalid rows versions cancellation and bounds are misses" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var writer = Writer{ .dir = .{ .dir = try tmp.dir.openDir(std.testing.io, ".", .{}) } };
+    defer writer.deinit();
+    var stop = std.atomic.Value(bool).init(false);
+    const invalid = [_]Entry{
+        .{ .fingerprint = @splat(1), .value = .{ .legacy_ranking = .{ .id = @constCast("relative"), .workspace_root = @constCast("relative"), .updated_at_ms = 20, .generation = @splat(0x11) } } },
+        .{ .fingerprint = @splat(1), .value = .{ .legacy_ranking = .{ .id = @constCast("negative"), .workspace_root = @constCast("/workspace"), .updated_at_ms = -1, .generation = @splat(0x11) } } },
+    };
+    for (invalid) |row| {
+        try writer.saveRanking(alloc, &.{row}, &stop);
+        var loaded = try Loaded.load(alloc, writer.dir, null);
+        defer loaded.deinit(alloc);
+        try std.testing.expect(!loaded.present());
+    }
+    const valid = Entry{ .fingerprint = @splat(1), .value = .{ .legacy_ranking = .{ .id = @constCast("valid"), .workspace_root = @constCast("/workspace"), .updated_at_ms = 20, .generation = @splat(0x11) } } };
+    try writer.saveRanking(alloc, &.{ valid, valid }, &stop);
+    var duplicate = try Loaded.load(alloc, writer.dir, null);
+    defer duplicate.deinit(alloc);
+    try std.testing.expect(!duplicate.present());
+    try writer.saveRanking(alloc, &.{valid}, &stop);
+    stop.store(true, .release);
+    try std.testing.expectError(error.Cancelled, writer.saveRanking(alloc, &.{}, &stop));
+    var retained = try Loaded.load(alloc, writer.dir, null);
+    defer retained.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 1), retained.rankingCount());
+    var file = try writer.dir.dir.openFile(std.testing.io, file_name, .{ .mode = .read_write });
+    defer file.close(std.testing.io);
+    for ([_][]const u8{ "1", "2", "3" }) |version| {
+        try file.writePositionalAll(std.testing.io, version, "fx-resume-catalog-v".len);
+        var old_version = try Loaded.load(alloc, writer.dir, null);
+        defer old_version.deinit(alloc);
+        try std.testing.expect(!old_version.present());
+    }
+    var payload: std.Io.Writer.Allocating = .init(alloc);
+    defer payload.deinit();
+    var written: usize = max_records;
+    try std.testing.expectError(error.CatalogCacheTooLarge, writeRow(&payload, &written, .{ .id = "id", .fingerprint = "", .value = .excluded }));
+}
+
+test "catalog ranking missing or malformed generation requires rebuilding" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var dir = io_mod.VerifiedDir{ .dir = try tmp.dir.openDir(std.testing.io, ".", .{}) };
+    defer dir.close();
+    const prefix = "[{\"id\":\"legacy\",\"fingerprint\":\"" ++ "1" ** 64 ++ "\",\"value\":{\"legacy_ranking\":{\"workspace_root\":\"/workspace\",\"updated_at_ms\":20";
+    for ([_][]const u8{ prefix ++ "}}}]", prefix ++ ",\"generation\":[1]}}}]", prefix ++ ",\"generation\":null}}}]" }) |payload| {
+        var digest: Fingerprint = undefined;
+        Sha256.hash(payload, &digest, .{});
+        var bytes: std.Io.Writer.Allocating = .init(alloc);
+        defer bytes.deinit();
+        try bytes.writer.writeAll(magic);
+        try bytes.writer.writeAll(&digest);
+        try bytes.writer.writeAll(payload);
+        try io_mod.durableReplaceVerified(alloc, &dir, file_name, bytes.written());
+        var loaded = try Loaded.load(alloc, dir, null);
+        defer loaded.deinit(alloc);
+        try std.testing.expect(!loaded.present());
+    }
+}
+
+test "catalog ranking allocation failures clean owned rows and merged publication" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try rankingTestSource(tmp.dir, "legacy");
+    var writer = Writer{ .dir = .{ .dir = try tmp.dir.openDir(std.testing.io, ".", .{}) } };
+    defer writer.deinit();
+    const stamp = (try rankingFingerprint(tmp.dir, "legacy", @splat(0x11))).?;
+    const ranking = Entry{ .fingerprint = stamp, .value = .{ .legacy_ranking = .{ .id = @constCast("legacy"), .workspace_root = @constCast("/workspace"), .updated_at_ms = 20, .generation = @splat(0x11) } } };
+    var stop = std.atomic.Value(bool).init(false);
+    try writer.saveRanking(alloc, &.{ranking}, &stop);
+    try std.testing.checkAllAllocationFailures(alloc, struct {
+        fn check(a: Allocator, output: *Writer, fingerprint_value: Fingerprint) !void {
+            var loaded = try Loaded.load(a, output.dir, null);
+            defer loaded.deinit(a);
+            var reused = (try loaded.reuseRanking(a, "legacy", fingerprint_value)).?;
+            defer reused.deinit(a);
+            var cancelled = std.atomic.Value(bool).init(false);
+            try output.saveRanking(a, &.{reused}, &cancelled);
+            try output.save(a, &.{}, &cancelled);
+        }
+    }.check, .{ &writer, stamp });
 }
 
 test "catalog fingerprint detects event appends and child directory permissions" {

--- a/src/core/session/session_catalog_cache.zig
+++ b/src/core/session/session_catalog_cache.zig
@@ -655,7 +655,7 @@ test "catalog ranking cache tolerates thousands of obsolete watermarks and binds
     }
     const generation: Generation = @splat(0x11);
     const stamp = (try rankingFingerprint(tmp.dir, "legacy", generation)).?;
-    var writer = Writer{ .dir = .{ .dir = try tmp.dir.openDir(std.testing.io, ".", .{}) } };
+    var writer = Writer{ .dir = .{ .dir = try tmp.dir.openDir(std.testing.io, ".", .{ .iterate = true, .follow_symlinks = false }) } };
     defer writer.deinit();
     const ranking = Entry{ .fingerprint = stamp, .value = .{ .legacy_ranking = .{ .id = @constCast("legacy"), .workspace_root = @constCast("/workspace"), .updated_at_ms = 20, .generation = generation } } };
     var stop = std.atomic.Value(bool).init(false);
@@ -680,7 +680,7 @@ test "catalog ranking invalid rows versions cancellation and bounds are misses" 
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
-    var writer = Writer{ .dir = .{ .dir = try tmp.dir.openDir(std.testing.io, ".", .{}) } };
+    var writer = Writer{ .dir = .{ .dir = try tmp.dir.openDir(std.testing.io, ".", .{ .iterate = true, .follow_symlinks = false }) } };
     defer writer.deinit();
     var stop = std.atomic.Value(bool).init(false);
     const invalid = [_]Entry{
@@ -722,7 +722,7 @@ test "catalog ranking missing or malformed generation requires rebuilding" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
-    var dir = io_mod.VerifiedDir{ .dir = try tmp.dir.openDir(std.testing.io, ".", .{}) };
+    var dir = io_mod.VerifiedDir{ .dir = try tmp.dir.openDir(std.testing.io, ".", .{ .iterate = true, .follow_symlinks = false }) };
     defer dir.close();
     const prefix = "[{\"id\":\"legacy\",\"fingerprint\":\"" ++ "1" ** 64 ++ "\",\"value\":{\"legacy_ranking\":{\"workspace_root\":\"/workspace\",\"updated_at_ms\":20";
     for ([_][]const u8{ prefix ++ "}}}]", prefix ++ ",\"generation\":[1]}}}]", prefix ++ ",\"generation\":null}}}]" }) |payload| {
@@ -745,7 +745,7 @@ test "catalog ranking allocation failures clean owned rows and merged publicatio
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try rankingTestSource(tmp.dir, "legacy");
-    var writer = Writer{ .dir = .{ .dir = try tmp.dir.openDir(std.testing.io, ".", .{}) } };
+    var writer = Writer{ .dir = .{ .dir = try tmp.dir.openDir(std.testing.io, ".", .{ .iterate = true, .follow_symlinks = false }) } };
     defer writer.deinit();
     const stamp = (try rankingFingerprint(tmp.dir, "legacy", @splat(0x11))).?;
     const ranking = Entry{ .fingerprint = stamp, .value = .{ .legacy_ranking = .{ .id = @constCast("legacy"), .workspace_root = @constCast("/workspace"), .updated_at_ms = 20, .generation = @splat(0x11) } } };

--- a/src/core/session/session_store.zig
+++ b/src/core/session/session_store.zig
@@ -7293,7 +7293,9 @@ test "writable last preserves conversation recency and allocation cleanup" {
         defer dir.close();
         var reference = try classifyReadOnlyCandidate(alloc, &dir, id);
         defer reference.deinit(alloc);
-        var candidate = (try ctx.store.resolveWritableCandidate(alloc, id, ctx.workspace, .{})).?;
+        var scan = Store.RankingScan{ .cache = .{} };
+        defer scan.deinit(alloc);
+        var candidate = (try ctx.store.resolveWritableCandidate(alloc, id, ctx.workspace, .{}, &scan)).?;
         defer candidate.deinit(alloc);
         try std.testing.expectEqual(reference.summary.updated_at_ms, candidate.updated_at_ms);
         try std.testing.expectEqualStrings(reference.summary.workspace_root.?, candidate.workspace_root);

--- a/src/core/session/session_store.zig
+++ b/src/core/session/session_store.zig
@@ -13,6 +13,7 @@ const command_replay_store = @import("command_replay_store.zig");
 const result_store = @import("result_store.zig");
 const session = @import("session.zig");
 const session_codec = @import("session_codec.zig");
+const catalog_cache = @import("session_catalog_cache.zig");
 const session_child_store = @import("session_child_store.zig");
 const relationship_index_codec = @import("session_relationship_index_codec.zig");
 const session_event = @import("session_event.zig");
@@ -2701,6 +2702,52 @@ pub const Store = struct {
         return true;
     }
 
+    const RankingScan = struct {
+        cache: catalog_cache.Loaded,
+        rows: std.ArrayList(catalog_cache.Entry) = .empty,
+        remaining_bytes: usize = catalog_cache.max_bytes,
+        publishable: bool = true,
+        reused: usize = 0,
+        refreshed: usize = 0,
+
+        fn deinit(self: *RankingScan, alloc: Allocator) void {
+            for (self.rows.items) |*row| row.deinit(alloc);
+            self.rows.deinit(alloc);
+            self.cache.deinit(alloc);
+        }
+
+        fn observe(self: *RankingScan, alloc: Allocator, stamp: [32]u8, id: []const u8, workspace: []const u8, updated_at_ms: i64, generation: session_event.Identifier) !void {
+            if (!self.publishable) return;
+            const bytes = id.len + workspace.len + 128;
+            if (self.rows.items.len == catalog_cache.max_records or bytes > self.remaining_bytes) {
+                self.publishable = false;
+                return;
+            }
+            var row = catalog_cache.Entry{ .fingerprint = stamp, .value = .{ .legacy_ranking = try catalog_cache.Entry.LegacyRanking.clone(alloc, id, workspace, updated_at_ms, generation) } };
+            errdefer row.deinit(alloc);
+            try self.rows.append(alloc, row);
+            self.remaining_bytes -= bytes;
+        }
+
+        fn publish(self: *RankingScan, store: Store, alloc: Allocator) void {
+            debug_trace.logf("session", "legacy ranking cache reused={d} refreshed={d}", .{ self.reused, self.refreshed });
+            if (!self.publishable) {
+                debug_trace.logf("session", "legacy ranking cache not saved reason=observation_limit", .{});
+                return;
+            }
+            if (self.refreshed == 0 and self.rows.items.len == self.cache.rankingCount()) return;
+            var writer = (catalog_cache.Writer.init(store) catch |err| {
+                debug_trace.logf("session", "legacy ranking cache not saved err={s}", .{@errorName(err)});
+                return;
+            }) orelse return;
+            defer writer.deinit();
+            var cancelled = std.atomic.Value(bool).init(false);
+            writer.saveRanking(alloc, self.rows.items, &cancelled) catch |err| {
+                debug_trace.logf("session", "legacy ranking cache not saved err={s}", .{@errorName(err)});
+            };
+        }
+    };
+
     fn selectWritableLastId(
         self: Store,
         alloc: Allocator,
@@ -2708,10 +2755,14 @@ pub const Store = struct {
         options: ResumeOptions,
     ) !?[]u8 {
         try validateWorkspaceRoot(workspace_root);
-        if (self.canonical_root.sessions == null) return null;
+        const sessions = self.canonical_root.sessions orelse return null;
+        var scan = RankingScan{ .cache = try catalog_cache.Loaded.load(alloc, sessions, null) };
+        defer scan.deinit(alloc);
         var selected: ?WritableCandidate = null;
         defer if (selected) |*candidate| candidate.deinit(alloc);
-        var iter = self.canonical_root.sessions.?.dir.iterate();
+        var dir = try sessions.dir.openDir(io_mod.getIo(), ".", .{ .iterate = true, .follow_symlinks = false });
+        defer dir.close(io_mod.getIo());
+        var iter = dir.iterate();
         while (try iter.next(io_mod.getIo())) |entry| {
             if (entry.kind != .directory) continue;
             if (std.mem.eql(u8, entry.name, retired_latest_sessions_dir)) {
@@ -2723,6 +2774,7 @@ pub const Store = struct {
                 entry.name,
                 workspace_root,
                 options,
+                &scan,
             ) catch |err| {
                 logDiscoveryError(
                     .workspace_writable_last,
@@ -2762,6 +2814,8 @@ pub const Store = struct {
                 candidate.deinit(alloc);
             }
         }
+        // No cache publication is reachable from an incomplete or failed scan.
+        scan.publish(self, alloc);
         if (selected) |candidate| {
             logDiscovery(
                 .workspace_writable_last,
@@ -2777,15 +2831,54 @@ pub const Store = struct {
         return null;
     }
 
+    // Publication-only proof: replay does not validate the authority/manifest
+    // gates skipped by early hits. Recheck them inside the fingerprint window.
+    // Recoverable missing/bad manifests still resolve canonically, without caching.
+    fn rankingPublicationFingerprint(
+        self: Store,
+        alloc: Allocator,
+        session_dir: *io_mod.VerifiedDir,
+        session_id: []const u8,
+        before: [32]u8,
+        observed_generation: session_event.Identifier,
+        replayed_generation: session_event.Identifier,
+    ) ?[32]u8 {
+        if (!std.mem.eql(u8, &observed_generation, &replayed_generation)) return null;
+        if (session_log.readConversationMetadata(alloc, session_dir) catch return null) |value| {
+            var metadata = value;
+            metadata.deinit();
+            return null;
+        }
+        if ((classifyAuthority(alloc, session_dir, session_id) catch return null) != .schema_v3) return null;
+        var candidate = classifySchemaV3Candidate(alloc, session_dir, session_id) catch return null;
+        defer candidate.deinit(alloc);
+        if (candidate.projection_state != .stale) return null;
+        const after = (catalog_cache.rankingFingerprintForOpenSession(self.canonical_root.sessions.?.dir, session_id, session_dir.dir, replayed_generation) catch return null) orelse return null;
+        if (!std.mem.eql(u8, &before, &after)) return null;
+        return after;
+    }
+
     fn resolveWritableCandidate(
         self: Store,
         alloc: Allocator,
         session_id: []const u8,
         workspace_root: []const u8,
         _: ResumeOptions,
+        scan: *RankingScan,
     ) !?WritableCandidate {
         var session_dir = try self.openSessionDir(session_id);
         defer session_dir.close();
+        if (scan.cache.rankingGeneration(session_id)) |generation| {
+            const current = catalog_cache.rankingFingerprintForOpenSession(self.canonical_root.sessions.?.dir, session_id, session_dir.dir, generation) catch null;
+            if (current) |stamp| if (try scan.cache.reuseRanking(alloc, session_id, stamp)) |value| {
+                var row = value;
+                defer row.deinit(alloc);
+                const ranking = row.value.legacy_ranking;
+                try scan.observe(alloc, stamp, ranking.id, ranking.workspace_root, ranking.updated_at_ms, ranking.generation);
+                scan.reused += 1;
+                return try dupeWritableCandidate(alloc, ranking.id, ranking.workspace_root, ranking.updated_at_ms, .schema_v3, .stale);
+            };
+        }
         if (try session_log.readConversationMetadata(alloc, &session_dir)) |value| {
             var metadata = value;
             defer metadata.deinit();
@@ -2853,6 +2946,20 @@ pub const Store = struct {
                     else => {},
                 }
 
+                // Only misses read the first envelope. Probe failures leave the
+                // canonical replay below in charge of errors and foreign fallback.
+                const generation: ?session_event.Identifier = blk: {
+                    var events = openSessionFile(&session_dir, "events.jsonl", .read_only) catch break :blk null;
+                    defer events.close(io_mod.getIo());
+                    break :blk session_replay.readFirstGeneration(alloc, events) catch |err| switch (err) {
+                        error.OutOfMemory => return err,
+                        else => null,
+                    };
+                };
+                const before = if (generation) |value|
+                    catalog_cache.rankingFingerprintForOpenSession(self.canonical_root.sessions.?.dir, session_id, session_dir.dir, value) catch null
+                else
+                    null;
                 var source = loadSchemaV3ReadOnly(
                     alloc,
                     &session_dir,
@@ -2874,6 +2981,14 @@ pub const Store = struct {
                     );
                 };
                 defer source.deinit(alloc);
+                scan.refreshed += 1;
+                // Only canonical successful replay reaches this point. The foreign
+                // workspace fallback above must never become reusable evidence.
+                if (before) |stamp| {
+                    if (self.rankingPublicationFingerprint(alloc, &session_dir, session_id, stamp, generation.?, source.generation)) |current| {
+                        try scan.observe(alloc, current, source.state.id, source.state.workspace_root, source.state.updated_at_ms, source.generation);
+                    }
+                }
                 return try dupeWritableCandidate(
                     alloc,
                     source.state.id,
@@ -4828,6 +4943,547 @@ test "store start does not publish session caches" {
         try std.testing.expectEqualStrings("cache-free-store", entry.name);
     }
     try std.testing.expectEqual(@as(usize, 1), count);
+}
+
+const ranking_test_generation: session_event.Identifier = @splat(1);
+const ranking_test_watermark = "commit.01010101010101010101010101010101.json";
+
+fn writeRankingWatermark(alloc: Allocator, dir: *io_mod.VerifiedDir, id: []const u8, seq: u64, event_id: session_event.Identifier, bytes: u64) !void {
+    const generation_hex = std.fmt.bytesToHex(ranking_test_generation, .lower);
+    const event_hex = std.fmt.bytesToHex(event_id, .lower);
+    const text = try std.json.Stringify.valueAlloc(alloc, .{
+        .schema_version = @as(u32, 1),
+        .session_id = id,
+        .log_generation = @as([]const u8, &generation_hex),
+        .through_seq = seq,
+        .through_event_id = @as([]const u8, &event_hex),
+        .through_event_log_bytes = bytes,
+    }, .{});
+    defer alloc.free(text);
+    // Deliberately overwrite in place, so directory mtime cannot detect this change.
+    var file = try dir.dir.createFile(std.testing.io, ranking_test_watermark, .{ .permissions = .fromMode(0o600) });
+    defer file.close(std.testing.io);
+    try file.writeStreamingAll(std.testing.io, text);
+}
+
+fn writeRankingFixture(alloc: Allocator, store: Store, id: []const u8, projected_workspace: []const u8, workspace: []const u8, updated_at_ms: i64) !void {
+    try makeSessionDir(alloc, store, id);
+    var dir = try store.openSessionDir(id);
+    defer dir.close();
+    try dir.dir.setPermissions(std.testing.io, .fromMode(0o700));
+    const preferences = session_codec.DurableSessionPreferences{ .model = @constCast("test/model"), .effort = .auto, .fast_mode = false };
+    const first = try session_event.encodeLegacyFixtureFrame(alloc, .{
+        .log_generation = ranking_test_generation,
+        .seq = 1,
+        .event_id = @splat(2),
+        .timestamp_ms = 10,
+        .event = .{ .session_started = .{
+            .id = @constCast(id),
+            .created_at_ms = 10,
+            .origin_workspace_root = @constCast(projected_workspace),
+            .workspace_root = @constCast(projected_workspace),
+            .conversation_language = .literal("en"),
+            .preferences = preferences,
+        } },
+    });
+    defer alloc.free(first);
+    const second = try session_event.encodeLegacyFixtureFrame(alloc, .{
+        .log_generation = ranking_test_generation,
+        .seq = 2,
+        .event_id = @splat(3),
+        .timestamp_ms = updated_at_ms,
+        .event = if (std.mem.eql(u8, projected_workspace, workspace)) .{ .preferences_changed = .{ .fast_mode = true } } else .{ .workspace_rebound = .{ .previous_workspace_root = @constCast(projected_workspace), .workspace_root = @constCast(workspace) } },
+    });
+    defer alloc.free(second);
+    var events = try dir.dir.createFile(std.testing.io, "events.jsonl", .{ .permissions = .fromMode(0o600) });
+    defer events.close(std.testing.io);
+    try events.writeStreamingAll(std.testing.io, first);
+    try events.writeStreamingAll(std.testing.io, second);
+    try writeRankingWatermark(alloc, &dir, id, 2, @splat(3), first.len + second.len);
+    const authority_id: session_event.Identifier = @splat(4);
+    const authority_hex = std.fmt.bytesToHex(authority_id, .lower);
+    const marker = try std.json.Stringify.valueAlloc(alloc, .{ .schema_version = @as(u32, 1), .storage_format = "event_log_v1", .session_id = id, .authority_id = @as([]const u8, &authority_hex), .source = "native_create" }, .{});
+    defer alloc.free(marker);
+    try io_mod.durableReplaceVerified(alloc, &dir, "authority.json", marker);
+    const manifest = try session_projection.encodeManifest(alloc, .{
+        .id = @constCast(id),
+        .authority_id = authority_id,
+        .log_generation = ranking_test_generation,
+        .created_at_ms = 10,
+        .updated_at_ms = 10,
+        .origin_workspace_root = @constCast(projected_workspace),
+        .workspace_root = @constCast(projected_workspace),
+        .conversation_language = .literal("en"),
+        .history_len = 0,
+        .total_input_tokens = 0,
+        .total_output_tokens = 0,
+        .last_event_seq = 1,
+        .event_log_bytes = first.len,
+        .event_log_stat_fingerprint = @splat(0),
+        .generation_base_seq = 1,
+        .generation_base_bytes = first.len,
+        .checkpoint_seq = null,
+        .checkpoint_sha256 = null,
+        .preferences = preferences,
+    });
+    defer alloc.free(manifest);
+    try io_mod.durableReplaceVerified(alloc, &dir, "session.json", manifest);
+}
+
+fn expectRankingSelection(store: Store, workspace: []const u8, expected: ?[]const u8) !void {
+    const alloc = std.testing.allocator;
+    const selected = try store.selectWritableLastId(alloc, workspace, .{});
+    defer if (selected) |id| alloc.free(id);
+    if (expected) |id| try std.testing.expectEqualStrings(id, selected.?) else try std.testing.expect(selected == null);
+}
+
+test "legacy ranking cache cold warm empty ties rebind and selected admission remain identical" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var ctx = try initTempStore(alloc, &tmp);
+    defer ctx.deinit(alloc);
+    try writeRankingFixture(alloc, ctx.store, "rank-a", "/old-workspace", ctx.workspace, 20);
+    try writeRankingFixture(alloc, ctx.store, "rank-b", "/old-workspace", ctx.workspace, 20);
+    {
+        var legacy = try ctx.store.openSessionDir("rank-a");
+        defer legacy.close();
+        var name_buffer: [64]u8 = undefined;
+        for (0..129) |index| {
+            const name = try std.fmt.bufPrint(&name_buffer, "commit.{x:0>32}.json", .{index});
+            var obsolete = try legacy.dir.createFile(std.testing.io, name, .{ .permissions = .fromMode(0o600) });
+            defer obsolete.close(std.testing.io);
+            try obsolete.writeStreamingAll(std.testing.io, "obsolete malformed watermark");
+        }
+    }
+    const trace_path = try std.fs.path.join(alloc, &.{ ctx.home, "ranking-trace.log" });
+    defer alloc.free(trace_path);
+    debug_trace.resetForTest();
+    try debug_trace.configureForTestWithScopes(alloc, trace_path, "session");
+    defer debug_trace.resetForTest();
+    try expectRankingSelection(ctx.store, ctx.workspace, "rank-b");
+    try expectRankingSelection(ctx.store, ctx.workspace, "rank-b");
+    try expectRankingSelection(ctx.store, "/old-workspace", null);
+    debug_trace.shutdown();
+    var trace_file = try std.Io.Dir.openFileAbsolute(std.testing.io, trace_path, .{});
+    defer trace_file.close(std.testing.io);
+    const trace = try io_mod.readFileToEnd(alloc, &trace_file, 64 * 1024);
+    defer alloc.free(trace);
+    try std.testing.expect(std.mem.find(u8, trace, "legacy ranking cache reused=0 refreshed=2") != null);
+    try std.testing.expect(std.mem.find(u8, trace, "legacy ranking cache reused=2 refreshed=0") != null);
+    var cache = try catalog_cache.Loaded.load(alloc, ctx.store.canonical_root.sessions, null);
+    defer cache.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 2), cache.rankingCount());
+    try std.testing.expectEqual(@as(usize, 0), cache.count());
+    {
+        var picker_state = try testDurableState(alloc, "rank-picker", "/picker-workspace");
+        defer picker_state.deinit(alloc);
+        picker_state.history = blk: {
+            const history = try alloc.alloc(session.HistoryTurn, 1);
+            errdefer alloc.free(history);
+            history[0] = try session.makeAssistantTurn(alloc, "saved question", "saved answer");
+            break :blk history;
+        };
+        var started = try ctx.store.startWritableSession(alloc, picker_state);
+        started.deinit(alloc);
+        var writer = (try catalog_cache.Writer.init(ctx.store)).?;
+        defer writer.deinit();
+        var picker = try @import("../subagent/resume_admission.zig").listActionableCatalog(ctx.store, alloc, null, null, &writer);
+        defer picker.deinit(alloc);
+        try std.testing.expectEqual(@as(usize, 1), picker.summaries.items.len);
+        try std.testing.expectEqualStrings("rank-picker", picker.summaries.items[0].id);
+        var preserved = try catalog_cache.Loaded.load(alloc, ctx.store.canonical_root.sessions, null);
+        defer preserved.deinit(alloc);
+        try std.testing.expectEqual(@as(usize, 2), preserved.rankingCount());
+        try std.testing.expectEqual(@as(usize, 1), preserved.count());
+        try expectRankingSelection(ctx.store, ctx.workspace, "rank-b");
+    }
+    var dir = try ctx.store.openSessionDir("rank-b");
+    defer dir.close();
+    {
+        var lock = try io_mod.acquireTimedAdvisoryLock(&dir, "session.lock", 0);
+        defer lock.release();
+        try std.testing.expectError(error.SessionBusy, ctx.store.resumeTargetForWrite(alloc, .last, ctx.workspace, .{ .log = .{ .session_lock_deadline_ms = 0 } }));
+    }
+    var resumed = try ctx.store.resumeTargetForWrite(alloc, .last, ctx.workspace, .{});
+    defer resumed.deinit(alloc);
+    try std.testing.expectEqualStrings("rank-b", resumed.active_id);
+    try std.testing.expectEqualStrings(ctx.workspace, resumed.state.workspace_root);
+    try std.testing.expectEqual(@as(usize, 0), resumed.state.history.len);
+}
+
+test "legacy ranking cache read only cold warm never writes and corruption rebuilds" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var ctx = try initTempStore(alloc, &tmp);
+    defer ctx.deinit(alloc);
+    try writeRankingFixture(alloc, ctx.store, "rank-readonly", ctx.workspace, ctx.workspace, 20);
+    var readonly = try Store.initReadOnlyFromHome(alloc, ctx.home, ctx.workspace);
+    defer readonly.deinit(alloc);
+    try std.testing.expect((try catalog_cache.Writer.init(readonly)) == null);
+    try expectRankingSelection(readonly, ctx.workspace, "rank-readonly");
+    const root = ctx.store.canonical_root.sessions.?;
+    try std.testing.expectError(error.FileNotFound, root.dir.statFile(std.testing.io, ".resume-catalog", .{}));
+    try expectRankingSelection(ctx.store, ctx.workspace, "rank-readonly");
+    const before = try root.dir.statFile(std.testing.io, ".resume-catalog", .{});
+    try expectRankingSelection(readonly, ctx.workspace, "rank-readonly");
+    const after = try root.dir.statFile(std.testing.io, ".resume-catalog", .{});
+    try std.testing.expectEqual(before.inode, after.inode);
+    try std.testing.expectEqual(before.mtime, after.mtime);
+    try std.testing.expectEqual(before.ctime, after.ctime);
+    var cache_dir = root;
+    try io_mod.durableReplaceVerified(alloc, &cache_dir, ".resume-catalog", "invalid");
+    try expectRankingSelection(readonly, ctx.workspace, "rank-readonly");
+    var invalid = try catalog_cache.Loaded.load(alloc, root, null);
+    defer invalid.deinit(alloc);
+    try std.testing.expect(!invalid.present());
+    try expectRankingSelection(ctx.store, ctx.workspace, "rank-readonly");
+    var rebuilt = try catalog_cache.Loaded.load(alloc, root, null);
+    defer rebuilt.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 1), rebuilt.rankingCount());
+    var session_dir = try ctx.store.openSessionDir("rank-readonly");
+    defer session_dir.close();
+    try io_mod.durableReplaceVerified(alloc, &session_dir, ranking_test_watermark, "{}");
+    try std.testing.expectError(error.InvalidSessionFormat, readonly.selectWritableLastId(alloc, ctx.workspace, .{}));
+    try root.dir.deleteFile(std.testing.io, ".resume-catalog");
+    try std.testing.expectError(error.InvalidSessionFormat, readonly.selectWritableLastId(alloc, ctx.workspace, .{}));
+    try std.testing.expectError(error.FileNotFound, root.dir.statFile(std.testing.io, ".resume-catalog", .{}));
+}
+
+test "legacy ranking cache watermark-only commit revalidates workspace and ordering" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var ctx = try initTempStore(alloc, &tmp);
+    defer ctx.deinit(alloc);
+    try writeRankingFixture(alloc, ctx.store, "rank-watermark", ctx.workspace, ctx.workspace, 20);
+    var dir = try ctx.store.openSessionDir("rank-watermark");
+    defer dir.close();
+    const next = try session_event.encodeLegacyFixtureFrame(alloc, .{
+        .log_generation = ranking_test_generation,
+        .seq = 3,
+        .event_id = @splat(5),
+        .timestamp_ms = 40,
+        .event = .{ .workspace_rebound = .{ .previous_workspace_root = ctx.workspace, .workspace_root = @constCast("/rebound") } },
+    });
+    defer alloc.free(next);
+    var events = try dir.dir.openFile(std.testing.io, "events.jsonl", .{ .mode = .read_write });
+    defer events.close(std.testing.io);
+    const bytes = (try events.stat(std.testing.io)).size;
+    try events.writePositionalAll(std.testing.io, next, bytes);
+    try expectRankingSelection(ctx.store, ctx.workspace, "rank-watermark");
+    try expectRankingSelection(ctx.store, ctx.workspace, "rank-watermark");
+    const before = try events.stat(std.testing.io);
+    try writeRankingWatermark(alloc, &dir, "rank-watermark", 3, @splat(5), bytes + next.len);
+    try expectRankingSelection(ctx.store, ctx.workspace, null);
+    try expectRankingSelection(ctx.store, "/rebound", "rank-watermark");
+    try std.testing.expectEqual(before.mtime, (try events.stat(std.testing.io)).mtime);
+    try std.testing.expectEqual(before.ctime, (try events.stat(std.testing.io)).ctime);
+}
+
+test "legacy ranking cache changed event generation selects and caches only the new watermark" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var ctx = try initTempStore(alloc, &tmp);
+    defer ctx.deinit(alloc);
+    const id = "rank-generation";
+    try writeRankingFixture(alloc, ctx.store, id, ctx.workspace, ctx.workspace, 20);
+    try expectRankingSelection(ctx.store, ctx.workspace, id);
+    const root = ctx.store.canonical_root.sessions.?;
+    var old = try catalog_cache.Loaded.load(alloc, root, null);
+    defer old.deinit(alloc);
+    try std.testing.expectEqual(ranking_test_generation, old.rankingGeneration(id).?);
+    var dir = try ctx.store.openSessionDir(id);
+    defer dir.close();
+    const generation: session_event.Identifier = @splat(6);
+    const generation_hex = std.fmt.bytesToHex(generation, .lower);
+    const first = try session_event.encodeLegacyFixtureFrame(alloc, .{
+        .log_generation = generation,
+        .seq = 1,
+        .event_id = generation,
+        .timestamp_ms = 40,
+        .event = .{ .session_started = .{
+            .id = @constCast(id),
+            .created_at_ms = 10,
+            .origin_workspace_root = ctx.workspace,
+            .workspace_root = @constCast("/new-generation"),
+            .conversation_language = .literal("en"),
+            .preferences = .{ .model = @constCast("test/model"), .effort = .auto, .fast_mode = false },
+        } },
+    });
+    defer alloc.free(first);
+    // Keep the old watermark and stale manifest; only the event generation decides.
+    var events = try dir.dir.openFile(std.testing.io, "events.jsonl", .{ .mode = .read_write });
+    defer events.close(std.testing.io);
+    try events.writePositionalAll(std.testing.io, first, 0);
+    try events.setLength(std.testing.io, first.len);
+    const watermark = try std.json.Stringify.valueAlloc(alloc, .{
+        .schema_version = @as(u32, 1),
+        .session_id = id,
+        .log_generation = @as([]const u8, &generation_hex),
+        .through_seq = @as(u64, 1),
+        .through_event_id = @as([]const u8, &generation_hex),
+        .through_event_log_bytes = first.len,
+    }, .{});
+    defer alloc.free(watermark);
+    var name_buffer: [64]u8 = undefined;
+    const name = try std.fmt.bufPrint(&name_buffer, "commit.{s}.json", .{generation_hex});
+    try io_mod.durableReplaceVerified(alloc, &dir, name, watermark);
+    const changed = (try catalog_cache.rankingFingerprint(root.dir, id, ranking_test_generation)).?;
+    try std.testing.expect((try old.reuseRanking(alloc, id, changed)) == null);
+    try expectRankingSelection(ctx.store, ctx.workspace, null);
+    try expectRankingSelection(ctx.store, "/new-generation", id);
+    var refreshed = try catalog_cache.Loaded.load(alloc, root, null);
+    defer refreshed.deinit(alloc);
+    try std.testing.expectEqual(generation, refreshed.rankingGeneration(id).?);
+    var scan = Store.RankingScan{ .cache = try catalog_cache.Loaded.load(alloc, root, null) };
+    defer scan.deinit(alloc);
+    var candidate = (try ctx.store.resolveWritableCandidate(alloc, id, "/new-generation", .{}, &scan)).?;
+    defer candidate.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 1), scan.reused);
+    try std.testing.expectEqual(@as(usize, 0), scan.refreshed);
+    try std.testing.expectEqual(@as(i64, 40), candidate.updated_at_ms);
+}
+
+test "legacy ranking cache never caches foreign failed replay and failed scans never publish" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var ctx = try initTempStore(alloc, &tmp);
+    defer ctx.deinit(alloc);
+    try writeRankingFixture(alloc, ctx.store, "rank-good", ctx.workspace, ctx.workspace, 20);
+    try writeRankingFixture(alloc, ctx.store, "rank-broken", "/foreign", "/foreign", 40);
+    var dir = try ctx.store.openSessionDir("rank-broken");
+    defer dir.close();
+    try io_mod.durableReplaceVerified(alloc, &dir, ranking_test_watermark, "{}");
+    try expectRankingSelection(ctx.store, ctx.workspace, "rank-good");
+    var cached = try catalog_cache.Loaded.load(alloc, ctx.store.canonical_root.sessions, null);
+    defer cached.deinit(alloc);
+    const stamp = (try catalog_cache.rankingFingerprint(ctx.store.canonical_root.sessions.?.dir, "rank-broken", ranking_test_generation)).?;
+    try std.testing.expect((try cached.reuseRanking(alloc, "rank-broken", stamp)) == null);
+    const root = ctx.store.canonical_root.sessions.?.dir;
+    const before = try root.statFile(std.testing.io, ".resume-catalog", .{});
+    try std.testing.expectError(error.InvalidSessionFormat, ctx.store.selectWritableLastId(alloc, "/foreign", .{}));
+    const after = try root.statFile(std.testing.io, ".resume-catalog", .{});
+    try std.testing.expectEqual(before.inode, after.inode);
+    try std.testing.expectEqual(before.mtime, after.mtime);
+    try root.deleteFile(std.testing.io, ".resume-catalog");
+    try std.testing.expectError(error.InvalidSessionFormat, ctx.store.selectWritableLastId(alloc, "/foreign", .{}));
+    try std.testing.expectError(error.FileNotFound, root.statFile(std.testing.io, ".resume-catalog", .{}));
+}
+
+test "legacy ranking cache observations clean allocation failures and never publish truncated scans" {
+    const alloc = std.testing.allocator;
+    try std.testing.checkAllAllocationFailures(alloc, struct {
+        fn check(a: Allocator) !void {
+            var scan = Store.RankingScan{ .cache = .{} };
+            defer scan.deinit(a);
+            try scan.observe(a, @splat(1), "rank", "/workspace", 20, ranking_test_generation);
+            try std.testing.expectEqual(@as(usize, 1), scan.rows.items.len);
+        }
+    }.check, .{});
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var ctx = try initTempStore(alloc, &tmp);
+    defer ctx.deinit(alloc);
+    var scan = Store.RankingScan{ .cache = .{}, .remaining_bytes = 0 };
+    defer scan.deinit(alloc);
+    try scan.observe(alloc, @splat(1), "rank", "/workspace", 20, ranking_test_generation);
+    try std.testing.expect(!scan.publishable);
+    scan.publish(ctx.store, alloc);
+    try std.testing.expectError(error.FileNotFound, ctx.store.canonical_root.sessions.?.dir.statFile(std.testing.io, ".resume-catalog", .{}));
+}
+
+test "legacy ranking publication rejects route changes during priming" {
+    const alloc = std.testing.allocator;
+    const Mutation = enum { fence, unsupported_manifest, missing_manifest, bad_manifest, invalid_authority };
+    for (std.enums.values(Mutation)) |mutation| {
+        var tmp = std.testing.tmpDir(.{});
+        defer tmp.cleanup();
+        var ctx = try initTempStore(alloc, &tmp);
+        defer ctx.deinit(alloc);
+        const id = "rank-priming";
+        try writeRankingFixture(alloc, ctx.store, id, ctx.workspace, ctx.workspace, 20);
+        var dir = try ctx.store.openSessionDir(id);
+        defer dir.close();
+        try std.testing.expectEqual(.schema_v3, try classifyAuthority(alloc, &dir, id));
+        var initial = try classifySchemaV3Candidate(alloc, &dir, id);
+        defer initial.deinit(alloc);
+        try std.testing.expectEqual(.stale, initial.projection_state);
+
+        // Reproduce the gap without a hook: mutate after initial classification
+        // but before the first fingerprint, leaving replay's inputs unchanged.
+        switch (mutation) {
+            .fence => try io_mod.durableReplaceVerified(alloc, &dir, "authority.pending.json", "pending"),
+            .unsupported_manifest => try io_mod.durableReplaceVerified(alloc, &dir, "session.json", "{\"schema_version\":99}"),
+            .missing_manifest => try dir.dir.deleteFile(std.testing.io, "session.json"),
+            .bad_manifest => try io_mod.durableReplaceVerified(alloc, &dir, "session.json", "{\"schema_version\":3}"),
+            .invalid_authority => try io_mod.durableReplaceVerified(alloc, &dir, "authority.json", "{}"),
+        }
+        const root = ctx.store.canonical_root.sessions.?;
+        const before = (try catalog_cache.rankingFingerprintForOpenSession(root.dir, id, dir.dir, ranking_test_generation)).?;
+        var source = try loadSchemaV3ReadOnly(alloc, &dir, id);
+        defer source.deinit(alloc);
+        try std.testing.expectEqualStrings(id, source.state.id);
+        try std.testing.expectEqual(@as(i64, 20), source.state.updated_at_ms);
+        const after = (try catalog_cache.rankingFingerprintForOpenSession(root.dir, id, dir.dir, source.generation)).?;
+        try std.testing.expectEqual(before, after);
+
+        var scan = Store.RankingScan{ .cache = .{}, .refreshed = 1 };
+        defer scan.deinit(alloc);
+        if (ctx.store.rankingPublicationFingerprint(alloc, &dir, id, before, ranking_test_generation, source.generation)) |stamp| {
+            try scan.observe(alloc, stamp, id, source.state.workspace_root, source.state.updated_at_ms, source.generation);
+        }
+        try std.testing.expectEqual(@as(usize, 0), scan.rows.items.len);
+        scan.publish(ctx.store, alloc);
+        var loaded = try catalog_cache.Loaded.load(alloc, root, null);
+        defer loaded.deinit(alloc);
+        try std.testing.expectEqual(@as(usize, 0), loaded.rankingCount());
+        try std.testing.expect((try loaded.reuseRanking(alloc, id, after)) == null);
+        if (mutation == .missing_manifest or mutation == .bad_manifest) {
+            // Stricter cache eligibility must not exclude recoverable sessions.
+            try expectRankingSelection(ctx.store, ctx.workspace, id);
+            try expectRankingSelection(ctx.store, ctx.workspace, id);
+            var uncached = try catalog_cache.Loaded.load(alloc, root, null);
+            defer uncached.deinit(alloc);
+            try std.testing.expectEqual(@as(usize, 0), uncached.rankingCount());
+        }
+    }
+}
+
+test "legacy ranking early hits expose postpriming manifest and fence errors" {
+    const alloc = std.testing.allocator;
+    for ([_]bool{ false, true }) |fenced| {
+        var tmp = std.testing.tmpDir(.{});
+        defer tmp.cleanup();
+        var ctx = try initTempStore(alloc, &tmp);
+        defer ctx.deinit(alloc);
+        const id = "rank-early-error";
+        try writeRankingFixture(alloc, ctx.store, id, ctx.workspace, ctx.workspace, 20);
+        var dir = try ctx.store.openSessionDir(id);
+        defer dir.close();
+        // This snapshot is irrelevant until the fence appears.
+        if (fenced) try io_mod.durableReplaceVerified(alloc, &dir, "session.legacy.json", "{broken");
+        try expectRankingSelection(ctx.store, ctx.workspace, id);
+        const root = ctx.store.canonical_root.sessions.?;
+        var primed = try catalog_cache.Loaded.load(alloc, root, null);
+        defer primed.deinit(alloc);
+        try std.testing.expectEqual(@as(usize, 1), primed.rankingCount());
+        const cache_stat = try root.dir.statFile(std.testing.io, ".resume-catalog", .{});
+        if (fenced) {
+            try io_mod.durableReplaceVerified(alloc, &dir, "authority.pending.json", "pending");
+        } else {
+            try io_mod.durableReplaceVerified(alloc, &dir, "session.json", "{\"schema_version\":99}");
+        }
+        const cached_error = blk: {
+            const selected = ctx.store.selectWritableLastId(alloc, ctx.workspace, .{}) catch |err| break :blk err;
+            if (selected) |value| alloc.free(value);
+            return error.TestExpectedError;
+        };
+        const retained = try root.dir.statFile(std.testing.io, ".resume-catalog", .{});
+        try std.testing.expectEqual(cache_stat.inode, retained.inode);
+        try std.testing.expectEqual(cache_stat.mtime, retained.mtime);
+        try root.dir.deleteFile(std.testing.io, ".resume-catalog");
+        try std.testing.expectError(cached_error, ctx.store.selectWritableLastId(alloc, ctx.workspace, .{}));
+        try std.testing.expectError(error.FileNotFound, root.dir.statFile(std.testing.io, ".resume-catalog", .{}));
+    }
+}
+
+test "legacy ranking publication rechecks are optional and source bound" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var ctx = try initTempStore(alloc, &tmp);
+    defer ctx.deinit(alloc);
+    const id = "rank-proof";
+    try writeRankingFixture(alloc, ctx.store, id, ctx.workspace, ctx.workspace, 20);
+    var dir = try ctx.store.openSessionDir(id);
+    defer dir.close();
+    const root = ctx.store.canonical_root.sessions.?;
+    const before = (try catalog_cache.rankingFingerprint(root.dir, id, ranking_test_generation)).?;
+    var source = try loadSchemaV3ReadOnly(alloc, &dir, id);
+    defer source.deinit(alloc);
+    try std.testing.expectEqual(before, ctx.store.rankingPublicationFingerprint(alloc, &dir, id, before, ranking_test_generation, source.generation).?);
+    try std.testing.expect(ctx.store.rankingPublicationFingerprint(alloc, &dir, id, before, @splat(9), source.generation) == null);
+    var failing = std.testing.FailingAllocator.init(alloc, .{ .fail_index = 0 });
+    try std.testing.expect(ctx.store.rankingPublicationFingerprint(failing.allocator(), &dir, id, before, ranking_test_generation, source.generation) == null);
+    try std.testing.expectEqual(@as(i64, 20), source.state.updated_at_ms);
+    try expectRankingSelection(ctx.store, ctx.workspace, id);
+    var manifest = try dir.dir.openFile(std.testing.io, "session.json", .{});
+    defer manifest.close(std.testing.io);
+    try manifest.setPermissions(std.testing.io, .fromMode(0o640));
+    try std.testing.expect(ctx.store.rankingPublicationFingerprint(alloc, &dir, id, before, ranking_test_generation, source.generation) == null);
+    var scan = Store.RankingScan{ .cache = try catalog_cache.Loaded.load(alloc, root, null) };
+    defer scan.deinit(alloc);
+    var candidate = (try ctx.store.resolveWritableCandidate(alloc, id, ctx.workspace, .{}, &scan)).?;
+    defer candidate.deinit(alloc);
+    try std.testing.expectEqualStrings(id, candidate.id);
+    try std.testing.expectEqual(@as(usize, 0), scan.reused);
+    try std.testing.expectEqual(@as(usize, 1), scan.refreshed);
+}
+
+test "legacy ranking publication excludes current projections and conversation metadata" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var ctx = try initTempStore(alloc, &tmp);
+    defer ctx.deinit(alloc);
+    const root = ctx.store.canonical_root.sessions.?;
+    const id = "rank-current-projection";
+    try writeRankingFixture(alloc, ctx.store, id, ctx.workspace, ctx.workspace, 20);
+    var dir = try ctx.store.openSessionDir(id);
+    defer dir.close();
+    const bytes = (try authority_module.readOptionalSessionFile(alloc, &dir, "session.json", session_projection.manifest_max_bytes)).?;
+    defer alloc.free(bytes);
+    var manifest = try session_projection.decodeManifest(alloc, bytes);
+    defer manifest.deinit(alloc);
+    const stat = try authority_module.eventFileStat(&dir, "events.jsonl");
+    manifest.event_log_bytes = stat.size;
+    manifest.last_event_seq = 2;
+    manifest.updated_at_ms = 20;
+    manifest.event_log_stat_fingerprint = try session_projection.eventFileStatFingerprint(stat, stat.size);
+    const encoded = try session_projection.encodeManifest(alloc, manifest);
+    defer alloc.free(encoded);
+    try io_mod.durableReplaceVerified(alloc, &dir, "session.json", encoded);
+    const before = (try catalog_cache.rankingFingerprint(root.dir, id, ranking_test_generation)).?;
+    var current = try classifySchemaV3Candidate(alloc, &dir, id);
+    defer current.deinit(alloc);
+    try std.testing.expectEqual(.current, current.projection_state);
+    try std.testing.expect(ctx.store.rankingPublicationFingerprint(alloc, &dir, id, before, ranking_test_generation, ranking_test_generation) == null);
+
+    var state = try testDurableState(alloc, "rank-current-format", ctx.workspace);
+    defer state.deinit(alloc);
+    var writable = try ctx.store.startWritableSession(alloc, state);
+    writable.deinit(alloc);
+    var conversation = try ctx.store.openSessionDir(state.id);
+    defer conversation.close();
+    const conversation_before = (try catalog_cache.rankingFingerprint(root.dir, state.id, ranking_test_generation)).?;
+    try std.testing.expect(ctx.store.rankingPublicationFingerprint(alloc, &conversation, state.id, conversation_before, ranking_test_generation, ranking_test_generation) == null);
+}
+
+test "legacy ranking cache changed authority preserves errors and best effort publication" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var ctx = try initTempStore(alloc, &tmp);
+    defer ctx.deinit(alloc);
+    try writeRankingFixture(alloc, ctx.store, "rank-authority", ctx.workspace, ctx.workspace, 20);
+    try expectRankingSelection(ctx.store, ctx.workspace, "rank-authority");
+    var dir = try ctx.store.openSessionDir("rank-authority");
+    defer dir.close();
+    var authority = try dir.dir.openFile(std.testing.io, "authority.json", .{ .mode = .read_write });
+    defer authority.close(std.testing.io);
+    try authority.writePositionalAll(std.testing.io, "!", 0);
+    try std.testing.expectError(error.InvalidSessionFormat, ctx.store.selectWritableLastId(alloc, ctx.workspace, .{}));
+    const root = ctx.store.canonical_root.sessions.?.dir;
+    try root.deleteFile(std.testing.io, ".resume-catalog");
+    try std.testing.expectError(error.InvalidSessionFormat, ctx.store.selectWritableLastId(alloc, ctx.workspace, .{}));
+    try writeRankingFixture(alloc, ctx.store, "rank-authority", ctx.workspace, ctx.workspace, 20);
+    // A directory at the disposable cache path prevents publication, not selection.
+    try root.createDir(std.testing.io, ".resume-catalog", .fromMode(0o700));
+    try expectRankingSelection(ctx.store, ctx.workspace, "rank-authority");
 }
 
 test "resume last selects conversation metadata without cache files" {

--- a/src/core/subagent/resume_admission.zig
+++ b/src/core/subagent/resume_admission.zig
@@ -194,7 +194,7 @@ pub fn listActionableCatalog(
                 errdefer copy.deinit(alloc);
                 try catalog.summaries.append(alloc, copy);
             },
-            .excluded => {},
+            .excluded, .legacy_ranking => {},
         }
     }
     if (cache_writer) |writer| {

--- a/tests/e2e/session-recovery.test.ts
+++ b/tests/e2e/session-recovery.test.ts
@@ -642,6 +642,7 @@ describe("session recovery", () => {
           await tui.waitForText(LEGACY_TITLE, TIMEOUT);
           await tui.waitForPane(() => readFileSync(trace, "utf8").includes("session catalog cache reused="), TIMEOUT);
           await tui.sendKeys("Escape");
+          await tui.waitForPane((pane) => !pane.includes("Esc Close"), TIMEOUT);
           await tui.waitForComposer(TIMEOUT);
         }
         await tui.sendText("/quit");

--- a/tests/e2e/session-recovery.test.ts
+++ b/tests/e2e/session-recovery.test.ts
@@ -617,6 +617,55 @@ describe("session recovery", () => {
     }
   }, TIMEOUT);
 
+  test.skipIf(!tmuxAvailable())("continue reuses legacy ranking after opening the resume picker", async () => {
+    const fixture = createFixture("fx-continue-ranking-cache-");
+    const legacy = createLegacySession(fixture, 3);
+    const gateway = startFakeGateway([fakeGatewayFinalText("LATEST_CACHE_HISTORY")]);
+    let tui: TmuxSession | null = null;
+    try {
+      const id = await createSavedSession(fixture, gateway);
+      const before = savedFileHashes(legacy.source);
+      for (const iteration of [0, 1]) {
+        const trace = join(fixture.root, `ranking-${iteration}.trace`);
+        const stderrPath = join(fixture.root, `ranking-${iteration}.stderr`);
+        tui = await TmuxSession.create({
+          cmd: `${JSON.stringify(FX_BIN)} -c`, cwd: fixture.workspace, stderrPath,
+          env: { ...gatewayEnv(fixture, gateway), FX_TRACE_LOG: trace, FX_TRACE_SCOPES: "session,core" },
+        });
+        await tui.waitForComposer(TIMEOUT);
+        await tui.waitForText("LATEST_CACHE_HISTORY", TIMEOUT);
+        expect(readFileSync(trace, "utf8")).toContain(iteration === 0
+          ? "legacy ranking cache reused=0 refreshed=1"
+          : "legacy ranking cache reused=1 refreshed=0");
+        if (iteration === 0) {
+          await tui.sendText("/resume");
+          await tui.waitForText(LEGACY_TITLE, TIMEOUT);
+          await tui.waitForPane(() => readFileSync(trace, "utf8").includes("session catalog cache reused="), TIMEOUT);
+          await tui.sendKeys("Escape");
+          await tui.waitForComposer(TIMEOUT);
+        }
+        await tui.sendText("/quit");
+        expect(await tui.waitForSessionEnd(TIMEOUT)).toBe(true);
+        expect(readFileSync(stderrPath, "utf8")).toBe("");
+        expect(savedFileHashes(legacy.source)).toEqual(before);
+        expect(gateway.requests).toHaveLength(1);
+        expect(gateway.classifierRequests).toHaveLength(0);
+        await tui.kill();
+        tui = null;
+      }
+      const resumed = await runFx(["session", "--id", id, "--json"], {
+        cwd: fixture.workspace, env: gatewayEnv(fixture, gateway), timeoutMs: TIMEOUT,
+      });
+      expect(resumed.code).toBe(0);
+      expect(resumed.stderr).toBe("");
+      expect(resumed.stdout).toContain("LATEST_CACHE_HISTORY");
+    } finally {
+      await tui?.kill();
+      gateway.stop();
+      rmSync(fixture.root, { recursive: true, force: true });
+    }
+  }, TIMEOUT * 2);
+
   for (const { version, entry } of [
     { version: 2, entry: "-r" },
     { version: 3, entry: "/resume" },


### PR DESCRIPTION
## Summary

- Reuse validated legacy-session summaries on repeated continuation instead of replaying unchanged histories. The first scan still validates those histories.
- Preserve the cached summaries when opening the resume picker.
- Revalidate changed session files and rebuild missing or invalid cache data without bypassing session admission or recovery checks.