### PR TITLE
Report rejected shell calls consistently

### DIFF
--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -8504,12 +8504,6 @@ fn processQueuedPromptLoop(
             switch (prepared_tool_call) {
                 .blocked => |blocked| {
                     if (blocked.kind == .malformed_arguments) {
-                        try stream_ctx.provisional_statuses.finishMalformedToolArguments(
-                            deps,
-                            arena,
-                            turn_id,
-                            tool_call,
-                        );
                         debug_trace.eventf(
                             "tool",
                             "argument_integrity_rejected",
@@ -8547,8 +8541,7 @@ fn processQueuedPromptLoop(
                         .model_output = blocked.model_output.?,
                     };
                     const prepared = try runtime_execution_memory.prepareToolExecutionOutput(arena, config, tool_call, execution, null);
-                    if (blocked.kind != .malformed_arguments and
-                        blocked.kind != .route_unavailable and
+                    if (blocked.kind != .route_unavailable and
                         blocked.kind != .required_vision)
                     {
                         _ = try stream_ctx.provisional_statuses.finishExecutedCall(

--- a/src/core/agent/runtime/tests/tool_flow.zig
+++ b/src/core/agent/runtime/tests/tool_flow.zig
@@ -1041,6 +1041,49 @@ test "processQueuedPrompt recovers malformed local arguments before tool semanti
     try std.testing.expect(tool_result_errors.isToolExecutionFailedOutput(execution.tool_steps[0].tool_results[0].output));
 }
 
+test "processQueuedPrompt settles rejected shell arguments without streamed activity" {
+    const alloc = std.testing.allocator;
+    for ([_]types.ToolArgumentIntegrity{ .malformed_json, .non_object_json }) |integrity| {
+        const calls = [_]ToolCall{.{
+            .id = "rejected_shell",
+            .name = "shell",
+            .arguments_json = "{}",
+            .argument_integrity = integrity,
+        }};
+        const completions = [_]FakeCompletion{
+            .{ .tool_calls = &calls },
+            .{ .content = "Recovered." },
+        };
+        var gateway = FakeGateway.init(alloc, &completions);
+        defer gateway.deinit();
+        var hooks = FakeAgentRuntimeDeps.init(alloc);
+        defer hooks.deinit();
+        var fixture = PromptFixture{};
+
+        try runFakePrompt(&gateway, &hooks, fixture.config(), fixture.job());
+
+        try expectSingleTerminalOutcome(hooks.lifecycle_events.items, "rejected_shell", .failed);
+        try std.testing.expectEqual(@as(usize, 2), gateway.request_bodies.items.len);
+        try std.testing.expectEqual(@as(usize, 0), hooks.validated_names.items.len);
+        try std.testing.expectEqual(@as(usize, 0), hooks.permission_names.items.len);
+        try std.testing.expectEqual(@as(usize, 0), hooks.executed_names.items.len);
+        try std.testing.expectEqual(@as(usize, 1), hooks.rejected_names.items.len);
+        const steps = hooks.history_turns.items[0].assistant.execution.tool_steps;
+        try std.testing.expectEqual(@as(usize, 1), steps.len);
+        try std.testing.expectEqualStrings("{}", steps[0].tool_calls[0].arguments_json);
+        try std.testing.expectEqual(@as(usize, 1), steps[0].tool_results.len);
+        try std.testing.expectEqual(types.PersistedToolStatus.failure, steps[0].tool_results[0].status);
+        for (hooks.lifecycle_events.items) |event| switch (event) {
+            .terminal => |terminal| {
+                try std.testing.expectEqualStrings(steps[0].tool_results[0].output, terminal.result.?);
+                const detail = if (integrity == .malformed_json) "invalid JSON arguments" else "non-object arguments";
+                try std.testing.expect(std.mem.find(u8, terminal.outcome.summary, detail) != null);
+            },
+            else => {},
+        };
+    }
+}
+
 test "processQueuedPrompt malformed parallel call preserves valid sibling exactly once" {
     const alloc = std.testing.allocator;
     const calls = [_]ToolCall{
@@ -1078,10 +1121,8 @@ test "processQueuedPrompt malformed parallel call preserves valid sibling exactl
     try std.testing.expectEqual(@as(usize, 1), hooks.rejected_names.items.len);
     try std.testing.expectEqualStrings("web_fetch", hooks.rejected_names.items[0]);
     try std.testing.expectEqual(@as(usize, 0), hooks.propagated_grants.items.len);
-    try expectLifecycleCallIds(
-        hooks.lifecycle_events.items,
-        &.{ "call_read", "call_read", "call_read" },
-    );
+    try expectSingleTerminalOutcome(hooks.lifecycle_events.items, "call_fetch", .failed);
+    try expectSingleTerminalOutcome(hooks.lifecycle_events.items, "call_read", .completed);
 }
 
 test "processQueuedPrompt malformed parallel fallback emits one terminal and rejection trace" {

--- a/src/core/agent/runtime/tool_batch.zig
+++ b/src/core/agent/runtime/tool_batch.zig
@@ -209,11 +209,19 @@ pub fn assembleParallelToolResults(
                 };
             }
         } else if (original_call.argument_integrity != .valid) {
-            try provisional_statuses.finishMalformedToolArguments(
+            _ = try provisional_statuses.finishExecutedCall(
                 hooks,
+                provisional_alloc,
                 arena,
                 turn_id,
                 original_call,
+                parallel_status_started[original_index],
+                null,
+                execution,
+                safe_tool_output,
+                prepared.memory,
+                null,
+                advertised_dynamic_tool_names,
             );
             debug_trace.eventf(
                 "tool",

--- a/src/core/agent/runtime/tool_presentation.zig
+++ b/src/core/agent/runtime/tool_presentation.zig
@@ -739,13 +739,13 @@ pub noinline fn startToolVisibleLifecycle(
     const activity_kind = activityKindForCall(arena, hooks.tool_registry, call);
     if (activity_kind == .ask) return false;
     const redacted_arguments = try text_utils.maskSecrets(arena, call.arguments_json);
-    const activity_line = try hooks.describe_tool_action(
+    const activity_line = if (call.argument_integrity == .valid) try hooks.describe_tool_action(
         hooks.ctx,
         arena,
         call,
         display_target,
         advertised_dynamic_tool_names,
-    );
+    ) else null;
     try hooks.push_tool_lifecycle(hooks.ctx, .{ .authoritative_started = .{
         .id = .{ .turn_id = turn_id, .call_id = call.id },
         .presentation_group_id = presentation_group_id,
@@ -755,10 +755,12 @@ pub noinline fn startToolVisibleLifecycle(
         .arguments_json = redacted_arguments,
         .place_after_current_transcript = false,
     } });
-    try hooks.push_tool_lifecycle(hooks.ctx, .{ .progress = .{
-        .id = .{ .turn_id = turn_id, .call_id = call.id },
-        .text = activity_line,
-    } });
+    if (activity_line) |line| {
+        try hooks.push_tool_lifecycle(hooks.ctx, .{ .progress = .{
+            .id = .{ .turn_id = turn_id, .call_id = call.id },
+            .text = line,
+        } });
+    }
     return true;
 }
 
@@ -1204,6 +1206,11 @@ fn failureStatusDetail(
     safe_result: []const u8,
     advertised_dynamic_tool_names: []const []const u8,
 ) !?[]const u8 {
+    switch (call.argument_integrity) {
+        .malformed_json => return "invalid JSON arguments",
+        .non_object_json => return "non-object arguments",
+        .valid => {},
+    }
     if (result.status_detail) |detail| {
         if (!std.mem.eql(u8, detail, "preflight failed")) return detail;
 
@@ -2016,6 +2023,91 @@ test "admitted provisional settlement consumes visible identity exactly once" {
     }
 }
 
+test "malformed final settlement retains diagnostics and consumes identity once" {
+    const alloc = std.testing.allocator;
+    for ([_]bool{ false, true }) |streamed| {
+        var arena_state = std.heap.ArenaAllocator.init(alloc);
+        defer arena_state.deinit();
+        const arena = arena_state.allocator();
+        var capture = ProvisionalStatusTestCapture{ .alloc = alloc };
+        defer capture.deinit();
+        const hooks = capture.hooks();
+        var statuses = ProvisionalToolStatuses{};
+        defer statuses.deinit(alloc);
+        if (streamed) _ = try statuses.record(alloc, "streamed_id");
+        const call: ToolCall = .{
+            .id = "final_id",
+            .name = "shell",
+            .arguments_json = "{}",
+            .argument_integrity = .malformed_json,
+            .provisional_id = if (streamed) "streamed_id" else null,
+        };
+        const result: ToolExecutionResult = .{ .status = .failure, .model_output = "safe diagnostic" };
+        const memory: types.ToolResultMemory = .{ .output_bytes = 15, .stored_output_bytes = 15 };
+        capture.fail_terminal = true;
+        try std.testing.expectError(error.TestTerminalPublicationFailure, statuses.finishExecutedCall(
+            &hooks,
+            alloc,
+            arena,
+            1,
+            call,
+            false,
+            null,
+            result,
+            result.model_output,
+            memory,
+            null,
+            &.{},
+        ));
+        try std.testing.expect(!statuses.hasTerminal(call.id));
+        if (streamed) try std.testing.expect(statuses.has("streamed_id"));
+        capture.fail_terminal = false;
+        try std.testing.expect(try statuses.finishExecutedCall(
+            &hooks,
+            alloc,
+            arena,
+            1,
+            call,
+            false,
+            null,
+            result,
+            result.model_output,
+            memory,
+            null,
+            &.{},
+        ));
+        try std.testing.expect(!try statuses.finishExecutedCall(
+            &hooks,
+            alloc,
+            arena,
+            1,
+            call,
+            false,
+            null,
+            result,
+            result.model_output,
+            memory,
+            null,
+            &.{},
+        ));
+        try std.testing.expectEqual(@as(usize, 0), statuses.tracked.items.len);
+        var terminal_count: usize = 0;
+        for (capture.events.items) |event| switch (event) {
+            .terminal => |terminal| {
+                terminal_count += 1;
+                try std.testing.expectEqualStrings(if (streamed) "streamed_id" else "final_id", terminal.id.call_id);
+                try std.testing.expectEqual(types.ToolOutcomeKind.failed, terminal.outcome.kind);
+                try std.testing.expectEqualStrings("Failed shell: invalid JSON arguments", terminal.outcome.summary);
+                try std.testing.expectEqualStrings(result.model_output, terminal.result.?);
+                try std.testing.expectEqual(@as(usize, 15), terminal.result_memory.?.output_bytes);
+            },
+            .progress => return error.TestUnexpectedResult,
+            else => {},
+        };
+        try std.testing.expectEqual(@as(usize, 1), terminal_count);
+    }
+}
+
 test "failed admitted settlement keeps identity when terminal publication fails" {
     const alloc = std.testing.allocator;
     var arena_state = std.heap.ArenaAllocator.init(alloc);
@@ -2045,6 +2137,22 @@ fn checkProvisionalLifecycleAllocationFailures(alloc: Allocator) !void {
 
     try statuses.publish(&hooks, alloc, 1, "read_1", "read_file", activityKind(hooks.tool_registry, "read_file"), eligibleActionLabel("read_file"), null);
     try std.testing.expect(statuses.has("read_1"));
+    var arena_state = std.heap.ArenaAllocator.init(alloc);
+    defer arena_state.deinit();
+    try std.testing.expect(try statuses.finishExecutedCall(
+        &hooks,
+        alloc,
+        arena_state.allocator(),
+        1,
+        .{ .id = "read_1", .name = "read_file", .arguments_json = "{}", .argument_integrity = .malformed_json },
+        false,
+        null,
+        .{ .status = .failure, .model_output = "diagnostic" },
+        "diagnostic",
+        .{},
+        null,
+        &.{},
+    ));
 }
 
 test "provisional lifecycle cleans up every copied-id allocation failure" {

--- a/src/tools/shell/shell.zig
+++ b/src/tools/shell/shell.zig
@@ -317,10 +317,6 @@ fn request_correction(alloc: Allocator, args_json: []const u8, supports_tty: boo
         try problems.append(arena, problem);
         repairable = false;
     }
-    if (candidate.timeout_ms == 0) {
-        try problems.append(arena, "request.timeout_ms must be at least 1; choose the intended deadline.");
-        repairable = false;
-    }
     if (!supports_tty and (canonical.contains("tty") or canonical.contains("shell") or canonical.contains("chars"))) {
         try problems.append(arena, "Interactive Shell fields require a saved session.");
         repairable = false;
@@ -354,6 +350,7 @@ fn argument_problem(input: Input) ?[]const u8 {
         .run => {
             const command = input.command orelse return "request.command is required.";
             if (command.len == 0 or command.len > terminal_contracts.max_command_bytes) return "request.command must contain 1-65536 bytes.";
+            if (input.timeout_ms == 0) return "request.timeout_ms must be at least 1; choose the intended deadline.";
             if (input.profile != null and input.shell != null) return "Choose either request.profile or request.shell.";
             if (!input.tty and input.shell != null) return "request.shell requires tty=true; choose the intended execution mode.";
             if (input.yield_time_ms > managed_contract.max_yield_time_ms) return "request.yield_time_ms must be between 0 and 30000.";
@@ -1787,6 +1784,39 @@ test "shell action fields are closed and command authority covers every run" {
         &.{ "action", "session_id", "chars", "yield_time_ms" },
         actionFieldContract(.interact).allowed,
     );
+}
+
+test "shell timeout minimum is enforced before correction and execution" {
+    const alloc = std.testing.allocator;
+    const zero = try decode(.{ .allocator = alloc }, "{\"action\":\"run\",\"command\":\"true\",\"timeout_ms\":0}");
+    switch (zero) {
+        .input => |input| {
+            input.deinit(alloc);
+            return error.TestUnexpectedResult;
+        },
+        .failure => |failure| {
+            defer alloc.free(failure);
+            var parsed = try std.json.parseFromSlice(std.json.Value, alloc, failure, .{});
+            defer parsed.deinit();
+            const detail = parsed.value.object.get("error").?.object;
+            try std.testing.expectEqualStrings("invalid_shell_request", detail.get("code").?.string);
+            try std.testing.expect(!detail.get("executed").?.bool);
+            try std.testing.expect(detail.get("retry_with") == null);
+        },
+    }
+    for ([_][]const u8{
+        "{\"action\":\"run\",\"command\":\"true\"}",
+        "{\"action\":\"run\",\"command\":\"true\",\"timeout_ms\":1}",
+    }) |args| {
+        const decoded = try decode(.{ .allocator = alloc }, args);
+        switch (decoded) {
+            .input => |input| input.deinit(alloc),
+            .failure => |failure| {
+                alloc.free(failure);
+                return error.TestUnexpectedResult;
+            },
+        }
+    }
 }
 
 test "shell request correction suggests only unambiguous repairs without executing" {

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -3907,6 +3907,83 @@ describe("gateway stream lifecycle", () => {
     }
   });
 
+  test.skipIf(!tmuxAvailable())("rejected shell calls remain visible without streamed activity", async () => {
+    const root = createFixtureRoot("shell-rejection-status");
+    const tracePath = join(root.root, "trace.log");
+    const stderrPath = join(root.root, "stderr.log");
+    const tapePath = join(root.root, "session.fxtape");
+    const clipboardBin = join(root.root, "bin");
+    mkdirSync(clipboardBin);
+    const clipboardStub = join(clipboardBin, "osascript");
+    writeFileSync(clipboardStub, "#!/bin/sh\nexit 1\n");
+    chmodSync(clipboardStub, 0o755);
+    const marker = join(root.workspace, "executions.txt");
+    let step = 0;
+    const gateway = startGateway((body) => {
+      switch (step++) {
+        case 0:
+          return fakeGatewaySse([
+            { type: "tool-call", toolCallId: "invalid_shell", toolName: "shell", input: '{"request":{"action":"run","command":"touch MUST_NOT_EXECUTE"' },
+            { type: "tool-call", toolCallId: "valid_shell", toolName: "shell", input: { request: { action: "run", command: "printf 'once\\n' >> executions.txt", profile: "clean" } } },
+            { type: "finish", finishReason: { unified: "tool-calls", raw: "tool-calls" } },
+          ]);
+        case 1:
+          expect(toolResultOutput(body, "invalid_shell")).toContain("Tool arguments were not valid JSON.");
+          expect(shellResult(body, "valid_shell").exit_code).toBe(0);
+          expect(readFileSync(marker, "utf8")).toBe("once\n");
+          return fakeGatewayFinalText("REJECTION_RECOVERED");
+        case 2:
+          return fakeGatewayToolCall("later_shell", "shell", { request: { action: "run", command: "printf 'later\\n' >> executions.txt", profile: "clean" } });
+        case 3:
+          expect(shellResult(body, "later_shell").exit_code).toBe(0);
+          return fakeGatewayFinalText("LATER_TURN_COMPLETE");
+        default:
+          return new Response("unexpected request", { status: 500 });
+      }
+    });
+    let tui: TmuxSession | null = null;
+    try {
+      tui = await TmuxSession.create({
+        cwd: root.workspace, width: 110, height: 40, stderrPath,
+        env: { ...fixtureEnv(root, gateway, tracePath), PATH: `${clipboardBin}:${process.env.PATH}`, TMPDIR: root.root, FX_PERMISSION_MODE: "yolo", FX_RECORD: tapePath, FX_TRACE_SCOPES: "agent,sse,tool,permission,ui_activity" },
+      });
+      await tui.waitForComposer(15_000);
+      await tui.sendText("Run the fixture and recover from its rejected input.");
+      await tui.waitForPane((pane) => pane.includes("REJECTION_RECOVERED") && hasEmptyComposer(pane), 15_000);
+      const recovered = await tui.captureFullScrollback();
+      expect(recovered.match(/Failed shell request: invalid JSON arguments/g)).toHaveLength(1);
+      expect(recovered).not.toContain("MUST_NOT_EXECUTE");
+      await tui.sendText("Run the next fixture command once.");
+      await tui.waitForPane((pane) => pane.includes("LATER_TURN_COMPLETE") && hasEmptyComposer(pane), 15_000);
+      expect((await tui.captureFullScrollback()).match(/Failed shell request: invalid JSON arguments/g)).toHaveLength(1);
+      await tui.sendText("/trace");
+      await tui.waitForText("Trace saved at", 10_000);
+      const traceFile = readdirSync(root.root).find((name) => name.startsWith("fx-trace-") && name.endsWith(".md"));
+      expect(traceFile).toBeDefined();
+      const report = readFileSync(join(root.root, traceFile!), "utf8");
+      expect(report).toContain("invalid JSON arguments");
+      expect(report).not.toContain("MUST_NOT_EXECUTE");
+      await tui.sendText("/quit");
+      expect(await tui.waitForSessionEnd(10_000)).toBe(true);
+      tui = null;
+      expect(readFileSync(marker, "utf8")).toBe("once\nlater\n");
+      expect(existsSync(join(root.workspace, "MUST_NOT_EXECUTE"))).toBe(false);
+      expect(gateway.requestCount()).toBe(4);
+      const trace = readFileSync(tracePath, "utf8");
+      expect(trace).toContain("event=argument_integrity_rejected");
+      expect(trace.split("\n").filter((line) => line.includes("call_id=invalid_shell") &&
+        (line.includes("permission_requested") || line.includes("execution_start")))).toHaveLength(0);
+      expect(readFileSync(stderrPath, "utf8")).toBe("");
+      const replay = await runFx(["replay", tapePath], { timeoutMs: 15_000 });
+      expect(replay.code).toBe(0);
+      expect(replay.stdout).toContain("invalid JSON arguments");
+    } finally {
+      if (tui) await tui.kill();
+      gateway.stop();
+      rmSync(root.root, { recursive: true, force: true });
+    }
+  }, 45_000);
+
   test("shell request correction repairs one call before its only execution", async () => {
     const root = createFixtureRoot("shell-request-correction");
     const tracePath = join(root.root, "trace.log");
@@ -3916,11 +3993,21 @@ describe("gateway stream lifecycle", () => {
     const gateway = startGateway((body) => {
       switch (step++) {
         case 0:
+          return fakeGatewayToolCall("zero_timeout", "shell", {
+            request: { action: "run", command, profile: "clean", timeout_ms: 0 },
+          });
+        case 1: {
+          expect(existsSync(marker)).toBe(false);
+          const correction = JSON.parse(toolResultOutput(body, "zero_timeout")).error;
+          expect(correction.code).toBe("invalid_shell_request");
+          expect(correction.executed).toBe(false);
+          expect(correction.retry_with).toBeUndefined();
           return fakeGatewayToolCall("repair_invalid", "shell", {
             request: { command, profile: "clean" },
             yield_time_ms: "1000",
           });
-        case 1: {
+        }
+        case 2: {
           expect(existsSync(marker)).toBe(false);
           const correction = JSON.parse(toolResultOutput(body, "repair_invalid")).error;
           expect(correction.code).toBe("invalid_shell_request");
@@ -3931,7 +4018,7 @@ describe("gateway stream lifecycle", () => {
           });
           return fakeGatewayToolCall("repair_valid", "shell", correction.retry_with);
         }
-        case 2:
+        case 3:
           expect(shellResult(body, "repair_valid")).toMatchObject({
             state: "completed", exit_code: 0, output_delta: "REPAIRED_SHELL_OK",
           });
@@ -3949,12 +4036,12 @@ describe("gateway stream lifecycle", () => {
       expect(result.code).toBe(0);
       expect(parseAskJson(result.stdout).output).toContain("SHELL_REPAIR_COMPLETE");
       expect(readFileSync(marker, "utf8")).toBe("once\n");
-      expect(gateway.requestCount()).toBe(3);
+      expect(gateway.requestCount()).toBe(4);
       expect(gateway.classifierRequests).toHaveLength(0);
       const trace = readFileSync(tracePath, "utf8");
       expect(trace).toContain("call_id=repair_invalid");
       expect(trace.split("\n").filter((line) =>
-        line.includes("call_id=repair_invalid") &&
+        (line.includes("call_id=repair_invalid") || line.includes("call_id=zero_timeout")) &&
         (line.includes("permission_request") || line.includes("execution_start"))
       )).toHaveLength(0);
       expect(result.stderr).not.toMatch(/panic|error:|error\./i);


### PR DESCRIPTION
## Summary

- Show malformed and non-object Shell failures with their diagnostics even when no streamed activity row exists.
- Keep malformed and non-object inputs from emitting working-progress messages.
- Reject zero command timeouts before permission or execution, without guessing a replacement deadline.
