### PR TITLE
Fix libfx loading in Node deployments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
 
       - name: Build SDK artifacts
         run: |
-          zig build -Dnapi-surface=core -Doptimize=ReleaseSafe
+          zig build libfx-napi -Dnapi-surface=core -Doptimize=ReleaseSafe -Dtarget=x86_64-linux-gnu.2.34 -Dcpu=baseline
           zig build -Dwasm-surface=core -Doptimize=ReleaseSmall
           zig build -Dwasm-surface=term -Doptimize=ReleaseSmall
 
@@ -176,6 +176,49 @@ jobs:
           bun sdk/tests/test-mcp-adapter.mjs http wasm
           bun sdk/tests/test-skills-adapter.mjs disk native
           bun sdk/tests/test-skills-adapter.mjs host wasm
+
+      - name: Check Linux addon compatibility
+        run: |
+          python3 sdk/tests/test-linux-abi.py
+          python3 sdk/scripts/check-linux-abi.py zig-out/lib/libfx.node
+          docker run --rm --network none --entrypoint /bin/bash \
+            --volume "$PWD:/workspace:ro" --workdir /workspace \
+            public.ecr.aws/lambda/nodejs@sha256:2472f0273d8848d8b2aa6528f5526b8a514b70703596199efe5a4b84d3d59b0b -euc '
+              node sdk/tests/test-native-core-ready.mjs
+              node sdk/tests/test-host-tools.mjs native
+              node sdk/tests/test-host-tool-cancel.mjs native
+            '
+
+      - name: Test Node package and backend diagnostics
+        run: |
+          node --experimental-wasm-jspi sdk/tests/test-backend-info.mjs
+          node sdk/tests/test-node-package.mjs
+          node sdk/tests/test-term-demo-package.mjs
+          node sdk/scripts/package-libfx.mjs sdk/dist/libfx
+          npm pack ./sdk/dist/libfx --ignore-scripts --json > /tmp/libfx-pack.json
+          mv "$(node -p 'require("/tmp/libfx-pack.json")[0].filename')" /tmp/libfx-package.tgz
+          node sdk/tests/test-packed-example.mjs /tmp/libfx-package.tgz native esm
+          node --no-experimental-require-module sdk/tests/test-packed-example.mjs /tmp/libfx-package.tgz native cjs
+          node --experimental-wasm-jspi sdk/tests/test-packed-example.mjs /tmp/libfx-package.tgz wasm esm
+          node --experimental-wasm-jspi --no-experimental-require-module sdk/tests/test-packed-example.mjs /tmp/libfx-package.tgz wasm cjs
+
+      - name: Install Next fixture package manager
+        run: npm install --global pnpm@11.1.1
+
+      - name: Test installed package through Next
+        env:
+          LIBFX_TEST_ARTIFACT_ROOT: ${{ runner.temp }}/libfx-package-evidence
+        run: node sdk/tests/test-next-package.mjs /tmp/libfx-package.tgz
+
+      - name: Retain Next package evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: libfx-next-package-evidence
+          path: |
+            ${{ runner.temp }}/libfx-package-evidence/libfx-next-*/*.log
+            ${{ runner.temp }}/libfx-package-evidence/libfx-next-*/results.json
+          if-no-files-found: ignore
 
   sdk-browser-wasm:
     name: SDK (Browser + WASM)

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -86,9 +86,11 @@ jobs:
         run: |
           cp sdk/fx-sdk.js fx-sdk.js
           cp sdk/core-output.js core-output.js
+          cp sdk/wasm-module.js wasm-module.js
           cp zig-out/bin/fx-term.wasm fx-term.wasm
           sha256sum fx-sdk.js > fx-sdk.js.sha256
           sha256sum core-output.js > core-output.js.sha256
+          sha256sum wasm-module.js > wasm-module.js.sha256
           sha256sum fx-term.wasm > fx-term.wasm.sha256
 
       - name: Upload artifact
@@ -100,6 +102,8 @@ jobs:
             fx-sdk.js.sha256
             core-output.js
             core-output.js.sha256
+            wasm-module.js
+            wasm-module.js.sha256
             fx-term.wasm
             fx-term.wasm.sha256
 
@@ -151,9 +155,10 @@ jobs:
 
           sha256sum --check fx-sdk.js.sha256
           sha256sum --check core-output.js.sha256
+          sha256sum --check wasm-module.js.sha256
           sha256sum --check fx-term.wasm.sha256
 
-          for FILE in fx-sdk.js fx-sdk.js.sha256 core-output.js core-output.js.sha256 fx-term.wasm fx-term.wasm.sha256; do
+          for FILE in fx-sdk.js fx-sdk.js.sha256 core-output.js core-output.js.sha256 wasm-module.js wasm-module.js.sha256 fx-term.wasm fx-term.wasm.sha256; do
             CONTENT_TYPE="application/octet-stream"
             [[ "$FILE" == *.js ]] && CONTENT_TYPE="text/javascript"
             [[ "$FILE" == *.wasm ]] && CONTENT_TYPE="application/wasm"

--- a/.github/workflows/publish-libfx.yml
+++ b/.github/workflows/publish-libfx.yml
@@ -327,48 +327,8 @@ jobs:
             libfx-package.tgz.sha256
           if-no-files-found: error
 
-  qualify-vercel:
-    needs: [metadata, package]
-    runs-on: ubuntu-24.04
-    env:
-      LIBFX_VERCEL_TOKEN: ${{ secrets.LIBFX_VERCEL_TOKEN }}
-      LIBFX_VERCEL_PROJECT_ID: ${{ vars.LIBFX_VERCEL_PROJECT_ID }}
-      LIBFX_VERCEL_ORG_ID: ${{ vars.LIBFX_VERCEL_ORG_ID }}
-      AI_GATEWAY_API_KEY: ${{ secrets.AI_GATEWAY_API_KEY }}
-    steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-        with:
-          ref: ${{ needs.metadata.outputs.sha }}
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        with:
-          node-version: "24.18.0"
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          name: libfx-package
-      - name: Verify release qualification access
-        run: |
-          test -n "$LIBFX_VERCEL_TOKEN"
-          test -n "$LIBFX_VERCEL_PROJECT_ID"
-          test -n "$LIBFX_VERCEL_ORG_ID"
-          test -n "$AI_GATEWAY_API_KEY"
-          sha256sum --check libfx-package.tgz.sha256
-      - run: npm install --global vercel@56.4.1 pnpm@11.1.1
-      - name: Test live native tools on Vercel
-        env:
-          LIBFX_TEST_ARTIFACT_ROOT: ${{ runner.temp }}/libfx-vercel-evidence
-        run: node sdk/tests/test-vercel-package.mjs libfx-package.tgz
-      - name: Retain Vercel qualification evidence
-        if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: libfx-vercel-evidence
-          path: |
-            ${{ runner.temp }}/libfx-vercel-evidence/libfx-vercel-*/*.log
-            ${{ runner.temp }}/libfx-vercel-evidence/libfx-vercel-*/results.json
-          if-no-files-found: ignore
-
   publish:
-    needs: [metadata, qualify-vercel]
+    needs: [metadata, package]
     runs-on: ubuntu-24.04
     environment: npm
     permissions:
@@ -416,11 +376,6 @@ jobs:
   verify-published:
     needs: [metadata, publish]
     runs-on: ubuntu-24.04
-    env:
-      LIBFX_VERCEL_TOKEN: ${{ secrets.LIBFX_VERCEL_TOKEN }}
-      LIBFX_VERCEL_PROJECT_ID: ${{ vars.LIBFX_VERCEL_PROJECT_ID }}
-      LIBFX_VERCEL_ORG_ID: ${{ vars.LIBFX_VERCEL_ORG_ID }}
-      AI_GATEWAY_API_KEY: ${{ secrets.AI_GATEWAY_API_KEY }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
@@ -428,18 +383,34 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "24.18.0"
-      - run: npm install --global vercel@56.4.1 pnpm@11.1.1
-      - name: Verify the immutable registry version
+      - run: npm install --global pnpm@11.1.1
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: libfx-package
+      - name: Download and compare the immutable registry version
+        env:
+          LIBFX_VERSION: ${{ needs.metadata.outputs.version }}
+        run: |
+          set -euo pipefail
+          sha256sum --check libfx-package.tgz.sha256
+          npm pack "libfx@${LIBFX_VERSION}" --ignore-scripts --registry=https://registry.npmjs.org/ --json > /tmp/libfx-registry-pack.json
+          mv "$(jq -r '.[0].filename' /tmp/libfx-registry-pack.json)" libfx-registry.tgz
+          cmp libfx-package.tgz libfx-registry.tgz
+      - name: Test the registry package in Node and Next
         env:
           LIBFX_TEST_ARTIFACT_ROOT: ${{ runner.temp }}/libfx-registry-evidence
-          LIBFX_VERSION: ${{ needs.metadata.outputs.version }}
-        run: node sdk/tests/test-vercel-package.mjs "$LIBFX_VERSION"
+        run: |
+          node sdk/tests/test-packed-example.mjs libfx-registry.tgz native esm
+          node --no-experimental-require-module sdk/tests/test-packed-example.mjs libfx-registry.tgz native cjs
+          node --experimental-wasm-jspi sdk/tests/test-packed-example.mjs libfx-registry.tgz wasm esm
+          node --experimental-wasm-jspi --no-experimental-require-module sdk/tests/test-packed-example.mjs libfx-registry.tgz wasm cjs
+          node sdk/tests/test-next-package.mjs libfx-registry.tgz
       - name: Retain registry qualification evidence
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: libfx-registry-evidence
           path: |
-            ${{ runner.temp }}/libfx-registry-evidence/libfx-vercel-*/*.log
-            ${{ runner.temp }}/libfx-registry-evidence/libfx-vercel-*/results.json
+            ${{ runner.temp }}/libfx-registry-evidence/libfx-next-*/*.log
+            ${{ runner.temp }}/libfx-registry-evidence/libfx-next-*/results.json
           if-no-files-found: ignore

--- a/.github/workflows/publish-libfx.yml
+++ b/.github/workflows/publish-libfx.yml
@@ -116,8 +116,12 @@ jobs:
         include:
           - runner: ubuntu-24.04
             package_platform: linux-x64
+            target_flags: -Dtarget=x86_64-linux-gnu.2.34 -Dcpu=baseline
+            runtime_image: public.ecr.aws/lambda/nodejs@sha256:2472f0273d8848d8b2aa6528f5526b8a514b70703596199efe5a4b84d3d59b0b
           - runner: ubuntu-24.04-arm
             package_platform: linux-arm64
+            target_flags: -Dtarget=aarch64-linux-gnu.2.34 -Dcpu=baseline
+            runtime_image: public.ecr.aws/lambda/nodejs@sha256:104527dd19c1907b4aaf328b5b3af1ac0c5db6bb9c76be8cb73fb295ec58b0fe
           - runner: macos-15-intel
             package_platform: darwin-x64
           - runner: macos-15
@@ -138,7 +142,25 @@ jobs:
           node-version: "24"
 
       - name: Build ReleaseSafe addon
-        run: zig build -Dnapi-surface=core -Doptimize=ReleaseSafe -Dupdate-channel=${{ needs.metadata.outputs.channel }}
+        run: zig build libfx-napi -Dnapi-surface=core -Doptimize=ReleaseSafe -Dupdate-channel=${{ needs.metadata.outputs.channel }} ${{ matrix.target_flags }}
+
+      - name: Check Linux ABI baseline
+        if: startsWith(matrix.package_platform, 'linux-')
+        run: |
+          python3 sdk/tests/test-linux-abi.py
+          python3 sdk/scripts/check-linux-abi.py zig-out/lib/libfx.node
+
+      - name: Test Linux addon on Amazon Linux 2023
+        if: startsWith(matrix.package_platform, 'linux-')
+        run: |
+          docker run --rm --network none --entrypoint /bin/bash \
+            --volume "$PWD:/workspace:ro" --workdir /workspace \
+            '${{ matrix.runtime_image }}' -euc '
+              node -e '\''const assert = require("node:assert/strict"); assert.equal(process.report.getReport().header.glibcVersionRuntime, "2.34");'\''
+              node sdk/tests/test-native-core-ready.mjs
+              node sdk/tests/test-host-tools.mjs native
+              node sdk/tests/test-host-tool-cancel.mjs native
+            '
 
       - name: Test native addon
         run: npm run --prefix sdk test:node-napi
@@ -196,57 +218,44 @@ jobs:
             zig-out/bin/fx-term.wasm
           if-no-files-found: error
 
-  publish:
+  package:
     needs: [metadata, native, wasm]
     runs-on: ubuntu-24.04
-    environment: npm
-    permissions:
-      contents: read
-      id-token: write
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
-          fetch-depth: 0
           ref: ${{ needs.metadata.outputs.sha }}
 
-      - name: Setup Node for npm trusted publishing
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: "24"
-          registry-url: https://registry.npmjs.org
+          node-version: "24.18.0"
 
-      - name: Install OIDC-capable npm
-        run: npm install --global npm@11.15.0
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.4.2"
 
-      - name: Download native addons
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - name: Install package test runner
+        run: npm install --global pnpm@11.1.1
+
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: libfx-native-*
           path: native-addons
           merge-multiple: true
 
-      - name: Download WebAssembly artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: libfx-wasm
           path: wasm-artifacts
 
-      - name: Restore package artifact layout
-        run: |
-          mkdir -p zig-out/bin
-          cp wasm-artifacts/fx-core.wasm zig-out/bin/fx-core.wasm
-          cp wasm-artifacts/fx-term.wasm zig-out/bin/fx-term.wasm
-
-      - name: Stage package without executing repository code
+      - name: Assemble package
         env:
           LIBFX_VERSION: ${{ needs.metadata.outputs.version }}
         run: |
           set -euo pipefail
-          test "$(find native-addons -type f -name '*.node' | wc -l | tr -d ' ')" = 4
-          for name in linux-x64 linux-arm64 darwin-x64 darwin-arm64; do
-            test -f "native-addons/libfx.${name}.node"
-          done
-
+          mkdir -p zig-out/bin zig-out/lib
+          cp wasm-artifacts/*.wasm zig-out/bin/
+          cp native-addons/libfx.linux-x64.node zig-out/lib/libfx.node
           jq -e '
             .name == "libfx" and
             .type == "module" and
@@ -259,29 +268,21 @@ jobs:
             (.bin == null)
           ' sdk/package.json >/dev/null
 
-          rm -rf sdk/dist/libfx
-          mkdir -p sdk/dist/libfx
-          cp sdk/package.json sdk/README.md sdk/browser.js sdk/node.js sdk/fx-sdk.js sdk/core-output.js sdk/mcp.js sdk/skills.js sdk/skills-node.js LICENSE sdk/dist/libfx/
-          cp wasm-artifacts/fx-core.wasm wasm-artifacts/fx-term.wasm sdk/dist/libfx/
-          cp native-addons/*.node sdk/dist/libfx/
-          jq --arg version "$LIBFX_VERSION" '.version = $version | del(.files)' \
+          node sdk/scripts/package-libfx.mjs sdk/dist/libfx native-addons/*.node
+          jq --arg version "$LIBFX_VERSION" '.version = $version' \
             sdk/dist/libfx/package.json > sdk/dist/libfx/package.json.tmp
           mv sdk/dist/libfx/package.json.tmp sdk/dist/libfx/package.json
-
-      - name: Run packed public API example
-        run: |
-          node sdk/tests/test-packed-example.mjs sdk/dist/libfx native
-          node --experimental-wasm-jspi sdk/tests/test-packed-example.mjs sdk/dist/libfx wasm
+          npm pack ./sdk/dist/libfx --ignore-scripts --json > /tmp/libfx-pack.json
+          mv "$(jq -r '.[0].filename' /tmp/libfx-pack.json)" libfx-package.tgz
+          sha256sum libfx-package.tgz > libfx-package.tgz.sha256
 
       - name: Validate package archive
         run: |
-          set -euo pipefail
-          npm pack --ignore-scripts --dry-run --json sdk/dist/libfx > /tmp/libfx-pack.json
           node -e '
             const report = require("/tmp/libfx-pack.json")[0];
             const names = new Set(report.files.map(({ path }) => path));
             const required = [
-              "package.json", "README.md", "LICENSE", "browser.js", "node.js", "fx-sdk.js",
+              "package.json", "README.md", "LICENSE", "browser.js", "node.js", "node.cjs", "fx-sdk.js", "wasm-module.js",
               "core-output.js", "mcp.js", "skills.js", "skills-node.js",
               "fx-core.wasm", "fx-term.wasm",
               "libfx.linux-x64.node", "libfx.linux-arm64.node",
@@ -294,6 +295,101 @@ jobs:
             console.log(`validated ${report.name}@${report.version}: ${report.files.length} files, ${report.size} bytes packed`);
           '
 
+      - name: Test installed package and diagnostics
+        run: |
+          node sdk/tests/test-packed-example.mjs libfx-package.tgz native esm
+          node --no-experimental-require-module sdk/tests/test-packed-example.mjs libfx-package.tgz native cjs
+          node --experimental-wasm-jspi sdk/tests/test-packed-example.mjs libfx-package.tgz wasm esm
+          node --experimental-wasm-jspi --no-experimental-require-module sdk/tests/test-packed-example.mjs libfx-package.tgz wasm cjs
+          node --experimental-wasm-jspi sdk/tests/test-backend-info.mjs
+          node sdk/tests/test-term-demo-package.mjs
+
+      - name: Test Next development, production and isolated output
+        env:
+          LIBFX_TEST_ARTIFACT_ROOT: ${{ runner.temp }}/libfx-package-evidence
+        run: node sdk/tests/test-next-package.mjs libfx-package.tgz
+
+      - name: Retain package qualification evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: libfx-package-evidence
+          path: |
+            ${{ runner.temp }}/libfx-package-evidence/libfx-next-*/*.log
+            ${{ runner.temp }}/libfx-package-evidence/libfx-next-*/results.json
+          if-no-files-found: ignore
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: libfx-package
+          path: |
+            libfx-package.tgz
+            libfx-package.tgz.sha256
+          if-no-files-found: error
+
+  qualify-vercel:
+    needs: [metadata, package]
+    runs-on: ubuntu-24.04
+    env:
+      LIBFX_VERCEL_TOKEN: ${{ secrets.LIBFX_VERCEL_TOKEN }}
+      LIBFX_VERCEL_PROJECT_ID: ${{ vars.LIBFX_VERCEL_PROJECT_ID }}
+      LIBFX_VERCEL_ORG_ID: ${{ vars.LIBFX_VERCEL_ORG_ID }}
+      AI_GATEWAY_API_KEY: ${{ secrets.AI_GATEWAY_API_KEY }}
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ needs.metadata.outputs.sha }}
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "24.18.0"
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: libfx-package
+      - name: Verify release qualification access
+        run: |
+          test -n "$LIBFX_VERCEL_TOKEN"
+          test -n "$LIBFX_VERCEL_PROJECT_ID"
+          test -n "$LIBFX_VERCEL_ORG_ID"
+          test -n "$AI_GATEWAY_API_KEY"
+          sha256sum --check libfx-package.tgz.sha256
+      - run: npm install --global vercel@56.4.1 pnpm@11.1.1
+      - name: Test live native tools on Vercel
+        env:
+          LIBFX_TEST_ARTIFACT_ROOT: ${{ runner.temp }}/libfx-vercel-evidence
+        run: node sdk/tests/test-vercel-package.mjs libfx-package.tgz
+      - name: Retain Vercel qualification evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: libfx-vercel-evidence
+          path: |
+            ${{ runner.temp }}/libfx-vercel-evidence/libfx-vercel-*/*.log
+            ${{ runner.temp }}/libfx-vercel-evidence/libfx-vercel-*/results.json
+          if-no-files-found: ignore
+
+  publish:
+    needs: [metadata, qualify-vercel]
+    runs-on: ubuntu-24.04
+    environment: npm
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.metadata.outputs.sha }}
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "24"
+          registry-url: https://registry.npmjs.org
+      - name: Install OIDC-capable npm
+        run: npm install --global npm@11.15.0
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: libfx-package
+      - run: sha256sum --check libfx-package.tgz.sha256
+
       - name: Confirm dev publish still targets main
         if: needs.metadata.outputs.channel == 'dev'
         env:
@@ -305,7 +401,7 @@ jobs:
             exit 1
           fi
 
-      - name: Publish with npm trusted publishing
+      - name: Publish the verified archive with npm trusted publishing
         env:
           LIBFX_VERSION: ${{ needs.metadata.outputs.version }}
           NPM_TAG: ${{ needs.metadata.outputs.npm_tag }}
@@ -315,4 +411,35 @@ jobs:
             echo "libfx@${LIBFX_VERSION} is already published; leaving ${NPM_TAG} unchanged"
             exit 0
           fi
-          npm publish sdk/dist/libfx --ignore-scripts --access public --tag "$NPM_TAG" --provenance
+          npm publish ./libfx-package.tgz --ignore-scripts --access public --tag "$NPM_TAG" --provenance
+
+  verify-published:
+    needs: [metadata, publish]
+    runs-on: ubuntu-24.04
+    env:
+      LIBFX_VERCEL_TOKEN: ${{ secrets.LIBFX_VERCEL_TOKEN }}
+      LIBFX_VERCEL_PROJECT_ID: ${{ vars.LIBFX_VERCEL_PROJECT_ID }}
+      LIBFX_VERCEL_ORG_ID: ${{ vars.LIBFX_VERCEL_ORG_ID }}
+      AI_GATEWAY_API_KEY: ${{ secrets.AI_GATEWAY_API_KEY }}
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ needs.metadata.outputs.sha }}
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "24.18.0"
+      - run: npm install --global vercel@56.4.1 pnpm@11.1.1
+      - name: Verify the immutable registry version
+        env:
+          LIBFX_TEST_ARTIFACT_ROOT: ${{ runner.temp }}/libfx-registry-evidence
+          LIBFX_VERSION: ${{ needs.metadata.outputs.version }}
+        run: node sdk/tests/test-vercel-package.mjs "$LIBFX_VERSION"
+      - name: Retain registry qualification evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: libfx-registry-evidence
+          path: |
+            ${{ runner.temp }}/libfx-registry-evidence/libfx-vercel-*/*.log
+            ${{ runner.temp }}/libfx-registry-evidence/libfx-vercel-*/results.json
+          if-no-files-found: ignore

--- a/sdk/NAPI.md
+++ b/sdk/NAPI.md
@@ -224,9 +224,22 @@ Consequently:
 - publishing must preserve provenance and use the exact tested artifacts;
 - addon load failures must not be mistaken for a safe sandbox boundary.
 
-The JavaScript loader searches for `libfx.node` first for local development, then `libfx.<platform>-<arch>.node` for packaged builds. It validates `libfxApiVersion` and the expected export shape before use. `backend: "native"` fails closed if a compatible addon is unavailable. `backend: "auto"` may fall back to WebAssembly when JSPI is available.
+The JavaScript loader uses literal references to the four packaged
+`libfx.<platform>-<arch>.node` names and selects the matching supported tuple.
+Local package assembly renames `zig-out/lib/libfx.node` to that tuple's package
+name. The loader validates `libfxApiVersion` and the expected export shape
+before use. `backend: "native"` fails closed if a compatible addon is
+unavailable. `backend: "auto"` may fall back to WebAssembly when JSPI is
+available. Explicit `nativeAddon` objects, paths, and URLs remain separate from
+packaged discovery.
 
 ## Build and packaging
+
+Linux package builds pin `x86_64-linux-gnu.2.34` or
+`aarch64-linux-gnu.2.34` with baseline CPUs. The release checks reject newer
+glibc requirements and exercise the addon on Amazon Linux 2023 before package
+assembly. Building against the CI host's glibc can introduce imports such as
+`arc4random_buf@GLIBC_2.36` that cannot load on the deployment runtime.
 
 The build is enabled with:
 
@@ -245,7 +258,13 @@ Published packages contain one addon for each supported tuple:
 - `darwin-x64`;
 - `darwin-arm64`.
 
-`package-libfx.mjs` requires exactly those four names when assembling a publishable multi-platform package. It rejects missing, duplicate, or unexpected addon names. The publish workflow builds and tests each addon on its native runner before combining the artifacts with both WebAssembly surfaces, the README, and the Apache-2.0 license.
+`package-libfx.mjs` requires exactly those four names when assembling a
+publishable multi-platform package. It rejects missing, duplicate, or
+unexpected addon names. Package assembly also generates a self-contained
+`node.cjs` from the dependency-free ESM source with package-relative module
+URLs. The publish workflow builds and tests each addon on its native runner
+before combining the artifacts with both WebAssembly surfaces, the README, and
+the Apache-2.0 license.
 
 ## Error model
 

--- a/sdk/NAPI.md
+++ b/sdk/NAPI.md
@@ -266,19 +266,24 @@ URLs. The publish workflow builds and tests each addon on its native runner
 before combining the artifacts with both WebAssembly surfaces, the README, and
 the Apache-2.0 license.
 
-The release workflow also requires a dedicated Next.js verification project.
-Configure its project-scoped token as the `LIBFX_VERCEL_TOKEN` repository
-secret, and its IDs as the `LIBFX_VERCEL_PROJECT_ID` and
-`LIBFX_VERCEL_ORG_ID` repository variables. Live turns use the existing
-`AI_GATEWAY_API_KEY` secret. The project uses Node.js 24 and the fixture's
-per-deployment request token; platform deployment protection must allow those
-requests, including the fixture's HTTP MCP calls.
-
 Package assembly and Next tests run without npm publishing credentials. The
-exact tarball is verified on Vercel before the OIDC publish, and the immutable
-registry version is checked afterward. Missing credentials or failed
-pre-publish qualification block publication. Redacted logs and structured
-results are retained as workflow artifacts, including on failure.
+OIDC publisher uploads the tested archive. The workflow then downloads that
+immutable registry version, compares it byte-for-byte with the archive, and
+exercises its Node entrypoints and Next development, production, and isolated
+deployment output. Failed package qualification blocks publication. Next
+logs and structured results are retained as workflow artifacts, including
+on failure.
+
+Live Vercel qualification is a separate release check. Run
+`node sdk/tests/test-vercel-package.mjs <tarball>` before publication, then run
+the same command with the immutable npm version afterward. Set
+`LIBFX_VERCEL_PROJECT_ID`, `LIBFX_VERCEL_ORG_ID`, and `AI_GATEWAY_API_KEY` in
+the environment. The harness uses the local Vercel CLI login, or
+`LIBFX_VERCEL_TOKEN` when supplied; npm publication does not require a Vercel
+token in GitHub. The dedicated verification project uses Node.js 24 and the
+fixture's per-deployment request token. Platform deployment protection must
+allow those requests, including the fixture's HTTP MCP calls. The harness
+retains redacted logs and results and removes its temporary deployment.
 
 ## Error model
 

--- a/sdk/NAPI.md
+++ b/sdk/NAPI.md
@@ -266,6 +266,20 @@ URLs. The publish workflow builds and tests each addon on its native runner
 before combining the artifacts with both WebAssembly surfaces, the README, and
 the Apache-2.0 license.
 
+The release workflow also requires a dedicated Next.js verification project.
+Configure its project-scoped token as the `LIBFX_VERCEL_TOKEN` repository
+secret, and its IDs as the `LIBFX_VERCEL_PROJECT_ID` and
+`LIBFX_VERCEL_ORG_ID` repository variables. Live turns use the existing
+`AI_GATEWAY_API_KEY` secret. The project uses Node.js 24 and the fixture's
+per-deployment request token; platform deployment protection must allow those
+requests, including the fixture's HTTP MCP calls.
+
+Package assembly and Next tests run without npm publishing credentials. The
+exact tarball is verified on Vercel before the OIDC publish, and the immutable
+registry version is checked afterward. Missing credentials or failed
+pre-publish qualification block publication. Redacted logs and structured
+results are retained as workflow artifacts, including on failure.
+
 ## Error model
 
 Native errors use stable codes where JavaScript needs to distinguish failure classes:

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -206,16 +206,97 @@ await createFxAgent({ apiKey, backend: "native" }); // require N-API
 await createFxAgent({ apiKey, backend: "wasm" });   // require Wasm + JSPI
 ```
 
-Within one JavaScript realm, libfx compiles each stable Wasm source once and
+CommonJS applications can load the same Node API with `require("libfx")`. The
+package chooses its generated CommonJS entry automatically and keeps asset
+paths relative to the installed package.
+
+Use `getBackendInfo()` to inspect backend availability without creating an
+Agent or terminal:
+
+```js
+import { getBackendInfo } from "libfx";
+
+const info = await getBackendInfo({ surface: "agent", backend: "auto" });
+// {
+//   surface: "agent",
+//   backend: "native" | "wasm-jspi" | "unavailable",
+//   attempts: [{ backend, available, reason }]
+// }
+```
+
+`surface` is `agent` by default and may also be `terminal`. `backend` has the
+same `auto`, `native`, and `wasm` selection as the factories. `nativeAddon` and
+`wasm` select explicit assets with the same meanings as their factory options.
+The probe loads and validates the native module or compiles the selected Wasm
+asset, then stops. It does not create a core, open a runtime socket, read
+credentials, start a model request, or write session state. A remote Wasm
+source can perform its normal asset fetch.
+
+Expected environmental failures resolve as structured attempts. Invalid
+options reject with `TypeError`. The stable reason codes are:
+
+| Code | Meaning |
+| --- | --- |
+| `LIBFX_UNSUPPORTED_PLATFORM` | No packaged native addon supports the current platform and architecture. |
+| `LIBFX_NATIVE_ARTIFACT_MISSING` | The selected native addon file is absent. |
+| `LIBFX_NATIVE_LOAD_FAILED` | Node could not load the selected native addon. |
+| `LIBFX_NATIVE_API_MISMATCH` | The addon API version is incompatible. |
+| `LIBFX_NATIVE_SURFACE_MISSING` | The addon does not implement the selected Agent or terminal surface. |
+| `LIBFX_NATIVE_DISABLED` | `nativeAddon: false` disabled native loading. |
+| `LIBFX_JSPI_UNAVAILABLE` | The current JavaScript runtime does not provide JSPI. |
+| `LIBFX_WASM_LOAD_FAILED` | The selected Wasm asset could not be loaded or compiled. |
+
+The optional `causeCode` field retains a Node error code such as `ENOENT` or
+`ERR_DLOPEN_FAILED` when one exists. Probe success establishes backend loading
+only; it does not validate credentials, a future Agent initialization, or a
+model request.
+
+Within one loaded SDK module, libfx compiles each stable Wasm source once and
 creates a separate WebAssembly instance for every Agent. Agent memory, history,
 tools, cancellation, and shutdown remain isolated. Workers and separate
-processes maintain their own module caches.
+processes maintain their own module caches, as do the ESM and CommonJS entries.
 
 Node.js 20+ is supported. Browser WebAssembly requires a JSPI-capable browser.
+The Linux x64 and arm64 native addons require glibc 2.34 or newer. Native
+agents do not require JSPI or experimental Node flags.
 Some Node versions require `--experimental-wasm-jspi`.
 Bun 1.4.2 is the tested recommendation for Bun's WebAssembly backend.
 Bun 1.3.14 can crash when a hot WebAssembly loop resumes through JSPI during
 JIT tier-up.
+
+### Next.js and Vercel
+
+Create agents in a server route using the Node.js runtime. Import `libfx`
+normally; the package includes its native assets and exposes both ESM and
+CommonJS Node entrypoints. No `serverExternalPackages` setting or manual native
+file inclusion is required.
+
+```js
+import { createFxAgent } from "libfx";
+
+export const runtime = "nodejs";
+
+export async function POST(request) {
+  const { prompt } = await request.json();
+  const agent = await createFxAgent({ apiKey: process.env.AI_GATEWAY_API_KEY });
+  try {
+    let text = "";
+    const turn = agent.prompt(prompt, { signal: request.signal });
+    for await (const event of turn) {
+      if (event.type === "text_delta") text += event.delta;
+    }
+    await turn.result;
+    return Response.json({ text });
+  } finally {
+    await agent.close();
+  }
+}
+```
+
+Use the application's normal authentication and request limits around the
+route. JavaScript tools and MCP clients remain host-owned and must be supplied
+when creating an agent, including after checkpoint restoration. The native
+backend does not enable the CLI's built-in shell or filesystem tools.
 
 ## Interactive terminal
 

--- a/sdk/fx-sdk.js
+++ b/sdk/fx-sdk.js
@@ -1,4 +1,5 @@
 import { CoreOutput, maxCoreMessageBytes } from "./core-output.js";
+import { loadModule } from "./wasm-module.js";
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
@@ -287,43 +288,6 @@ class ByteQueue {
   wake() {
     this.waiters.splice(0).forEach((resolve) => resolve());
   }
-}
-
-const modulePromisesBySource = new Map();
-const modulePromisesByObject = new WeakMap();
-
-async function compileModule(input) {
-  if (input instanceof WebAssembly.Module) return input;
-  if (typeof input === "string") input = fetch(input);
-  if (input instanceof Promise) input = await input;
-  if (input instanceof WebAssembly.Module) return input;
-  if (input instanceof Response) {
-    const contentType = input.headers.get("content-type")?.split(";", 1)[0].trim().toLowerCase();
-    if (contentType === "application/wasm" && typeof WebAssembly.compileStreaming === "function") {
-      return WebAssembly.compileStreaming(input);
-    }
-    const bytes = await input.arrayBuffer();
-    return WebAssembly.compile(bytes);
-  }
-  if (input instanceof ArrayBuffer || ArrayBuffer.isView(input)) {
-    return WebAssembly.compile(input);
-  }
-  throw new TypeError("wasm must be a URL, Response, ArrayBuffer, typed array, or WebAssembly.Module");
-}
-
-function loadModule(input) {
-  if (input instanceof WebAssembly.Module) return Promise.resolve(input);
-  const isString = typeof input === "string";
-  if (!isString && (typeof input !== "object" || input === null)) return compileModule(input);
-  const cache = isString ? modulePromisesBySource : modulePromisesByObject;
-  const cached = cache.get(input);
-  if (cached) return cached;
-  const pending = compileModule(input);
-  cache.set(input, pending);
-  pending.catch(() => {
-    if (cache.get(input) === pending) cache.delete(input);
-  });
-  return pending;
 }
 
 function raceWithTimeout(promise, timeoutMs, timeoutValue) {

--- a/sdk/node.js
+++ b/sdk/node.js
@@ -6,6 +6,7 @@ import { homedir } from "node:os";
 import { isAbsolute, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { CoreOutput } from "./core-output.js";
+import { loadModule, withModuleFailure } from "./wasm-module.js";
 import {
   createFxAgent as createWasmAgent,
   createFxTerminal as createWasmTerminal,
@@ -24,15 +25,22 @@ const fetchOperationStale = 0;
 const fetchOperationApplied = 1;
 const fetchOperationBackpressure = 2;
 
-const require = createRequire(import.meta.url);
+const nodeRequire = createRequire(import.meta.url);
 const defaultCoreWasm = new URL("./fx-core.wasm", import.meta.url);
 const defaultTermWasm = new URL("./fx-term.wasm", import.meta.url);
-const defaultNativeCandidates = [
-  "./libfx.node",
-  `./libfx.${process.platform}-${process.arch}.node`,
-];
 let nativeBackendPromise;
 const wasmFilePromises = new Map();
+
+const backendReasonCodes = {
+  unsupportedPlatform: "LIBFX_UNSUPPORTED_PLATFORM",
+  missingArtifact: "LIBFX_NATIVE_ARTIFACT_MISSING",
+  nativeLoad: "LIBFX_NATIVE_LOAD_FAILED",
+  nativeApi: "LIBFX_NATIVE_API_MISMATCH",
+  missingSurface: "LIBFX_NATIVE_SURFACE_MISSING",
+  disabledNative: "LIBFX_NATIVE_DISABLED",
+  jspiUnavailable: "LIBFX_JSPI_UNAVAILABLE",
+  wasmLoad: "LIBFX_WASM_LOAD_FAILED",
+};
 
 function jspiFallbackError(surface, nativeError) {
   const nativeDetail = nativeError ? ` Native loading failed: ${nativeError.message}.` : " No compatible native addon was found.";
@@ -50,7 +58,8 @@ async function loadNativeCandidate(candidate) {
   if (candidate == null) return null;
   if (candidate instanceof URL) {
     if (candidate.protocol === "file:" && candidate.pathname.endsWith(".node")) {
-      return require(fileURLToPath(candidate));
+      // Bundlers trace the asset URL; Node must load the native file at runtime.
+      return Reflect.apply(nodeRequire, undefined, [fileURLToPath(candidate)]);
     }
     const imported = await import(candidate.href);
     return imported.default ?? imported;
@@ -59,9 +68,27 @@ async function loadNativeCandidate(candidate) {
   if (typeof candidate !== "string") {
     throw new TypeError("nativeAddon must be a module, path, URL, false, or undefined");
   }
-  if (candidate.endsWith(".node")) return require(isAbsolute(candidate) ? candidate : resolve(candidate));
+  if (candidate.endsWith(".node")) {
+    return Reflect.apply(nodeRequire, undefined, [isAbsolute(candidate) ? candidate : resolve(candidate)]);
+  }
   const imported = await import(candidate.startsWith("file:") ? candidate : pathToFileURL(candidate).href);
   return imported.default ?? imported;
+}
+
+function defaultNativeCandidate() {
+  if (process.platform === "linux" && process.arch === "x64") {
+    return new URL("./libfx.linux-x64.node", import.meta.url);
+  }
+  if (process.platform === "linux" && process.arch === "arm64") {
+    return new URL("./libfx.linux-arm64.node", import.meta.url);
+  }
+  if (process.platform === "darwin" && process.arch === "x64") {
+    return new URL("./libfx.darwin-x64.node", import.meta.url);
+  }
+  if (process.platform === "darwin" && process.arch === "arm64") {
+    return new URL("./libfx.darwin-arm64.node", import.meta.url);
+  }
+  return null;
 }
 
 function validateNativeBackend(backend) {
@@ -78,50 +105,216 @@ function validateNativeBackend(backend) {
   return backend;
 }
 
-async function discoverNativeBackend() {
-  for (const relativePath of defaultNativeCandidates) {
-    const url = new URL(relativePath, import.meta.url);
-    try {
-      await access(fileURLToPath(url));
-    } catch (error) {
-      if (error?.code === "ENOENT") continue;
-      return { backend: null, error };
-    }
-    try {
-      return { backend: validateNativeBackend(await loadNativeCandidate(url)), error: null };
-    } catch (error) {
-      return { backend: null, error };
-    }
+function missingArtifact(error) {
+  return error?.code === "ENOENT" || error?.code === "MODULE_NOT_FOUND" || error?.code === "ERR_MODULE_NOT_FOUND";
+}
+
+function nativeCandidateFilePath(candidate) {
+  if (candidate instanceof URL) return candidate.protocol === "file:" ? fileURLToPath(candidate) : null;
+  if (typeof candidate !== "string") return null;
+  if (candidate.startsWith("file:")) return fileURLToPath(new URL(candidate));
+  return URL.canParse(candidate) ? null : resolve(candidate);
+}
+
+async function nativeArtifactMissing(candidate) {
+  try {
+    const path = nativeCandidateFilePath(candidate);
+    if (path === null) return false;
+    await access(path);
+    return false;
+  } catch (error) {
+    return missingArtifact(error);
   }
-  return { backend: null, error: null };
+}
+
+function validationFailure(error) {
+  return error?.message?.startsWith("native addon API version ") ? "api" : "surface";
+}
+
+async function loadAndValidateNativeCandidate(candidate, artifactMissing = false) {
+  let backend;
+  try {
+    backend = await loadNativeCandidate(candidate);
+  } catch (error) {
+    return { backend: null, error, failure: artifactMissing ? "missing" : "load" };
+  }
+  try {
+    return { backend: validateNativeBackend(backend), error: null, failure: null };
+  } catch (error) {
+    return { backend: null, error, failure: validationFailure(error) };
+  }
+}
+
+async function discoverNativeBackend() {
+  const candidate = defaultNativeCandidate();
+  if (!candidate) {
+    return { backend: null, error: null, failure: "unsupported" };
+  }
+  try {
+    await access(fileURLToPath(candidate));
+  } catch (error) {
+    if (missingArtifact(error)) {
+      return { backend: null, error: null, probeError: error, failure: "missing" };
+    }
+    return { backend: null, error, failure: "load" };
+  }
+  return loadAndValidateNativeCandidate(candidate);
 }
 
 async function resolveNativeBackend(nativeAddon) {
-  if (nativeAddon === false) return { backend: null, error: null };
+  if (nativeAddon === false) return { backend: null, error: null, failure: "disabled" };
   if (nativeAddon !== undefined) {
-    try {
-      return { backend: validateNativeBackend(await loadNativeCandidate(nativeAddon)), error: null };
-    } catch (error) {
-      return { backend: null, error };
-    }
+    return loadAndValidateNativeCandidate(nativeAddon, await nativeArtifactMissing(nativeAddon));
   }
   nativeBackendPromise ??= discoverNativeBackend();
   return nativeBackendPromise;
 }
 
-function wasmBytes(input) {
-  let path;
-  if (input instanceof URL && input.protocol === "file:") path = fileURLToPath(input);
-  else if (typeof input === "string" && !URL.canParse(input)) path = resolve(input);
-  else return input;
+function wasmInput(input) {
+  const path = wasmFilePath(input);
+  if (path === null) {
+    if (input instanceof URL) return input.href;
+    return input;
+  }
   const cached = wasmFilePromises.get(path);
   if (cached) return cached;
-  const pending = readFile(path);
+  const pendingRead = readFile(path);
+  let pending;
+  pending = withModuleFailure(pendingRead, () => {
+    if (wasmFilePromises.get(path) === pending) wasmFilePromises.delete(path);
+  });
   wasmFilePromises.set(path, pending);
-  pending.catch(() => {
+  pendingRead.catch(() => {
     if (wasmFilePromises.get(path) === pending) wasmFilePromises.delete(path);
   });
   return pending;
+}
+
+function wasmFilePath(input) {
+  if (input instanceof URL && input.protocol === "file:") return fileURLToPath(input);
+  if (typeof input === "string" && !URL.canParse(input)) return resolve(input);
+  return null;
+}
+
+function reason(code, message, error) {
+  const causeCode = error?.code;
+  return {
+    code,
+    message,
+    ...(typeof causeCode === "string" || typeof causeCode === "number" ? { causeCode } : {}),
+  };
+}
+
+function nativeFailureReason(result) {
+  const detailError = result.probeError ?? result.error;
+  switch (result.failure) {
+    case "unsupported":
+      return reason(
+        backendReasonCodes.unsupportedPlatform,
+        `native addon is not available for ${process.platform}-${process.arch}`,
+      );
+    case "missing":
+      return reason(
+        backendReasonCodes.missingArtifact,
+        `native addon artifact was not found${detailError?.message ? `: ${detailError.message}` : ""}`,
+        detailError,
+      );
+    case "load":
+      return reason(
+        backendReasonCodes.nativeLoad,
+        `native addon failed to load${result.error?.message ? `: ${result.error.message}` : ""}`,
+        result.error,
+      );
+    case "api":
+      return reason(backendReasonCodes.nativeApi, result.error.message, result.error);
+    case "surface":
+      return reason(backendReasonCodes.missingSurface, result.error.message, result.error);
+    case "disabled":
+      return reason(backendReasonCodes.disabledNative, "native addon loading is disabled");
+    default:
+      return reason(backendReasonCodes.nativeLoad, "native addon is unavailable", result.error);
+  }
+}
+
+function validateBackendInfoOptions(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError("getBackendInfo() options must be an object");
+  }
+  const options = { ...value };
+  for (const key of Object.keys(options)) {
+    if (!new Set(["surface", "backend", "nativeAddon", "wasm"]).has(key)) {
+      throw new TypeError(`getBackendInfo() does not accept ${key}`);
+    }
+  }
+  const surface = options.surface ?? "agent";
+  if (!new Set(["agent", "terminal"]).has(surface)) {
+    throw new TypeError('surface must be "agent" or "terminal"');
+  }
+  const backend = options.backend ?? "auto";
+  if (!new Set(["auto", "native", "wasm"]).has(backend)) {
+    throw new TypeError('backend must be "auto", "native", or "wasm"');
+  }
+  if (Object.hasOwn(options, "nativeAddon") && options.nativeAddon !== undefined && options.nativeAddon !== false &&
+    typeof options.nativeAddon !== "string" && !(options.nativeAddon instanceof URL) &&
+    (typeof options.nativeAddon !== "object" || options.nativeAddon === null)) {
+    throw new TypeError("nativeAddon must be a module, path, URL, false, or undefined");
+  }
+  const validWasm = options.wasm === undefined || typeof options.wasm === "string" || options.wasm instanceof URL ||
+    options.wasm instanceof Promise || options.wasm instanceof WebAssembly.Module || options.wasm instanceof Response ||
+    options.wasm instanceof ArrayBuffer || ArrayBuffer.isView(options.wasm);
+  if (Object.hasOwn(options, "wasm") && !validWasm) {
+    throw new TypeError("wasm must be a URL, Response, ArrayBuffer, typed array, or WebAssembly.Module");
+  }
+  return { ...options, surface, backend };
+}
+
+export async function getBackendInfo(value = {}) {
+  const { surface, backend, nativeAddon, wasm } = validateBackendInfoOptions(value);
+  const attempts = [];
+  if (backend !== "wasm") {
+    const native = await resolveNativeBackend(nativeAddon);
+    const nativeMethod = surface === "agent" ? "createCore" : "createFxTerminal";
+    if (typeof native.backend?.[nativeMethod] === "function") {
+      attempts.push({ backend: "native", available: true, reason: null });
+      return { surface, backend: "native", attempts };
+    }
+    const failureReason = native.backend
+      ? reason(backendReasonCodes.missingSurface, `native addon does not provide ${nativeMethod}()`)
+      : nativeFailureReason(native);
+    attempts.push({ backend: "native", available: false, reason: failureReason });
+    if (backend === "native") return { surface, backend: "unavailable", attempts };
+  }
+
+  if (!supportsJspi()) {
+    attempts.push({
+      backend: "wasm-jspi",
+      available: false,
+      reason: reason(
+        backendReasonCodes.jspiUnavailable,
+        "WebAssembly backend requires JavaScript Promise Integration (JSPI)",
+      ),
+    });
+    return { surface, backend: "unavailable", attempts };
+  }
+  const defaultWasm = surface === "agent" ? defaultCoreWasm : defaultTermWasm;
+  const wasmSource = wasm ?? defaultWasm;
+  const pendingWasm = wasmInput(wasmSource);
+  try {
+    await loadModule(pendingWasm);
+    attempts.push({ backend: "wasm-jspi", available: true, reason: null });
+    return { surface, backend: "wasm-jspi", attempts };
+  } catch (error) {
+    attempts.push({
+      backend: "wasm-jspi",
+      available: false,
+      reason: reason(
+        backendReasonCodes.wasmLoad,
+        `WebAssembly asset failed to load or compile: ${error?.message ?? String(error)}`,
+        error,
+      ),
+    });
+    return { surface, backend: "unavailable", attempts };
+  }
 }
 
 function createNativeCoreRuntime(addon, options) {
@@ -321,10 +514,8 @@ async function createWithFallback(surface, nativeMethod, wasmFactory, defaultWas
     if (nativeAttempted) throw nativeError;
     throw jspiFallbackError(surface, nativeError);
   }
-  return wasmFactory({
-    ...runtimeOptions,
-    wasm: await wasmBytes(runtimeOptions.wasm ?? defaultWasm),
-  });
+  const wasmSource = runtimeOptions.wasm ?? defaultWasm;
+  return wasmFactory({ ...runtimeOptions, wasm: wasmInput(wasmSource) });
 }
 
 export async function createFxAgent(options = {}) {

--- a/sdk/node.js
+++ b/sdk/node.js
@@ -298,9 +298,8 @@ export async function getBackendInfo(value = {}) {
   }
   const defaultWasm = surface === "agent" ? defaultCoreWasm : defaultTermWasm;
   const wasmSource = wasm ?? defaultWasm;
-  const pendingWasm = wasmInput(wasmSource);
   try {
-    await loadModule(pendingWasm);
+    await loadModule(wasmInput(wasmSource));
     attempts.push({ backend: "wasm-jspi", available: true, reason: null });
     return { surface, backend: "wasm-jspi", attempts };
   } catch (error) {

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -17,11 +17,17 @@
   },
   "exports": {
     ".": {
-      "node": "./node.js",
+      "node": {
+        "import": "./node.js",
+        "require": "./node.cjs"
+      },
       "browser": "./browser.js",
       "default": "./browser.js"
     },
-    "./node": "./node.js",
+    "./node": {
+      "import": "./node.js",
+      "require": "./node.cjs"
+    },
     "./browser": "./browser.js",
     "./wasm": "./fx-sdk.js",
     "./mcp": "./mcp.js",
@@ -31,7 +37,9 @@
   "files": [
     "browser.js",
     "node.js",
+    "node.cjs",
     "fx-sdk.js",
+    "wasm-module.js",
     "core-output.js",
     "mcp.js",
     "skills.js",

--- a/sdk/scripts/build-node-cjs.mjs
+++ b/sdk/scripts/build-node-cjs.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { mkdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = fileURLToPath(new URL(".", import.meta.url));
+const repoRoot = resolve(scriptDir, "../..");
+const output = resolve(process.argv[2] || resolve(repoRoot, "sdk/dist/libfx/node.cjs"));
+mkdirSync(dirname(output), { recursive: true });
+const result = spawnSync(process.env.BUN_BIN || "bun", [
+  "build",
+  resolve(repoRoot, "sdk/node.js"),
+  "--target=node",
+  "--format=cjs",
+  "--external=*.node",
+  "--define",
+  "import.meta.url=__libfxModuleUrl",
+  "--banner",
+  'var __libfxModuleUrl = require("node:url").pathToFileURL(__filename).href;',
+  "--outfile",
+  output,
+], {
+  cwd: repoRoot,
+  stdio: "inherit",
+});
+
+if (result.error) throw result.error;
+if (result.status !== 0) process.exit(result.status ?? 1);
+console.log(`built CommonJS Node entry in ${output}`);

--- a/sdk/scripts/check-linux-abi.py
+++ b/sdk/scripts/check-linux-abi.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Reject Linux addons that require glibc newer than the release baseline."""
+
+import re
+import subprocess
+import sys
+
+
+def check_versions(report):
+    versions = set(re.findall(r"\bGLIBC_([0-9]+(?:\.[0-9]+)+)\b", report))
+    if not versions:
+        raise ValueError("no glibc version requirements found")
+    if "GLIBC_PRIVATE" in report:
+        raise ValueError("addon requires private glibc symbols")
+    newest = max(versions, key=lambda value: tuple(map(int, value.split("."))))
+    if tuple(map(int, newest.split("."))) > (2, 34, 0):
+        raise ValueError(f"addon requires GLIBC_{newest}; maximum supported is GLIBC_2.34")
+    return newest
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        sys.exit("usage: check-linux-abi.py addon.node")
+    try:
+        report = subprocess.run(
+            ["readelf", "--version-info", sys.argv[1]],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+        newest = check_versions(report)
+    except (OSError, subprocess.CalledProcessError, ValueError) as error:
+        sys.exit(str(error))
+    print(f"Linux addon requires at most GLIBC_{newest} (baseline: GLIBC_2.34)")

--- a/sdk/scripts/package-libfx.mjs
+++ b/sdk/scripts/package-libfx.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { spawnSync } from "node:child_process";
 import { cp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { basename, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -15,6 +16,12 @@ const requiredNativeNames = new Set([
   "libfx.darwin-x64.node",
   "libfx.darwin-arm64.node",
 ]);
+const localNativeName = {
+  "linux-x64": "libfx.linux-x64.node",
+  "linux-arm64": "libfx.linux-arm64.node",
+  "darwin-x64": "libfx.darwin-x64.node",
+  "darwin-arm64": "libfx.darwin-arm64.node",
+}[`${process.platform}-${process.arch}`];
 const files = [
   ["sdk/package.json", "package.json"],
   ["sdk/README.md", "README.md"],
@@ -22,6 +29,7 @@ const files = [
   ["sdk/browser.js", "browser.js"],
   ["sdk/node.js", "node.js"],
   ["sdk/fx-sdk.js", "fx-sdk.js"],
+  ["sdk/wasm-module.js", "wasm-module.js"],
   ["sdk/core-output.js", "core-output.js"],
   ["sdk/mcp.js", "mcp.js"],
   ["sdk/skills.js", "skills.js"],
@@ -44,15 +52,25 @@ if (requestedNativeAddons.length) {
     ].filter(Boolean).join("; "));
   }
 }
+if (!requestedNativeAddons.length && !localNativeName) {
+  throw new Error(`local native packaging is unsupported on ${process.platform}-${process.arch}`);
+}
 
 await rm(outputDir, { recursive: true, force: true });
 await mkdir(outputDir, { recursive: true });
+const cjsBuild = spawnSync(process.execPath, [
+  resolve(repoRoot, "sdk/scripts/build-node-cjs.mjs"),
+  resolve(outputDir, "node.cjs"),
+], { cwd: repoRoot, stdio: "inherit" });
+if (cjsBuild.error) throw cjsBuild.error;
+if (cjsBuild.status !== 0) process.exit(cjsBuild.status ?? 1);
 for (const [source, destination] of files) {
   await cp(resolve(repoRoot, source), resolve(outputDir, destination));
 }
 for (const addon of nativeAddons) {
   if (!addon.endsWith(".node")) throw new Error(`native addon must end in .node: ${addon}`);
-  await cp(addon, resolve(outputDir, basename(addon)));
+  const destination = requestedNativeAddons.length ? basename(addon) : localNativeName;
+  await cp(addon, resolve(outputDir, destination));
 }
 
 const manifest = JSON.parse(await readFile(resolve(outputDir, "package.json"), "utf8"));
@@ -60,5 +78,8 @@ manifest.files = undefined;
 await writeFile(resolve(outputDir, "package.json"), `${JSON.stringify(manifest, null, 2)}\n`);
 
 console.log(`packaged ${manifest.name} in ${outputDir}`);
+console.log("  node.cjs");
 for (const [, destination] of files) console.log(`  ${destination}`);
-for (const addon of nativeAddons) console.log(`  ${basename(addon)}`);
+for (const addon of nativeAddons) {
+  console.log(`  ${requestedNativeAddons.length ? basename(addon) : localNativeName}`);
+}

--- a/sdk/scripts/package-term-demo.mjs
+++ b/sdk/scripts/package-term-demo.mjs
@@ -11,13 +11,15 @@ const htmlPath = resolve(repoRoot, "sdk/term-demo.html");
 const browserPath = resolve(repoRoot, "sdk/browser.js");
 const sdkPath = resolve(repoRoot, "sdk/fx-sdk.js");
 const coreOutputPath = resolve(repoRoot, "sdk/core-output.js");
+const wasmModulePath = resolve(repoRoot, "sdk/wasm-module.js");
 const wasmPath = resolve(repoRoot, "zig-out/bin/fx-term.wasm");
 
-const [htmlSource, browserBytes, sdkSource, coreOutputBytes, wasmBytes] = await Promise.all([
+const [htmlSource, browserBytes, sdkSource, coreOutputBytes, wasmModuleBytes, wasmBytes] = await Promise.all([
   readFile(htmlPath, "utf8"),
   readFile(browserPath),
   readFile(sdkPath),
   readFile(coreOutputPath),
+  readFile(wasmModulePath),
   readFile(wasmPath),
 ]);
 
@@ -25,7 +27,11 @@ const digest = (bytes) => createHash("sha256").update(bytes).digest("hex");
 const integrity = (bytes) => `sha256-${createHash("sha256").update(bytes).digest("base64")}`;
 const coreOutputHash = digest(coreOutputBytes);
 const coreOutputName = `core-output.${coreOutputHash}.js`;
-const sdkBytes = Buffer.from(sdkSource.toString().replace('from "./core-output.js";', `from "./${coreOutputName}";`));
+const wasmModuleHash = digest(wasmModuleBytes);
+const wasmModuleName = `wasm-module.${wasmModuleHash}.js`;
+const sdkBytes = Buffer.from(sdkSource.toString()
+  .replace('from "./core-output.js";', `from "./${coreOutputName}";`)
+  .replace('from "./wasm-module.js";', `from "./${wasmModuleName}";`));
 const sdkHash = digest(sdkBytes);
 const wasmHash = digest(wasmBytes);
 const sdkName = `fx-sdk.${sdkHash}.js`;
@@ -75,6 +81,10 @@ const vercelConfig = {
       headers: [{ key: "Cache-Control", value: "public, max-age=31536000, immutable" }],
     },
     {
+      source: `/${wasmModuleName}`,
+      headers: [{ key: "Cache-Control", value: "public, max-age=31536000, immutable" }],
+    },
+    {
       source: `/${wasmName}`,
       headers: [{ key: "Cache-Control", value: "public, max-age=31536000, immutable" }],
     },
@@ -89,6 +99,7 @@ await Promise.all([
   writeFile(resolve(outputDir, browserName), packagedBrowser),
   writeFile(resolve(outputDir, sdkName), sdkBytes),
   writeFile(resolve(outputDir, coreOutputName), coreOutputBytes),
+  writeFile(resolve(outputDir, wasmModuleName), wasmModuleBytes),
   writeFile(resolve(outputDir, wasmName), wasmBytes),
   writeFile(resolve(outputDir, "vercel.json"), `${JSON.stringify(vercelConfig, null, 2)}\n`),
 ]);
@@ -98,6 +109,7 @@ const manifest = {
   browser: { file: browserName, sha256: digest(packagedBrowser), bytes: packagedBrowser.byteLength },
   sdk: { file: sdkName, sha256: sdkHash, bytes: sdkBytes.byteLength },
   coreOutput: { file: coreOutputName, sha256: coreOutputHash, bytes: coreOutputBytes.byteLength },
+  wasmModule: { file: wasmModuleName, sha256: wasmModuleHash, bytes: wasmModuleBytes.byteLength },
   wasm: { file: wasmName, sha256: wasmHash, integrity: integrity(wasmBytes), bytes: wasmBytes.byteLength },
 };
 await writeFile(resolve(outputDir, "manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`);
@@ -106,4 +118,5 @@ console.log(`packaged ${basename(outputDir)}`);
 console.log(`  ${browserName}`);
 console.log(`  ${sdkName}`);
 console.log(`  ${coreOutputName}`);
+console.log(`  ${wasmModuleName}`);
 console.log(`  ${wasmName}`);

--- a/sdk/tests/next/app/api/fx/route.js
+++ b/sdk/tests/next/app/api/fx/route.js
@@ -1,0 +1,144 @@
+import { randomUUID } from "node:crypto";
+import { createFxAgent, getBackendInfo } from "libfx";
+import { createMcpAdapter } from "libfx/mcp";
+
+export const runtime = "nodejs";
+
+function stream(events) {
+  const data = [...events, "[DONE]"].map((event) => `data: ${typeof event === "string" ? event : JSON.stringify(event)}\n\n`).join("");
+  return new Response(data, { headers: { "content-type": "text/event-stream" } });
+}
+
+export async function GET(request) {
+  const token = process.env.LIBFX_SMOKE_TOKEN;
+  const live = process.env.LIBFX_LIVE === "1";
+  if ((token && request.headers.get("authorization") !== `Bearer ${token}`) || (live && !token)) {
+    return new Response(null, { status: 401 });
+  }
+  const url = new URL(request.url);
+  const backend = url.searchParams.get("backend") ?? "auto";
+  const scenario = url.searchParams.get("scenario") ?? "host";
+  if (!["host", "mcp", "error", "cancel", "resume"].includes(scenario)) {
+    return Response.json({ error: "Unknown scenario" }, { status: 400 });
+  }
+  let agent;
+  let adapter;
+  let closedMcp = false;
+  let toolCalls = 0;
+  let modelRequests = 0;
+  let observedValue;
+  let toolAborted = false;
+  const events = [];
+  const expectedValue = `verified:${randomUUID()}`;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 30_000);
+  try {
+    const probe = await getBackendInfo({ backend });
+    if (probe.backend === "unavailable") return Response.json({ probe }, { status: 503 });
+    let tools = [{
+      name: "lookup",
+      description: "Get the verification value. Call once with key alpha, then repeat the returned value.",
+      inputSchema: { type: "object", properties: { key: { type: "string" } }, required: ["key"] },
+      async execute(input, { signal }) {
+        toolCalls++;
+        if (input.key !== "alpha") throw new Error("Unexpected lookup key");
+        if (scenario === "error") throw new Error("fixture tool failure");
+        if (scenario === "cancel") {
+          signal.addEventListener("abort", () => { toolAborted = true; }, { once: true });
+          controller.abort();
+          return new Promise(() => {});
+        }
+        observedValue = expectedValue;
+        return expectedValue;
+      },
+    }];
+    if (scenario === "mcp") {
+      let id = 0;
+      const rpc = async (method, params, signal) => {
+        const response = await fetch(new URL("/api/mcp", request.url), {
+          method: "POST", signal,
+          headers: { "content-type": "application/json", ...(token ? { authorization: `Bearer ${token}` } : {}) },
+          body: JSON.stringify({ jsonrpc: "2.0", id: ++id, method, params }),
+        });
+        if (!response.ok) throw new Error(`MCP HTTP ${response.status}`);
+        const message = await response.json();
+        if (message.error) throw new Error(message.error.message);
+        return message.result;
+      };
+      adapter = await createMcpAdapter({
+        listTools: (params) => rpc("tools/list", params, controller.signal),
+        async callTool(params, _schema, options) {
+          toolCalls++;
+          const result = await rpc("tools/call", params, options.signal);
+          observedValue = result.content[0].text;
+          return result;
+        },
+        async close() { closedMcp = true; },
+      });
+      tools = adapter.tools;
+    }
+    const options = {
+      backend,
+      apiKey: live ? process.env.AI_GATEWAY_API_KEY : "fixture-unused-key",
+      model: live ? process.env.LIBFX_TEST_MODEL : "fixture/model",
+      tools,
+      instructions: "Call lookup exactly once with key alpha, then repeat its returned value. If it fails, say tool failed.",
+      ...(!live ? { fetch: async (_url, init) => {
+        if (init?.method === "GET") return Response.json({ data: [{ id: "fixture/model", type: "language", tags: ["tool-use"] }] });
+        modelRequests++;
+        const body = JSON.parse(init.body);
+        if (modelRequests === 1) {
+          if (!body.tools.some((tool) => tool.name === "lookup")) throw new Error("Tool schema missing from request");
+          return stream([
+            { type: "tool-call", toolCallId: "lookup-1", toolName: "lookup", input: { key: "alpha" } },
+            { type: "finish", finishReason: { unified: "tool-calls", raw: "tool-calls" } },
+          ]);
+        }
+        const expected = scenario === "error" ? "fixture tool failure" : observedValue;
+        if (!expected || !JSON.stringify(body).includes(expected)) throw new Error("Tool result missing from next request");
+        return stream([
+          { type: "text-delta", delta: scenario === "error" ? "tool failed" : expected },
+          { type: "finish", finishReason: { unified: "stop", raw: "stop" }, usage: { inputTokens: { total: 1 }, outputTokens: { total: 1 } } },
+        ]);
+      } } : {}),
+    };
+    agent = await createFxAgent(options);
+    const turn = agent.prompt("Look up key alpha and repeat its value.", { signal: controller.signal });
+    let text = "";
+    for await (const event of turn) {
+      events.push(event.type);
+      if (event.type === "text_delta") text += event.delta;
+    }
+    const result = await turn.result;
+    if (toolCalls !== 1) throw new Error(`Expected one tool callback, received ${toolCalls}`);
+    if (!events.includes("tool_start")) throw new Error("Missing tool_start event");
+    if (scenario === "cancel") {
+      if (result.stopReason !== "cancelled" || !toolAborted) throw new Error("Tool cancellation did not settle");
+    } else {
+      if (result.stopReason !== "end_turn" || !events.includes("tool_end")) throw new Error("Tool turn did not complete");
+      if (scenario !== "error" && !text.includes(observedValue)) throw new Error("Model did not use the tool result");
+    }
+    const checkpoint = await agent.checkpoint();
+    await agent.close();
+    agent = null;
+    if (scenario === "resume") {
+      agent = await createFxAgent({ ...options, checkpoint });
+      const resumed = agent.prompt("Repeat the value you looked up without calling another tool.", { signal: controller.signal });
+      let resumedText = "";
+      for await (const event of resumed) if (event.type === "text_delta") resumedText += event.delta;
+      if ((await resumed.result).stopReason !== "end_turn" || !resumedText.includes(observedValue)) throw new Error("Checkpoint restore lost tool history");
+      await agent.close();
+      agent = null;
+    }
+    await adapter?.close();
+    adapter = null;
+    return Response.json({ ok: true, scenario, probe, toolCalls, modelRequests, events, result, checkpointBytes: checkpoint.length,
+      closedMcp, node: process.version, arch: process.arch, glibc: process.report.getReport().header.glibcVersionRuntime ?? null });
+  } catch (error) {
+    return Response.json({ ok: false, code: error.code, message: error.message }, { status: 500 });
+  } finally {
+    clearTimeout(timeout);
+    await agent?.close();
+    await adapter?.close();
+  }
+}

--- a/sdk/tests/next/app/api/mcp/route.js
+++ b/sdk/tests/next/app/api/mcp/route.js
@@ -1,0 +1,24 @@
+import { randomUUID } from "node:crypto";
+
+export const runtime = "nodejs";
+
+export async function POST(request) {
+  const token = process.env.LIBFX_SMOKE_TOKEN;
+  if (token && request.headers.get("authorization") !== `Bearer ${token}`) {
+    return new Response(null, { status: 401 });
+  }
+  const { id, method, params } = await request.json();
+  let result;
+  if (method === "tools/list") {
+    result = { tools: [{
+      name: "lookup",
+      description: "Get the verification value. Call once with key alpha, then repeat the returned value.",
+      inputSchema: { type: "object", properties: { key: { type: "string" } }, required: ["key"] },
+    }] };
+  } else if (method === "tools/call" && params?.name === "lookup") {
+    result = { content: [{ type: "text", text: `verified:${randomUUID()}` }] };
+  } else {
+    return Response.json({ jsonrpc: "2.0", id, error: { code: -32601, message: "Unknown method" } });
+  }
+  return Response.json({ jsonrpc: "2.0", id, result });
+}

--- a/sdk/tests/next/app/layout.js
+++ b/sdk/tests/next/app/layout.js
@@ -1,0 +1,3 @@
+export default function Layout({ children }) {
+  return <html><body>{children}</body></html>;
+}

--- a/sdk/tests/next/app/page.js
+++ b/sdk/tests/next/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return "libfx package integration fixture";
+}

--- a/sdk/tests/next/package.json
+++ b/sdk/tests/next/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "libfx-next-test",
+  "private": true,
+  "type": "module",
+  "packageManager": "pnpm@11.1.1",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "16.3.4",
+    "react": "19.2.4",
+    "react-dom": "19.2.4"
+  }
+}

--- a/sdk/tests/next/pnpm-lock.yaml
+++ b/sdk/tests/next/pnpm-lock.yaml
@@ -1,0 +1,580 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      next:
+        specifier: 16.3.4
+        version: 16.3.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react:
+        specifier: 19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: 19.2.4
+        version: 19.2.4(react@19.2.4)
+
+packages:
+
+  '@emnapi/runtime@1.11.3':
+    resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
+
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.35.4':
+    resolution: {integrity: sha512-Uhfl4V4lhP2nbUVF9+hyH1+luj86f1gUFeo8ALYxFoULoU+G87D43BfeMP8XHsk9boxAnCY/bf2EHwhA7MuGsA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.35.4':
+    resolution: {integrity: sha512-hWniXY3bG5qKpkKrAwPe4y+VTPmf086YQAnkxWh7uA1YrlRouWGa0M0Mxj3ZjnXFkv7/TD1bTy9lGUK26vRvWw==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-freebsd-wasm32@0.35.4':
+    resolution: {integrity: sha512-lIsKw/BU+kjB4eZjxrYrZmwOJYi3Ajrv66iAlBmUPyKc3HpnloevB1g3wxGD9P/5BbQ1brBGl65VRRrCvQDEqA==}
+    engines: {node: '>=20.9.0'}
+    os: [freebsd]
+
+  '@img/sharp-libvips-darwin-arm64@1.3.3':
+    resolution: {integrity: sha512-suTBPTDGrI9WodccaDdwZItTSaBYASlBk1NSfElSHrUfzu3szG6lvIF58+WiFvnfzuK8ZBFS5zE00PxqxnRiPg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.3.3':
+    resolution: {integrity: sha512-FVJZ5mITMobmXIz/hPDTw0EintTW5H3WfrxwLqEqjiIihlu+hVRyGrFQ60xl0Lxn7Bt3zdpevPaQi0HEzqz9fw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.3.3':
+    resolution: {integrity: sha512-0DaL0A6Xu6sQSQFwe4iVCrKWU2cCTItnRsYsCdxAMm9NF6twAA9BKnoqy4hqz4+azQ0JHuA26qiUKsf1XJ/v5A==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm@1.3.3':
+    resolution: {integrity: sha512-3rbU4vqXXc3hY/OiXdl52xZvT0F1yEngWfvqudtPJg/KkyiaQw2DRsFrNzpmLvfavbwOq3qXn36GP8obHRULQA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-ppc64@1.3.3':
+    resolution: {integrity: sha512-cdn1OvUBwsXhbC0zSzJnNzf5MZ/mTrobawDvNXBTxe8VtqKAm0sRuEY2Evzovb/w9JMk4TvRxqt1mekSuJz64w==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-riscv64@1.3.3':
+    resolution: {integrity: sha512-HjPVx7yKz+0lqdhDlTw1tt90wamBoxhiXpvl1XZpJLiHH4RCJ5yDTqH+VlYPv2fwFs89JFw4c1IexYOcQUi4IQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.3.3':
+    resolution: {integrity: sha512-neWLh+3yCNThxnfy3c4BbVBeGgt9aftno+XbT56iK28RgeDs3UOFWviLWlUu0bArYVYJaFDK+RRohbicUNCm8Q==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-x64@1.3.3':
+    resolution: {integrity: sha512-4vKmvAst9nrowcqquKFAyZJUDolUaIp8uRiN0mWFguJ1IplC9/pitXtlnnlU4aa/eJw3J7i67V+pwUL+wZGdsA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.3':
+    resolution: {integrity: sha512-Y9kQaLMuNoB0bPYOOdcZMaseNrFpPodIWWMrx+CZyydf2xn68j9WYc6sWWRrDwNkzCQjKYfc68L7jKjGlHMibw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.3.3':
+    resolution: {integrity: sha512-fj8Mv0HHfD1Rr+4I68+3agJynxDWtBFgicTbSOb9Bke6pIwzGcJ+RX/yHjmiEGFMCavY/dxvem7MyNaJF+wDiw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linux-arm64@0.35.4':
+    resolution: {integrity: sha512-De4jpEnAU8Hd5oT0j1G3uL4ZvTuipVMn7YC6vPaJhy6/7EwEae0SVAoBrUMYQbkLGDm85taVWwuPc1a44LTzCQ==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.35.4':
+    resolution: {integrity: sha512-7OAS8gI0EReKGVN2HssHlM6umJgxF5VI3xN0p9FA91p/YO+ou5hiNghLdZ5BEHztwaaK5+bLKRf8x/o2L2nk9A==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-ppc64@0.35.4':
+    resolution: {integrity: sha512-2oYZJeIl4kCcMGk4ouZVjnkCtFrpQFlNEtJ6GbxzhHQchwH0NH/qEb9ykmOl29dqwMq+JhFdZn+1ak2FKhI9fQ==}
+    engines: {node: '>=20.9.0'}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-riscv64@0.35.4':
+    resolution: {integrity: sha512-cPbNChoRURAWdebDIHSenxRpgEdy7JkPydSnUxRm9VvKD7m0/xVaR/8Fzlu81pk5nHEvHH87UZUA7cTtwnbJSA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-s390x@0.35.4':
+    resolution: {integrity: sha512-RY0JFY8Fd6RonCBtHz+DvadaPkXDSI1AUn6yWL9TipqkZ1vY8w8evqdgyDFnkm4/K1ve1TvZiaePP5oSd4+WVQ==}
+    engines: {node: '>=20.9.0'}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.35.4':
+    resolution: {integrity: sha512-9qvvEAuk8k89TfWUoX2htWjbAMX8p+NxCppjpcg5k6xMsjhBQPTsoIh36h9Qde4WRuGpJeYnOjdosDn/cnv+OA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linuxmusl-arm64@0.35.4':
+    resolution: {integrity: sha512-KB5jxpfWQTr0nc3xdHtWChdbifHrBGsd2SM62Eyxrl8afikm+f5qGBU75SJIZBT/S1MC8XyacdlXBMSWq6OURA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.35.4':
+    resolution: {integrity: sha512-f+eZJZIQNEEd26RPSW+76chwOf1XtA2Y/O+5ocVyLliHkeih3e+jhLVBdNTd2rS3IbNXK8+ug93Vf5ZXtF5Lxg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-wasm32@0.35.4':
+    resolution: {integrity: sha512-zQnl4Kwp7Q6NHsENtU2T/00Zi+w3AQNwz3+UaTyVBy2FpXrzXzGjndpK61onhZjRtRpQXxCTeqw19bVyXOh7jA==}
+    engines: {node: '>=20.9.0'}
+
+  '@img/sharp-webcontainers-wasm32@0.35.4':
+    resolution: {integrity: sha512-ESfNkywmCfPNyaZjxooddJQiQ+l/nTpGEOGthxiLnIHXC/CmcBixnfwUleX9mCz9ovrUUvKMap/pm8RYbzfwaA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.35.4':
+    resolution: {integrity: sha512-iNdlBX9gLVvqe2I3uIJSIKTq6wckP/DYxZtcqxm09x5Gi24DnFBmPAWZmr60ZyYMG0xlzo6goG3670ar+RXvRw==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.35.4':
+    resolution: {integrity: sha512-kqRsbaa5CS6KHlpxnN7WhE6vAAugXyZButpRdvDWetlv6Qv4N9WTcrWzF7tXfB9T7MsoadqdI8hmwLq6UlLvtw==}
+    engines: {node: ^20.9.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.35.4':
+    resolution: {integrity: sha512-XtmnYhBcrORsJ4XJngyzr/EWP0hRZLAZRFaApdKuviyqF78+ylxh2y06ZmtULAMOnObJ3ucpN0AcwSWnMowTRg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@next/env@16.3.4':
+    resolution: {integrity: sha512-cjWZnUUa6jZq2kFaNe/ZyJdZonOZ/QoN0Zka2nz/FLOrfx14pQuM9c5RaSVkWMqgdt4ksgPAMWPyHSs/CyV48Q==}
+
+  '@next/swc-darwin-arm64@16.3.4':
+    resolution: {integrity: sha512-iBr3I5LZNk5/bgl5//iTgD2tcym14MX0Xo7fD//u9dYAEgGzza1y9oywluPtf74YnOswVdH1908aK9xVz7zQTw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@next/swc-darwin-x64@16.3.4':
+    resolution: {integrity: sha512-2dpiSyl2Jw/NrBPaU2MAKGSa+2MR82pJIn4Sm5Rjr+gxAeuh0z158Su3Z2O8zn7UNNq+ej4bToed6RcRN/Lydg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@next/swc-linux-arm64-gnu@16.3.4':
+    resolution: {integrity: sha512-+t+U8HZT+fApePCS5h89CSH3datz29MkzyfCn+6fpsZBG/oiEOhINcb9rtkv6sdpToLGFn2e6146NzaKCXkqrA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-arm64-musl@16.3.4':
+    resolution: {integrity: sha512-mx03GNs1ocQA5JQ4FxDMmIsNkdrZh8cuezKCrId28e5/gIPU/l7Kcy2+vmCCzdjnnmXJy+iOAu+7K0QppO6Urg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@next/swc-linux-x64-gnu@16.3.4':
+    resolution: {integrity: sha512-YIhGY6fSMfha52bnVxnzc9zaVBzJg+cqQTOD8tXIBSx4fuv0pVMxQTE0PaS59YhnMOiYiG09IMwxJAf/CFm/Dw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-x64-musl@16.3.4':
+    resolution: {integrity: sha512-+eaaX6axpDb0yF1GCpiERe6njplvdC+nks/fKfcHu3XPGRrald8P3/X7yv7QLdjA51knnxwl9pxdIJsg+w1L+Q==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@next/swc-win32-arm64-msvc@16.3.4':
+    resolution: {integrity: sha512-0jcXW7Xs/uzICrmgV3MhDYDeRy++1CqnpDIerlPIqYO4bhzB4WNbX/aRnQclustsAyTkFKB0z6rbcjmNg5tR8A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@next/swc-win32-x64-msvc@16.3.4':
+    resolution: {integrity: sha512-vvBzwu1pYQCp92maZCFCIw/XgOTMR5tur9GjakwIo2cmwRTMKajRZZDS9+e4KsUZWKu1E007WUeAFXRRjZeuzw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@swc/helpers@0.5.23':
+    resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
+
+  baseline-browser-mapping@2.11.21:
+    resolution: {integrity: sha512-uh8vpY/1/YyFkunIDFH/12p7/7VdPKA1hejMVEbdkEaWnUz0Hesvx5EbiU6XxjyHZIOju+ZMbQJkRh+es3/spQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  caniuse-lite@1.0.30001810:
+    resolution: {integrity: sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==}
+
+  client-only@0.0.1:
+    resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  next@16.3.4:
+    resolution: {integrity: sha512-/Ztf6CeRH+ejEXUrYtqI4gkS66eFIHuSwqi60RgcpWKodxFZx2/dqVCMKBwILfAHXQ+F1b1vAudgj3mnxqtoIA==}
+    engines: {node: '>=20.9.0'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.51.1
+      babel-plugin-react-compiler: '*'
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+      sass:
+        optional: true
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  react-dom@19.2.4:
+    resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
+    peerDependencies:
+      react: ^19.2.4
+
+  react@19.2.4:
+    resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
+    engines: {node: '>=0.10.0'}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  sharp@0.35.4:
+    resolution: {integrity: sha512-n++8XWcj+jCOr2IOl7h8LbKnGBDY4aPbmprMONBNFdn0ImXqpGVv5zliDs0V9HbmbCQLpbuo2ej9rAoOQTvMDA==}
+    engines: {node: '>=20.9.0'}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  styled-jsx@5.1.6:
+    resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
+    engines: {node: '>= 12.0.0'}
+    peerDependencies:
+      '@babel/core': '*'
+      babel-plugin-macros: '*'
+      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      babel-plugin-macros:
+        optional: true
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+snapshots:
+
+  '@emnapi/runtime@1.11.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@img/colour@1.1.0':
+    optional: true
+
+  '@img/sharp-darwin-arm64@0.35.4':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.3.3
+    optional: true
+
+  '@img/sharp-darwin-x64@0.35.4':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.3.3
+    optional: true
+
+  '@img/sharp-freebsd-wasm32@0.35.4':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.3.3':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.3.3':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.3.3':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.3.3':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.3.3':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.3.3':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.3.3':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.3.3':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.3':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.3.3':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.35.4':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.3.3
+    optional: true
+
+  '@img/sharp-linux-arm@0.35.4':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.3.3
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.35.4':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.3.3
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.35.4':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.3.3
+    optional: true
+
+  '@img/sharp-linux-s390x@0.35.4':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.3.3
+    optional: true
+
+  '@img/sharp-linux-x64@0.35.4':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.3.3
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.35.4':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.3
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.35.4':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.3
+    optional: true
+
+  '@img/sharp-wasm32@0.35.4':
+    dependencies:
+      '@emnapi/runtime': 1.11.3
+    optional: true
+
+  '@img/sharp-webcontainers-wasm32@0.35.4':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.4
+    optional: true
+
+  '@img/sharp-win32-arm64@0.35.4':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.35.4':
+    optional: true
+
+  '@img/sharp-win32-x64@0.35.4':
+    optional: true
+
+  '@next/env@16.3.4': {}
+
+  '@next/swc-darwin-arm64@16.3.4':
+    optional: true
+
+  '@next/swc-darwin-x64@16.3.4':
+    optional: true
+
+  '@next/swc-linux-arm64-gnu@16.3.4':
+    optional: true
+
+  '@next/swc-linux-arm64-musl@16.3.4':
+    optional: true
+
+  '@next/swc-linux-x64-gnu@16.3.4':
+    optional: true
+
+  '@next/swc-linux-x64-musl@16.3.4':
+    optional: true
+
+  '@next/swc-win32-arm64-msvc@16.3.4':
+    optional: true
+
+  '@next/swc-win32-x64-msvc@16.3.4':
+    optional: true
+
+  '@swc/helpers@0.5.23':
+    dependencies:
+      tslib: 2.8.1
+
+  baseline-browser-mapping@2.11.21: {}
+
+  caniuse-lite@1.0.30001810: {}
+
+  client-only@0.0.1: {}
+
+  detect-libc@2.1.2:
+    optional: true
+
+  nanoid@3.3.18: {}
+
+  next@16.3.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@next/env': 16.3.4
+      '@swc/helpers': 0.5.23
+      baseline-browser-mapping: 2.11.21
+      caniuse-lite: 1.0.30001810
+      postcss: 8.5.23
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      styled-jsx: 5.1.6(react@19.2.4)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 16.3.4
+      '@next/swc-darwin-x64': 16.3.4
+      '@next/swc-linux-arm64-gnu': 16.3.4
+      '@next/swc-linux-arm64-musl': 16.3.4
+      '@next/swc-linux-x64-gnu': 16.3.4
+      '@next/swc-linux-x64-musl': 16.3.4
+      '@next/swc-win32-arm64-msvc': 16.3.4
+      '@next/swc-win32-x64-msvc': 16.3.4
+      sharp: 0.35.4
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@types/node'
+      - babel-plugin-macros
+
+  picocolors@1.1.1: {}
+
+  postcss@8.5.23:
+    dependencies:
+      nanoid: 3.3.18
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  react-dom@19.2.4(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      scheduler: 0.27.0
+
+  react@19.2.4: {}
+
+  scheduler@0.27.0: {}
+
+  semver@7.8.5:
+    optional: true
+
+  sharp@0.35.4:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.5
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.35.4
+      '@img/sharp-darwin-x64': 0.35.4
+      '@img/sharp-freebsd-wasm32': 0.35.4
+      '@img/sharp-libvips-darwin-arm64': 1.3.3
+      '@img/sharp-libvips-darwin-x64': 1.3.3
+      '@img/sharp-libvips-linux-arm': 1.3.3
+      '@img/sharp-libvips-linux-arm64': 1.3.3
+      '@img/sharp-libvips-linux-ppc64': 1.3.3
+      '@img/sharp-libvips-linux-riscv64': 1.3.3
+      '@img/sharp-libvips-linux-s390x': 1.3.3
+      '@img/sharp-libvips-linux-x64': 1.3.3
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.3
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.3
+      '@img/sharp-linux-arm': 0.35.4
+      '@img/sharp-linux-arm64': 0.35.4
+      '@img/sharp-linux-ppc64': 0.35.4
+      '@img/sharp-linux-riscv64': 0.35.4
+      '@img/sharp-linux-s390x': 0.35.4
+      '@img/sharp-linux-x64': 0.35.4
+      '@img/sharp-linuxmusl-arm64': 0.35.4
+      '@img/sharp-linuxmusl-x64': 0.35.4
+      '@img/sharp-webcontainers-wasm32': 0.35.4
+      '@img/sharp-win32-arm64': 0.35.4
+      '@img/sharp-win32-ia32': 0.35.4
+      '@img/sharp-win32-x64': 0.35.4
+    optional: true
+
+  source-map-js@1.2.1: {}
+
+  styled-jsx@5.1.6(react@19.2.4):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.2.4
+
+  tslib@2.8.1: {}

--- a/sdk/tests/test-backend-info.mjs
+++ b/sdk/tests/test-backend-info.mjs
@@ -19,6 +19,7 @@ const replacedWasm = join(temp, "replaced.wasm");
 const stableWasm = join(temp, "stable.wasm");
 const dependencyAddon = join(temp, "dependency-addon.mjs");
 const nonlocalAddon = new URL("file://other-host/tmp/addon.node");
+const nonlocalWasm = new URL("file://other-host/tmp/core.wasm");
 await writeFile(corruptAddon, "not a native addon");
 await writeFile(corruptWasm, "not WebAssembly");
 await writeFile(replacedWasm, "not WebAssembly");
@@ -162,6 +163,22 @@ try {
   const nonlocalCheckpoint = await nonlocalFallback.checkpoint();
   await nonlocalFallback.close();
   assert.ok(nonlocalCheckpoint.length > 0, "auto mode must fall back after a nonlocal addon URL fails");
+
+  const nonlocalWasmInfo = await getBackendInfo({ backend: "wasm", wasm: nonlocalWasm });
+  assert.equal(nonlocalWasmInfo.backend, "unavailable");
+  assert.equal(nonlocalWasmInfo.attempts[0].reason.code, "LIBFX_WASM_LOAD_FAILED");
+  assert.equal(nonlocalWasmInfo.attempts[0].reason.causeCode, "ERR_INVALID_FILE_URL_HOST");
+  const nonlocalWasmAuto = await getBackendInfo({ backend: "auto", nativeAddon: false, wasm: nonlocalWasm });
+  assert.equal(nonlocalWasmAuto.backend, "unavailable");
+  assert.deepEqual(nonlocalWasmAuto.attempts.map(({ backend, reason }) => [backend, reason?.code]), [
+    ["native", "LIBFX_NATIVE_DISABLED"],
+    ["wasm-jspi", "LIBFX_WASM_LOAD_FAILED"],
+  ]);
+  await assert.rejects(
+    createFxAgent({ backend: "wasm", wasm: nonlocalWasm, apiKey: "nonlocal-wasm-key" }),
+    (error) => error?.code === "ERR_INVALID_FILE_URL_HOST",
+  );
+  assert.equal((await getBackendInfo({ backend: "auto", nativeAddon: false, wasm: coreWasm })).backend, "wasm-jspi");
 
   const missingWasmInfo = await getBackendInfo({ backend: "wasm", wasm: missingWasm });
   assert.equal(missingWasmInfo.backend, "unavailable");

--- a/sdk/tests/test-backend-info.mjs
+++ b/sdk/tests/test-backend-info.mjs
@@ -1,0 +1,275 @@
+#!/usr/bin/env node
+import { strict as assert } from "node:assert";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createFxAgent, createFxTerminal, getBackendInfo } from "../node.js";
+
+const scriptDir = fileURLToPath(new URL(".", import.meta.url));
+const coreWasm = resolve(scriptDir, "../../zig-out/bin/fx-core.wasm");
+const termWasm = resolve(scriptDir, "../../zig-out/bin/fx-term.wasm");
+const temp = await mkdtemp(join(tmpdir(), "libfx-backend-info-"));
+const missingAddon = join(temp, "missing.node");
+const corruptAddon = join(temp, "corrupt.node");
+const missingWasm = join(temp, "missing.wasm");
+const corruptWasm = join(temp, "corrupt.wasm");
+const replacedWasm = join(temp, "replaced.wasm");
+const stableWasm = join(temp, "stable.wasm");
+const dependencyAddon = join(temp, "dependency-addon.mjs");
+const nonlocalAddon = new URL("file://other-host/tmp/addon.node");
+await writeFile(corruptAddon, "not a native addon");
+await writeFile(corruptWasm, "not WebAssembly");
+await writeFile(replacedWasm, "not WebAssembly");
+await writeFile(stableWasm, await readFile(coreWasm));
+await writeFile(dependencyAddon, `
+  import "./missing-dependency.mjs";
+  export const libfxApiVersion = 3;
+  export function createCore() { throw new Error("dependency addon factory invoked"); }
+`);
+
+const matchingCore = {
+  libfxApiVersion: 3,
+  createCore() { assert.fail("backend probing must not create a core"); },
+};
+const matchingTerminal = {
+  libfxApiVersion: 2,
+  createFxTerminal() { assert.fail("backend probing must not create a terminal"); },
+};
+
+try {
+  for (const options of [null, [], 1, { surface: "browser" }, { backend: "other" }, { nativeAddon: true }]) {
+    await assert.rejects(getBackendInfo(options), TypeError);
+  }
+
+  assert.deepEqual(await getBackendInfo({ backend: "native", nativeAddon: matchingCore }), {
+    surface: "agent",
+    backend: "native",
+    attempts: [{ backend: "native", available: true, reason: null }],
+  });
+
+  assert.equal((await getBackendInfo({
+    surface: "terminal",
+    backend: "native",
+    nativeAddon: matchingTerminal,
+  })).backend, "native");
+
+  assert.deepEqual(await getBackendInfo({ surface: "terminal", backend: "native", nativeAddon: matchingCore }), {
+    surface: "terminal",
+    backend: "unavailable",
+    attempts: [{
+      backend: "native",
+      available: false,
+      reason: {
+        code: "LIBFX_NATIVE_SURFACE_MISSING",
+        message: "native addon does not provide createFxTerminal()",
+      },
+    }],
+  });
+
+  const incompatible = await getBackendInfo({
+    backend: "native",
+    nativeAddon: { libfxApiVersion: 2, createCore() { assert.fail("must validate before calling createCore"); } },
+  });
+  assert.equal(incompatible.backend, "unavailable");
+  assert.equal(incompatible.attempts[0].reason.code, "LIBFX_NATIVE_API_MISMATCH");
+  assert.match(incompatible.attempts[0].reason.message, /expected API version 3/);
+
+  const disabled = await getBackendInfo({ backend: "native", nativeAddon: false });
+  assert.equal(disabled.backend, "unavailable");
+  assert.equal(disabled.attempts[0].reason.code, "LIBFX_NATIVE_DISABLED");
+
+  const missing = await getBackendInfo({ backend: "native", nativeAddon: missingAddon });
+  assert.equal(missing.backend, "unavailable");
+  assert.equal(missing.attempts[0].reason.code, "LIBFX_NATIVE_ARTIFACT_MISSING");
+  assert.equal(missing.attempts[0].reason.causeCode, "MODULE_NOT_FOUND");
+  await assert.rejects(
+    createFxAgent({ backend: "native", nativeAddon: missingAddon, apiKey: "missing-override-key" }),
+    (error) => error?.code === "MODULE_NOT_FOUND",
+  );
+
+  const dependencyFailure = await getBackendInfo({ backend: "native", nativeAddon: dependencyAddon });
+  assert.equal(dependencyFailure.backend, "unavailable");
+  assert.equal(dependencyFailure.attempts[0].reason.code, "LIBFX_NATIVE_LOAD_FAILED");
+  assert.equal(dependencyFailure.attempts[0].reason.causeCode, "ERR_MODULE_NOT_FOUND");
+  await assert.rejects(
+    createFxAgent({ backend: "native", nativeAddon: dependencyAddon, apiKey: "dependency-override-key" }),
+    (error) => error?.code === "ERR_MODULE_NOT_FOUND",
+  );
+
+  const defaultMissing = await getBackendInfo({ backend: "native" });
+  assert.equal(defaultMissing.backend, "unavailable");
+  assert.equal(defaultMissing.attempts[0].reason.code, "LIBFX_NATIVE_ARTIFACT_MISSING");
+  assert.equal(defaultMissing.attempts[0].reason.causeCode, "ENOENT");
+  await assert.rejects(
+    createFxAgent({ backend: "native", apiKey: "missing-default-key" }),
+    (error) => error?.code === "LIBFX_NATIVE_UNAVAILABLE",
+  );
+  await assert.rejects(
+    createFxTerminal({ backend: "native" }),
+    (error) => error?.code === "LIBFX_NATIVE_UNAVAILABLE",
+  );
+
+  const corrupt = await getBackendInfo({ backend: "native", nativeAddon: corruptAddon });
+  assert.equal(corrupt.backend, "unavailable");
+  assert.equal(corrupt.attempts[0].reason.code, "LIBFX_NATIVE_LOAD_FAILED");
+  assert.equal(corrupt.attempts[0].reason.causeCode, "ERR_DLOPEN_FAILED");
+  assert.doesNotThrow(() => JSON.stringify(corrupt));
+  assert.equal(corrupt.attempts[0].reason instanceof Error, false);
+
+  const nonlocal = await getBackendInfo({ backend: "native", nativeAddon: nonlocalAddon });
+  assert.equal(nonlocal.backend, "unavailable");
+  assert.equal(nonlocal.attempts[0].reason.code, "LIBFX_NATIVE_LOAD_FAILED");
+  assert.equal(nonlocal.attempts[0].reason.causeCode, "ERR_INVALID_FILE_URL_HOST");
+  await assert.rejects(
+    createFxAgent({ backend: "native", nativeAddon: nonlocalAddon, apiKey: "nonlocal-key" }),
+    (error) => error?.code === "ERR_INVALID_FILE_URL_HOST",
+  );
+
+  const savedSuspending = WebAssembly.Suspending;
+  const savedPromising = WebAssembly.promising;
+  try {
+    Object.defineProperty(WebAssembly, "Suspending", { configurable: true, value: undefined });
+    Object.defineProperty(WebAssembly, "promising", { configurable: true, value: undefined });
+    assert.deepEqual(await getBackendInfo({ backend: "wasm" }), {
+      surface: "agent",
+      backend: "unavailable",
+      attempts: [{
+        backend: "wasm-jspi",
+        available: false,
+        reason: {
+          code: "LIBFX_JSPI_UNAVAILABLE",
+          message: "WebAssembly backend requires JavaScript Promise Integration (JSPI)",
+        },
+      }],
+    });
+    await assert.rejects(
+      createFxAgent({ backend: "auto", nativeAddon: nonlocalAddon, apiKey: "nonlocal-key" }),
+      (error) => error?.code === "LIBFX_JSPI_REQUIRED" && error.cause?.code === "ERR_INVALID_FILE_URL_HOST",
+    );
+  } finally {
+    Object.defineProperty(WebAssembly, "Suspending", { configurable: true, value: savedSuspending });
+    Object.defineProperty(WebAssembly, "promising", { configurable: true, value: savedPromising });
+  }
+
+  const nonlocalFallback = await createFxAgent({
+    backend: "auto",
+    nativeAddon: nonlocalAddon,
+    wasm: coreWasm,
+    apiKey: "nonlocal-fallback-key",
+  });
+  const nonlocalCheckpoint = await nonlocalFallback.checkpoint();
+  await nonlocalFallback.close();
+  assert.ok(nonlocalCheckpoint.length > 0, "auto mode must fall back after a nonlocal addon URL fails");
+
+  const missingWasmInfo = await getBackendInfo({ backend: "wasm", wasm: missingWasm });
+  assert.equal(missingWasmInfo.backend, "unavailable");
+  assert.equal(missingWasmInfo.attempts[0].reason.code, "LIBFX_WASM_LOAD_FAILED");
+  assert.equal(missingWasmInfo.attempts[0].reason.causeCode, "ENOENT");
+
+  const corruptWasmInfo = await getBackendInfo({ backend: "wasm", wasm: corruptWasm });
+  assert.equal(corruptWasmInfo.backend, "unavailable");
+  assert.equal(corruptWasmInfo.attempts[0].reason.code, "LIBFX_WASM_LOAD_FAILED");
+
+  const firstFileProbe = await getBackendInfo({ backend: "wasm", wasm: replacedWasm });
+  assert.equal(firstFileProbe.backend, "unavailable");
+  await writeFile(replacedWasm, await readFile(coreWasm));
+  const secondFileProbe = await getBackendInfo({ backend: "wasm", wasm: replacedWasm });
+  assert.equal(secondFileProbe.backend, "wasm-jspi", "replaced Wasm file must be read again after compile failure");
+  const replacedAgent = await createFxAgent({ backend: "wasm", wasm: replacedWasm, apiKey: "probe-retry-key" });
+  const replacedCheckpoint = await replacedAgent.checkpoint();
+  await replacedAgent.close();
+  assert.ok(replacedCheckpoint.length > 0, "factory must reuse the valid replacement after the failed probe");
+
+  const stableCompileDescriptor = Object.getOwnPropertyDescriptor(WebAssembly, "compile");
+  const stableRealCompile = WebAssembly.compile.bind(WebAssembly);
+  let stableCompileCalls = 0;
+  Object.defineProperty(WebAssembly, "compile", {
+    ...stableCompileDescriptor,
+    configurable: true,
+    value: async (bytes) => {
+      stableCompileCalls += 1;
+      return stableRealCompile(bytes);
+    },
+  });
+  try {
+    assert.equal((await getBackendInfo({ backend: "wasm", wasm: stableWasm })).backend, "wasm-jspi");
+    await assert.rejects(
+      createFxAgent({
+        backend: "wasm",
+        wasm: stableWasm,
+        apiKey: "stable-cache-key",
+        checkpoint: new Uint8Array([1, 2, 3]),
+      }),
+      /Invalid or non-fresh libfx checkpoint/,
+    );
+    assert.equal((await getBackendInfo({ backend: "wasm", wasm: stableWasm })).backend, "wasm-jspi");
+    const stableAgent = await createFxAgent({ backend: "wasm", wasm: stableWasm, apiKey: "stable-cache-key" });
+    await stableAgent.close();
+    assert.equal(stableCompileCalls, 1, "downstream factory errors must retain a successful compiled module");
+  } finally {
+    Object.defineProperty(WebAssembly, "compile", stableCompileDescriptor);
+  }
+
+  const automatic = await getBackendInfo({ backend: "auto", nativeAddon: false, wasm: coreWasm });
+  assert.equal(automatic.backend, "wasm-jspi");
+  assert.deepEqual(automatic.attempts.map(({ backend, available }) => ({ backend, available })), [
+    { backend: "native", available: false },
+    { backend: "wasm-jspi", available: true },
+  ]);
+  assert.equal(automatic.attempts[0].reason.code, "LIBFX_NATIVE_DISABLED");
+  assert.equal(automatic.attempts[1].reason, null);
+
+  const terminalWasm = await getBackendInfo({ surface: "terminal", backend: "wasm", wasm: termWasm });
+  assert.equal(terminalWasm.surface, "terminal");
+  assert.equal(terminalWasm.backend, "wasm-jspi");
+
+  const remoteBytes = await readFile(coreWasm);
+  const server = createServer((request, response) => {
+    response.writeHead(200, { "content-type": "application/wasm" });
+    response.end(remoteBytes);
+  });
+  await new Promise((resolveListen) => server.listen(0, "127.0.0.1", resolveListen));
+  const remoteUrl = new URL(`http://127.0.0.1:${server.address().port}/fx-core.wasm`);
+  try {
+    const remote = await getBackendInfo({ backend: "wasm", wasm: remoteUrl });
+    assert.equal(remote.backend, "wasm-jspi");
+  } finally {
+    await new Promise((resolveClose) => server.close(resolveClose));
+  }
+  const networkFailure = await getBackendInfo({
+    backend: "wasm",
+    wasm: new URL("unavailable.wasm", remoteUrl),
+  });
+  assert.equal(networkFailure.backend, "unavailable");
+  assert.equal(networkFailure.attempts[0].reason.code, "LIBFX_WASM_LOAD_FAILED");
+
+  const compileDescriptor = Object.getOwnPropertyDescriptor(WebAssembly, "compile");
+  const realCompile = WebAssembly.compile.bind(WebAssembly);
+  const retryBytes = new Uint8Array(await readFile(coreWasm));
+  let compileCalls = 0;
+  Object.defineProperty(WebAssembly, "compile", {
+    ...compileDescriptor,
+    configurable: true,
+    value: async (bytes) => {
+      compileCalls += 1;
+      if (compileCalls === 1) throw new Error("injected probe compilation failure");
+      return realCompile(bytes);
+    },
+  });
+  try {
+    const first = await getBackendInfo({ backend: "wasm", wasm: retryBytes });
+    assert.equal(first.backend, "unavailable");
+    assert.equal(first.attempts[0].reason.code, "LIBFX_WASM_LOAD_FAILED");
+    const second = await getBackendInfo({ backend: "wasm", wasm: retryBytes });
+    assert.equal(second.backend, "wasm-jspi");
+    assert.equal(compileCalls, 2, "failed compilation must be evicted so probing can retry");
+  } finally {
+    Object.defineProperty(WebAssembly, "compile", compileDescriptor);
+  }
+
+  console.log("backend info passed: side-effect-free selection, structured reasons, and retryable Wasm probes");
+} finally {
+  await rm(temp, { recursive: true, force: true });
+}

--- a/sdk/tests/test-linux-abi.py
+++ b/sdk/tests/test-linux-abi.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+import importlib.util
+from pathlib import Path
+import unittest
+
+spec = importlib.util.spec_from_file_location(
+    "linux_abi", Path(__file__).resolve().parents[1] / "scripts/check-linux-abi.py"
+)
+abi = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(abi)
+
+
+class LinuxAbiTest(unittest.TestCase):
+    def test_baseline_and_older_symbols(self):
+        self.assertEqual(abi.check_versions("GLIBC_2.2.5 GLIBC_2.9 GLIBC_2.34"), "2.34")
+        self.assertEqual(abi.check_versions("GLIBC_2.34.0"), "2.34.0")
+
+    def test_newer_symbols_are_rejected(self):
+        for version in ["2.35", "2.36", "2.40", "3.0"]:
+            with self.subTest(version=version), self.assertRaisesRegex(ValueError, "maximum supported"):
+                abi.check_versions(f"GLIBC_2.34 GLIBC_{version}")
+
+    def test_missing_or_private_requirements_are_rejected(self):
+        for report in ["", "GLIBCXX_3.4", "GLIBC_2.34 GLIBC_PRIVATE"]:
+            with self.subTest(report=report), self.assertRaises(ValueError):
+                abi.check_versions(report)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdk/tests/test-next-package.mjs
+++ b/sdk/tests/test-next-package.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+import { strict as assert } from "node:assert";
+import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { once } from "node:events";
+import { createWriteStream } from "node:fs";
+import { cp, mkdir, mkdtemp, readFile, rename, writeFile } from "node:fs/promises";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const tarball = resolve(process.argv[2]);
+const artifactRoot = process.env.LIBFX_TEST_ARTIFACT_ROOT || tmpdir();
+await mkdir(artifactRoot, { recursive: true });
+const root = await mkdtemp(resolve(artifactRoot, "libfx-next-"));
+const app = resolve(root, "app");
+const fixture = fileURLToPath(new URL("./next/", import.meta.url));
+const token = randomUUID();
+const env = { ...process.env, NODE_OPTIONS: "", NODE_PATH: "", NEXT_TELEMETRY_DISABLED: "1", AI_GATEWAY_API_KEY: "",
+  LIBFX_LIVE: "0", LIBFX_SMOKE_TOKEN: token, LIBFX_TEST_MODEL: "" };
+const servers = new Set();
+const results = [];
+
+async function run(command, args, cwd, name) {
+  const log = createWriteStream(resolve(root, `${name}.log`));
+  const child = spawn(command, args, { cwd, env, stdio: ["ignore", "pipe", "pipe"] });
+  child.stdout.pipe(log, { end: false });
+  child.stderr.pipe(log, { end: false });
+  const timer = setTimeout(() => child.kill("SIGKILL"), 180_000);
+  try {
+    const [code, signal] = await once(child, "close");
+    assert.equal(code, 0, `${name} exited ${code} (${signal}); see ${root}/${name}.log`);
+  } finally { clearTimeout(timer); log.end(); }
+}
+
+async function start(cwd, args, name) {
+  const reservation = createServer();
+  await new Promise((resolveListen) => reservation.listen(0, "127.0.0.1", resolveListen));
+  const port = reservation.address().port;
+  await new Promise((resolveClose) => reservation.close(resolveClose));
+  const log = createWriteStream(resolve(root, `${name}.log`));
+  const child = spawn(process.execPath, ["--no-experimental-require-module", ...args, ...(name === "standalone" ? [] : ["--hostname", "127.0.0.1", "--port", String(port)])], {
+    cwd, env: { ...env, HOSTNAME: "127.0.0.1", PORT: String(port) }, detached: true, stdio: ["ignore", "pipe", "pipe"],
+  });
+  child.stdout.pipe(log, { end: false });
+  child.stderr.pipe(log, { end: false });
+  const closed = once(child, "close");
+  const server = { child, closed, log, url: `http://127.0.0.1:${port}` };
+  servers.add(server);
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    assert.equal(child.exitCode, null, `${name} exited during startup; see ${root}/${name}.log`);
+    try {
+      const response = await fetch(server.url, { signal: AbortSignal.timeout(1000) });
+      await response.arrayBuffer();
+      if (response.ok) return server;
+    } catch {}
+    await new Promise((resolveWait) => setTimeout(resolveWait, 100));
+  }
+  throw new Error(`${name} did not become ready; see ${root}/${name}.log`);
+}
+
+async function stop(server) {
+  try { process.kill(-server.child.pid, "SIGTERM"); } catch (error) { if (error.code !== "ESRCH") throw error; }
+  const timer = setTimeout(() => { try { process.kill(-server.child.pid, "SIGKILL"); } catch {} }, 5000);
+  try { await server.closed; } finally { clearTimeout(timer); server.log.end(); servers.delete(server); }
+}
+
+async function exercise(server, stage) {
+  const unauthorized = await fetch(`${server.url}/api/fx`);
+  assert.equal(unauthorized.status, 401);
+  for (const backend of ["native", "auto"]) {
+    for (const scenario of ["host", "mcp", "error", "cancel", "resume"]) {
+      const response = await fetch(`${server.url}/api/fx?backend=${backend}&scenario=${scenario}`, {
+        headers: { authorization: `Bearer ${token}` }, signal: AbortSignal.timeout(60_000),
+      });
+      const result = await response.json();
+      assert.equal(response.status, 200, `${stage}/${backend}/${scenario}: ${JSON.stringify(result)}`);
+      assert.equal(result.ok, true);
+      assert.equal(result.probe.backend, "native");
+      assert.equal(result.toolCalls, 1);
+      assert.ok(result.checkpointBytes > 48);
+      if (scenario === "mcp") assert.equal(result.closedMcp, true);
+      results.push({ stage, backend, scenario, status: response.status, ...result });
+      console.log(`${stage}/${backend}/${scenario} passed`);
+    }
+  }
+  const concurrent = await Promise.all(Array.from({ length: 8 }, async () => {
+    const response = await fetch(`${server.url}/api/fx?backend=native`, {
+      headers: { authorization: `Bearer ${token}` }, signal: AbortSignal.timeout(60_000),
+    });
+    const result = await response.json();
+    assert.equal(response.status, 200, JSON.stringify(result));
+    return result;
+  }));
+  assert.ok(concurrent.every((result) => result.toolCalls === 1 && result.ok));
+  console.log(`${stage}/eight concurrent tool turns passed`);
+}
+
+try {
+  await cp(fixture, app, { recursive: true, filter: (path) => !["node_modules", ".next"].includes(path.split("/").at(-1)) });
+  await cp(tarball, resolve(app, "libfx.tgz"));
+  const manifest = JSON.parse(await readFile(resolve(app, "package.json"), "utf8"));
+  manifest.dependencies.libfx = "file:./libfx.tgz";
+  await writeFile(resolve(app, "package.json"), JSON.stringify(manifest, null, 2));
+  await run(process.env.PNPM_BIN || "pnpm", ["install", "--no-frozen-lockfile", "--ignore-scripts"], app, "install");
+  const next = resolve(app, "node_modules/next/dist/bin/next");
+  const dev = await start(app, [next, "dev"], "dev");
+  await exercise(dev, "dev");
+  await stop(dev);
+  await run(process.execPath, ["--no-experimental-require-module", next, "build"], app, "build");
+  const production = await start(app, [next, "start"], "start");
+  await exercise(production, "start");
+  await stop(production);
+
+  await writeFile(resolve(app, "next.config.mjs"), 'export default { output: "standalone" };\n');
+  await run(process.execPath, ["--no-experimental-require-module", next, "build"], app, "standalone-build");
+  const isolated = resolve(root, "isolated");
+  await cp(resolve(app, ".next/standalone"), isolated, { recursive: true, verbatimSymlinks: true });
+  await mkdir(resolve(isolated, ".next"), { recursive: true });
+  await cp(resolve(app, ".next/static"), resolve(isolated, ".next/static"), { recursive: true });
+  await rename(app, resolve(root, "source-unavailable"));
+  const standalone = await start(isolated, [resolve(isolated, "server.js")], "standalone");
+  await exercise(standalone, "standalone");
+  await stop(standalone);
+  await writeFile(resolve(root, "results.json"), JSON.stringify({ node: process.version, tarball, results }, null, 2));
+  console.log(`Next package integration passed: ${root}`);
+} finally {
+  for (const server of servers) await stop(server);
+  console.log(`Next package evidence: ${root}`);
+}

--- a/sdk/tests/test-node-package.mjs
+++ b/sdk/tests/test-node-package.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+import { strict as assert } from "node:assert";
+import { spawnSync } from "node:child_process";
+import { cp, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
+const temp = await mkdtemp(join(tmpdir(), "libfx-node-package-"));
+const packageDir = join(temp, "package");
+const consumerDir = join(temp, "consumer");
+const installedPackage = join(consumerDir, "node_modules", "libfx");
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd ?? repoRoot,
+    encoding: "utf8",
+    env: { ...process.env, ...options.env },
+  });
+  if (result.error) throw result.error;
+  assert.equal(result.status, 0, `${command} ${args.join(" ")} failed:\n${result.stdout}\n${result.stderr}`);
+  return result;
+}
+
+try {
+  run(process.execPath, [resolve(repoRoot, "sdk/scripts/package-libfx.mjs"), packageDir]);
+
+  const manifest = JSON.parse(await readFile(join(packageDir, "package.json"), "utf8"));
+  assert.deepEqual(manifest.exports["."], {
+    node: { import: "./node.js", require: "./node.cjs" },
+    browser: "./browser.js",
+    default: "./browser.js",
+  });
+  assert.deepEqual(manifest.exports["./node"], { import: "./node.js", require: "./node.cjs" });
+  assert.equal(manifest.exports["./browser"], "./browser.js");
+  assert.equal(manifest.exports["./wasm"], "./fx-sdk.js");
+  assert.equal(manifest.exports["./mcp"], "./mcp.js");
+  assert.equal(manifest.exports["./skills"], "./skills.js");
+  assert.equal(manifest.exports["./skills/node"], "./skills-node.js");
+
+  const cjs = await readFile(join(packageDir, "node.cjs"), "utf8");
+  assert.doesNotMatch(cjs, new RegExp(repoRoot.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  for (const platform of ["linux-x64", "linux-arm64", "darwin-x64", "darwin-arm64"]) {
+    assert.match(cjs, new RegExp(`libfx\\.${platform}\\.node`));
+  }
+
+  const source = await readFile(resolve(repoRoot, "sdk/node.js"), "utf8");
+  assert.doesNotMatch(source, /["']\.\/libfx\.node["']/);
+  for (const platform of ["linux-x64", "linux-arm64", "darwin-x64", "darwin-arm64"]) {
+    assert.match(source, new RegExp(`["']\\.\\/libfx\\.${platform}\\.node["']`));
+  }
+
+  await cp(packageDir, installedPackage, { recursive: true });
+  await writeFile(join(consumerDir, "package.json"), '{"type":"module"}\n');
+  await writeFile(join(consumerDir, "esm.mjs"), `
+    import * as libfx from "libfx";
+    import * as nodeEntry from "libfx/node";
+    const { createFxAgent, createFxTerminal, getBackendInfo } = libfx;
+    if (JSON.stringify(Object.keys(libfx).sort()) !== JSON.stringify(Object.keys(nodeEntry).sort())) {
+      throw new Error("root and Node subpath ESM exports differ");
+    }
+    const info = await getBackendInfo({ backend: "native" });
+    if (typeof createFxAgent !== "function" || typeof createFxTerminal !== "function" || info.backend !== "native") {
+      throw new Error(JSON.stringify(info));
+    }
+    const agent = await createFxAgent({ backend: "native", apiKey: "package-test-key" });
+    const checkpoint = await agent.checkpoint();
+    await agent.close();
+    if (!(checkpoint instanceof Uint8Array) || checkpoint.length === 0) throw new Error("empty checkpoint");
+    console.log(JSON.stringify(Object.keys(libfx).sort()));
+  `);
+  await writeFile(join(consumerDir, "cjs.cjs"), `
+    const libfx = require("libfx");
+    const nodeEntry = require("libfx/node");
+    const { createFxAgent, createFxTerminal, getBackendInfo } = libfx;
+    (async () => {
+      if (JSON.stringify(Object.keys(libfx).sort()) !== JSON.stringify(Object.keys(nodeEntry).sort())) {
+        throw new Error("root and Node subpath CommonJS exports differ");
+      }
+      const info = await getBackendInfo({ backend: "native" });
+      if (typeof createFxAgent !== "function" || typeof createFxTerminal !== "function" || info.backend !== "native") {
+        throw new Error(JSON.stringify(info));
+      }
+      const agent = await createFxAgent({ backend: "native", apiKey: "package-test-key" });
+      const checkpoint = await agent.checkpoint();
+      await agent.close();
+      if (!(checkpoint instanceof Uint8Array) || checkpoint.length === 0) throw new Error("empty checkpoint");
+      console.log(JSON.stringify(Object.keys(libfx).sort()));
+    })();
+  `);
+
+  const esm = run(process.execPath, ["esm.mjs"], { cwd: consumerDir });
+  const cjsResult = run(process.execPath, ["--no-experimental-require-module", "cjs.cjs"], { cwd: consumerDir });
+  assert.deepEqual(JSON.parse(cjsResult.stdout), JSON.parse(esm.stdout));
+  console.log("Node package passed: conditional exports, relocated CJS, literal native assets, and bare imports");
+} finally {
+  await rm(temp, { recursive: true, force: true });
+}

--- a/sdk/tests/test-package-resilience.mjs
+++ b/sdk/tests/test-package-resilience.mjs
@@ -1,0 +1,999 @@
+#!/usr/bin/env node
+import { strict as assert } from "node:assert";
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { cp, mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
+const captureLimit = 8 * 1024 * 1024;
+
+function parseArgs(argv) {
+  const options = {
+    packageInput: null,
+    cheapCycles: 1000,
+    toolWorkflows: 100,
+    durationMs: 180_000,
+    concurrency: 4,
+    stageTimeoutMs: 900_000,
+    faultTimeoutMs: 45_000,
+    jsonOut: null,
+    npmBin: process.env.LIBFX_TEST_NPM_BIN ?? "npm",
+    keepTemp: false,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--keep-temp") {
+      options.keepTemp = true;
+      continue;
+    }
+    const key = argument.startsWith("--") ? argument.slice(2) : null;
+    if (!key) {
+      if (options.packageInput) throw new Error(`unexpected argument: ${argument}`);
+      options.packageInput = argument;
+      continue;
+    }
+    const value = argv[++index];
+    if (value === undefined) throw new Error(`missing value for ${argument}`);
+    if (key === "package") options.packageInput = value;
+    else if (key === "cheap-cycles") options.cheapCycles = Number(value);
+    else if (key === "tool-workflows") options.toolWorkflows = Number(value);
+    else if (key === "duration-ms") options.durationMs = Number(value);
+    else if (key === "concurrency") options.concurrency = Number(value);
+    else if (key === "stage-timeout-ms") options.stageTimeoutMs = Number(value);
+    else if (key === "fault-timeout-ms") options.faultTimeoutMs = Number(value);
+    else if (key === "json-out") options.jsonOut = value;
+    else if (key === "npm-bin") options.npmBin = value;
+    else throw new Error(`unknown option: ${argument}`);
+  }
+  if (!options.packageInput) {
+    throw new Error("usage: test-package-resilience.mjs --package <staged-directory-or-tarball> [options]");
+  }
+  for (const key of ["cheapCycles", "toolWorkflows", "durationMs", "concurrency", "stageTimeoutMs", "faultTimeoutMs"]) {
+    if (!Number.isInteger(options[key]) || options[key] <= 0) throw new Error(`${key} must be a positive integer`);
+  }
+  if (options.concurrency > 16) throw new Error("concurrency must be at most 16");
+  options.packageInput = resolve(options.packageInput);
+  if (options.jsonOut) options.jsonOut = resolve(options.jsonOut);
+  return options;
+}
+
+function isInside(parent, candidate) {
+  const path = relative(resolve(parent), resolve(candidate));
+  return path === "" || (!path.startsWith(`..${sep}`) && path !== "..");
+}
+
+async function sha256File(path) {
+  return createHash("sha256").update(await readFile(path)).digest("hex");
+}
+
+async function packageIdentity(packageDir, input, inputType) {
+  const manifestPath = join(packageDir, "package.json");
+  const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+  const inventory = [];
+  async function visit(directory, prefix = "") {
+    for (const entry of (await readdir(directory, { withFileTypes: true })).sort((a, b) => a.name.localeCompare(b.name))) {
+      const relativePath = join(prefix, entry.name);
+      if (entry.isDirectory()) await visit(join(directory, entry.name), relativePath);
+      else if (entry.isFile()) inventory.push([relativePath, await sha256File(join(directory, entry.name))]);
+    }
+  }
+  await visit(packageDir);
+  const digest = createHash("sha256");
+  for (const [path, hash] of inventory) digest.update(`${path}\0${hash}\n`);
+  return {
+    input,
+    inputType,
+    name: manifest.name,
+    version: manifest.version,
+    packageDigestSha256: digest.digest("hex"),
+    fileCount: inventory.length,
+  };
+}
+
+async function installPackage(input, consumerDir, npmBin) {
+  const inputStat = await stat(input);
+  await mkdir(join(consumerDir, "node_modules"), { recursive: true });
+  await writeFile(join(consumerDir, "package.json"), '{"name":"libfx-resilience-consumer","private":true,"type":"module"}\n');
+  if (inputStat.isDirectory()) {
+    await cp(input, join(consumerDir, "node_modules", "libfx"), { recursive: true });
+    return "staged-directory-copy";
+  }
+  const npmArgs = ["install", "--ignore-scripts", "--no-audit", "--no-fund", "--no-package-lock", input];
+  const npmIsJavaScript = npmBin.endsWith(".js") || npmBin.endsWith(".cjs");
+  await runProcess({
+    label: "tarball installation",
+    command: npmIsJavaScript ? process.execPath : npmBin,
+    args: npmIsJavaScript ? [npmBin, ...npmArgs] : npmArgs,
+    cwd: consumerDir,
+    timeoutMs: 180_000,
+    expectedStatus: 0,
+    env: { NPM_CONFIG_USERCONFIG: "/dev/null" },
+  });
+  return "npm-tarball-install";
+}
+
+function cleanEnvironment() {
+  const env = { ...process.env };
+  for (const name of [
+    "AI_GATEWAY_API_KEY",
+    "VERCEL_OIDC_TOKEN",
+    "NPM_TOKEN",
+    "NODE_AUTH_TOKEN",
+    "GITHUB_TOKEN",
+    "GH_TOKEN",
+  ]) delete env[name];
+  return env;
+}
+
+async function runProcess({ label, command, args, cwd, timeoutMs, expectedStatus, relayStderr = false, env = {} }) {
+  return await new Promise((resolveRun, rejectRun) => {
+    const child = spawn(command, args, {
+      cwd,
+      env: { ...cleanEnvironment(), ...env },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    let overflow = false;
+    const append = (current, chunk) => {
+      if (current.length >= captureLimit) {
+        overflow = true;
+        return current;
+      }
+      return (current + chunk).slice(0, captureLimit);
+    };
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => { stdout = append(stdout, chunk); });
+    child.stderr.on("data", (chunk) => {
+      stderr = append(stderr, chunk);
+      if (relayStderr) process.stderr.write(chunk);
+    });
+    const timer = setTimeout(() => child.kill("SIGKILL"), timeoutMs);
+    child.on("error", (error) => {
+      clearTimeout(timer);
+      rejectRun(error);
+    });
+    child.on("close", (status, signal) => {
+      clearTimeout(timer);
+      const result = { label, command, args, cwd, status, signal, stdout, stderr, captureOverflow: overflow };
+      if (status !== expectedStatus) {
+        const error = new Error(`${label} exited ${status ?? signal}; stdout=${stdout.slice(-4000)} stderr=${stderr.slice(-4000)}`);
+        error.result = result;
+        rejectRun(error);
+        return;
+      }
+      resolveRun(result);
+    });
+  });
+}
+
+function lastJsonLine(stdout) {
+  const lines = stdout.trim().split("\n").filter(Boolean);
+  if (lines.length === 0) throw new Error("worker produced no structured result");
+  return JSON.parse(lines.at(-1));
+}
+
+async function installedWorkerMain() {
+  const { strict: assert } = await import("node:assert");
+  const { createRequire } = await import("node:module");
+  const { createServer } = await import("node:http");
+  const { readdir, readFile, writeFile } = await import("node:fs/promises");
+  const { performance } = await import("node:perf_hooks");
+  const config = JSON.parse(process.argv[2]);
+
+  const errorRecord = (error) => ({
+    name: error?.name ?? typeof error,
+    code: error?.code ?? null,
+    message: error?.message ?? String(error),
+    cause: error?.cause ? {
+      name: error.cause.name ?? typeof error.cause,
+      code: error.cause.code ?? null,
+      message: error.cause.message ?? String(error.cause),
+    } : null,
+  });
+  const expectedError = async (action) => {
+    try {
+      await action();
+    } catch (error) {
+      return error;
+    }
+    assert.fail("expected operation to fail");
+  };
+  const quantile = (values, fraction) => {
+    const sorted = [...values].sort((a, b) => a - b);
+    if (sorted.length === 0) return null;
+    return sorted[Math.min(sorted.length - 1, Math.ceil(sorted.length * fraction) - 1)];
+  };
+  const stats = (values) => ({
+    samples: values.length,
+    p50Ms: quantile(values, 0.5),
+    p95Ms: quantile(values, 0.95),
+    p99Ms: values.length >= 100 ? quantile(values, 0.99) : null,
+    maxMs: values.length ? Math.max(...values) : null,
+    rawMs: values,
+  });
+  const slopePerMinute = (values, key) => {
+    if (values.length < 2) return null;
+    const origin = values[0].timestampMs;
+    const points = values.map((value) => ({ x: (value.timestampMs - origin) / 60_000, y: value[key] }));
+    const meanX = points.reduce((sum, point) => sum + point.x, 0) / points.length;
+    const meanY = points.reduce((sum, point) => sum + point.y, 0) / points.length;
+    const denominator = points.reduce((sum, point) => sum + ((point.x - meanX) ** 2), 0);
+    if (denominator === 0) return null;
+    return points.reduce((sum, point) => sum + (point.x - meanX) * (point.y - meanY), 0) / denominator;
+  };
+  const activeResources = () => {
+    const counts = {};
+    for (const name of process.getActiveResourcesInfo()) counts[name] = (counts[name] ?? 0) + 1;
+    return counts;
+  };
+  const fdCount = async () => {
+    try { return (await readdir("/dev/fd")).length; } catch { return null; }
+  };
+  const memorySnapshot = async (label) => ({
+    label,
+    timestampMs: Date.now(),
+    ...process.memoryUsage(),
+    fdCount: await fdCount(),
+    activeResources: activeResources(),
+  });
+  const delay = (milliseconds) => new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds));
+  const withTimeout = async (promise, milliseconds, label) => {
+    let timer;
+    try {
+      return await Promise.race([
+        promise,
+        new Promise((_, reject) => {
+          timer = setTimeout(() => reject(new Error(`${label} timed out after ${milliseconds}ms`)), milliseconds);
+        }),
+      ]);
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+
+  const esm = await import("libfx");
+  const cjs = createRequire(import.meta.url)("libfx");
+  const exportNames = Object.keys(esm).sort();
+  assert.deepEqual(Object.keys(cjs).sort(), exportNames, "ESM and CJS exports differ");
+
+  if (config.mode === "cjs-happy") {
+    assert.equal(typeof cjs.createFxAgent, "function");
+    const info = await cjs.getBackendInfo({ backend: "native" });
+    assert.equal(info.backend, "native");
+    console.log(JSON.stringify({ mode: config.mode, exportNames, info }));
+    return;
+  }
+
+  if (config.mode === "fault-missing-addon" || config.mode === "fault-corrupt-addon") {
+    const info = await esm.getBackendInfo({ backend: "native" });
+    assert.equal(info.backend, "unavailable");
+    const reason = info.attempts[0].reason;
+    assert.equal(reason.code, config.mode === "fault-missing-addon"
+      ? "LIBFX_NATIVE_ARTIFACT_MISSING"
+      : "LIBFX_NATIVE_LOAD_FAILED");
+    if (config.mode === "fault-missing-addon") assert.equal(reason.causeCode, "ENOENT");
+    else assert.equal(reason.causeCode, "ERR_DLOPEN_FAILED");
+    const factoryError = await expectedError(() => esm.createFxAgent({ backend: "native", apiKey: "test-placeholder" }));
+    assert.ok(factoryError.code, "factory error must preserve a code");
+    console.log(JSON.stringify({ mode: config.mode, info, factoryError: errorRecord(factoryError) }));
+    return;
+  }
+
+  if (config.mode === "fault-no-jspi") {
+    Object.defineProperty(WebAssembly, "Suspending", { configurable: true, value: undefined });
+    Object.defineProperty(WebAssembly, "promising", { configurable: true, value: undefined });
+    const forcedWasm = await esm.getBackendInfo({ backend: "wasm" });
+    assert.equal(forcedWasm.backend, "unavailable");
+    assert.equal(forcedWasm.attempts[0].reason.code, "LIBFX_JSPI_UNAVAILABLE");
+    const factoryError = await expectedError(() => esm.createFxAgent({ backend: "wasm", apiKey: "test-placeholder" }));
+    assert.equal(factoryError.code, "LIBFX_JSPI_REQUIRED");
+    const automatic = await esm.getBackendInfo({ backend: "auto" });
+    assert.equal(automatic.backend, "native");
+    console.log(JSON.stringify({ mode: config.mode, forcedWasm, automatic, factoryError: errorRecord(factoryError) }));
+    return;
+  }
+
+  if (config.mode === "fault-bad-api") {
+    const badAddon = { libfxApiVersion: 2, createCore() { assert.fail("bad API factory must not be called"); } };
+    const info = await esm.getBackendInfo({ backend: "native", nativeAddon: badAddon });
+    assert.equal(info.backend, "unavailable");
+    assert.equal(info.attempts[0].reason.code, "LIBFX_NATIVE_API_MISMATCH");
+    const factoryError = await expectedError(() => esm.createFxAgent({
+      backend: "native",
+      nativeAddon: badAddon,
+      apiKey: "test-placeholder",
+    }));
+    assert.equal(factoryError.code, "LIBFX_NATIVE_UNAVAILABLE");
+    assert.match(factoryError.message, /expected API version 3/);
+    console.log(JSON.stringify({ mode: config.mode, info, factoryError: errorRecord(factoryError) }));
+    return;
+  }
+
+  if (config.mode === "fault-invalid-input") {
+    const invalidProbe = await expectedError(() => esm.getBackendInfo(null));
+    assert.ok(invalidProbe instanceof TypeError);
+    assert.equal(invalidProbe.message, "getBackendInfo() options must be an object");
+    const invalidBackend = await expectedError(() => esm.createFxAgent({ backend: "other", apiKey: "test-placeholder" }));
+    assert.ok(invalidBackend instanceof TypeError);
+    assert.equal(invalidBackend.message, 'backend must be "auto", "native", or "wasm"');
+    const invalidCheckpoint = await expectedError(() => esm.createFxAgent({
+      backend: "native",
+      apiKey: "test-placeholder",
+      checkpoint: new Uint8Array([1, 2, 3]),
+    }));
+    assert.match(invalidCheckpoint.message, /Invalid or non-fresh libfx checkpoint/);
+    const recovery = await esm.createFxAgent({ backend: "native", apiKey: "test-placeholder" });
+    const checkpoint = await recovery.checkpoint();
+    await recovery.close();
+    assert.ok(checkpoint.length > 48);
+    console.log(JSON.stringify({
+      mode: config.mode,
+      invalidProbe: errorRecord(invalidProbe),
+      invalidBackend: errorRecord(invalidBackend),
+      invalidCheckpoint: errorRecord(invalidCheckpoint),
+      recoveryCheckpointBytes: checkpoint.length,
+    }));
+    return;
+  }
+
+  if (config.mode === "fault-missing-wasm" || config.mode === "fault-corrupt-wasm") {
+    const first = await esm.getBackendInfo({ backend: "wasm" });
+    assert.equal(first.backend, "unavailable");
+    assert.equal(first.attempts[0].reason.code, "LIBFX_WASM_LOAD_FAILED");
+    if (config.mode === "fault-missing-wasm") assert.equal(first.attempts[0].reason.causeCode, "ENOENT");
+    const factoryError = await expectedError(() => esm.createFxAgent({ backend: "wasm", apiKey: "test-placeholder" }));
+    await writeFile(config.wasmPath, await readFile(config.restoreWasmPath));
+    const second = await esm.getBackendInfo({ backend: "wasm" });
+    assert.equal(second.backend, "wasm-jspi");
+    const recovery = await esm.createFxAgent({ backend: "wasm", apiKey: "test-placeholder" });
+    const checkpoint = await recovery.checkpoint();
+    await recovery.close();
+    assert.ok(checkpoint.length > 48);
+    console.log(JSON.stringify({
+      mode: config.mode,
+      first,
+      factoryError: errorRecord(factoryError),
+      second,
+      recoveryCheckpointBytes: checkpoint.length,
+    }));
+    return;
+  }
+
+  assert.equal(config.mode, "workload");
+  assert.ok(config.cheapCycles >= 1 && config.toolWorkflows >= 1 && config.durationMs >= 1);
+  const baselineNative = await esm.getBackendInfo({ backend: "native" });
+  const baselineAuto = await esm.getBackendInfo({ backend: "auto" });
+  assert.equal(baselineNative.backend, "native");
+  assert.equal(baselineAuto.backend, "native");
+
+  const provider = {
+    fetchCalls: 0,
+    getRequests: 0,
+    requests: 0,
+    toolFirstSteps: 0,
+    toolResultSteps: 0,
+    failures: [],
+    markerModes: new Map(),
+    markerRequestCounts: new Map(),
+    uniqueMarkers: 0,
+    lateResultSeen: false,
+  };
+  const markerPattern = /marker_[a-z0-9_]+/g;
+  const sendSse = (response, records) => {
+    response.writeHead(200, { "content-type": "text/event-stream" });
+    response.end([...records.map((record) => `data: ${JSON.stringify(record)}`), "data: [DONE]", ""].join("\n\n"));
+  };
+  const server = createServer((request, response) => {
+    let body = "";
+    request.setEncoding("utf8");
+    request.on("data", (chunk) => {
+      body += chunk;
+      if (body.length > 2 * 1024 * 1024) request.destroy(new Error("provider request exceeded 2 MiB"));
+    });
+    request.on("end", () => {
+      try {
+        if (request.method === "GET") {
+          provider.getRequests += 1;
+          response.writeHead(200, { "content-type": "application/json" });
+          response.end(JSON.stringify({ object: "list", data: [{ id: "resilience/model", type: "language" }] }));
+          return;
+        }
+        provider.requests += 1;
+        const markers = [...new Set(body.match(markerPattern) ?? [])];
+        assert.equal(markers.length, 1, `provider request mixed agent markers: ${JSON.stringify(markers)}`);
+        const marker = markers[0];
+        const mode = provider.markerModes.get(marker);
+        assert.ok(mode, `unknown marker ${marker}`);
+        if (body.includes("late-result:")) provider.lateResultSeen = true;
+        const seen = provider.markerRequestCounts.get(marker) ?? 0;
+        provider.markerRequestCounts.set(marker, seen + 1);
+        if (body.includes(`AFTER_LATE ${marker}`)) {
+          assert.doesNotMatch(body, /late-result:/);
+          sendSse(response, [
+            { type: "text-delta", delta: `after-late:${marker}` },
+            { type: "finish", finishReason: { unified: "stop", raw: "stop" } },
+          ]);
+          return;
+        }
+        if (body.includes(`RECOVER ${marker}`)) {
+          assert.doesNotMatch(body, /late-result:/);
+          sendSse(response, [
+            { type: "text-delta", delta: `recovered:${marker}` },
+            { type: "finish", finishReason: { unified: "stop", raw: "stop" } },
+          ]);
+          return;
+        }
+        if (body.includes(`RESTORE ${marker}`)) {
+          assert.ok(body.includes(`value:${marker}`), "restored request omitted the prior tool result");
+          sendSse(response, [
+            { type: "text-delta", delta: `restored:${marker}` },
+            { type: "finish", finishReason: { unified: "stop", raw: "stop" } },
+          ]);
+          return;
+        }
+        if (seen === 0) {
+          const payload = JSON.parse(body);
+          const expectedToolName = mode === "cancel" ? "wait" : "lookup";
+          const advertised = payload.tools?.find((tool) => tool.name === expectedToolName);
+          assert.ok(advertised, `${expectedToolName} was not advertised to the provider`);
+          assert.equal(advertised.inputSchema?.type, "object");
+          assert.equal(advertised.inputSchema?.additionalProperties, false);
+          if (expectedToolName === "lookup") {
+            assert.equal(advertised.inputSchema.properties?.key?.type, "string");
+            assert.deepEqual(advertised.inputSchema.required, ["key"]);
+          }
+          provider.toolFirstSteps += 1;
+          sendSse(response, [
+            { type: "tool-call", toolCallId: `call_${marker}`, toolName: mode === "cancel" ? "wait" : "lookup", input: { key: marker } },
+            { type: "finish", finishReason: { unified: "tool-calls", raw: "tool-calls" } },
+          ]);
+          return;
+        }
+        if (mode === "success" || mode === "restore") {
+          assert.ok(body.includes(`value:${marker}`), `tool result did not reach inference for ${marker}`);
+        } else if (mode === "reject") {
+          assert.ok(body.includes(`rejected:${marker}`), `tool rejection did not reach inference for ${marker}`);
+        } else {
+          assert.fail(`unexpected second inference request for ${mode}`);
+        }
+        provider.toolResultSteps += 1;
+        sendSse(response, [
+          { type: "text-delta", delta: `done:${marker}` },
+          { type: "finish", finishReason: { unified: "stop", raw: "stop" } },
+        ]);
+      } catch (error) {
+        provider.failures.push(errorRecord(error));
+        response.writeHead(500, { "content-type": "text/plain" });
+        response.end("provider assertion failed");
+      }
+    });
+  });
+  await new Promise((resolveListen) => server.listen(0, "127.0.0.1", resolveListen));
+  const gatewayChatUrl = `http://127.0.0.1:${server.address().port}/chat`;
+  const providerOrigin = new URL(gatewayChatUrl).origin;
+  const localFetch = (input, init = {}) => {
+    const rawUrl = input instanceof Request ? input.url : input;
+    const url = init.method === "GET" ? `${providerOrigin}/models` : rawUrl;
+    assert.equal(new URL(url).origin, providerOrigin, `kernel attempted fetch outside the fake provider: ${url}`);
+    provider.fetchCalls += 1;
+    return fetch(url, init);
+  };
+  let markerCounter = 0;
+  const nextMarker = (label) => `marker_${label}_${String(markerCounter++).padStart(8, "0")}`;
+  const baseOptions = (backend, tools, checkpoint) => ({
+    backend,
+    apiKey: "test-placeholder",
+    model: "resilience/model",
+    gatewayChatUrl,
+    fetch: localFetch,
+    home: process.cwd(),
+    workspaceRoot: process.cwd(),
+    tools,
+    ...(checkpoint ? { checkpoint } : {}),
+  });
+  const lookupTool = (marker, mode, state) => ({
+    name: "lookup",
+    description: "Return a deterministic value for one marker.",
+    inputSchema: {
+      type: "object",
+      properties: { key: { type: "string" } },
+      required: ["key"],
+      additionalProperties: false,
+    },
+    async execute(input, { signal }) {
+      state.callbacks += 1;
+      assert.equal(signal.aborted, false);
+      assert.equal(input.key, marker);
+      if (mode === "reject") throw new Error(`rejected:${marker}`);
+      return `value:${marker}`;
+    },
+  });
+  const consumeTurn = async (turn) => {
+    let text = "";
+    const events = [];
+    for await (const event of turn) {
+      events.push(event);
+      if (event.type === "text_delta") text += event.delta;
+    }
+    return { text, events, result: await turn.result };
+  };
+  const runToolWorkflow = async ({ mode = "success", backend = "native", label = "tool" } = {}) => {
+    const marker = nextMarker(label);
+    provider.markerModes.set(marker, mode);
+    provider.uniqueMarkers += 1;
+    const state = { callbacks: 0 };
+    const started = performance.now();
+    let agent;
+    try {
+      agent = await esm.createFxAgent(baseOptions(backend, [lookupTool(marker, mode, state)]));
+      const observed = await withTimeout(consumeTurn(agent.prompt(`CALL ${marker}`)), 10_000, `tool workflow ${marker}`);
+      assert.equal(observed.result.stopReason, "end_turn");
+      assert.equal(observed.text, `done:${marker}`);
+      assert.equal(state.callbacks, 1);
+      assert.equal(observed.events.filter((event) => event.type === "tool_start").length, 1);
+      assert.equal(observed.events.filter((event) => event.type === "tool_end").length, 1);
+      const toolEnd = observed.events.find((event) => event.type === "tool_end");
+      assert.equal(Boolean(toolEnd.isError), mode === "reject");
+      const result = { marker, latencyMs: performance.now() - started };
+      await agent.close();
+      agent = null;
+      return result;
+    } finally {
+      await agent?.close().catch(() => {});
+      provider.markerModes.delete(marker);
+      provider.markerRequestCounts.delete(marker);
+    }
+  };
+  const runRestoreWorkflow = async () => {
+    const marker = nextMarker("restore");
+    provider.markerModes.set(marker, "restore");
+    provider.uniqueMarkers += 1;
+    const state = { callbacks: 0 };
+    const tools = [lookupTool(marker, "restore", state)];
+    const started = performance.now();
+    let source;
+    let restored;
+    try {
+      source = await esm.createFxAgent(baseOptions("native", tools));
+      const first = await consumeTurn(source.prompt(`CALL ${marker}`));
+      assert.equal(first.text, `done:${marker}`);
+      const checkpoint = await source.checkpoint();
+      assert.ok(checkpoint.length > 48);
+      await source.close();
+      source = null;
+      restored = await esm.createFxAgent(baseOptions("native", tools, checkpoint));
+      const second = await consumeTurn(restored.prompt(`RESTORE ${marker}`));
+      assert.equal(second.text, `restored:${marker}`);
+      assert.equal(state.callbacks, 1);
+      const result = { marker, checkpointBytes: checkpoint.length, latencyMs: performance.now() - started };
+      await restored.close();
+      restored = null;
+      return result;
+    } finally {
+      await source?.close().catch(() => {});
+      await restored?.close().catch(() => {});
+      provider.markerModes.delete(marker);
+      provider.markerRequestCounts.delete(marker);
+    }
+  };
+  const runCancellationWorkflow = async () => {
+    const marker = nextMarker("cancel");
+    provider.markerModes.set(marker, "cancel");
+    provider.uniqueMarkers += 1;
+    let startResolve;
+    const toolStarted = new Promise((resolveStarted) => { startResolve = resolveStarted; });
+    let settle;
+    let signalAborted = false;
+    let callbacks = 0;
+    const controller = new AbortController();
+    const waitTool = {
+      name: "wait",
+      description: "Wait for cancellation.",
+      inputSchema: { type: "object", properties: {}, additionalProperties: false },
+      execute(_input, { signal }) {
+        callbacks += 1;
+        startResolve();
+        signal.addEventListener("abort", () => { signalAborted = true; }, { once: true });
+        return new Promise((resolveTool) => { settle = () => resolveTool(`late-result:${marker}`); });
+      },
+    };
+    const started = performance.now();
+    const runtimeEvents = [];
+    let agent;
+    try {
+      agent = await esm.createFxAgent({
+        ...baseOptions("native", [waitTool]),
+        onEvent(event) { runtimeEvents.push(event); },
+      });
+      const pending = consumeTurn(agent.prompt(`CALL ${marker}`, { signal: controller.signal }));
+      await withTimeout(toolStarted, 5_000, `cancel tool start ${marker}`);
+      controller.abort();
+      const cancelled = await withTimeout(pending, 10_000, `cancelled turn ${marker}`);
+      assert.equal(cancelled.result.stopReason, "cancelled");
+      assert.equal(callbacks, 1);
+      assert.equal(signalAborted, true);
+      const recovery = await withTimeout(consumeTurn(agent.prompt(`RECOVER ${marker}`)), 10_000, `cancel recovery ${marker}`);
+      assert.equal(recovery.text, `recovered:${marker}`);
+      const checkpointBeforeLate = await agent.checkpoint();
+      const sendsBeforeLate = runtimeEvents.filter((event) => event.type === "acp.send").length;
+      settle();
+      await delay(25);
+      assert.equal(provider.lateResultSeen, false);
+      assert.equal(runtimeEvents.filter((event) => event.type === "acp.send").length, sendsBeforeLate);
+      assert.deepEqual(await agent.checkpoint(), checkpointBeforeLate);
+      assert.doesNotMatch(JSON.stringify(runtimeEvents), /late-result:/);
+      const afterLate = await withTimeout(
+        consumeTurn(agent.prompt(`AFTER_LATE ${marker}`)),
+        10_000,
+        `post-settlement turn ${marker}`,
+      );
+      assert.equal(afterLate.text, `after-late:${marker}`);
+      assert.doesNotMatch(JSON.stringify(afterLate.events), /late-result:/);
+      const checkpointAfterLate = await agent.checkpoint();
+      assert.equal(Buffer.from(checkpointAfterLate).includes(Buffer.from("late-result:")), false);
+      const result = { marker, checkpointBytes: checkpointAfterLate.length, latencyMs: performance.now() - started };
+      await agent.close();
+      agent = null;
+      return result;
+    } finally {
+      settle?.();
+      await agent?.close().catch(() => {});
+      provider.markerModes.delete(marker);
+      provider.markerRequestCounts.delete(marker);
+    }
+  };
+  const runLifecycle = async (backend = "native") => {
+    const started = performance.now();
+    const info = await esm.getBackendInfo({ backend });
+    assert.equal(info.backend, "native");
+    const agent = await esm.createFxAgent({
+      backend,
+      apiKey: "test-placeholder",
+      home: process.cwd(),
+      workspaceRoot: process.cwd(),
+    });
+    try {
+      const checkpoint = await agent.checkpoint();
+      assert.ok(checkpoint.length > 48);
+      return performance.now() - started;
+    } finally {
+      await agent.close();
+    }
+  };
+
+  const samples = { lifecycleMs: [], toolMs: [], rejectMs: [], cancelMs: [], restoreMs: [], mixedMs: [] };
+  const counts = {
+    warmupCycles: 0,
+    cheapCycles: 0,
+    toolWorkflows: 0,
+    isolationWorkflows: 0,
+    restoreWorkflows: 0,
+    rejectedWorkflows: 0,
+    cancellationWorkflows: 0,
+    mixedOperations: 0,
+    laterSuccessfulInteractions: 0,
+  };
+  const memory = { samples: [] };
+  memory.start = await memorySnapshot("start");
+  const sampler = setInterval(async () => {
+    if (memory.samples.length < 50_000) memory.samples.push(await memorySnapshot("sample"));
+  }, 50);
+  try {
+    for (let index = 0; index < Math.min(10, config.cheapCycles); index += 1) {
+      await runLifecycle(index % 2 ? "auto" : "native");
+      counts.warmupCycles += 1;
+    }
+    memory.afterWarmup = await memorySnapshot("after-warmup");
+    for (let index = 0; index < config.cheapCycles; index += 1) {
+      samples.lifecycleMs.push(await runLifecycle(index % 2 ? "auto" : "native"));
+      counts.cheapCycles += 1;
+      if ((index + 1) % 100 === 0) console.error(JSON.stringify({ progress: "cheap-cycles", completed: index + 1 }));
+    }
+    for (let index = 0; index < config.toolWorkflows; index += 1) {
+      const result = await runToolWorkflow({ backend: index % 2 ? "auto" : "native", label: "required" });
+      samples.toolMs.push(result.latencyMs);
+      counts.toolWorkflows += 1;
+      if ((index + 1) % 10 === 0) console.error(JSON.stringify({ progress: "tool-workflows", completed: index + 1 }));
+    }
+    const isolated = await Promise.all(Array.from({ length: config.concurrency }, (_, index) =>
+      runToolWorkflow({ backend: index % 2 ? "auto" : "native", label: "isolation" })));
+    samples.toolMs.push(...isolated.map((item) => item.latencyMs));
+    counts.isolationWorkflows += isolated.length;
+    const restore = await runRestoreWorkflow();
+    samples.restoreMs.push(restore.latencyMs);
+    counts.restoreWorkflows += 1;
+
+    const mixedStarted = performance.now();
+    const mixedDeadline = mixedStarted + config.durationMs;
+    let operation = 0;
+    let nextProgress = mixedStarted + 15_000;
+    while (performance.now() < mixedDeadline) {
+      const waveStarted = performance.now();
+      const wave = Array.from({ length: config.concurrency }, async () => {
+        const selected = operation++ % 16;
+        if (selected < 9) {
+          const value = await runToolWorkflow({ backend: selected % 2 ? "auto" : "native", label: "mixed_success" });
+          samples.toolMs.push(value.latencyMs);
+          return "success";
+        }
+        if (selected < 11) {
+          const value = await runToolWorkflow({ mode: "reject", backend: selected % 2 ? "auto" : "native", label: "mixed_reject" });
+          samples.rejectMs.push(value.latencyMs);
+          return "reject";
+        }
+        if (selected === 11) {
+          const value = await runCancellationWorkflow();
+          samples.cancelMs.push(value.latencyMs);
+          return "cancel";
+        }
+        if (selected === 12) {
+          const value = await runRestoreWorkflow();
+          samples.restoreMs.push(value.latencyMs);
+          return "restore";
+        }
+        samples.lifecycleMs.push(await runLifecycle(selected % 2 ? "auto" : "native"));
+        return "lifecycle";
+      });
+      const outcomes = await Promise.all(wave);
+      counts.mixedOperations += outcomes.length;
+      counts.rejectedWorkflows += outcomes.filter((value) => value === "reject").length;
+      counts.cancellationWorkflows += outcomes.filter((value) => value === "cancel").length;
+      counts.restoreWorkflows += outcomes.filter((value) => value === "restore").length;
+      samples.mixedMs.push(performance.now() - waveStarted);
+      if (performance.now() >= nextProgress) {
+        console.error(JSON.stringify({ progress: "mixed", elapsedMs: performance.now() - mixedStarted, operations: counts.mixedOperations }));
+        nextProgress += 15_000;
+      }
+      await delay(5);
+    }
+    counts.mixedDurationMs = performance.now() - mixedStarted;
+    const later = await runToolWorkflow({ backend: "auto", label: "later_success" });
+    samples.toolMs.push(later.latencyMs);
+    counts.laterSuccessfulInteractions += 1;
+  } finally {
+    clearInterval(sampler);
+    server.closeAllConnections();
+    await new Promise((resolveClose) => server.close(resolveClose));
+  }
+  await delay(500);
+  if (typeof globalThis.gc === "function") globalThis.gc();
+  await delay(100);
+  memory.after = await memorySnapshot("after-quiescence");
+  assert.deepEqual(provider.failures, []);
+  assert.equal(provider.lateResultSeen, false);
+  assert.equal(counts.cheapCycles, config.cheapCycles);
+  assert.equal(counts.toolWorkflows, config.toolWorkflows);
+  assert.ok(counts.mixedDurationMs >= config.durationMs);
+  assert.equal(counts.laterSuccessfulInteractions, 1);
+  assert.ok(counts.rejectedWorkflows > 0 && counts.cancellationWorkflows > 0 && counts.restoreWorkflows > 0);
+  const allMemory = [memory.start, memory.afterWarmup, ...memory.samples, memory.after];
+  memory.peakRss = allMemory.reduce((current, sample) => sample.rss > current.rss ? sample : current);
+  memory.peakHeapUsed = allMemory.reduce((current, sample) => sample.heapUsed > current.heapUsed ? sample : current);
+  memory.peakFileDescriptors = allMemory
+    .filter((sample) => sample.fdCount !== null)
+    .reduce((current, sample) => current === null || sample.fdCount > current.fdCount ? sample : current, null);
+  memory.sampleCount = allMemory.length;
+  const steadySamples = memory.samples.filter((sample) => sample.timestampMs >= memory.afterWarmup.timestampMs);
+  memory.growthPerMinute = {
+    rssBytes: slopePerMinute(steadySamples, "rss"),
+    heapUsedBytes: slopePerMinute(steadySamples, "heapUsed"),
+    fileDescriptors: steadySamples.every((sample) => sample.fdCount !== null)
+      ? slopePerMinute(steadySamples, "fdCount")
+      : null,
+  };
+  const result = {
+    mode: config.mode,
+    package: config.packageIdentity,
+    runtime: {
+      node: process.version,
+      execPath: process.execPath,
+      platform: process.platform,
+      arch: process.arch,
+      jspi: typeof WebAssembly.Suspending === "function" && typeof WebAssembly.promising === "function",
+      execArgv: process.execArgv,
+    },
+    exports: exportNames,
+    backends: { forcedNative: baselineNative, automatic: baselineAuto },
+    counts,
+    provider: {
+      fetchCalls: provider.fetchCalls,
+      getRequests: provider.getRequests,
+      requests: provider.requests,
+      toolFirstSteps: provider.toolFirstSteps,
+      toolResultSteps: provider.toolResultSteps,
+      uniqueMarkers: provider.uniqueMarkers,
+      retainedMarkerModes: provider.markerModes.size,
+      retainedMarkerRequestCounts: provider.markerRequestCounts.size,
+    },
+    latency: Object.fromEntries(Object.entries(samples).map(([key, values]) => [key, stats(values)])),
+    memory,
+  };
+  console.log(JSON.stringify(result));
+}
+
+const workerSource = `#!/usr/bin/env node\n(${installedWorkerMain.toString()})().catch((error) => {\n  const record = { name: error?.name ?? typeof error, code: error?.code ?? null, message: error?.message ?? String(error), stack: error?.stack ?? null };\n  console.error(JSON.stringify({ workerFailure: record }));\n  process.exitCode = 1;\n});\n`;
+
+async function makeConsumer(root, name, sourcePackage) {
+  const consumer = join(root, name);
+  await mkdir(join(consumer, "node_modules"), { recursive: true });
+  await writeFile(join(consumer, "package.json"), '{"name":"libfx-resilience-consumer","private":true,"type":"module"}\n');
+  await cp(sourcePackage, join(consumer, "node_modules", "libfx"), { recursive: true });
+  await writeFile(join(consumer, "worker.mjs"), workerSource);
+  return consumer;
+}
+
+function cpuProfileFlags(tempRoot) {
+  if (!process.execArgv.some((argument) => argument === "--cpu-prof" || argument.startsWith("--cpu-prof="))) return [];
+  const suppliedDir = process.execArgv.find((argument) => argument.startsWith("--cpu-prof-dir="))?.slice("--cpu-prof-dir=".length);
+  const directory = resolve(suppliedDir ?? join(tempRoot, "cpu-profile"));
+  if (isInside(repoRoot, directory)) throw new Error("CPU profiles must be written outside the source checkout");
+  return ["--cpu-prof", `--cpu-prof-dir=${directory}`];
+}
+
+async function runWorker({ consumer, config, timeoutMs, flags = [], expectedStatus = 0, relayStderr = false }) {
+  const result = await runProcess({
+    label: config.mode,
+    command: process.execPath,
+    args: [...flags, join(consumer, "worker.mjs"), JSON.stringify(config)],
+    cwd: consumer,
+    timeoutMs,
+    expectedStatus,
+    relayStderr,
+  });
+  return { ...result, parsed: expectedStatus === 0 ? lastJsonLine(result.stdout) : null };
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.jsonOut && isInside(repoRoot, options.jsonOut)) {
+    throw new Error("structured evidence must be written outside the source checkout");
+  }
+  const tempRoot = await mkdtemp(join(tmpdir(), "libfx-package-resilience-"));
+  let failed = true;
+  const stages = [];
+  try {
+    const baseConsumer = join(tempRoot, "base-consumer");
+    const installMethod = await installPackage(options.packageInput, baseConsumer, options.npmBin);
+    const basePackage = join(baseConsumer, "node_modules", "libfx");
+    await writeFile(join(baseConsumer, "worker.mjs"), workerSource);
+    const identity = await packageIdentity(basePackage, options.packageInput, installMethod);
+    console.error(JSON.stringify({ progress: "package-staged", identity, tempRoot }));
+    const profileFlags = cpuProfileFlags(tempRoot);
+    if (profileFlags.length) await mkdir(profileFlags[1].slice("--cpu-prof-dir=".length), { recursive: true });
+
+    const workload = await runWorker({
+      consumer: baseConsumer,
+      config: {
+        mode: "workload",
+        cheapCycles: options.cheapCycles,
+        toolWorkflows: options.toolWorkflows,
+        durationMs: options.durationMs,
+        concurrency: options.concurrency,
+        packageIdentity: identity,
+      },
+      timeoutMs: options.stageTimeoutMs,
+      flags: ["--expose-gc", ...profileFlags],
+      relayStderr: true,
+    });
+    stages.push({ name: "workload", status: "PASS", result: workload.parsed, stderr: workload.stderr });
+
+    const cjsBaseline = await runWorker({
+      consumer: baseConsumer,
+      config: { mode: "cjs-happy" },
+      timeoutMs: options.faultTimeoutMs,
+    });
+    stages.push({ name: "cjs-happy", status: "PASS", result: cjsBaseline.parsed });
+
+    const nativeFile = `libfx.${process.platform}-${process.arch}.node`;
+    for (const mode of ["fault-missing-addon", "fault-corrupt-addon"]) {
+      const consumer = await makeConsumer(tempRoot, mode, basePackage);
+      const addonPath = join(consumer, "node_modules", "libfx", nativeFile);
+      if (mode === "fault-missing-addon") await rm(addonPath);
+      else await writeFile(addonPath, "not a native addon");
+      const outcome = await runWorker({ consumer, config: { mode }, timeoutMs: options.faultTimeoutMs });
+      stages.push({ name: mode, status: "PASS_EXPECTED_FAULT", result: outcome.parsed });
+    }
+
+    for (const mode of ["fault-no-jspi", "fault-bad-api", "fault-invalid-input"]) {
+      const consumer = await makeConsumer(tempRoot, mode, basePackage);
+      const outcome = await runWorker({ consumer, config: { mode }, timeoutMs: options.faultTimeoutMs });
+      stages.push({ name: mode, status: "PASS_EXPECTED_FAULT", result: outcome.parsed });
+    }
+
+    for (const mode of ["fault-missing-wasm", "fault-corrupt-wasm"]) {
+      const consumer = await makeConsumer(tempRoot, mode, basePackage);
+      const packageDir = join(consumer, "node_modules", "libfx");
+      const wasmPath = join(packageDir, "fx-core.wasm");
+      const restoreWasmPath = join(packageDir, "fx-core.valid.wasm");
+      await cp(wasmPath, restoreWasmPath);
+      if (mode === "fault-missing-wasm") await rm(wasmPath);
+      else await writeFile(wasmPath, "not WebAssembly");
+      const outcome = await runWorker({
+        consumer,
+        config: { mode, wasmPath, restoreWasmPath },
+        timeoutMs: options.faultTimeoutMs,
+        flags: ["--experimental-wasm-jspi"],
+      });
+      stages.push({ name: mode, status: "PASS_EXPECTED_FAULT_WITH_RECOVERY", result: outcome.parsed });
+    }
+
+    const mutationConsumer = await makeConsumer(tempRoot, "mutation-broken-cjs", basePackage);
+    const mutationManifestPath = join(mutationConsumer, "node_modules", "libfx", "package.json");
+    const mutationManifest = JSON.parse(await readFile(mutationManifestPath, "utf8"));
+    mutationManifest.exports["."].node.require = "./missing-node.cjs";
+    mutationManifest.exports["./node"].require = "./missing-node.cjs";
+    await writeFile(mutationManifestPath, `${JSON.stringify(mutationManifest, null, 2)}\n`);
+    const mutation = await runWorker({
+      consumer: mutationConsumer,
+      config: { mode: "cjs-happy" },
+      timeoutMs: options.faultTimeoutMs,
+      expectedStatus: 1,
+    });
+    assert.match(mutation.stderr, /ERR_MODULE_NOT_FOUND|MODULE_NOT_FOUND|Cannot find module/);
+    stages.push({
+      name: "mutation-broken-cjs-export",
+      status: "PASS_ORACLE_REJECTED_MUTATION",
+      result: { exitStatus: mutation.status, signal: mutation.signal, stderr: mutation.stderr.slice(-4000) },
+    });
+
+    const report = {
+      schemaVersion: 1,
+      generatedAt: new Date().toISOString(),
+      package: identity,
+      runtime: {
+        node: process.version,
+        execPath: process.execPath,
+        platform: process.platform,
+        arch: process.arch,
+        execArgv: process.execArgv,
+      },
+      configuration: {
+        cheapCycles: options.cheapCycles,
+        toolWorkflows: options.toolWorkflows,
+        sustainedDurationMs: options.durationMs,
+        concurrency: options.concurrency,
+        stageTimeoutMs: options.stageTimeoutMs,
+        faultTimeoutMs: options.faultTimeoutMs,
+      },
+      summary: {
+        passedStages: stages.length,
+        failedStages: 0,
+        expectedFaultStages: stages.filter((stage) => stage.status.includes("EXPECTED_FAULT")).length,
+        qualifiedMutationStages: stages.filter((stage) => stage.status.includes("ORACLE_REJECTED")).length,
+      },
+      cpuProfileDirectory: profileFlags.length ? profileFlags[1].slice("--cpu-prof-dir=".length) : null,
+      tempRoot: options.keepTemp ? tempRoot : null,
+      stages,
+    };
+    if (options.jsonOut) {
+      await mkdir(dirname(options.jsonOut), { recursive: true });
+      await writeFile(options.jsonOut, `${JSON.stringify(report, null, 2)}\n`);
+    }
+    console.log(JSON.stringify(report, null, 2));
+    failed = false;
+  } catch (error) {
+    if (options.jsonOut) {
+      await mkdir(dirname(options.jsonOut), { recursive: true });
+      await writeFile(options.jsonOut, `${JSON.stringify({
+        generatedAt: new Date().toISOString(),
+        packageInput: options.packageInput,
+        runtime: { node: process.version, execPath: process.execPath, platform: process.platform, arch: process.arch },
+        failure: { name: error.name, code: error.code ?? null, message: error.message, stack: error.stack },
+        processResult: error.result ?? null,
+        completedStages: stages,
+        retainedTempRoot: tempRoot,
+      }, null, 2)}\n`);
+    }
+    throw error;
+  } finally {
+    if (!options.keepTemp && !failed) await rm(tempRoot, { recursive: true, force: true });
+    else if (failed) console.error(JSON.stringify({ progress: "retained-failure-repro", tempRoot }));
+  }
+}
+
+await main();

--- a/sdk/tests/test-packed-example.mjs
+++ b/sdk/tests/test-packed-example.mjs
@@ -1,59 +1,88 @@
 #!/usr/bin/env node
 import { strict as assert } from "node:assert";
 import { createServer } from "node:http";
+import { spawnSync } from "node:child_process";
+import { cp, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { createRequire } from "node:module";
 import { resolve } from "node:path";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 
-const packageRoot = resolve(process.argv[2]);
 const backend = process.argv[3] || "native";
-const platform = `${process.platform}-${process.arch}`;
-const { createFxAgent } = await import(pathToFileURL(resolve(packageRoot, "node.js")));
-const { createMcpAdapter } = await import(pathToFileURL(resolve(packageRoot, "mcp.js")));
-const { createSkillsAdapter } = await import(pathToFileURL(resolve(packageRoot, "skills.js")));
-assert.equal(typeof createMcpAdapter, "function");
-assert.equal(typeof createSkillsAdapter, "function");
+const format = process.argv[4] || "esm";
+if (process.argv[2] !== "--installed") {
+  const temp = await mkdtemp(resolve(tmpdir(), "libfx-packed-"));
+  function run(command, args, cwd) {
+    const result = spawnSync(command, args, { cwd, encoding: "utf8", timeout: 120_000 });
+    if (result.error) throw result.error;
+    assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+    return result.stdout;
+  }
+  try {
+    const input = resolve(process.argv[2]);
+    const consumer = resolve(temp, "consumer");
+    await mkdir(consumer);
+    await writeFile(resolve(consumer, "package.json"), '{"private":true,"type":"module"}\n');
+    const archive = input.endsWith(".tgz") ? input : resolve(temp,
+      JSON.parse(run("npm", ["pack", input, "--ignore-scripts", "--pack-destination", temp, "--json"], temp))[0].filename);
+    run("npm", ["install", "--ignore-scripts", "--no-audit", "--no-fund", archive], consumer);
+    await cp(fileURLToPath(import.meta.url), resolve(consumer, "example.mjs"));
+    console.log(run(process.execPath, [...process.execArgv, "example.mjs", "--installed", backend, format], consumer).trim());
+  } finally {
+    await rm(temp, { recursive: true, force: true });
+  }
+} else {
+  const { createFxAgent } = format === "cjs" ? createRequire(import.meta.url)("libfx") : await import("libfx");
+  const { createMcpAdapter } = await import("libfx/mcp");
+  const { createSkillsAdapter } = await import("libfx/skills");
+  assert.equal(typeof createMcpAdapter, "function");
+  assert.equal(typeof createSkillsAdapter, "function");
 
-let requestedAuthorization;
-let requestedModel;
-const server = createServer((request, response) => {
-  request.resume();
-  request.on("end", () => {
-    if (request.method === "GET") {
-      response.writeHead(200, { "content-type": "application/json" });
-      response.end('{"object":"list","data":[]}');
-      return;
-    }
-    requestedAuthorization = request.headers.authorization;
-    requestedModel = request.headers["ai-language-model-id"];
-    response.writeHead(200, { "content-type": "text/event-stream" });
-    response.end('data: {"type":"text-delta","delta":"packed"}\n\ndata: {"type":"finish","finishReason":{"unified":"stop","raw":"stop"},"usage":{"inputTokens":{"total":1},"outputTokens":{"total":1}}}\n\ndata: [DONE]\n\n');
+  let requestedAuthorization;
+  let requestedModel;
+  const server = createServer((request, response) => {
+    request.resume();
+    request.on("end", () => {
+      if (request.method === "GET") {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end('{"object":"list","data":[]}');
+        return;
+      }
+      requestedAuthorization = request.headers.authorization;
+      requestedModel = request.headers["ai-language-model-id"];
+      response.writeHead(200, { "content-type": "text/event-stream" });
+      response.end('data: {"type":"text-delta","delta":"packed"}\n\ndata: {"type":"finish","finishReason":{"unified":"stop","raw":"stop"},"usage":{"inputTokens":{"total":1},"outputTokens":{"total":1}}}\n\ndata: [DONE]\n\n');
+    });
   });
-});
-await new Promise((resolveListen) => server.listen(0, "127.0.0.1", resolveListen));
+  await new Promise((resolveListen) => server.listen(0, "127.0.0.1", resolveListen));
 
-const agent = await createFxAgent({
-  backend,
-  nativeAddon: resolve(packageRoot, `libfx.${platform}.node`),
-  wasm: resolve(packageRoot, "fx-core.wasm"),
-  fetch,
-  apiKey: "packed-key",
-  gatewayChatUrl: `http://127.0.0.1:${server.address().port}/chat`,
-  model: "packed/model",
-});
-try {
-  assert.deepEqual(Object.keys(agent).sort(), ["checkpoint", "close", "prompt"]);
-  const turn = agent.prompt("hello");
-  let text = "";
-  for await (const event of turn) if (event.type === "text_delta") text += event.delta;
-  assert.equal(text, "packed");
-  assert.deepEqual(await turn.result, { stopReason: "end_turn", usage: { inputTokens: 1, outputTokens: 1 } });
-  assert.equal(requestedAuthorization, "Bearer packed-key");
-  assert.equal(requestedModel, "packed/model");
-  assert.ok((await agent.checkpoint()).length > 48);
-  await agent.close();
-  console.log(`${backend} packed libfx example passed`);
-} finally {
-  await agent.close().catch(() => {});
-  server.closeAllConnections();
-  await new Promise((resolveClose) => server.close(resolveClose));
+  const agent = await createFxAgent({
+    backend,
+    fetch(input, init) {
+      const origin = `http://127.0.0.1:${server.address().port}`;
+      const url = init?.method === "GET" ? `${origin}/models` : String(input);
+      assert.equal(new URL(url).origin, origin);
+      return fetch(url, init);
+    },
+    apiKey: "packed-key",
+    gatewayChatUrl: `http://127.0.0.1:${server.address().port}/chat`,
+    model: "packed/model",
+  });
+  try {
+    assert.deepEqual(Object.keys(agent).sort(), ["checkpoint", "close", "prompt"]);
+    const turn = agent.prompt("hello");
+    let text = "";
+    for await (const event of turn) if (event.type === "text_delta") text += event.delta;
+    assert.equal(text, "packed");
+    assert.deepEqual(await turn.result, { stopReason: "end_turn", usage: { inputTokens: 1, outputTokens: 1 } });
+    assert.equal(requestedAuthorization, "Bearer packed-key");
+    assert.equal(requestedModel, "packed/model");
+    assert.ok((await agent.checkpoint()).length > 48);
+    await agent.close();
+    console.log(`${format} ${backend} packed libfx example passed`);
+  } finally {
+    await agent.close().catch(() => {});
+    server.closeAllConnections();
+    await new Promise((resolveClose) => server.close(resolveClose));
+  }
 }

--- a/sdk/tests/test-term-demo-package.mjs
+++ b/sdk/tests/test-term-demo-package.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+import { strict as assert } from "node:assert";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
+const temp = await mkdtemp(join(tmpdir(), "fx-term-demo-package-"));
+const digest = (bytes) => createHash("sha256").update(bytes).digest("hex");
+
+try {
+  const result = spawnSync(process.execPath, [
+    resolve(repoRoot, "sdk/scripts/package-term-demo.mjs"),
+    temp,
+  ], { cwd: repoRoot, encoding: "utf8" });
+  if (result.error) throw result.error;
+  assert.equal(result.status, 0, result.stderr);
+
+  const manifest = JSON.parse(await readFile(join(temp, "manifest.json"), "utf8"));
+  const wasmModule = await readFile(join(temp, manifest.wasmModule.file));
+  assert.equal(digest(wasmModule), manifest.wasmModule.sha256);
+  assert.equal(wasmModule.byteLength, manifest.wasmModule.bytes);
+
+  const sdk = await readFile(join(temp, manifest.sdk.file), "utf8");
+  assert.match(sdk, new RegExp(`from "\\./${manifest.wasmModule.file.replaceAll(".", "\\.")}";`));
+  assert.doesNotMatch(sdk, /from "\.\/wasm-module\.js";/);
+
+  const vercel = JSON.parse(await readFile(join(temp, "vercel.json"), "utf8"));
+  const header = vercel.headers.find(({ source }) => source === `/${manifest.wasmModule.file}`);
+  assert.deepEqual(header?.headers, [{ key: "Cache-Control", value: "public, max-age=31536000, immutable" }]);
+  console.log("terminal demo package passed: shared Wasm module is hashed, rewritten, and immutable");
+} finally {
+  await rm(temp, { recursive: true, force: true });
+}

--- a/sdk/tests/test-vercel-package.mjs
+++ b/sdk/tests/test-vercel-package.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+import { strict as assert } from "node:assert";
+import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { once } from "node:events";
+import { cp, mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const input = process.argv[2];
+assert.ok(input, "provide a published libfx version or local tarball");
+const projectId = process.env.LIBFX_VERCEL_PROJECT_ID;
+const orgId = process.env.LIBFX_VERCEL_ORG_ID;
+assert.ok(projectId && orgId, "LIBFX_VERCEL_PROJECT_ID and LIBFX_VERCEL_ORG_ID are required");
+assert.ok(process.env.AI_GATEWAY_API_KEY, "AI_GATEWAY_API_KEY is required for live verification");
+const artifactRoot = process.env.LIBFX_TEST_ARTIFACT_ROOT || tmpdir();
+await mkdir(artifactRoot, { recursive: true });
+const directory = await mkdtemp(resolve(artifactRoot, "libfx-vercel-"));
+const app = resolve(directory, "app");
+const secret = randomUUID();
+const tokenArgs = process.env.LIBFX_VERCEL_TOKEN ? ["--token", process.env.LIBFX_VERCEL_TOKEN] : [];
+let deployment;
+let deploymentRef;
+let failure;
+
+async function run(command, args, name) {
+  const child = spawn(command, args, { cwd: app, stdio: ["ignore", "pipe", "pipe"] });
+  let output = "";
+  let errors = "";
+  child.stdout.on("data", (chunk) => { output += chunk; });
+  child.stderr.on("data", (chunk) => { errors += chunk; });
+  const timeout = setTimeout(() => child.kill("SIGKILL"), 300_000);
+  try {
+    const [code] = await once(child, "close");
+    const redact = (text) => [secret, process.env.AI_GATEWAY_API_KEY, process.env.LIBFX_VERCEL_TOKEN]
+      .filter(Boolean).reduce((value, credential) => value.replaceAll(credential, "[redacted]"), text);
+    await writeFile(resolve(directory, `${name}.log`), redact(`${output}\n${errors}`));
+    assert.equal(code, 0, `Vercel ${name} failed; see ${directory}/${name}.log`);
+    return output;
+  } finally { clearTimeout(timeout); }
+}
+
+function vercel(args, name) {
+  return run("vercel", [...args, "--scope", orgId, ...tokenArgs], name);
+}
+
+try {
+  await cp(fileURLToPath(new URL("./next/", import.meta.url)), app, {
+    recursive: true, filter: (path) => !["node_modules", ".next"].includes(path.split("/").at(-1)),
+  });
+  const manifest = JSON.parse(await readFile(resolve(app, "package.json"), "utf8"));
+  if (input.endsWith(".tgz")) {
+    await cp(resolve(input), resolve(app, "libfx.tgz"));
+    manifest.dependencies.libfx = "file:./libfx.tgz";
+  } else {
+    assert.match(input, /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/, "pin an immutable version, not a tag");
+    manifest.dependencies.libfx = input;
+  }
+  await writeFile(resolve(app, "package.json"), JSON.stringify(manifest, null, 2));
+  await run(process.env.PNPM_BIN || "pnpm", ["install", "--lockfile-only", "--no-frozen-lockfile", "--ignore-scripts"], "prepare");
+  await mkdir(resolve(app, ".vercel"));
+  await writeFile(resolve(app, ".vercel/project.json"), JSON.stringify({ projectId, orgId }));
+  const output = await vercel([
+    "deploy", "--yes", "--no-wait", "--force", "--target", "preview",
+    "--env", `LIBFX_SMOKE_TOKEN=${secret}`,
+    "--env", "LIBFX_LIVE=1",
+    "--env", `AI_GATEWAY_API_KEY=${process.env.AI_GATEWAY_API_KEY}`,
+    "--env", `LIBFX_TEST_MODEL=${process.env.LIBFX_TEST_MODEL || "openai/gpt-5.4-mini"}`,
+  ], "deploy");
+  try {
+    const result = JSON.parse(output).deployment;
+    deployment = result?.url;
+    deploymentRef = result?.id;
+  } catch {}
+  deployment ??= output.trim().split(/\s+/).findLast((value) => /^https:\/\/[^/]+$/.test(value));
+  assert.ok(deployment, `No deployment URL returned; see ${directory}/deploy.log`);
+  deploymentRef ??= deployment;
+  await vercel(["inspect", deploymentRef, "--wait", "--timeout", "5m"], "inspect");
+  const unauthorized = await fetch(`${deployment}/api/fx`);
+  assert.equal(unauthorized.status, 401, "live tool endpoint must require its verification token");
+  const results = [];
+  for (let round = 0; round < 3; round++) {
+    for (const backend of ["native", "auto"]) {
+      for (const scenario of ["host", "mcp"]) {
+        const response = await fetch(`${deployment}/api/fx?backend=${backend}&scenario=${scenario}`, {
+          headers: { authorization: `Bearer ${secret}` }, signal: AbortSignal.timeout(60_000),
+        });
+        const result = await response.json();
+        assert.equal(response.status, 200, JSON.stringify(result));
+        assert.equal(result.ok, true);
+        assert.equal(result.probe.backend, "native");
+        assert.equal(result.toolCalls, 1);
+        assert.ok(result.events.includes("tool_start") && result.events.includes("tool_end"));
+        assert.ok(result.checkpointBytes > 48);
+        assert.equal(result.result.stopReason, "end_turn");
+        if (scenario === "mcp") assert.equal(result.closedMcp, true);
+        results.push({ round, backend, scenario, ...result });
+        console.log(`Vercel round ${round + 1}/${backend}/${scenario} passed (${result.node}, glibc ${result.glibc})`);
+      }
+    }
+  }
+  await writeFile(resolve(directory, "results.json"), JSON.stringify({ input, deployment, results }, null, 2));
+  console.log(`Live Vercel package verification passed: ${directory}`);
+} catch (error) {
+  failure = error;
+  if (deploymentRef) {
+    try { await vercel(["inspect", deploymentRef, "--logs"], "build"); } catch {}
+  }
+} finally {
+  if (deployment && process.env.LIBFX_KEEP_DEPLOYMENT !== "1") {
+    try { await vercel(["remove", deploymentRef, "--yes"], "cleanup"); }
+    catch (error) { failure = failure ? new AggregateError([failure, error], "Verification and cleanup failed") : error; }
+  }
+  console.log(`Vercel package evidence: ${directory}`);
+}
+if (failure) throw failure;

--- a/sdk/wasm-module.js
+++ b/sdk/wasm-module.js
@@ -1,0 +1,50 @@
+const modulePromisesBySource = new Map();
+const modulePromisesByObject = new WeakMap();
+const moduleFailureSource = Symbol("libfx.moduleFailureSource");
+
+export function withModuleFailure(input, onFailure) {
+  return { [moduleFailureSource]: { input, onFailure } };
+}
+
+async function compileModule(input) {
+  const failureSource = input?.[moduleFailureSource];
+  if (failureSource) {
+    try {
+      return await compileModule(failureSource.input);
+    } catch (error) {
+      failureSource.onFailure();
+      throw error;
+    }
+  }
+  if (input instanceof WebAssembly.Module) return input;
+  if (typeof input === "string") input = fetch(input);
+  if (input instanceof Promise) input = await input;
+  if (input instanceof WebAssembly.Module) return input;
+  if (input instanceof Response) {
+    const contentType = input.headers.get("content-type")?.split(";", 1)[0].trim().toLowerCase();
+    if (contentType === "application/wasm" && typeof WebAssembly.compileStreaming === "function") {
+      return WebAssembly.compileStreaming(input);
+    }
+    const bytes = await input.arrayBuffer();
+    return WebAssembly.compile(bytes);
+  }
+  if (input instanceof ArrayBuffer || ArrayBuffer.isView(input)) {
+    return WebAssembly.compile(input);
+  }
+  throw new TypeError("wasm must be a URL, Response, ArrayBuffer, typed array, or WebAssembly.Module");
+}
+
+export function loadModule(input) {
+  if (input instanceof WebAssembly.Module) return Promise.resolve(input);
+  const isString = typeof input === "string";
+  if (!isString && (typeof input !== "object" || input === null)) return compileModule(input);
+  const cache = isString ? modulePromisesBySource : modulePromisesByObject;
+  const cached = cache.get(input);
+  if (cached) return cached;
+  const pending = compileModule(input);
+  cache.set(input, pending);
+  pending.catch(() => {
+    if (cache.get(input) === pending) cache.delete(input);
+  });
+  return pending;
+}


### PR DESCRIPTION
libfx now provides complete ESM and CommonJS Node entrypoints, statically traced native addons, and Linux binaries targeting glibc 2.34. Next.js applications can load the native backend without bundler configuration. The new getBackendInfo() API reports backend availability and structured failure reasons.

Package qualification exercises agent turns, JavaScript and HTTP MCP tools, cancellation, checkpoint restoration, and concurrent requests in Next development, production, and isolated traced output. Live Vercel native/auto tool turns and bounded lifecycle stress tests passed. Browser and terminal Wasm behavior is preserved.

Publishing retains the package and Linux runtime gates and verifies that the downloaded npm archive exactly matches the tested artifact before rerunning Node and Next tests. Live Vercel qualification is performed separately with the release harness, so npm publication does not depend on a Vercel deployment credential.

Published as `libfx@0.0.8-dev.820.g1d9d3b63d6ea` on the `dev` channel. The registry archive matched the tested archive byte-for-byte, and the npm version passed 12 live Vercel JavaScript and HTTP MCP tool turns in native and auto modes on Node 24.18.0 with glibc 2.34. [Release verification](https://github.com/vercel-labs/fx/actions/runs/34054833757).
