### PR TITLE
Preserve Gateway v3 reasoning parts through tool continuation and resume

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -38,6 +38,11 @@ pub fn build(b: *std.Build) void {
         "napi-surface",
         "Build a Node-API addon surface (core)",
     ) orelse .none;
+    const test_filter = b.option(
+        []const u8,
+        "test-filter",
+        "Run only unit tests whose name contains this substring",
+    );
 
     const git_commit = readGitCommit(b);
     const app_version = readAppVersion(b);
@@ -79,6 +84,7 @@ pub fn build(b: *std.Build) void {
 
     const exe_tests = b.addTest(.{
         .root_module = exe.root_module,
+        .filters = if (test_filter) |filter| &.{filter} else &.{},
     });
     const run_exe_tests = b.addRunArtifact(exe_tests);
     run_exe_tests.step.dependOn(b.getInstallStep());

--- a/src/core/agent/execution_memory.zig
+++ b/src/core/agent/execution_memory.zig
@@ -121,6 +121,44 @@ pub fn redactText(alloc: Allocator, text: []const u8) ![]u8 {
     return @constCast(masked);
 }
 
+fn textUnalteredByRedaction(alloc: Allocator, text: []const u8) !bool {
+    const masked = text_utils.maskSecrets(alloc, text) catch |err| switch (err) {
+        error.OutOfMemory, error.WriteFailed => return error.OutOfMemory,
+    };
+    if (masked.ptr == text.ptr) return true;
+    alloc.free(@constCast(masked));
+    return false;
+}
+
+/// Retains ordered replay parts across the durable boundary only when the
+/// segment survives redaction byte-for-byte: every text and reasoning payload
+/// must be unmasked, and every tool-call reference must resolve to a surviving
+/// call whose final identity was not rewritten. Anything redaction would alter
+/// marks the whole replay unit unavailable; the legacy projection then carries
+/// the step and no signature is attached to altered content.
+pub fn durableRetainedAssistantParts(
+    alloc: Allocator,
+    parts: ?[]const types.AssistantPart,
+    persisted_calls: []const types.ToolCall,
+) !?[]types.AssistantPart {
+    const source = parts orelse return null;
+    for (source) |part| {
+        switch (part) {
+            .text => |text_part| {
+                if (!try textUnalteredByRedaction(alloc, text_part.text)) return null;
+            },
+            .reasoning => |reasoning_part| {
+                if (!try textUnalteredByRedaction(alloc, reasoning_part.text)) return null;
+            },
+            .tool_call_ref => |ref| {
+                const call = findToolCallById(persisted_calls, ref.id) orelse return null;
+                if (call.final_identity != .valid) return null;
+            },
+        }
+    }
+    return try types.dupeAssistantParts(alloc, source);
+}
+
 fn dupeRedactedCommittedFilePresentation(
     alloc: Allocator,
     presentation: types.CommittedFilePresentation,
@@ -263,6 +301,10 @@ const ChatMessageAdapter = struct {
         return value.tool_result_memory;
     }
 
+    fn assistantParts(value: Message) ?[]const types.AssistantPart {
+        return value.assistant_parts;
+    }
+
     fn content(value: Message) ?[]const u8 {
         return value.content;
     }
@@ -305,6 +347,10 @@ const MessageAdapter = struct {
 
     fn toolResultMemory(value: Message) ?types.ToolResultMemory {
         return value.tool_result_memory;
+    }
+
+    fn assistantParts(value: Message) ?[]const types.AssistantPart {
+        return value.assistant_parts;
     }
 
     fn content(value: Message) ?[]const u8 {
@@ -417,10 +463,17 @@ fn buildNormalExecutionMemory(
         errdefer types.freeToolCallSlice(alloc, persisted_calls);
         const owned_results = try results.toOwnedSlice(alloc);
         errdefer types.freePersistedToolResults(alloc, owned_results);
+        const assistant_parts = try durableRetainedAssistantParts(
+            alloc,
+            Adapter.assistantParts(msg),
+            persisted_calls,
+        );
+        errdefer if (assistant_parts) |parts| types.freeAssistantParts(alloc, parts);
         const step = types.ToolExecutionStep{
             .assistant = assistant,
             .tool_calls = persisted_calls,
             .tool_results = owned_results,
+            .assistant_parts = assistant_parts,
         };
         try tool_steps.append(alloc, step);
         i = j;
@@ -526,14 +579,33 @@ pub fn dupeRedactedToolCall(alloc: Allocator, call: ToolCall) !ToolCall {
     errdefer if (provisional_id) |value| alloc.free(value);
     const provider_result = if (call.provider_result) |result| try redactText(alloc, result) else null;
     errdefer if (provider_result) |result| alloc.free(result);
+    // Signed replay metadata stays attached only when the call's identity and
+    // payloads survive redaction byte-for-byte; a masked call is replayed by
+    // the legacy projection without its signatures.
+    const call_unaltered = std.mem.eql(u8, id, call.id) and
+        std.mem.eql(u8, arguments_json, call.arguments_json) and
+        (call.provider_result == null or
+            (provider_result != null and std.mem.eql(u8, provider_result.?, call.provider_result.?)));
+    const provider_options_json = if (call_unaltered and call.provider_options_json != null)
+        try alloc.dupe(u8, call.provider_options_json.?)
+    else
+        null;
+    errdefer if (provider_options_json) |options| alloc.free(options);
+    const provider_result_options_json = if (call_unaltered and call.provider_result_options_json != null)
+        try alloc.dupe(u8, call.provider_result_options_json.?)
+    else
+        null;
+    errdefer if (provider_result_options_json) |options| alloc.free(options);
     return .{
         .id = id,
         .name = name,
         .arguments_json = arguments_json,
         .provisional_id = provisional_id,
         .provider_result = provider_result,
+        .provider_result_options_json = provider_result_options_json,
         .final_identity = call.final_identity,
         .provenance = call.provenance,
+        .provider_options_json = provider_options_json,
     };
 }
 

--- a/src/core/agent/execution_memory.zig
+++ b/src/core/agent/execution_memory.zig
@@ -142,13 +142,17 @@ pub fn durableRetainedAssistantParts(
     persisted_calls: []const types.ToolCall,
 ) !?[]types.AssistantPart {
     const source = parts orelse return null;
+    var joined: std.ArrayList(u8) = .empty;
+    defer joined.deinit(alloc);
     for (source) |part| {
         switch (part) {
             .text => |text_part| {
                 if (!try textUnalteredByRedaction(alloc, text_part.text)) return null;
+                try joined.appendSlice(alloc, text_part.text);
             },
             .reasoning => |reasoning_part| {
                 if (!try textUnalteredByRedaction(alloc, reasoning_part.text)) return null;
+                try joined.appendSlice(alloc, reasoning_part.text);
             },
             .tool_call_ref => |ref| {
                 const call = findToolCallById(persisted_calls, ref.id) orelse return null;
@@ -156,6 +160,9 @@ pub fn durableRetainedAssistantParts(
             },
         }
     }
+    // A secret split across part boundaries would mask the joined text but not
+    // the individual parts; the display projection checks the joined form.
+    if (!try textUnalteredByRedaction(alloc, joined.items)) return null;
     return try types.dupeAssistantParts(alloc, source);
 }
 
@@ -1732,6 +1739,71 @@ fn expectEquivalentNormalExecutionMemory(
         );
         try std.testing.expectEqual(expected_file.stale, actual_file.stale);
     }
+}
+
+test "durable replay parts persist only when redaction leaves the segment exact" {
+    const alloc = std.testing.allocator;
+    const calls = [_]ToolCall{.{ .id = "call_clean", .name = "read_file", .arguments_json = "{}" }};
+    const clean_parts = [_]types.AssistantPart{
+        .{ .reasoning = .{ .text = "Read the note first.", .provider_options = "{\"anthropic\":{\"signature\":\"sig_1\"}}" } },
+        .{ .tool_call_ref = .{ .id = "call_clean" } },
+    };
+    const retained = try durableRetainedAssistantParts(alloc, &clean_parts, &calls);
+    defer if (retained) |parts| types.freeAssistantParts(alloc, parts);
+    try std.testing.expectEqual(@as(usize, 2), retained.?.len);
+
+    // A reasoning block whose text masks a secret-looking value: the durable
+    // step keeps the masked display text, and the signed replay unit becomes
+    // unavailable instead of attaching the signature to altered content.
+    const masked_parts = [_]types.AssistantPart{
+        .{ .reasoning = .{ .text = "The token is sk-abcdefghijklmnop here.", .provider_options = "{\"anthropic\":{\"signature\":\"sig_1\"}}" } },
+        .{ .tool_call_ref = .{ .id = "call_clean" } },
+    };
+    const dropped = try durableRetainedAssistantParts(alloc, &masked_parts, &calls);
+    try std.testing.expect(dropped == null);
+
+    // A secret split across part boundaries is caught on the joined text.
+    const split_parts = [_]types.AssistantPart{
+        .{ .text = .{ .text = "prefix sk-" } },
+        .{ .text = .{ .text = "abcdefghijklmnop suffix" } },
+    };
+    const split_dropped = try durableRetainedAssistantParts(alloc, &split_parts, &calls);
+    try std.testing.expect(split_dropped == null);
+
+    // A reference to a call that did not survive redaction/filtering is stale.
+    const stale_parts = [_]types.AssistantPart{
+        .{ .tool_call_ref = .{ .id = "call_gone" } },
+    };
+    const stale_dropped = try durableRetainedAssistantParts(alloc, &stale_parts, &calls);
+    try std.testing.expect(stale_dropped == null);
+}
+
+test "durable execution memory keeps signed call metadata only for unaltered calls" {
+    const alloc = std.testing.allocator;
+    const clean_call = ToolCall{
+        .id = "call_clean",
+        .name = "read_file",
+        .arguments_json = "{}",
+        .provider_options_json = "{\"google\":{\"thoughtSignature\":\"ts_1\"}}",
+    };
+    const clean = try dupeRedactedToolCall(alloc, clean_call);
+    defer types.freeToolCall(alloc, clean);
+    try std.testing.expectEqualStrings(
+        "{\"google\":{\"thoughtSignature\":\"ts_1\"}}",
+        clean.provider_options_json.?,
+    );
+
+    const secret_call = ToolCall{
+        .id = "call_secret",
+        .name = "read_file",
+        .arguments_json = "{\"api_key\":\"sk-abcdefghijklmnop\"}",
+        .provider_options_json = "{\"google\":{\"thoughtSignature\":\"ts_1\"}}",
+    };
+    const altered = try dupeRedactedToolCall(alloc, secret_call);
+    defer types.freeToolCall(alloc, altered);
+    // The masked arguments no longer match the signature's payload.
+    try std.testing.expect(altered.provider_options_json == null);
+    try std.testing.expect(std.mem.find(u8, altered.arguments_json, "sk-") == null);
 }
 
 fn expectOptionalStringEqual(

--- a/src/core/agent/runtime/checkpoint.zig
+++ b/src/core/agent/runtime/checkpoint.zig
@@ -116,9 +116,14 @@ pub fn decode(alloc: Allocator, bytes: []const u8) Error!Decoded {
 
 test "kernel checkpoint round trips history and usage" {
     const alloc = std.testing.allocator;
+    const final_parts = [_]types.AssistantPart{
+        .{ .reasoning = .{ .text = "thinking", .provider_options = "{\"anthropic\":{\"signature\":\"sig_kernel\"}}" } },
+        .{ .text = .{ .text = "world" } },
+    };
     const history = [_]types.HistoryTurn{.{ .assistant = .{
         .user = .{ .text = @constCast("hello") },
         .assistant = @constCast("world"),
+        .assistant_parts = @constCast(&final_parts),
     } }};
     const bytes = try encode(alloc, &history, .{ .input_tokens = 3, .output_tokens = 2 });
     defer alloc.free(bytes);
@@ -127,6 +132,13 @@ test "kernel checkpoint round trips history and usage" {
     try std.testing.expectEqual(@as(usize, 1), decoded.history.len);
     try std.testing.expectEqualStrings("hello", decoded.history[0].assistant.user.text);
     try std.testing.expectEqualStrings("world", decoded.history[0].assistant.assistant);
+    const decoded_parts = decoded.history[0].assistant.assistant_parts orelse
+        return error.TestExpectedAssistantParts;
+    try std.testing.expectEqual(@as(usize, 2), decoded_parts.len);
+    try std.testing.expectEqualStrings(
+        "{\"anthropic\":{\"signature\":\"sig_kernel\"}}",
+        decoded_parts[0].reasoning.provider_options.?,
+    );
     try std.testing.expectEqual(@as(?u64, 3), decoded.usage.input_tokens);
 }
 

--- a/src/core/agent/runtime/execution_memory.zig
+++ b/src/core/agent/runtime/execution_memory.zig
@@ -89,22 +89,27 @@ pub fn buildExecutionMemory(alloc: Allocator, within_turn_suffix: []const ChatMe
         for (steering.items) |item| {
             alloc.free(item.text);
             if (item.assistant_prefix) |prefix| alloc.free(prefix);
+            if (item.assistant_prefix_parts) |parts| types.freeAssistantParts(alloc, parts);
         }
         steering.deinit(alloc);
     }
     var tool_step_count: usize = 0;
     var assistant_prefix: ?[]const u8 = null;
+    var assistant_prefix_parts: ?[]const types.AssistantPart = null;
     for (within_turn_suffix, 0..) |message, index| {
         if (startsPersistedToolStep(within_turn_suffix, index)) {
             tool_step_count += 1;
             assistant_prefix = null;
+            assistant_prefix_parts = null;
         } else if (message.role == .assistant) {
             assistant_prefix = message.content;
+            assistant_prefix_parts = message.assistant_parts;
         }
         if (message.role != .user) continue;
         const content = message.content orelse continue;
         const text = steeringText(content) orelse {
             assistant_prefix = null;
+            assistant_prefix_parts = null;
             continue;
         };
         const copy = try alloc.dupe(u8, text);
@@ -115,16 +120,32 @@ pub fn buildExecutionMemory(alloc: Allocator, within_turn_suffix: []const ChatMe
             }
         else
             null;
+        // The prefix replay unit survives only when the prefix text crosses the
+        // redaction boundary byte-for-byte.
+        const prefix_parts = if (assistant_prefix_parts != null and
+            prefix_copy != null and
+            assistant_prefix != null and
+            std.mem.eql(u8, prefix_copy.?, assistant_prefix.?))
+            execution_memory_helpers.durableRetainedAssistantParts(alloc, assistant_prefix_parts, &.{}) catch |err| {
+                alloc.free(copy);
+                if (prefix_copy) |prefix| alloc.free(prefix);
+                return err;
+            }
+        else
+            null;
         steering.append(alloc, .{
             .text = copy,
             .assistant_prefix = prefix_copy,
+            .assistant_prefix_parts = prefix_parts,
             .after_tool_step_count = tool_step_count,
         }) catch |err| {
             alloc.free(copy);
             if (prefix_copy) |prefix| alloc.free(prefix);
+            if (prefix_parts) |parts| types.freeAssistantParts(alloc, parts);
             return err;
         };
         assistant_prefix = null;
+        assistant_prefix_parts = null;
     }
     std.debug.assert(tool_step_count == execution.tool_steps.len);
     execution.steering = try steering.toOwnedSlice(alloc);
@@ -189,6 +210,11 @@ pub fn buildInterruptedExecutionMemory(
         for (allocated_call_slices.items) |calls| alloc.free(calls);
         allocated_call_slices.deinit(alloc);
     }
+    var allocated_part_slices: std.ArrayList([]types.AssistantPart) = .empty;
+    defer {
+        for (allocated_part_slices.items) |parts| alloc.free(parts);
+        allocated_part_slices.deinit(alloc);
+    }
 
     var active_group_index: ?usize = null;
     if (active_tool_call) |active| {
@@ -245,6 +271,14 @@ pub fn buildInterruptedExecutionMemory(
 
             var projected = item;
             projected.tool_calls = calls;
+            // Keep the replay sequence in sync with the filtered call set:
+            // references to the removed active or incomplete calls are dropped
+            // with the calls, in the same pass.
+            if (item.assistant_parts) |parts| {
+                const projected_parts = try types.filterAssistantPartsToCalls(alloc, parts, calls);
+                if (projected_parts) |kept| try allocated_part_slices.append(alloc, kept);
+                projected.assistant_parts = projected_parts;
+            }
             filtered.appendAssumeCapacity(projected);
             for (result_messages) |result| {
                 const result_call_id = result.tool_call_id orelse continue;

--- a/src/core/agent/runtime/finalization.zig
+++ b/src/core/agent/runtime/finalization.zig
@@ -155,6 +155,7 @@ pub fn finishAssistantTerminalWithExecution(
     execution: types.ExecutionMemory,
     summary: *TurnSummaryAccumulator,
     assistant_text: []const u8,
+    assistant_parts: ?[]const types.AssistantPart,
     outcome: types.TurnPresentationOutcome,
     disposition: ?types.ProviderCompletionDisposition,
     finish_trace: *PromptFinishTrace,
@@ -164,11 +165,16 @@ pub fn finishAssistantTerminalWithExecution(
     defer projection_arena.deinit();
     const context_execution = try finalization.compacted_execution.project(projection_arena.allocator(), execution);
     const completed_summary = summary.finish();
-    var turn: HistoryTurn = .{ .assistant = .{
-        .user = .{ .text = job.prompt, .images = job.images },
-        .assistant = @constCast(assistant_text),
-        .execution = context_execution,
-    } };
+    var turn: HistoryTurn = .{
+        .assistant = .{
+            .user = .{ .text = job.prompt, .images = job.images },
+            .assistant = @constCast(assistant_text),
+            .execution = context_execution,
+            // Borrowed like `assistant` text; the turn is deep-copied before it
+            // outlives this scope.
+            .assistant_parts = @constCast(assistant_parts),
+        },
+    };
     types.setHistoryTurnSummary(&turn, completed_summary);
     const finished = try types.dupeFinishedPrompt(
         std.heap.c_allocator,
@@ -212,6 +218,7 @@ pub fn finishExecutionOnlyFailureIfNeeded(
         execution,
         summary,
         "",
+        null,
         .failed,
         null,
         finish_trace,
@@ -249,6 +256,7 @@ pub fn finalizeRetainedCandidateFailure(
         execution,
         summary,
         assistant_text,
+        null,
         .failed,
         null,
         finish_trace,

--- a/src/core/agent/runtime/gateway_step.zig
+++ b/src/core/agent/runtime/gateway_step.zig
@@ -189,6 +189,8 @@ pub fn projectToolImageMessages(alloc: Allocator, messages: []const types.ChatMe
             const content = message.content orelse "";
             const keep = @import("../../config/context_limits.zig").utf8PrefixLength(content, text_limit -| notice.len);
             memory.truncated = memory.truncated or keep < content.len;
+            // The rewritten result text detaches signed result metadata.
+            memory.provider_options_json = null;
             message.content = try std.mem.concat(alloc, u8, &.{ notice[0..@min(notice.len, text_limit)], content[0..keep] });
         }
     }

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -124,6 +124,7 @@ fn append_pending_steering_after_assistant(
     within_turn_suffix: *std.ArrayList(ChatMessage),
     turn_id: u64,
     assistant_text: []const u8,
+    assistant_parts: ?[]const types.AssistantPart,
 ) !bool {
     const boundary = try take_steering_boundary(deps, arena, turn_id, .model);
     const guidance = switch (boundary) {
@@ -134,6 +135,7 @@ fn append_pending_steering_after_assistant(
     try within_turn_suffix.append(arena, .{
         .role = .assistant,
         .content = assistant_text,
+        .assistant_parts = assistant_parts,
     });
     try append_steering_guidance(arena, within_turn_suffix, guidance);
     return true;
@@ -571,6 +573,9 @@ fn project_terminal_request_messages(
         target.* = message;
         target.content = null;
         target.tool_calls = &.{};
+        // This projection rewrites calls and text; replay parts stay with the
+        // canonical request, not this legacy view.
+        target.assistant_parts = null;
         initialized += 1;
         target.content = if (message.content) |content|
             try alloc.dupe(u8, content)
@@ -826,6 +831,9 @@ fn project_subagent_request_messages(
         target.* = message;
         target.content = if (message.content) |content| try alloc.dupe(u8, content) else null;
         target.tool_calls = &.{};
+        // This projection rewrites subagent calls and text; replay parts stay
+        // with the canonical request, not this derived view.
+        target.assistant_parts = null;
         initialized += 1;
 
         if (message.role == .tool and message.tool_call_id != null) {
@@ -869,6 +877,9 @@ fn project_subagent_request_messages(
                     )) orelse try alloc.dupe(u8, call.arguments_json);
                     var copied = call;
                     copied.arguments_json = arguments;
+                    // Rewritten arguments detach signed replay metadata.
+                    copied.provider_options_json = null;
+                    copied.provider_result_options_json = null;
                     projected_calls.append(alloc, copied) catch |err| {
                         alloc.free(arguments);
                         return err;
@@ -1085,6 +1096,9 @@ fn project_read_tool_result_request_messages(
             }
             @constCast(projected.?[message_index].tool_calls)[call_index].arguments_json =
                 arguments_json;
+            // Rewritten arguments detach signed replay metadata.
+            @constCast(projected.?[message_index].tool_calls)[call_index].provider_options_json = null;
+            @constCast(projected.?[message_index].tool_calls)[call_index].provider_result_options_json = null;
         }
     }
     return projected orelse source;
@@ -1251,6 +1265,9 @@ fn normalize_terminal_request_tool_calls(
             };
         }
         normalized.?[index].arguments_json = arguments_json;
+        // Rewritten arguments detach signed replay metadata for this call.
+        normalized.?[index].provider_options_json = null;
+        normalized.?[index].provider_result_options_json = null;
     }
     return normalized orelse source;
 }
@@ -1288,6 +1305,8 @@ fn normalize_subagent_request_tool_calls(
             };
         }
         normalized.?[index].arguments_json = arguments_json;
+        normalized.?[index].provider_options_json = null;
+        normalized.?[index].provider_result_options_json = null;
     }
     return normalized orelse source;
 }
@@ -2578,6 +2597,7 @@ fn materializeConfirmedProviderTools(
         novel_calls,
         completion.assistant_phase,
         completion.provider_state_json,
+        try types.filterAssistantPartsToCalls(arena, completion.assistant_parts, novel_calls),
     );
     var batch: runtime_tool_batch.StepBatchState = .{};
     reportProviderExecutedUsage(deps, novel_calls);
@@ -2802,6 +2822,9 @@ fn finishPendingCancelledCalls(
 
 pub const CommonStopState = struct {
     retained_candidate: ?[]const u8 = null,
+    /// Replay parts of the retained candidate segment, joined chronologically
+    /// with the next segment's parts when the candidate text is joined.
+    retained_candidate_parts: ?[]const types.AssistantPart = null,
     latest_partial: ?[]const u8 = null,
     dispatched: bool = false,
     terminal_materializing: bool = false,
@@ -6777,6 +6800,9 @@ fn processQueuedPromptLoop(
                         stream_ctx.drop_staged_response_language_candidate();
                         if (streamCompletionPtr(&stream_result)) |candidate| {
                             candidate.content = null;
+                            // The rejected prose must not stay available for
+                            // replay through the canonical part sequence.
+                            candidate.assistant_parts = null;
                         }
                     },
                     .retry_once, .fail_without_commit => {
@@ -7124,6 +7150,13 @@ fn processQueuedPromptLoop(
         ) else .{ .calls = completion.tool_calls, .removed = 0 };
         completion.tool_calls = filtered_provider_calls.calls;
         if (filtered_provider_calls.removed > 0) {
+            completion.assistant_parts = try types.filterAssistantPartsToCalls(
+                arena,
+                completion.assistant_parts,
+                completion.tool_calls,
+            );
+        }
+        if (filtered_provider_calls.removed > 0) {
             debug_trace.eventf(
                 "agent",
                 "provider_tool_recovery_duplicate_suppressed",
@@ -7187,6 +7220,7 @@ fn processQueuedPromptLoop(
                     within_turn_suffix.items,
                     &summary_accumulator,
                     assistant_text,
+                    null,
                     .failed,
                     null,
                     &finish_trace,
@@ -7204,6 +7238,7 @@ fn processQueuedPromptLoop(
                     within_turn_suffix.items,
                     &summary_accumulator,
                     partial_assistant,
+                    null,
                     .failed,
                     null,
                     &finish_trace,
@@ -7455,6 +7490,7 @@ fn processQueuedPromptLoop(
                     within_turn_suffix.items,
                     &summary_accumulator,
                     persisted_text,
+                    null,
                     .failed,
                     .length_limited,
                     &finish_trace,
@@ -7496,10 +7532,11 @@ fn processQueuedPromptLoop(
                     if (completion.content) |content| content.len else 0,
                     if (completion.provider_state_json != null) "true" else "false",
                 });
-                if (completion.provider_state_json) |state| {
+                if (completion.provider_state_json != null or completion.assistant_parts != null) {
                     try within_turn_suffix.append(arena, .{
                         .role = .assistant,
-                        .provider_state_json = state,
+                        .provider_state_json = completion.provider_state_json,
+                        .assistant_parts = completion.assistant_parts,
                     });
                 }
                 try within_turn_suffix.append(arena, .{ .role = .user, .content = continuation_prompt });
@@ -7521,6 +7558,7 @@ fn processQueuedPromptLoop(
                     &within_turn_suffix,
                     turn_id,
                     history_text,
+                    completion.assistant_parts,
                 ))
             {
                 try deps.push_text(deps.ctx, .{ .assistant_rendered = "\n" });
@@ -7538,6 +7576,11 @@ fn processQueuedPromptLoop(
                     stop_state.retained_candidate,
                     history_text,
                 );
+                const persisted_parts = try types.concatAssistantParts(
+                    arena,
+                    stop_state.retained_candidate_parts,
+                    completion.assistant_parts,
+                );
                 stop_state.terminal_materializing =
                     stop_state.retained_candidate != null;
                 try finishCommonAssistantTerminal(
@@ -7548,6 +7591,7 @@ fn processQueuedPromptLoop(
                     within_turn_suffix.items,
                     &summary_accumulator,
                     persisted_text,
+                    persisted_parts,
                     .completed,
                     if (disposition == .length_limited)
                         .length_limited
@@ -7560,6 +7604,7 @@ fn processQueuedPromptLoop(
             }
 
             stop_state.retained_candidate = history_text;
+            stop_state.retained_candidate_parts = completion.assistant_parts;
             stop_state.latest_partial = null;
             if (!has_content) {
                 try deps.push_text(deps.ctx, .{ .operational = rendered });
@@ -7586,6 +7631,7 @@ fn processQueuedPromptLoop(
                         history_text,
                     )) {
                         stop_state.retained_candidate = null;
+                        stop_state.retained_candidate_parts = null;
                         stop_state.latest_partial = null;
                         continue :agent_steps_loop;
                     }
@@ -7621,6 +7667,7 @@ fn processQueuedPromptLoop(
                         within_turn_suffix.items,
                         &summary_accumulator,
                         history_text,
+                        completion.assistant_parts,
                         .completed,
                         if (disposition == .length_limited)
                             .length_limited
@@ -7635,6 +7682,7 @@ fn processQueuedPromptLoop(
                     try within_turn_suffix.append(arena, .{
                         .role = .assistant,
                         .content = history_text,
+                        .assistant_parts = completion.assistant_parts,
                     });
                     const synthetic = try hooks.prompt.buildContinuationMessage(
                         arena,
@@ -7761,6 +7809,7 @@ fn processQueuedPromptLoop(
                 partial_assistant,
             .tool_calls = effective_tool_calls,
             .provider_state_json = completion.provider_state_json,
+            .assistant_parts = if (terminal_provider_completion) null else completion.assistant_parts,
         };
 
         var preparation_batch = tool_preparation.ReadyCallBatch.init(
@@ -7993,6 +8042,7 @@ fn processQueuedPromptLoop(
             effective_tool_calls,
             completion.assistant_phase,
             completion.provider_state_json,
+            if (terminal_provider_completion) null else completion.assistant_parts,
         );
 
         const step_has_content = !terminal_provider_completion and completion.content != null and completion.content.?.len > 0;
@@ -10046,6 +10096,7 @@ fn processQueuedPromptLoop(
                     within_turn_suffix.items,
                     &summary_accumulator,
                     assistant_text,
+                    null,
                     .completed,
                     null,
                     &finish_trace,
@@ -10171,6 +10222,7 @@ fn processQueuedPromptLoop(
                 within_turn_suffix.items,
                 &summary_accumulator,
                 assistant_text,
+                null,
                 .completed,
                 null,
                 &finish_trace,
@@ -10212,6 +10264,7 @@ fn processQueuedPromptLoop(
                     &within_turn_suffix,
                     turn_id,
                     rendered,
+                    completion.assistant_parts,
                 ))
             {
                 try deps.push_text(deps.ctx, .{ .assistant_rendered = "\n" });
@@ -10230,6 +10283,11 @@ fn processQueuedPromptLoop(
                     stop_state.retained_candidate,
                     history_text,
                 );
+                const persisted_parts = try types.concatAssistantParts(
+                    arena,
+                    stop_state.retained_candidate_parts,
+                    completion.assistant_parts,
+                );
                 stop_state.terminal_materializing =
                     stop_state.retained_candidate != null;
                 try finishCommonAssistantTerminal(
@@ -10240,6 +10298,7 @@ fn processQueuedPromptLoop(
                     within_turn_suffix.items,
                     &summary_accumulator,
                     persisted_text,
+                    persisted_parts,
                     .completed,
                     null,
                     &finish_trace,
@@ -10249,6 +10308,7 @@ fn processQueuedPromptLoop(
             }
 
             stop_state.retained_candidate = rendered;
+            stop_state.retained_candidate_parts = completion.assistant_parts;
             stop_state.latest_partial = null;
             try deps.push_text(deps.ctx, .{ .assistant_rendered = "\n" });
 
@@ -10296,6 +10356,7 @@ fn processQueuedPromptLoop(
                         within_turn_suffix.items,
                         &summary_accumulator,
                         rendered,
+                        completion.assistant_parts,
                         .completed,
                         null,
                         &finish_trace,
@@ -10307,6 +10368,7 @@ fn processQueuedPromptLoop(
                     try within_turn_suffix.append(arena, .{
                         .role = .assistant,
                         .content = rendered,
+                        .assistant_parts = completion.assistant_parts,
                     });
                     const synthetic = try hooks.prompt.buildContinuationMessage(
                         arena,
@@ -10374,6 +10436,7 @@ fn finishFailedTurnWithNotice(
             current_turn_messages,
             summary_accumulator,
             assistant_text,
+            null,
             .failed,
             null,
             finish_trace,
@@ -10408,6 +10471,7 @@ pub fn finishCommonAssistantTerminal(
     current_turn_messages: []const ChatMessage,
     summary_accumulator: *runtime_telemetry.TurnSummaryAccumulator,
     assistant_text: []const u8,
+    assistant_parts: ?[]const types.AssistantPart,
     outcome: types.TurnPresentationOutcome,
     disposition: ?types.ProviderCompletionDisposition,
     finish_trace: *PromptFinishTrace,
@@ -10424,6 +10488,7 @@ pub fn finishCommonAssistantTerminal(
         execution_memory,
         summary_accumulator,
         assistant_text,
+        assistant_parts,
         outcome,
         disposition,
         finish_trace,
@@ -10438,6 +10503,7 @@ fn finishCommonAssistantTerminalWithExecution(
     execution_memory: types.ExecutionMemory,
     summary_accumulator: *runtime_telemetry.TurnSummaryAccumulator,
     assistant_text: []const u8,
+    assistant_parts: ?[]const types.AssistantPart,
     outcome: types.TurnPresentationOutcome,
     disposition: ?types.ProviderCompletionDisposition,
     finish_trace: *PromptFinishTrace,
@@ -10450,6 +10516,7 @@ fn finishCommonAssistantTerminalWithExecution(
         execution_memory,
         summary_accumulator,
         assistant_text,
+        assistant_parts,
         outcome,
         disposition,
         finish_trace,

--- a/src/core/agent/runtime/tests/finalization_flow.zig
+++ b/src/core/agent/runtime/tests/finalization_flow.zig
@@ -1678,6 +1678,7 @@ test "common Stop terminal payload construction failure leaves guard open for on
             &messages,
             &summary,
             "candidate",
+            null,
             .failed,
             null,
             &finish_trace,

--- a/src/core/agent/runtime/tests/gateway_flow.zig
+++ b/src/core/agent/runtime/tests/gateway_flow.zig
@@ -3430,6 +3430,89 @@ test "processQueuedPrompt does not compact away its only recent exchange" {
     try std.testing.expectEqual(@as(usize, 1), hooks.history_turns.items[0].assistant.execution.tool_steps.len);
 }
 
+test "processQueuedPrompt replays retained reasoning parts in the tool continuation request" {
+    const alloc = std.testing.allocator;
+    const step_parts = [_]types.AssistantPart{
+        .{ .reasoning = .{ .text = "The file holds the answer.", .provider_options = "{\"anthropic\":{\"signature\":\"sig_step\"}}" } },
+        .{ .text = .{ .text = "Reading the file." } },
+        .{ .tool_call_ref = .{ .id = "call_reasoning" } },
+    };
+    const final_parts = [_]types.AssistantPart{
+        .{ .reasoning = .{ .text = "The result answers the question.", .provider_options = "{\"anthropic\":{\"signature\":\"sig_final\"}}" } },
+        .{ .text = .{ .text = "The file says hello." } },
+    };
+    var call = toolCall("call_reasoning", "read_file", "{\"path\":\"note.txt\"}");
+    call.provider_options_json = "{\"google\":{\"thoughtSignature\":\"ts_1\"}}";
+    const calls = [_]ToolCall{call};
+
+    var gateway = FakeGateway.init(alloc, &.{
+        .{
+            .content = "Reading the file.",
+            .tool_calls = &calls,
+            .assistant_parts = &step_parts,
+        },
+        .{
+            .content = "The file says hello.",
+            .assistant_parts = &final_parts,
+        },
+    });
+    defer gateway.deinit();
+    var hooks = FakeAgentRuntimeDeps.init(alloc);
+    defer hooks.deinit();
+    hooks.permission_decisions = &.{.once};
+    hooks.exec_plans = &.{.{ .result = .{ .model_output = "file contents: hello" } }};
+    var fixture = PromptFixture{};
+    var job = fixture.job();
+    job.model = @constCast("provider/reasoning-model");
+
+    try runFakePrompt(&gateway, &hooks, fixture.config(), job);
+
+    try std.testing.expectEqual(@as(usize, 2), gateway.request_bodies.items.len);
+    var parsed = try std.json.parseFromSlice(
+        std.json.Value,
+        alloc,
+        gateway.request_bodies.items[1],
+        .{},
+    );
+    defer parsed.deinit();
+    const prompt = parsed.value.object.get("prompt").?.array.items;
+    var assistant_entry: ?std.json.Value = null;
+    for (prompt) |entry| {
+        if (entry != .object) continue;
+        const role = entry.object.get("role") orelse continue;
+        if (role == .string and std.mem.eql(u8, role.string, "assistant")) assistant_entry = entry;
+    }
+    const assistant = assistant_entry orelse return error.TestExpectedPromptMessageMissing;
+    var content_out: std.Io.Writer.Allocating = .init(alloc);
+    defer content_out.deinit();
+    try std.json.Stringify.value(assistant.object.get("content").?, .{}, &content_out.writer);
+    try std.testing.expectEqualStrings(
+        "[{\"type\":\"reasoning\",\"text\":\"The file holds the answer.\",\"providerOptions\":{\"anthropic\":{\"signature\":\"sig_step\"}}}," ++
+            "{\"type\":\"text\",\"text\":\"Reading the file.\"}," ++
+            "{\"type\":\"tool-call\",\"toolCallId\":\"call_reasoning\",\"toolName\":\"read_file\",\"input\":{\"path\":\"note.txt\"},\"providerOptions\":{\"google\":{\"thoughtSignature\":\"ts_1\"}}}]",
+        content_out.written(),
+    );
+
+    // The durable turn retains the step's parts and the final answer's parts.
+    try std.testing.expectEqual(@as(usize, 1), hooks.history_turns.items.len);
+    const completed = hooks.history_turns.items[0].assistant;
+    const persisted_step_parts = completed.execution.tool_steps[0].assistant_parts orelse
+        return error.TestExpectedAssistantParts;
+    try std.testing.expectEqual(@as(usize, 3), persisted_step_parts.len);
+    try std.testing.expectEqualStrings(
+        "{\"anthropic\":{\"signature\":\"sig_step\"}}",
+        persisted_step_parts[0].reasoning.provider_options.?,
+    );
+    try std.testing.expectEqualStrings("call_reasoning", persisted_step_parts[2].tool_call_ref.id);
+    const persisted_final_parts = completed.assistant_parts orelse return error.TestExpectedAssistantParts;
+    try std.testing.expectEqual(@as(usize, 2), persisted_final_parts.len);
+    try std.testing.expectEqualStrings(
+        "{\"anthropic\":{\"signature\":\"sig_final\"}}",
+        persisted_final_parts[0].reasoning.provider_options.?,
+    );
+    try std.testing.expectEqualStrings("The file says hello.", persisted_final_parts[1].text.text);
+}
+
 test "automatic compaction summarizes a newest exchange larger than the input window" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});

--- a/src/core/agent/runtime/tests/gateway_flow.zig
+++ b/src/core/agent/runtime/tests/gateway_flow.zig
@@ -2743,7 +2743,7 @@ test "processQueuedPrompt omits Fast without catalog support" {
 
     try std.testing.expectEqual(@as(usize, 1), hooks.capability_queries.items.len);
     try std.testing.expectEqual(@as(usize, 1), gateway.request_bodies.items.len);
-    try expectBodyContains(&gateway, 0, "\"reasoning\":\"high\"");
+    try expectRootFieldAbsent(&gateway, 0, "reasoning");
     try expectRootFieldAbsent(&gateway, 0, "fast");
     try expectBodyContains(&gateway, 0, "\"providerOptions\":{\"gateway\":{\"caching\":\"auto\"}}");
     try expectBodyNotContains(&gateway, 0, "\"maxOutputTokens\"");
@@ -3656,7 +3656,7 @@ test "processQueuedPrompt resolves catalog capabilities for opaque effort" {
 
     try std.testing.expectEqual(@as(usize, 1), hooks.capability_queries.items.len);
     try std.testing.expectEqualStrings("provider/new-reasoning-model", hooks.capability_queries.items[0]);
-    try expectBodyContains(&gateway, 0, "\"reasoning\":\"future-tier\"");
+    try expectRootFieldAbsent(&gateway, 0, "reasoning");
     try expectBodyContains(&gateway, 0, "\"providerOptions\":{\"gateway\":{\"caching\":\"auto\"}}");
 
     const trace = try readTraceFile(alloc, trace_path, 65536);
@@ -3837,7 +3837,7 @@ test "processQueuedPrompt filters stale controls against each queued model" {
 
         try runFakePrompt(&gateway, &hooks, config, job);
 
-        try expectBodyContains(&gateway, 0, "\"reasoning\":\"xhigh\"");
+        try expectRootFieldAbsent(&gateway, 0, "reasoning");
         try expectRootFieldAbsent(&gateway, 0, "fast");
         try expectBodyContains(&gateway, 0, "\"providerOptions\":{\"gateway\":{\"speed\":\"fast\",\"caching\":\"auto\"}}");
     }
@@ -3967,7 +3967,7 @@ test "processQueuedPrompt provider payload follows queued model sync boundaries"
         try runFakePrompt(&gateway, &hooks, config, supported_job);
 
         try std.testing.expectEqual(@as(usize, 1), gateway.request_bodies.items.len);
-        try expectBodyContains(&gateway, 0, "\"reasoning\":\"high\"");
+        try expectRootFieldAbsent(&gateway, 0, "reasoning");
         try expectRootFieldAbsent(&gateway, 0, "fast");
         try expectBodyContains(&gateway, 0, "\"providerOptions\":{\"gateway\":{\"speed\":\"fast\",\"caching\":\"auto\"}}");
     }

--- a/src/core/agent/runtime/tests/support.zig
+++ b/src/core/agent/runtime/tests/support.zig
@@ -200,6 +200,9 @@ pub const FakeCompletion = struct {
     reasoning_chunks: []const []const u8 = &.{},
     content: ?[]const u8 = null,
     provider_state_json: ?[]const u8 = null,
+    /// Retained ordered replay parts for the completion, as the real gateway
+    /// decoder would capture them.
+    assistant_parts: ?[]const types.AssistantPart = null,
     tool_calls: []const ToolCall = &.{},
     streamed_tool_starts: []const ToolCall = &.{},
     provider_result_identity_failure: ?types.ProviderResultIdentityFailure = null,
@@ -339,6 +342,7 @@ pub const FakeGateway = struct {
             .completion = .{
                 .content = completion.content,
                 .provider_state_json = completion.provider_state_json,
+                .assistant_parts = completion.assistant_parts,
                 .tool_calls = completion.tool_calls,
                 .provider_result_identity_failure = completion.provider_result_identity_failure,
                 .provider_failure_cause = completion.provider_failure_cause,

--- a/src/core/agent/runtime/tool_batch.zig
+++ b/src/core/agent/runtime/tool_batch.zig
@@ -48,6 +48,7 @@ pub fn appendAssistantToolCallStep(
     tool_calls: []const ToolCall,
     assistant_phase: ?types.AssistantMessagePhase,
     provider_state_json: ?[]const u8,
+    assistant_parts: ?[]const types.AssistantPart,
 ) !void {
     try within_turn_suffix.append(arena, .{
         .role = .assistant,
@@ -55,6 +56,7 @@ pub fn appendAssistantToolCallStep(
         .tool_calls = tool_calls,
         .assistant_phase = assistant_phase,
         .provider_state_json = provider_state_json,
+        .assistant_parts = assistant_parts,
     });
 }
 
@@ -556,7 +558,7 @@ test "drained batch feedback follows all tool results and keeps its source call"
         .{ .id = "call_second", .name = "run_command", .arguments_json = "{}" },
     };
 
-    try appendAssistantToolCallStep(alloc, &suffix, null, &calls, .commentary, null);
+    try appendAssistantToolCallStep(alloc, &suffix, null, &calls, .commentary, null, null);
     try appendToolResultContent(
         alloc,
         &suffix,

--- a/src/core/agent/stream_provider.zig
+++ b/src/core/agent/stream_provider.zig
@@ -326,6 +326,7 @@ pub const Result = union(enum) {
                 types.freeToolCallSlice(alloc, @constCast(completed.completion.tool_calls));
                 if (completed.completion.provider_failure_detail) |detail| alloc.free(@constCast(detail));
                 if (completed.completion.provider_state_json) |state| alloc.free(@constCast(state));
+                if (completed.completion.assistant_parts) |parts| types.freeAssistantParts(alloc, parts);
             },
             .failed => |failure| if (failure.ownership == .owned) {
                 if (failure.detail) |detail| alloc.free(detail);

--- a/src/core/permissions/auto_classifier.zig
+++ b/src/core/permissions/auto_classifier.zig
@@ -470,6 +470,7 @@ pub const Reviewer = struct {
         // attachments are untrusted and do not identify the action.
         target_pending_assistant.images = &.{};
         target_pending_assistant.content = null;
+        target_pending_assistant.assistant_parts = null;
         const instructions = [_]types.ChatMessage{.{ .role = .system, .content = instruction }};
         const messages = [_]types.ChatMessage{ user_message, target_pending_assistant };
 

--- a/src/core/session/session.zig
+++ b/src/core/session/session.zig
@@ -2036,12 +2036,17 @@ pub fn contextHistoryRange(
             execution.files = &.{};
             execution.turn_summary = null;
             switch (turn) {
-                .assistant => |*entry| entry.assistant = @constCast(""),
+                // Clearing the final answer also clears its replay parts.
+                .assistant => |*entry| {
+                    entry.assistant = @constCast("");
+                    entry.assistant_parts = null;
+                },
                 .interrupted => |*entry| {
                     entry.assistant = null;
                     entry.tool_call = null;
                     entry.completed_tool_names = &.{};
                     entry.cancelled_command = null;
+                    entry.assistant_parts = null;
                 },
                 .compacted_summary => unreachable,
             }
@@ -3166,7 +3171,11 @@ pub fn appendExecutionMemoryChatMessages(
             const steering = execution.steering[steering_index];
             if (steering.assistant_prefix) |prefix| {
                 if (prefix.len > 0) {
-                    try messages.append(alloc, .{ .role = .assistant, .content = prefix });
+                    try messages.append(alloc, .{
+                        .role = .assistant,
+                        .content = prefix,
+                        .assistant_parts = steering.assistant_prefix_parts,
+                    });
                 }
             }
             if (steering.text.len > 0) {
@@ -3179,6 +3188,7 @@ pub fn appendExecutionMemoryChatMessages(
             .role = .assistant,
             .content = step.assistant,
             .tool_calls = step.tool_calls,
+            .assistant_parts = step.assistant_parts,
         });
         for (step.tool_results) |result| {
             try messages.append(alloc, .{
@@ -3209,7 +3219,11 @@ pub fn appendExecutionMemoryChatMessages(
         const steering = execution.steering[steering_index];
         if (steering.assistant_prefix) |prefix| {
             if (prefix.len > 0) {
-                try messages.append(alloc, .{ .role = .assistant, .content = prefix });
+                try messages.append(alloc, .{
+                    .role = .assistant,
+                    .content = prefix,
+                    .assistant_parts = steering.assistant_prefix_parts,
+                });
             }
         }
         if (steering.text.len == 0) continue;
@@ -3230,6 +3244,7 @@ fn toolResultMemory(result: core_types.PersistedToolResult) core_types.ToolResul
         .command_output_replay = result.command_output_replay,
         .command_process_presentation = result.command_process_presentation,
         .terminal_action_presentation = result.terminal_action_presentation,
+        .provider_options_json = result.provider_options_json,
     };
 }
 
@@ -3252,8 +3267,15 @@ fn appendHistoryChatMessagesImpl(
             .assistant => |entry| {
                 try messages.append(alloc, .{ .role = .user, .content = entry.user.text, .images = entry.user.images });
                 try appendExecutionMemoryChatMessages(alloc, messages, entry.execution);
-                if (entry.assistant.len > 0) {
-                    try messages.append(alloc, .{ .role = .assistant, .content = entry.assistant });
+                // A reasoning-only final answer still carries replay parts.
+                if (entry.assistant.len > 0 or
+                    (entry.assistant_parts != null and entry.assistant_parts.?.len > 0))
+                {
+                    try messages.append(alloc, .{
+                        .role = .assistant,
+                        .content = entry.assistant,
+                        .assistant_parts = entry.assistant_parts,
+                    });
                 }
             },
             .interrupted => |entry| {

--- a/src/core/session/session.zig
+++ b/src/core/session/session.zig
@@ -2175,10 +2175,16 @@ pub fn dupeHistoryTurn(alloc: Allocator, turn: HistoryTurn) !HistoryTurn {
             const assistant_copy = try alloc.dupe(u8, entry.assistant);
             errdefer alloc.free(assistant_copy);
             const execution = try core_types.dupeExecutionMemory(alloc, entry.execution);
+            errdefer core_types.freeExecutionMemory(alloc, execution);
+            const assistant_parts = if (entry.assistant_parts) |parts|
+                try core_types.dupeAssistantParts(alloc, parts)
+            else
+                null;
             return .{ .assistant = .{
                 .user = user,
                 .assistant = assistant_copy,
                 .execution = execution,
+                .assistant_parts = assistant_parts,
             } };
         },
         .interrupted => |entry| {
@@ -2198,6 +2204,11 @@ pub fn dupeHistoryTurn(alloc: Allocator, turn: HistoryTurn) !HistoryTurn {
                 core_types.freeCancelledCommandPresentation(alloc, presentation);
             };
             const execution = try core_types.dupeExecutionMemory(alloc, entry.execution);
+            errdefer core_types.freeExecutionMemory(alloc, execution);
+            const assistant_parts = if (entry.assistant_parts) |parts|
+                try core_types.dupeAssistantParts(alloc, parts)
+            else
+                null;
             return .{ .interrupted = .{
                 .user = user,
                 .assistant = assistant,
@@ -2206,6 +2217,7 @@ pub fn dupeHistoryTurn(alloc: Allocator, turn: HistoryTurn) !HistoryTurn {
                 .execution = execution,
                 .cancelled_command = cancelled_command,
                 .terminal_reason = entry.terminal_reason,
+                .assistant_parts = assistant_parts,
             } };
         },
     }

--- a/src/core/session/session.zig
+++ b/src/core/session/session.zig
@@ -3870,6 +3870,70 @@ test "resume history projects steering before the final assistant" {
     }
 }
 
+test "history projection keeps reasoning-only segments with their replay parts" {
+    const alloc = std.testing.allocator;
+    var arena_state = std.heap.ArenaAllocator.init(alloc);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const step_parts = [_]core_types.AssistantPart{
+        .{ .reasoning = .{ .text = "The note holds it.", .provider_options = "{\"anthropic\":{\"signature\":\"sig_step\"}}" } },
+        .{ .tool_call_ref = .{ .id = "call_read" } },
+    };
+    var calls = [_]ToolCall{.{
+        .id = "call_read",
+        .name = "read_file",
+        .arguments_json = "{\"path\":\"note.txt\"}",
+    }};
+    var results = [_]PersistedToolResult{.{
+        .tool_call_id = @constCast("call_read"),
+        .tool_name = @constCast("read_file"),
+        .status = .success,
+        .output = @constCast("note contents"),
+        .output_bytes = 13,
+        .stored_output_bytes = 13,
+    }};
+    var steps = [_]ToolExecutionStep{.{
+        .tool_calls = calls[0..],
+        .tool_results = results[0..],
+        .assistant_parts = @constCast(&step_parts),
+    }};
+    const final_parts = [_]core_types.AssistantPart{
+        .{ .reasoning = .{ .text = "", .provider_options = "{\"anthropic\":{\"redactedData\":\"red_1\"}}" } },
+    };
+    const history = [_]HistoryTurn{.{
+        .assistant = .{
+            .user = .{ .text = @constCast("inspect the note") },
+            // A reasoning-only final answer has no display text.
+            .assistant = @constCast(""),
+            .execution = .{ .tool_steps = steps[0..] },
+            .assistant_parts = @constCast(&final_parts),
+        },
+    }};
+
+    var chat_messages: std.ArrayList(core_types.ChatMessage) = .empty;
+    defer chat_messages.deinit(arena);
+    try appendHistoryChatMessages(arena, &chat_messages, &history);
+
+    // user, assistant step (reasoning-only, parts-carried), tool result, final
+    // assistant (reasoning-only, parts-carried): nothing disappears.
+    try std.testing.expectEqual(@as(usize, 4), chat_messages.items.len);
+    try std.testing.expectEqual(.assistant, chat_messages.items[1].role);
+    const projected_step_parts = chat_messages.items[1].assistant_parts orelse
+        return error.TestExpectedAssistantParts;
+    try std.testing.expectEqual(@as(usize, 2), projected_step_parts.len);
+    try std.testing.expectEqualStrings("call_read", projected_step_parts[1].tool_call_ref.id);
+    try std.testing.expectEqual(.tool, chat_messages.items[2].role);
+    try std.testing.expectEqual(.assistant, chat_messages.items[3].role);
+    const projected_final_parts = chat_messages.items[3].assistant_parts orelse
+        return error.TestExpectedAssistantParts;
+    try std.testing.expectEqual(@as(usize, 1), projected_final_parts.len);
+    try std.testing.expectEqualStrings(
+        "{\"anthropic\":{\"redactedData\":\"red_1\"}}",
+        projected_final_parts[0].reasoning.provider_options.?,
+    );
+}
+
 test "resume history preserves steering between tool episodes" {
     const alloc = std.testing.allocator;
     var first_calls = [_]ToolCall{.{

--- a/src/core/session/session_codec.zig
+++ b/src/core/session/session_codec.zig
@@ -475,6 +475,10 @@ pub fn writeHistoryTurn(writer: *std.Io.Writer, turn: session.HistoryTurn) !void
             try writeUserTurn(writer, entry.user);
             try writer.writeAll(",\"assistant\":");
             try writeDurableBytes(writer, entry.assistant);
+            if (entry.assistant_parts) |parts| {
+                try writer.writeAll(",\"assistant_parts\":");
+                try writeAssistantParts(writer, parts);
+            }
             try writer.writeAll(",\"execution\":");
             try writeExecutionMemory(writer, entry.execution);
             try writer.writeByte('}');
@@ -496,6 +500,10 @@ pub fn writeHistoryTurn(writer: *std.Io.Writer, turn: session.HistoryTurn) !void
                 try writeDurableBytes(writer, name);
             }
             try writer.writeByte(']');
+            if (entry.assistant_parts) |parts| {
+                try writer.writeAll(",\"assistant_parts\":");
+                try writeAssistantParts(writer, parts);
+            }
             try writer.writeAll(",\"terminal_reason\":");
             try writeJsonString(writer, @tagName(entry.terminal_reason));
             if (hasDurableExecutionMemory(entry.execution)) {
@@ -589,17 +597,33 @@ pub fn parseHistoryTurn(alloc: Allocator, value: std.json.Value) !session.Histor
         } };
     }
     if (std.mem.eql(u8, kind, "assistant")) {
-        const object = try exactObject(value, &.{ "kind", "user", "assistant", "execution" });
+        const source = try requireObject(value);
+        const has_parts = source.get("assistant_parts") != null;
+        const object = if (has_parts)
+            try exactObject(value, &.{ "kind", "user", "assistant", "assistant_parts", "execution" })
+        else
+            try exactObject(value, &.{ "kind", "user", "assistant", "execution" });
         const user = try parseUserTurn(alloc, object.get("user") orelse return error.InvalidSessionFormat);
         errdefer session.freeUserTurn(alloc, user);
         const assistant = try parseRequiredDurableBytes(alloc, object, "assistant");
         errdefer alloc.free(assistant);
+        const assistant_parts = if (has_parts)
+            try parseAssistantParts(alloc, object.get("assistant_parts") orelse return error.InvalidSessionFormat)
+        else
+            null;
+        errdefer if (assistant_parts) |parts| types.freeAssistantParts(alloc, parts);
+        // A completed final answer has no pending calls to reference.
+        if (assistant_parts) |parts| {
+            types.validateAssistantParts(parts, &.{}) catch
+                return error.InvalidSessionFormat;
+        }
         const execution = try parseExecutionMemory(alloc, object.get("execution") orelse return error.InvalidSessionFormat);
         errdefer session.freeExecutionMemory(alloc, execution);
         return .{ .assistant = .{
             .user = user,
             .assistant = assistant,
             .execution = execution,
+            .assistant_parts = assistant_parts,
         } };
     }
     if (std.mem.eql(u8, kind, "background_command")) {
@@ -644,18 +668,34 @@ pub fn parseHistoryTurn(alloc: Allocator, value: std.json.Value) !session.Histor
         const has_execution = source.get("execution") != null;
         const has_presentation = source.get("cancelled_command") != null;
         const has_terminal_reason = source.get("terminal_reason") != null;
+        const has_parts = source.get("assistant_parts") != null;
         const object = try exactInterruptedHistoryObject(
             value,
             has_execution,
             has_presentation,
             has_terminal_reason,
+            has_parts,
         );
         const user = try parseUserTurn(alloc, object.get("user") orelse return error.InvalidSessionFormat);
         errdefer session.freeUserTurn(alloc, user);
         const assistant = try parseOptionalDurableBytes(alloc, object.get("assistant") orelse return error.InvalidSessionFormat);
         errdefer if (assistant) |owned| alloc.free(owned);
+        const assistant_parts = if (has_parts)
+            try parseAssistantParts(alloc, object.get("assistant_parts") orelse return error.InvalidSessionFormat)
+        else
+            null;
+        errdefer if (assistant_parts) |parts| types.freeAssistantParts(alloc, parts);
         const tool_call = try parseOptionalToolCall(alloc, object.get("tool_call") orelse return error.InvalidSessionFormat);
         errdefer if (tool_call) |call| session.freeToolCall(alloc, call);
+        // Interrupted parts may reference only the turn's own active call.
+        if (assistant_parts) |parts| {
+            const reference_calls: []const types.ToolCall = if (tool_call) |*call|
+                @as([*]const types.ToolCall, @ptrCast(call))[0..1]
+            else
+                &.{};
+            types.validateAssistantParts(parts, reference_calls) catch
+                return error.InvalidSessionFormat;
+        }
         const completed_tool_names = try parseDurableBytesArray(
             alloc,
             object.get("completed_tool_names") orelse return error.InvalidSessionFormat,
@@ -695,6 +735,7 @@ pub fn parseHistoryTurn(alloc: Allocator, value: std.json.Value) !session.Histor
             .execution = execution,
             .cancelled_command = cancelled_command,
             .terminal_reason = terminal_reason,
+            .assistant_parts = assistant_parts,
         } };
     }
     return error.InvalidSessionFormat;
@@ -1295,6 +1336,10 @@ fn writeExecutionMemory(writer: *std.Io.Writer, execution: session.ExecutionMemo
         if (i > 0) try writer.writeByte(',');
         try writer.writeAll("{\"assistant\":");
         try writeOptionalDurableBytes(writer, step.assistant);
+        if (step.assistant_parts) |parts| {
+            try writer.writeAll(",\"assistant_parts\":");
+            try writeAssistantParts(writer, parts);
+        }
         try writer.writeAll(",\"tool_calls\":[");
         for (step.tool_calls, 0..) |tool_call, call_index| {
             if (call_index > 0) try writer.writeByte(',');
@@ -1319,6 +1364,10 @@ fn writeExecutionMemory(writer: *std.Io.Writer, execution: session.ExecutionMemo
         try writeDurableBytes(writer, steering.text);
         try writer.writeAll(",\"assistant_prefix\":");
         try writeOptionalDurableBytes(writer, steering.assistant_prefix);
+        if (steering.assistant_prefix_parts) |parts| {
+            try writer.writeAll(",\"assistant_prefix_parts\":");
+            try writeAssistantParts(writer, parts);
+        }
         try writer.print(",\"after_tool_step_count\":{d}}}", .{steering.after_tool_step_count});
     }
     try writer.writeAll("],\"turn_summary\":");
@@ -1359,7 +1408,110 @@ fn writeToolCall(writer: *std.Io.Writer, tool_call: session.ToolCall) !void {
     try writeDurableBytes(writer, tool_call.arguments_json);
     try writer.writeAll(",\"provider_result\":");
     try writeOptionalDurableBytes(writer, tool_call.provider_result);
+    if (tool_call.provider_options_json) |options| {
+        try writer.writeAll(",\"provider_options_json\":");
+        try writeDurableBytes(writer, options);
+    }
+    if (tool_call.provider_result_options_json) |options| {
+        try writer.writeAll(",\"provider_result_options_json\":");
+        try writeDurableBytes(writer, options);
+    }
     try writer.writeByte('}');
+}
+
+/// Writes the ordered replay part sequence as a JSON array. Part metadata
+/// travels as validated JSON object bytes, matching `arguments_json`.
+fn writeAssistantParts(writer: *std.Io.Writer, parts: []const types.AssistantPart) !void {
+    try writer.writeByte('[');
+    for (parts, 0..) |part, index| {
+        if (index > 0) try writer.writeByte(',');
+        switch (part) {
+            .text => |text_part| {
+                try writer.writeAll("{\"type\":\"text\",\"text\":");
+                try writeDurableBytes(writer, text_part.text);
+                if (text_part.provider_options) |options| {
+                    try writer.writeAll(",\"provider_options_json\":");
+                    try writeDurableBytes(writer, options);
+                }
+                try writer.writeByte('}');
+            },
+            .reasoning => |reasoning_part| {
+                try writer.writeAll("{\"type\":\"reasoning\",\"text\":");
+                try writeDurableBytes(writer, reasoning_part.text);
+                if (reasoning_part.provider_options) |options| {
+                    try writer.writeAll(",\"provider_options_json\":");
+                    try writeDurableBytes(writer, options);
+                }
+                try writer.writeByte('}');
+            },
+            .tool_call_ref => |ref| {
+                try writer.writeAll("{\"type\":\"tool_call_ref\",\"call_id\":");
+                try writeDurableBytes(writer, ref.id);
+                try writer.writeByte('}');
+            },
+        }
+    }
+    try writer.writeByte(']');
+}
+
+fn parseAssistantParts(alloc: Allocator, value: std.json.Value) ![]types.AssistantPart {
+    if (value != .array) return error.InvalidSessionFormat;
+    if (value.array.items.len == 0) return &.{};
+    if (value.array.items.len > 1024) return error.InvalidSessionFormat;
+    const parts = try alloc.alloc(types.AssistantPart, value.array.items.len);
+    errdefer alloc.free(parts);
+    var parsed_count: usize = 0;
+    errdefer for (parts[0..parsed_count]) |part| {
+        switch (part) {
+            .text => |text_part| {
+                alloc.free(text_part.text);
+                if (text_part.provider_options) |options| alloc.free(options);
+            },
+            .reasoning => |reasoning_part| {
+                alloc.free(reasoning_part.text);
+                if (reasoning_part.provider_options) |options| alloc.free(options);
+            },
+            .tool_call_ref => |ref| alloc.free(ref.id),
+        }
+    };
+    for (value.array.items, 0..) |item, i| {
+        const source = try requireObject(item);
+        const has_text = source.get("text") != null;
+        const has_options = source.get("provider_options_json") != null;
+        const has_call_id = source.get("call_id") != null;
+        const type_value = try requireString(source, "type");
+        if (std.mem.eql(u8, type_value, "text") or std.mem.eql(u8, type_value, "reasoning")) {
+            if (!has_text or has_call_id) return error.InvalidSessionFormat;
+            const object = if (has_options)
+                try exactObject(item, &.{ "type", "text", "provider_options_json" })
+            else
+                try exactObject(item, &.{ "type", "text" });
+            const text = try parseRequiredDurableBytes(alloc, object, "text");
+            errdefer alloc.free(text);
+            const options = if (has_options)
+                try parseRequiredDurableBytes(alloc, object, "provider_options_json")
+            else
+                null;
+            errdefer if (options) |owned| alloc.free(owned);
+            if (options) |owned| {
+                types.validateProviderOptionsJson(alloc, owned) catch
+                    return error.InvalidSessionFormat;
+            }
+            parts[i] = if (std.mem.eql(u8, type_value, "text"))
+                .{ .text = .{ .text = text, .provider_options = options } }
+            else
+                .{ .reasoning = .{ .text = text, .provider_options = options } };
+        } else if (std.mem.eql(u8, type_value, "tool_call_ref")) {
+            if (!has_call_id or has_text or has_options) return error.InvalidSessionFormat;
+            const object = try exactObject(item, &.{ "type", "call_id" });
+            const id = try parseRequiredDurableBytes(alloc, object, "call_id");
+            parts[i] = .{ .tool_call_ref = .{ .id = id } };
+        } else {
+            return error.InvalidSessionFormat;
+        }
+        parsed_count += 1;
+    }
+    return parts;
 }
 
 fn writePersistedToolResult(writer: *std.Io.Writer, result: session.PersistedToolResult) !void {
@@ -1408,6 +1560,10 @@ fn writePersistedToolResult(writer: *std.Io.Writer, result: session.PersistedToo
         writer,
         result.terminal_action_presentation,
     );
+    if (result.provider_options_json) |options| {
+        try writer.writeAll(",\"provider_options_json\":");
+        try writeDurableBytes(writer, options);
+    }
     if (result.tool_image_handle) |handle| {
         try writer.writeAll(",\"tool_image_handle\":");
         try writeDurableBytes(writer, handle);
@@ -1739,6 +1895,7 @@ fn parsePersistedSteering(
     errdefer for (steering[0..parsed_count]) |item| {
         alloc.free(item.text);
         if (item.assistant_prefix) |prefix| alloc.free(prefix);
+        if (item.assistant_prefix_parts) |parts| types.freeAssistantParts(alloc, parts);
     };
     var prior_tool_step_count: usize = 0;
     for (value.array.items, 0..) |item, index| {
@@ -1748,7 +1905,12 @@ fn parsePersistedSteering(
                 .after_tool_step_count = tool_step_count,
             }
         else blk: {
-            const object = try exactObject(item, &.{ "text", "assistant_prefix", "after_tool_step_count" });
+            const item_source = try requireObject(item);
+            const has_parts = item_source.get("assistant_prefix_parts") != null;
+            const object = if (has_parts)
+                try exactObject(item, &.{ "text", "assistant_prefix", "assistant_prefix_parts", "after_tool_step_count" })
+            else
+                try exactObject(item, &.{ "text", "assistant_prefix", "after_tool_step_count" });
             const after_tool_step_count = try requireUsize(object, "after_tool_step_count");
             if (after_tool_step_count > tool_step_count or
                 (index > 0 and after_tool_step_count < prior_tool_step_count))
@@ -1759,16 +1921,20 @@ fn parsePersistedSteering(
                 alloc,
                 object.get("text") orelse return error.InvalidSessionFormat,
             );
-            const assistant_prefix = parseOptionalDurableBytes(
+            errdefer alloc.free(text);
+            const assistant_prefix = try parseOptionalDurableBytes(
                 alloc,
                 object.get("assistant_prefix") orelse return error.InvalidSessionFormat,
-            ) catch |err| {
-                alloc.free(text);
-                return err;
-            };
+            );
+            errdefer if (assistant_prefix) |prefix| alloc.free(prefix);
+            const assistant_prefix_parts = if (has_parts)
+                try parseAssistantParts(alloc, object.get("assistant_prefix_parts") orelse return error.InvalidSessionFormat)
+            else
+                null;
             break :blk types.PersistedSteering{
                 .text = text,
                 .assistant_prefix = assistant_prefix,
+                .assistant_prefix_parts = assistant_prefix_parts,
                 .after_tool_step_count = after_tool_step_count,
             };
         };
@@ -1828,7 +1994,12 @@ fn parseToolSteps(
         session.freePersistedToolResults(alloc, step.tool_results);
     };
     for (value.array.items, 0..) |step_value, i| {
-        const object = try exactObject(step_value, &.{ "assistant", "tool_calls", "tool_results" });
+        const step_source = try requireObject(step_value);
+        const has_parts = step_source.get("assistant_parts") != null;
+        const object = if (has_parts)
+            try exactObject(step_value, &.{ "assistant", "assistant_parts", "tool_calls", "tool_results" })
+        else
+            try exactObject(step_value, &.{ "assistant", "tool_calls", "tool_results" });
         const assistant = try parseOptionalDurableBytes(alloc, object.get("assistant") orelse return error.InvalidSessionFormat);
         errdefer if (assistant) |owned| alloc.free(owned);
         const tool_calls = try parseToolCalls(alloc, object.get("tool_calls") orelse return error.InvalidSessionFormat);
@@ -1839,11 +2010,21 @@ fn parseToolSteps(
             schema_version,
         );
         errdefer session.freePersistedToolResults(alloc, tool_results);
+        const assistant_parts = if (has_parts)
+            try parseAssistantParts(alloc, object.get("assistant_parts") orelse return error.InvalidSessionFormat)
+        else
+            null;
+        errdefer if (assistant_parts) |parts| types.freeAssistantParts(alloc, parts);
+        if (assistant_parts) |parts| {
+            types.validateAssistantParts(parts, tool_calls) catch
+                return error.InvalidSessionFormat;
+        }
         try session.repairPersistedToolArguments(alloc, tool_calls, tool_results, .schema_v3);
         steps[i] = .{
             .assistant = assistant,
             .tool_calls = tool_calls,
             .tool_results = tool_results,
+            .assistant_parts = assistant_parts,
         };
         parsed_count += 1;
     }
@@ -1865,12 +2046,17 @@ fn parseToolCalls(alloc: Allocator, value: std.json.Value) ![]session.ToolCall {
 }
 
 fn parseToolCall(alloc: Allocator, value: std.json.Value) !session.ToolCall {
-    const object = try exactObject(value, &.{
-        "id",
-        "name",
-        "arguments_json",
-        "provider_result",
-    });
+    const source = try requireObject(value);
+    const has_options = source.get("provider_options_json") != null;
+    const has_result_options = source.get("provider_result_options_json") != null;
+    const object = if (has_options and has_result_options)
+        try exactObject(value, &.{ "id", "name", "arguments_json", "provider_result", "provider_options_json", "provider_result_options_json" })
+    else if (has_options)
+        try exactObject(value, &.{ "id", "name", "arguments_json", "provider_result", "provider_options_json" })
+    else if (has_result_options)
+        try exactObject(value, &.{ "id", "name", "arguments_json", "provider_result", "provider_result_options_json" })
+    else
+        try exactObject(value, &.{ "id", "name", "arguments_json", "provider_result" });
     const id = try parseRequiredDurableBytes(alloc, object, "id");
     errdefer alloc.free(id);
     const name = try parseRequiredDurableBytes(alloc, object, "name");
@@ -1887,12 +2073,33 @@ fn parseToolCall(alloc: Allocator, value: std.json.Value) !session.ToolCall {
         alloc,
         object.get("provider_result") orelse return error.InvalidSessionFormat,
     );
+    errdefer if (provider_result) |result| alloc.free(result);
+    const provider_options_json = if (has_options)
+        try parseRequiredDurableBytes(alloc, object, "provider_options_json")
+    else
+        null;
+    errdefer if (provider_options_json) |options| alloc.free(options);
+    if (provider_options_json) |options| {
+        types.validateProviderOptionsJson(alloc, options) catch
+            return error.InvalidSessionFormat;
+    }
+    const provider_result_options_json = if (has_result_options)
+        try parseRequiredDurableBytes(alloc, object, "provider_result_options_json")
+    else
+        null;
+    errdefer if (provider_result_options_json) |options| alloc.free(options);
+    if (provider_result_options_json) |options| {
+        types.validateProviderOptionsJson(alloc, options) catch
+            return error.InvalidSessionFormat;
+    }
     return .{
         .id = id,
         .name = name,
         .arguments_json = arguments_json,
         .argument_integrity = argument_integrity,
         .provider_result = provider_result,
+        .provider_result_options_json = provider_result_options_json,
+        .provider_options_json = provider_options_json,
     };
 }
 
@@ -1934,6 +2141,7 @@ fn parseToolResults(
         if (result.command_output_replay) |replay| {
             types.freeCommandOutputReplay(alloc, replay);
         }
+        if (result.provider_options_json) |options| alloc.free(options);
     };
     for (value.array.items, 0..) |result_value, i| {
         results[i] = try parseToolResult(alloc, result_value, schema_version);
@@ -2024,17 +2232,23 @@ fn parseToolResult(
         "command_process_presentation",
         "terminal_action_presentation",
     };
+    const has_provider_options = value == .object and value.object.contains("provider_options_json");
+    const v4_with_options_keys = v4_keys.* ++ [_][]const u8{"provider_options_json"};
+    const v4_with_images_keys = v4_keys.* ++ [_][]const u8{"tool_images"};
+    const v4_with_handle_keys = v4_keys.* ++ [_][]const u8{"tool_image_handle"};
+    const v4_with_options_images_keys = v4_with_options_keys ++ [_][]const u8{"tool_images"};
+    const v4_with_options_handle_keys = v4_with_options_keys ++ [_][]const u8{"tool_image_handle"};
     const result_shape: ExactVariantObject = switch (schema_version) {
         1 => .{ .object = try exactObject(value, v1_keys), .extended = false },
         2 => try exactVariantObject(value, v2_keys, v2_extended_keys),
         3 => .{ .object = try exactObject(value, v3_keys), .extended = true },
-        4, 5, 6, 7 => .{ .object = try exactObject(value, v4_keys), .extended = true },
+        4, 5, 6, 7 => .{ .object = try exactObject(value, if (has_provider_options) &v4_with_options_keys else v4_keys), .extended = true },
         8 => .{ .object = if (value == .object and value.object.contains("tool_images"))
-            try exactObject(value, &(v4_keys.* ++ [_][]const u8{"tool_images"}))
+            try exactObject(value, if (has_provider_options) &v4_with_options_images_keys else &v4_with_images_keys)
         else if (value == .object and value.object.contains("tool_image_handle"))
-            try exactObject(value, &(v4_keys.* ++ [_][]const u8{"tool_image_handle"}))
+            try exactObject(value, if (has_provider_options) &v4_with_options_handle_keys else &v4_with_handle_keys)
         else
-            try exactObject(value, v4_keys), .extended = true },
+            try exactObject(value, if (has_provider_options) &v4_with_options_keys else v4_keys), .extended = true },
         else => return error.InvalidSessionFormat,
     };
     const object = result_shape.object;
@@ -2094,6 +2308,15 @@ fn parseToolResult(
         )
     else
         null;
+    const provider_options_json = if (has_provider_options)
+        try parseRequiredDurableBytes(alloc, object, "provider_options_json")
+    else
+        null;
+    errdefer if (provider_options_json) |options| alloc.free(options);
+    if (provider_options_json) |options| {
+        types.validateProviderOptionsJson(alloc, options) catch
+            return error.InvalidSessionFormat;
+    }
     const tool_image_handle = if (object.get("tool_image_handle")) |value_handle| try parseOptionalDurableBytes(alloc, value_handle) else null;
     errdefer if (tool_image_handle) |handle| alloc.free(handle);
     const tool_images = if (object.get("tool_images")) |images| images: {
@@ -2137,6 +2360,7 @@ fn parseToolResult(
         .command_output_replay = command_output_replay,
         .command_process_presentation = command_process_presentation,
         .terminal_action_presentation = terminal_action_presentation,
+        .provider_options_json = provider_options_json,
     };
 }
 
@@ -2645,14 +2869,19 @@ fn exactInterruptedHistoryObject(
     has_execution: bool,
     has_presentation: bool,
     has_terminal_reason: bool,
+    has_parts: bool,
 ) !std.json.ObjectMap {
-    var keys: [8][]const u8 = undefined;
+    var keys: [9][]const u8 = undefined;
     keys[0] = "kind";
     keys[1] = "user";
     keys[2] = "assistant";
     keys[3] = "tool_call";
     keys[4] = "completed_tool_names";
     var len: usize = 5;
+    if (has_parts) {
+        keys[len] = "assistant_parts";
+        len += 1;
+    }
     if (has_execution) {
         keys[len] = "execution";
         len += 1;
@@ -3428,6 +3657,154 @@ test "execution memory codec preserves feedback and reads v1 results without it"
     try std.testing.expectError(
         error.InvalidSessionFormat,
         parseHistoryTurn(alloc, invalid_v7_parsed.value),
+    );
+}
+
+test "history codec round-trips replay parts, metadata scopes, and interrupted turns" {
+    const alloc = std.testing.allocator;
+    var step_calls = [_]session.ToolCall{.{
+        .id = "call_codec",
+        .name = "read_file",
+        .arguments_json = "{\"path\":\"note.txt\"}",
+        .provider_options_json = "{\"google\":{\"thoughtSignature\":\"ts_1\"}}",
+    }};
+    var step_results = [_]session.PersistedToolResult{.{
+        .tool_call_id = @constCast("call_codec"),
+        .tool_name = @constCast("read_file"),
+        .status = .success,
+        .output = @constCast("note contents"),
+        .output_bytes = 13,
+        .stored_output_bytes = 13,
+        .provider_options_json = @constCast("{\"gateway\":{\"resultNote\":\"rn_1\"}}"),
+    }};
+    var step_parts = [_]types.AssistantPart{
+        .{ .reasoning = .{ .text = "Read it first.", .provider_options = "{\"anthropic\":{\"signature\":\"sig_step\"}}" } },
+        .{ .text = .{ .text = "Reading." } },
+        .{ .tool_call_ref = .{ .id = "call_codec" } },
+    };
+    var steps = [_]session.ToolExecutionStep{.{
+        .assistant = @constCast("Reading."),
+        .tool_calls = &step_calls,
+        .tool_results = &step_results,
+        .assistant_parts = &step_parts,
+    }};
+    var prefix_parts = [_]types.AssistantPart{
+        .{ .reasoning = .{ .text = "Prefix thought.", .provider_options = "{\"anthropic\":{\"signature\":\"sig_prefix\"}}" } },
+    };
+    var steering = [_]types.PersistedSteering{.{
+        .text = @constCast("steer now"),
+        .assistant_prefix = @constCast("partial prefix"),
+        .assistant_prefix_parts = &prefix_parts,
+        .after_tool_step_count = 1,
+    }};
+    var final_parts = [_]types.AssistantPart{
+        .{ .reasoning = .{ .text = "", .provider_options = "{\"anthropic\":{\"redactedData\":\"red_1\"}}" } },
+        .{ .text = .{ .text = "Final answer." } },
+    };
+    const turn: session.HistoryTurn = .{ .assistant = .{
+        .user = .{ .text = @constCast("read the note") },
+        .assistant = @constCast("Final answer."),
+        .execution = .{ .tool_steps = steps[0..], .steering = steering[0..] },
+        .assistant_parts = &final_parts,
+    } };
+
+    var encoded: std.Io.Writer.Allocating = .init(alloc);
+    defer encoded.deinit();
+    try writeHistoryTurn(&encoded.writer, turn);
+    // Absent fields are omitted, never written as null keys.
+    try std.testing.expect(std.mem.find(u8, encoded.written(), "\"assistant_parts\":null") == null);
+    try std.testing.expect(std.mem.find(u8, encoded.written(), "sig_step") != null);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, encoded.written(), .{});
+    defer parsed.deinit();
+    const decoded = try parseHistoryTurn(alloc, parsed.value);
+    defer session.freeHistoryTurn(alloc, decoded);
+    const decoded_step = decoded.assistant.execution.tool_steps[0];
+    const decoded_step_parts = decoded_step.assistant_parts orelse return error.TestExpectedAssistantParts;
+    try std.testing.expectEqual(@as(usize, 3), decoded_step_parts.len);
+    try std.testing.expectEqualStrings("Read it first.", decoded_step_parts[0].reasoning.text);
+    try std.testing.expectEqualStrings(
+        "{\"anthropic\":{\"signature\":\"sig_step\"}}",
+        decoded_step_parts[0].reasoning.provider_options.?,
+    );
+    try std.testing.expectEqualStrings("call_codec", decoded_step_parts[2].tool_call_ref.id);
+    try std.testing.expectEqualStrings(
+        "{\"google\":{\"thoughtSignature\":\"ts_1\"}}",
+        decoded_step.tool_calls[0].provider_options_json.?,
+    );
+    try std.testing.expectEqualStrings(
+        "{\"gateway\":{\"resultNote\":\"rn_1\"}}",
+        decoded_step.tool_results[0].provider_options_json.?,
+    );
+    const decoded_prefix_parts = decoded.assistant.execution.steering[0].assistant_prefix_parts orelse
+        return error.TestExpectedAssistantParts;
+    try std.testing.expectEqual(@as(usize, 1), decoded_prefix_parts.len);
+    try std.testing.expectEqualStrings(
+        "{\"anthropic\":{\"signature\":\"sig_prefix\"}}",
+        decoded_prefix_parts[0].reasoning.provider_options.?,
+    );
+    const decoded_final = decoded.assistant.assistant_parts orelse return error.TestExpectedAssistantParts;
+    try std.testing.expectEqual(@as(usize, 2), decoded_final.len);
+    try std.testing.expectEqualStrings("", decoded_final[0].reasoning.text);
+    try std.testing.expectEqualStrings(
+        "{\"anthropic\":{\"redactedData\":\"red_1\"}}",
+        decoded_final[0].reasoning.provider_options.?,
+    );
+
+    // A parts reference to a call that did not survive fails strictly.
+    const stale =
+        "{\"kind\":\"assistant\",\"user\":{\"text\":\"prompt\",\"images\":[]},\"assistant\":\"done\",\"execution\":{\"schema_version\":7,\"tool_steps\":[{\"assistant\":null,\"assistant_parts\":[{\"type\":\"tool_call_ref\",\"call_id\":\"ghost\"}],\"tool_calls\":[],\"tool_results\":[]}],\"files\":[],\"steering\":[],\"turn_summary\":null}}";
+    var stale_parsed = try std.json.parseFromSlice(std.json.Value, alloc, stale, .{});
+    defer stale_parsed.deinit();
+    try std.testing.expectError(
+        error.InvalidSessionFormat,
+        parseHistoryTurn(alloc, stale_parsed.value),
+    );
+
+    // Interrupted turns carry parts explicitly when present.
+    const interrupted: session.HistoryTurn = .{ .interrupted = .{
+        .user = .{ .text = @constCast("stop soon") },
+        .assistant = @constCast("partial"),
+        .completed_tool_names = &.{},
+        .assistant_parts = &final_parts,
+    } };
+    var interrupted_encoded: std.Io.Writer.Allocating = .init(alloc);
+    defer interrupted_encoded.deinit();
+    try writeHistoryTurn(&interrupted_encoded.writer, interrupted);
+    var interrupted_parsed = try std.json.parseFromSlice(std.json.Value, alloc, interrupted_encoded.written(), .{});
+    defer interrupted_parsed.deinit();
+    const decoded_interrupted = try parseHistoryTurn(alloc, interrupted_parsed.value);
+    defer session.freeHistoryTurn(alloc, decoded_interrupted);
+    const decoded_interrupted_parts = decoded_interrupted.interrupted.assistant_parts orelse
+        return error.TestExpectedAssistantParts;
+    try std.testing.expectEqual(@as(usize, 2), decoded_interrupted_parts.len);
+    try std.testing.expectEqualStrings(
+        "{\"anthropic\":{\"redactedData\":\"red_1\"}}",
+        decoded_interrupted_parts[0].reasoning.provider_options.?,
+    );
+}
+
+test "history codec keeps old records free of replay state" {
+    const alloc = std.testing.allocator;
+    const v7 =
+        "{\"kind\":\"assistant\",\"user\":{\"text\":\"write a note\",\"images\":[]},\"assistant\":\"done\",\"execution\":{\"schema_version\":7,\"tool_steps\":[{\"assistant\":null,\"tool_calls\":[{\"id\":\"call_feedback\",\"name\":\"write_file\",\"arguments_json\":\"{\\\"path\\\":\\\"note.txt\\\"}\",\"provider_result\":null}],\"tool_results\":[{\"tool_call_id\":\"call_feedback\",\"tool_name\":\"write_file\",\"status\":\"success\",\"output\":\"wrote note.txt\",\"output_handle\":null,\"preview\":null,\"output_bytes\":15,\"stored_output_bytes\":15,\"truncated\":false,\"provider_native\":false,\"created_at_ms\":1,\"permission_feedback\":[],\"committed_file_presentation\":null,\"command_output_replay\":null,\"command_process_presentation\":null,\"terminal_action_presentation\":null}]}],\"files\":[],\"steering\":[],\"turn_summary\":null}}";
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, v7, .{});
+    defer parsed.deinit();
+    const decoded = try parseHistoryTurn(alloc, parsed.value);
+    defer session.freeHistoryTurn(alloc, decoded);
+    try std.testing.expect(decoded.assistant.assistant_parts == null);
+    try std.testing.expect(decoded.assistant.execution.tool_steps[0].assistant_parts == null);
+    try std.testing.expect(decoded.assistant.execution.tool_steps[0].tool_calls[0].provider_options_json == null);
+    try std.testing.expect(decoded.assistant.execution.tool_steps[0].tool_results[0].provider_options_json == null);
+
+    // Unknown envelope keys stay rejected.
+    const unknown =
+        "{\"kind\":\"assistant\",\"user\":{\"text\":\"prompt\",\"images\":[]},\"assistant\":\"done\",\"unknown_new\":1,\"execution\":{\"schema_version\":7,\"tool_steps\":[],\"files\":[],\"steering\":[],\"turn_summary\":null}}";
+    var unknown_parsed = try std.json.parseFromSlice(std.json.Value, alloc, unknown, .{});
+    defer unknown_parsed.deinit();
+    try std.testing.expectError(
+        error.InvalidSessionFormat,
+        parseHistoryTurn(alloc, unknown_parsed.value),
     );
 }
 

--- a/src/core/session/session_event.zig
+++ b/src/core/session/session_event.zig
@@ -20,6 +20,7 @@ pub const max_conversation_text_bytes: usize = event_frame_max_bytes;
 pub const max_conversation_identity_bytes: usize = types.ConversationIdentity.max_bytes;
 pub const max_conversation_arguments_bytes: usize = event_frame_max_bytes;
 pub const max_conversation_preview_bytes: usize = 4 * 1024;
+pub const max_conversation_part_count: usize = 1024;
 
 pub const ArtifactCompleteness = enum {
     complete,
@@ -29,6 +30,25 @@ pub const ArtifactCompleteness = enum {
 
 pub const ConversationText = struct {
     text: []const u8,
+};
+
+/// Assistant event payload carrying the ordered replay parts when present.
+/// Parts borrow the turn's state for the append's lifetime. Old frames without
+/// `parts` decode with parts absent.
+pub const ConversationAssistant = struct {
+    text: []const u8,
+    parts: ?[]const types.AssistantPart = null,
+
+    pub fn jsonStringify(self: ConversationAssistant, jw: anytype) !void {
+        try jw.beginObject();
+        try jw.objectField("text");
+        try jw.write(self.text);
+        if (self.parts) |parts| {
+            try jw.objectField("parts");
+            try jw.write(parts);
+        }
+        try jw.endObject();
+    }
 };
 
 pub const ConversationUser = struct {
@@ -46,6 +66,39 @@ pub const ConversationToolCall = struct {
     provider_result: ?[]const u8 = null,
     final_identity: types.FinalToolIdentity = .valid,
     provenance: types.ToolExecutionProvenance = .fx_local,
+    /// Validated JSON object bytes for this call part's providerOptions.
+    provider_options_json: ?[]const u8 = null,
+    /// Validated JSON object bytes captured from the final provider result event.
+    provider_result_options_json: ?[]const u8 = null,
+
+    pub fn jsonStringify(self: ConversationToolCall, jw: anytype) !void {
+        try jw.beginObject();
+        try jw.objectField("call_id");
+        try jw.write(self.call_id);
+        try jw.objectField("tool_name");
+        try jw.write(self.tool_name);
+        try jw.objectField("arguments_json");
+        try jw.write(self.arguments_json);
+        try jw.objectField("argument_integrity");
+        try jw.write(self.argument_integrity);
+        try jw.objectField("provisional_id");
+        try jw.write(self.provisional_id);
+        try jw.objectField("provider_result");
+        try jw.write(self.provider_result);
+        try jw.objectField("final_identity");
+        try jw.write(self.final_identity);
+        try jw.objectField("provenance");
+        try jw.write(self.provenance);
+        if (self.provider_options_json) |options| {
+            try jw.objectField("provider_options_json");
+            try jw.write(options);
+        }
+        if (self.provider_result_options_json) |options| {
+            try jw.objectField("provider_result_options_json");
+            try jw.write(options);
+        }
+        try jw.endObject();
+    }
 };
 
 pub const ConversationToolResult = struct {
@@ -66,6 +119,51 @@ pub const ConversationToolResult = struct {
     command_replay_bytes: ?u64 = null,
     command_process_presentation: ?types.CommandProcessPresentation = null,
     terminal_action_presentation: ?types.TerminalActionPresentation = null,
+    /// Validated JSON object bytes for this result part's providerOptions.
+    provider_options_json: ?[]const u8 = null,
+
+    pub fn jsonStringify(self: ConversationToolResult, jw: anytype) !void {
+        try jw.beginObject();
+        try jw.objectField("call_id");
+        try jw.write(self.call_id);
+        try jw.objectField("tool_name");
+        try jw.write(self.tool_name);
+        try jw.objectField("status");
+        try jw.write(self.status);
+        try jw.objectField("artifact_ref");
+        try jw.write(self.artifact_ref);
+        try jw.objectField("tool_image_handle");
+        try jw.write(self.tool_image_handle);
+        try jw.objectField("output_bytes");
+        try jw.write(self.output_bytes);
+        try jw.objectField("stored_bytes");
+        try jw.write(self.stored_bytes);
+        try jw.objectField("completeness");
+        try jw.write(self.completeness);
+        try jw.objectField("preview");
+        try jw.write(self.preview);
+        try jw.objectField("provider_native");
+        try jw.write(self.provider_native);
+        try jw.objectField("created_at_ms");
+        try jw.write(self.created_at_ms);
+        try jw.objectField("permission_feedback");
+        try jw.write(self.permission_feedback);
+        try jw.objectField("committed_file_presentation");
+        try jw.write(self.committed_file_presentation);
+        try jw.objectField("command_replay_ref");
+        try jw.write(self.command_replay_ref);
+        try jw.objectField("command_replay_bytes");
+        try jw.write(self.command_replay_bytes);
+        try jw.objectField("command_process_presentation");
+        try jw.write(self.command_process_presentation);
+        try jw.objectField("terminal_action_presentation");
+        try jw.write(self.terminal_action_presentation);
+        if (self.provider_options_json) |options| {
+            try jw.objectField("provider_options_json");
+            try jw.write(options);
+        }
+        try jw.endObject();
+    }
 };
 
 pub const ConversationInterruption = struct {
@@ -90,7 +188,7 @@ pub const ConversationCheckpoint = struct {
 
 pub const ConversationEvent = union(enum) {
     user: ConversationUser,
-    assistant: ConversationText,
+    assistant: ConversationAssistant,
     tool_call: ConversationToolCall,
     tool_result: ConversationToolResult,
     steering: ConversationText,
@@ -113,6 +211,26 @@ pub const PendingToolCall = struct {
     tool_name: []const u8,
     seq: u64,
 };
+
+/// Validates and deep-copies decoded frame parts into owned replay parts.
+/// Invalid provider-metadata envelopes fail with `error.InvalidConversationFrame`.
+pub fn dupeAssistantPartsFromConversation(
+    alloc: Allocator,
+    parts: []const types.AssistantPart,
+) ![]types.AssistantPart {
+    for (parts) |part| {
+        const options: ?[]const u8 = switch (part) {
+            .text => |text_part| text_part.provider_options,
+            .reasoning => |reasoning_part| reasoning_part.provider_options,
+            .tool_call_ref => null,
+        };
+        if (options) |value| {
+            types.validateProviderOptionsJson(alloc, value) catch
+                return error.InvalidConversationFrame;
+        }
+    }
+    return types.dupeAssistantParts(alloc, parts);
+}
 
 pub const ConversationStateView = struct {
     last_seq: u64 = 0,
@@ -196,7 +314,37 @@ fn validateConversationEventShape(event: ConversationEvent) ConversationTransiti
             }
             if (value.work_id) |work_id| try validateConversationIdentity(work_id);
         },
-        .assistant, .steering => |value| try validateConversationText(value.text),
+        .assistant => |value| {
+            try validateConversationText(value.text);
+            if (value.parts) |parts| {
+                if (parts.len > max_conversation_part_count) return error.InvalidConversationEvent;
+                for (parts) |part| {
+                    const options: ?[]const u8 = switch (part) {
+                        .text => |text_part| blk: {
+                            try validateConversationText(text_part.text);
+                            break :blk text_part.provider_options;
+                        },
+                        .reasoning => |reasoning_part| blk: {
+                            try validateConversationText(reasoning_part.text);
+                            break :blk reasoning_part.provider_options;
+                        },
+                        .tool_call_ref => |ref| blk: {
+                            try validateConversationIdentity(ref.id);
+                            break :blk null;
+                        },
+                    };
+                    if (options) |value_bytes| {
+                        if (value_bytes.len == 0 or
+                            value_bytes.len > max_conversation_arguments_bytes or
+                            !std.unicode.utf8ValidateSlice(value_bytes))
+                        {
+                            return error.InvalidConversationEvent;
+                        }
+                    }
+                }
+            }
+        },
+        .steering => |value| try validateConversationText(value.text),
         .tool_call => |call| {
             try validateConversationIdentity(call.call_id);
             try validateConversationIdentity(call.tool_name);
@@ -209,6 +357,22 @@ fn validateConversationEventShape(event: ConversationEvent) ConversationTransiti
             if (call.provisional_id) |value| try validateConversationIdentity(value);
             if (call.provider_result) |value| {
                 if (value.len > max_conversation_arguments_bytes or
+                    !std.unicode.utf8ValidateSlice(value))
+                {
+                    return error.InvalidConversationEvent;
+                }
+            }
+            if (call.provider_options_json) |value| {
+                if (value.len == 0 or
+                    value.len > max_conversation_arguments_bytes or
+                    !std.unicode.utf8ValidateSlice(value))
+                {
+                    return error.InvalidConversationEvent;
+                }
+            }
+            if (call.provider_result_options_json) |value| {
+                if (value.len == 0 or
+                    value.len > max_conversation_arguments_bytes or
                     !std.unicode.utf8ValidateSlice(value))
                 {
                     return error.InvalidConversationEvent;
@@ -260,6 +424,14 @@ fn validateConversationEventShape(event: ConversationEvent) ConversationTransiti
             }
             if (result.command_replay_ref) |handle| {
                 try validateConversationIdentity(handle);
+            }
+            if (result.provider_options_json) |value| {
+                if (value.len == 0 or
+                    value.len > max_conversation_arguments_bytes or
+                    !std.unicode.utf8ValidateSlice(value))
+                {
+                    return error.InvalidConversationEvent;
+                }
             }
         },
         .interrupted => |interrupted| {
@@ -390,8 +562,13 @@ pub fn appendHistoryTurnConversationEvents(
                 .work_id = entry.user.work_id,
             } });
             try appendExecutionConversationEvents(alloc, events, entry.execution);
-            if (entry.assistant.len > 0) {
-                try events.append(alloc, .{ .assistant = .{ .text = entry.assistant } });
+            if (entry.assistant.len > 0 or
+                (entry.assistant_parts != null and entry.assistant_parts.?.len > 0))
+            {
+                try events.append(alloc, .{ .assistant = .{
+                    .text = entry.assistant,
+                    .parts = entry.assistant_parts,
+                } });
             }
             try events.append(alloc, .{ .turn_completed = .{
                 .files = entry.execution.files,
@@ -415,6 +592,8 @@ pub fn appendHistoryTurnConversationEvents(
                     .provider_result = call.provider_result,
                     .final_identity = call.final_identity,
                     .provenance = call.provenance,
+                    .provider_options_json = call.provider_options_json,
+                    .provider_result_options_json = call.provider_result_options_json,
                 } });
             }
             try events.append(alloc, .{ .interrupted = .{
@@ -470,7 +649,13 @@ fn appendExecutionConversationEvents(
     }
     for (execution.tool_steps, 0..) |step, step_index| {
         if (step.assistant) |assistant| {
-            if (assistant.len > 0) try events.append(alloc, .{ .assistant = .{ .text = assistant } });
+            const has_parts = step.assistant_parts != null and step.assistant_parts.?.len > 0;
+            if (assistant.len > 0 or has_parts) {
+                try events.append(alloc, .{ .assistant = .{
+                    .text = assistant,
+                    .parts = step.assistant_parts,
+                } });
+            }
         }
         for (step.tool_calls) |call| {
             try events.append(alloc, .{ .tool_call = .{
@@ -482,6 +667,8 @@ fn appendExecutionConversationEvents(
                 .provider_result = call.provider_result,
                 .final_identity = call.final_identity,
                 .provenance = call.provenance,
+                .provider_options_json = call.provider_options_json,
+                .provider_result_options_json = call.provider_result_options_json,
             } });
         }
         for (step.tool_results) |result| {
@@ -513,6 +700,7 @@ fn appendExecutionConversationEvents(
                 .command_replay_bytes = resultCommandReplayBytes(result),
                 .command_process_presentation = result.command_process_presentation,
                 .terminal_action_presentation = result.terminal_action_presentation,
+                .provider_options_json = result.provider_options_json,
             } });
         }
         const completed_steps = step_index + 1;
@@ -534,7 +722,13 @@ fn appendSteeringConversationEvents(
     steering: types.PersistedSteering,
 ) !void {
     if (steering.assistant_prefix) |assistant| {
-        if (assistant.len > 0) try events.append(alloc, .{ .assistant = .{ .text = assistant } });
+        const has_parts = steering.assistant_prefix_parts != null and steering.assistant_prefix_parts.?.len > 0;
+        if (assistant.len > 0 or has_parts) {
+            try events.append(alloc, .{ .assistant = .{
+                .text = assistant,
+                .parts = steering.assistant_prefix_parts,
+            } });
+        }
     }
     if (steering.text.len > 0) {
         try events.append(alloc, .{ .steering = .{ .text = steering.text } });

--- a/src/core/session/session_event.zig
+++ b/src/core/session/session_event.zig
@@ -321,11 +321,13 @@ fn validateConversationEventShape(event: ConversationEvent) ConversationTransiti
                 for (parts) |part| {
                     const options: ?[]const u8 = switch (part) {
                         .text => |text_part| blk: {
-                            try validateConversationText(text_part.text);
+                            // Part texts may be empty: metadata-only reasoning
+                            // blocks carry replay state with no text.
+                            try validateOptionalConversationText(text_part.text);
                             break :blk text_part.provider_options;
                         },
                         .reasoning => |reasoning_part| blk: {
-                            try validateConversationText(reasoning_part.text);
+                            try validateOptionalConversationText(reasoning_part.text);
                             break :blk reasoning_part.provider_options;
                         },
                         .tool_call_ref => |ref| blk: {

--- a/src/core/session/session_log.zig
+++ b/src/core/session/session_log.zig
@@ -930,7 +930,7 @@ fn replayConversationHistory(
         defer decoded.deinit();
         switch (decoded.value.event) {
             .user => |value| try turn.begin(value),
-            .assistant => |value| try turn.appendAssistant(value.text),
+            .assistant => |value| try turn.appendAssistant(value),
             .tool_call => |value| try turn.appendToolCall(value),
             .tool_result => |value| try turn.appendToolResult(value),
             .steering => |value| try turn.appendSteering(value.text),
@@ -1004,7 +1004,7 @@ pub const ConversationHistoryReader = struct {
                     break :blk null;
                 },
                 .assistant => |value| blk: {
-                    try self.builder.appendAssistant(value.text);
+                    try self.builder.appendAssistant(value);
                     break :blk null;
                 },
                 .tool_call => |value| blk: {
@@ -1093,7 +1093,7 @@ pub fn loadConversationArchive(
                 break :blk null;
             },
             .assistant => |value| blk: {
-                try builder.appendAssistant(value.text);
+                try builder.appendAssistant(value);
                 break :blk null;
             },
             .tool_call => |value| blk: {
@@ -1233,6 +1233,7 @@ const ConversationTurnBuilder = struct {
     alloc: Allocator,
     user: ?types.UserTurn = null,
     pending_assistant: ?[]u8 = null,
+    pending_assistant_parts: ?[]types.AssistantPart = null,
     calls: std.ArrayList(types.ToolCall) = .empty,
     results: std.ArrayList(types.PersistedToolResult) = .empty,
     steps: std.ArrayList(types.ToolExecutionStep) = .empty,
@@ -1245,6 +1246,7 @@ const ConversationTurnBuilder = struct {
     fn deinit(self: *ConversationTurnBuilder) void {
         if (self.user) |user| types.freeUserTurn(self.alloc, user);
         if (self.pending_assistant) |text| self.alloc.free(text);
+        if (self.pending_assistant_parts) |parts| types.freeAssistantParts(self.alloc, parts);
         for (self.calls.items) |call| types.freeToolCall(self.alloc, call);
         self.calls.deinit(self.alloc);
         for (self.results.items) |result| freeConversationToolResult(self.alloc, result);
@@ -1253,10 +1255,12 @@ const ConversationTurnBuilder = struct {
             if (step.assistant) |text| self.alloc.free(text);
             types.freeToolCallSlice(self.alloc, step.tool_calls);
             types.freePersistedToolResults(self.alloc, step.tool_results);
+            if (step.assistant_parts) |parts| types.freeAssistantParts(self.alloc, parts);
         }
         for (self.steering.items) |item| {
             self.alloc.free(item.text);
             if (item.assistant_prefix) |text| self.alloc.free(text);
+            if (item.assistant_prefix_parts) |parts| types.freeAssistantParts(self.alloc, parts);
         }
         self.steps.deinit(self.alloc);
         self.steering.deinit(self.alloc);
@@ -1266,6 +1270,7 @@ const ConversationTurnBuilder = struct {
     fn isIdle(self: *const ConversationTurnBuilder) bool {
         return self.user == null and
             self.pending_assistant == null and
+            self.pending_assistant_parts == null and
             self.calls.items.len == 0 and
             self.results.items.len == 0 and
             self.steps.items.len == 0 and
@@ -1284,11 +1289,23 @@ const ConversationTurnBuilder = struct {
         });
     }
 
-    fn appendAssistant(self: *ConversationTurnBuilder, text: []const u8) !void {
+    fn appendAssistant(
+        self: *ConversationTurnBuilder,
+        value: session_event.ConversationAssistant,
+    ) !void {
         if (self.user == null or self.pending_assistant != null or self.calls.items.len != 0) {
             return error.InvalidConversationFrame;
         }
-        self.pending_assistant = try self.alloc.dupe(u8, text);
+        self.pending_assistant = try self.alloc.dupe(u8, value.text);
+        if (value.parts) |parts| {
+            self.pending_assistant_parts = session_event.dupeAssistantPartsFromConversation(
+                self.alloc,
+                parts,
+            ) catch |err| switch (err) {
+                error.OutOfMemory => return error.OutOfMemory,
+                error.InvalidConversationFrame => return error.InvalidConversationFrame,
+            };
+        }
     }
 
     fn appendToolCall(
@@ -1301,6 +1318,14 @@ const ConversationTurnBuilder = struct {
         for (self.calls.items) |call| {
             if (std.mem.eql(u8, call.id, value.call_id)) return error.InvalidConversationFrame;
         }
+        if (value.provider_options_json) |options| {
+            types.validateProviderOptionsJson(self.alloc, options) catch
+                return error.InvalidConversationFrame;
+        }
+        if (value.provider_result_options_json) |options| {
+            types.validateProviderOptionsJson(self.alloc, options) catch
+                return error.InvalidConversationFrame;
+        }
         const call = try types.dupeToolCall(self.alloc, .{
             .id = value.call_id,
             .name = value.tool_name,
@@ -1310,6 +1335,8 @@ const ConversationTurnBuilder = struct {
             .provider_result = value.provider_result,
             .final_identity = value.final_identity,
             .provenance = value.provenance,
+            .provider_options_json = value.provider_options_json,
+            .provider_result_options_json = value.provider_result_options_json,
         });
         errdefer types.freeToolCall(self.alloc, call);
         try self.calls.append(self.alloc, call);
@@ -1350,12 +1377,18 @@ const ConversationTurnBuilder = struct {
         errdefer types.freeToolCallSlice(self.alloc, calls);
         const results = try self.results.toOwnedSlice(self.alloc);
         errdefer types.freePersistedToolResults(self.alloc, results);
+        if (self.pending_assistant_parts) |parts| {
+            types.validateAssistantParts(parts, calls) catch
+                return error.InvalidConversationFrame;
+        }
         self.steps.appendAssumeCapacity(.{
             .assistant = self.pending_assistant,
             .tool_calls = calls,
             .tool_results = results,
+            .assistant_parts = self.pending_assistant_parts,
         });
         self.pending_assistant = null;
+        self.pending_assistant_parts = null;
     }
 
     fn appendSteering(self: *ConversationTurnBuilder, text: []const u8) !void {
@@ -1367,9 +1400,11 @@ const ConversationTurnBuilder = struct {
         try self.steering.append(self.alloc, .{
             .text = owned,
             .assistant_prefix = self.pending_assistant,
+            .assistant_prefix_parts = self.pending_assistant_parts,
             .after_tool_step_count = self.steps.items.len,
         });
         self.pending_assistant = null;
+        self.pending_assistant_parts = null;
     }
 
     fn finishAssistant(
@@ -1383,17 +1418,26 @@ const ConversationTurnBuilder = struct {
             text
         else
             try self.alloc.dupe(u8, "");
+        // A completed final answer carries no pending tool calls, so its parts
+        // must not reference any.
+        if (self.pending_assistant_parts) |parts| {
+            types.validateAssistantParts(parts, &.{}) catch
+                return error.InvalidConversationFrame;
+        }
         const execution = try self.takeExecution(
             completed.files,
             completed.turn_summary,
         );
         const user = self.user.?;
         self.user = null;
+        const assistant_parts = self.pending_assistant_parts;
         self.pending_assistant = null;
+        self.pending_assistant_parts = null;
         return .{ .assistant = .{
             .user = user,
             .assistant = assistant,
             .execution = execution,
+            .assistant_parts = assistant_parts,
         } };
     }
 
@@ -1412,6 +1456,10 @@ const ConversationTurnBuilder = struct {
         if (self.pending_assistant) |text| {
             self.alloc.free(text);
             self.pending_assistant = null;
+        }
+        if (self.pending_assistant_parts) |parts| {
+            types.freeAssistantParts(self.alloc, parts);
+            self.pending_assistant_parts = null;
         }
         const assistant = if (value.partial_text) |text|
             try self.alloc.dupe(u8, text)
@@ -1538,6 +1586,12 @@ fn dupeConversationToolResult(
     errdefer if (committed_file_presentation) |presentation| {
         types.freeCommittedFilePresentation(alloc, presentation);
     };
+    const provider_options_json = if (value.provider_options_json) |options| blk: {
+        types.validateProviderOptionsJson(alloc, options) catch
+            return error.InvalidConversationFrame;
+        break :blk try alloc.dupe(u8, options);
+    } else null;
+    errdefer if (provider_options_json) |options| alloc.free(options);
     const stored_bytes = std.math.cast(usize, value.stored_bytes) orelse
         return error.ConversationSizeOverflow;
     const output_bytes = std.math.cast(
@@ -1562,6 +1616,7 @@ fn dupeConversationToolResult(
         .command_output_replay = command_output_replay,
         .command_process_presentation = value.command_process_presentation,
         .terminal_action_presentation = value.terminal_action_presentation,
+        .provider_options_json = provider_options_json,
     };
 }
 
@@ -1584,6 +1639,7 @@ fn freeConversationToolResult(
     if (result.command_output_replay) |replay| {
         types.freeCommandOutputReplay(alloc, replay);
     }
+    if (result.provider_options_json) |options| alloc.free(options);
 }
 
 fn latestConversationCheckpointIndex(history: []const session.HistoryTurn) usize {
@@ -3508,6 +3564,170 @@ test "conversation writer flattens a canonical history turn" {
         bytes,
         "\"snapshot_path\":\"/tmp/session/images",
     ) == null);
+}
+
+test "conversation log round-trips assistant replay parts and part metadata" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const file = try tmp.dir.createFile(std.testing.io, "events.jsonl", .{
+        .read = true,
+        .truncate = true,
+    });
+    var writer = try ConversationWriter.init(alloc, file);
+    defer writer.deinit();
+
+    var step_calls = [_]types.ToolCall{.{
+        .id = "call-reasoning",
+        .name = "read_file",
+        .arguments_json = "{\"path\":\"note.txt\"}",
+        .provider_options_json = "{\"google\":{\"thoughtSignature\":\"ts_1\"}}",
+    }};
+    var step_results = [_]types.PersistedToolResult{.{
+        .tool_call_id = @constCast("call-reasoning"),
+        .tool_name = @constCast("read_file"),
+        .status = .success,
+        .output = @constCast("hello"),
+        .output_handle = @constCast("result-call-reasoning.txt"),
+        .output_bytes = 5,
+        .stored_output_bytes = 5,
+        .provider_options_json = @constCast("{\"gateway\":{\"resultNote\":\"rn_1\"}}"),
+    }};
+    var step_parts = [_]types.AssistantPart{
+        .{ .reasoning = .{ .text = "Read the note first.", .provider_options = "{\"anthropic\":{\"signature\":\"sig_step\"}}" } },
+        .{ .text = .{ .text = "Reading the note." } },
+        .{ .tool_call_ref = .{ .id = "call-reasoning" } },
+    };
+    var steps = [_]types.ToolExecutionStep{.{
+        .assistant = @constCast("Reading the note."),
+        .tool_calls = &step_calls,
+        .tool_results = &step_results,
+        .assistant_parts = &step_parts,
+    }};
+    var prefix_parts = [_]types.AssistantPart{
+        .{ .reasoning = .{ .text = "Thinking before steering.", .provider_options = "{\"anthropic\":{\"signature\":\"sig_prefix\"}}" } },
+        .{ .text = .{ .text = "Prefix answer." } },
+    };
+    var steering = [_]types.PersistedSteering{.{
+        .text = @constCast("Also check the other file."),
+        .assistant_prefix = @constCast("Prefix answer."),
+        .assistant_prefix_parts = &prefix_parts,
+        .after_tool_step_count = 1,
+    }};
+    var final_parts = [_]types.AssistantPart{
+        .{ .reasoning = .{ .text = "Both files read.", .provider_options = "{\"anthropic\":{\"signature\":\"sig_final\"}}" } },
+        .{ .text = .{ .text = "Done reading." } },
+    };
+    try writer.appendHistoryTurn(alloc, 10, .{ .assistant = .{
+        .user = .{ .text = @constCast("Read the note.") },
+        .assistant = @constCast("Done reading."),
+        .execution = .{ .tool_steps = &steps, .steering = &steering },
+        .assistant_parts = &final_parts,
+    } });
+
+    const bytes = try writer.readAllForTest(alloc);
+    defer alloc.free(bytes);
+    // Metadata rides as validated bytes, never as a nested object or a second
+    // transcript of the calls.
+    try std.testing.expect(std.mem.find(u8, bytes, "\"providerOptions\"") == null);
+    try std.testing.expect(std.mem.find(u8, bytes, "\"provider_options_json\":") != null);
+
+    var conversation_seq: u64 = 0;
+    var open_work_id: ?[]u8 = null;
+    defer if (open_work_id) |work_id| alloc.free(work_id);
+    const history = try replayConversationHistory(alloc, file, &conversation_seq, &open_work_id);
+    defer session.freeHistoryTurnSlice(alloc, history);
+
+    try std.testing.expectEqual(@as(usize, 1), history.len);
+    const turn = history[0].assistant;
+    try std.testing.expectEqualStrings("Done reading.", turn.assistant);
+    const restored_step_parts = turn.execution.tool_steps[0].assistant_parts orelse
+        return error.TestExpectedAssistantParts;
+    try std.testing.expectEqual(@as(usize, 3), restored_step_parts.len);
+    try std.testing.expectEqualStrings("Read the note first.", restored_step_parts[0].reasoning.text);
+    try std.testing.expectEqualStrings(
+        "{\"anthropic\":{\"signature\":\"sig_step\"}}",
+        restored_step_parts[0].reasoning.provider_options.?,
+    );
+    try std.testing.expectEqualStrings("Reading the note.", restored_step_parts[1].text.text);
+    try std.testing.expectEqualStrings("call-reasoning", restored_step_parts[2].tool_call_ref.id);
+    const restored_call = turn.execution.tool_steps[0].tool_calls[0];
+    try std.testing.expectEqualStrings(
+        "{\"google\":{\"thoughtSignature\":\"ts_1\"}}",
+        restored_call.provider_options_json.?,
+    );
+    const restored_result = turn.execution.tool_steps[0].tool_results[0];
+    try std.testing.expectEqualStrings(
+        "{\"gateway\":{\"resultNote\":\"rn_1\"}}",
+        restored_result.provider_options_json.?,
+    );
+    const restored_prefix_parts = turn.execution.steering[0].assistant_prefix_parts orelse
+        return error.TestExpectedAssistantParts;
+    try std.testing.expectEqual(@as(usize, 2), restored_prefix_parts.len);
+    try std.testing.expectEqualStrings(
+        "{\"anthropic\":{\"signature\":\"sig_prefix\"}}",
+        restored_prefix_parts[0].reasoning.provider_options.?,
+    );
+    const restored_final_parts = turn.assistant_parts orelse return error.TestExpectedAssistantParts;
+    try std.testing.expectEqual(@as(usize, 2), restored_final_parts.len);
+    try std.testing.expectEqualStrings(
+        "{\"anthropic\":{\"signature\":\"sig_final\"}}",
+        restored_final_parts[0].reasoning.provider_options.?,
+    );
+    try std.testing.expectEqualStrings("Done reading.", restored_final_parts[1].text.text);
+}
+
+test "conversation log keeps old frames without replay parts absent" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const file = try tmp.dir.createFile(std.testing.io, "events.jsonl", .{
+        .read = true,
+        .truncate = true,
+    });
+    var writer = try ConversationWriter.init(alloc, file);
+    defer writer.deinit();
+
+    var step_calls = [_]types.ToolCall{.{
+        .id = "call-plain",
+        .name = "read_file",
+        .arguments_json = "{}",
+    }};
+    var step_results = [_]types.PersistedToolResult{.{
+        .tool_call_id = @constCast("call-plain"),
+        .tool_name = @constCast("read_file"),
+        .status = .success,
+        .output = @constCast("hello"),
+        .output_handle = @constCast("result-call-plain.txt"),
+        .output_bytes = 5,
+        .stored_output_bytes = 5,
+    }};
+    var steps = [_]types.ToolExecutionStep{.{
+        .assistant = @constCast("Reading."),
+        .tool_calls = &step_calls,
+        .tool_results = &step_results,
+    }};
+    try writer.appendHistoryTurn(alloc, 10, .{ .assistant = .{
+        .user = .{ .text = @constCast("Read it.") },
+        .assistant = @constCast("Done."),
+        .execution = .{ .tool_steps = &steps },
+    } });
+
+    const bytes = try writer.readAllForTest(alloc);
+    defer alloc.free(bytes);
+    try std.testing.expect(std.mem.find(u8, bytes, "\"parts\":") == null);
+    try std.testing.expect(std.mem.find(u8, bytes, "provider_options_json") == null);
+
+    var conversation_seq: u64 = 0;
+    var open_work_id: ?[]u8 = null;
+    defer if (open_work_id) |work_id| alloc.free(work_id);
+    const history = try replayConversationHistory(alloc, file, &conversation_seq, &open_work_id);
+    defer session.freeHistoryTurnSlice(alloc, history);
+    try std.testing.expectEqual(@as(usize, 1), history.len);
+    const turn = history[0].assistant;
+    try std.testing.expect(turn.assistant_parts == null);
+    try std.testing.expect(turn.execution.tool_steps[0].assistant_parts == null);
+    try std.testing.expect(turn.execution.tool_steps[0].tool_calls[0].provider_options_json == null);
 }
 
 test "legacy import recovery restores old authority or keeps published current data" {

--- a/src/core/shared/message.zig
+++ b/src/core/shared/message.zig
@@ -149,6 +149,7 @@ pub fn freeToolCalls(alloc: std.mem.Allocator, tool_calls: []const ToolCall) voi
         alloc.free(call.arguments_json);
         if (call.provisional_id) |provisional_id| alloc.free(provisional_id);
         if (call.provider_result) |provider_result| alloc.free(provider_result);
+        if (call.provider_result_options_json) |options| alloc.free(options);
         if (call.provider_options_json) |options| alloc.free(options);
     }
     if (tool_calls.len > 0) alloc.free(tool_calls);

--- a/src/core/shared/message.zig
+++ b/src/core/shared/message.zig
@@ -36,8 +36,11 @@ pub const Message = struct {
     tool_result_status: ?types.PersistedToolStatus = null,
     tool_result_memory: ?types.ToolResultMemory = null,
     permission_feedback: bool = false,
+    /// Ordered assistant replay parts; present is authoritative for replay.
+    assistant_parts: ?[]const types.AssistantPart = null,
     owns_content: bool = false,
     owns_tool_calls: bool = false,
+    owns_assistant_parts: bool = false,
 
     /// Builds a borrowed system message.
     pub fn systemText(text: []const u8) Message {
@@ -116,6 +119,9 @@ pub const Message = struct {
             if (self.content) |content| alloc.free(content.asText());
         }
         if (self.owns_tool_calls) freeToolCalls(alloc, self.tool_calls);
+        if (self.owns_assistant_parts) {
+            if (self.assistant_parts) |parts| types.freeAssistantParts(alloc, parts);
+        }
         self.* = .{ .role = .user };
     }
 };
@@ -143,6 +149,7 @@ pub fn freeToolCalls(alloc: std.mem.Allocator, tool_calls: []const ToolCall) voi
         alloc.free(call.arguments_json);
         if (call.provisional_id) |provisional_id| alloc.free(provisional_id);
         if (call.provider_result) |provider_result| alloc.free(provider_result);
+        if (call.provider_options_json) |options| alloc.free(options);
     }
     if (tool_calls.len > 0) alloc.free(tool_calls);
 }

--- a/src/core/shared/types.zig
+++ b/src/core/shared/types.zig
@@ -742,6 +742,10 @@ pub const ToolCall = struct {
     argument_integrity: ToolArgumentIntegrity = .valid,
     provisional_id: ?[]const u8 = null,
     provider_result: ?[]const u8 = null,
+    /// Owned validated JSON object captured from the final provider-executed
+    /// result event, carried beside `provider_result` until the result scope
+    /// takes ownership. Replayed as the tool-result part's `providerOptions`.
+    provider_result_options_json: ?[]const u8 = null,
     final_identity: FinalToolIdentity = .valid,
     provenance: ToolExecutionProvenance = .fx_local,
     /// Owned validated JSON object replayed verbatim as this call part's
@@ -1025,6 +1029,9 @@ pub const ToolResultMemory = struct {
     command_output_replay: ?CommandOutputReplay = null,
     command_process_presentation: ?CommandProcessPresentation = null,
     terminal_action_presentation: ?TerminalActionPresentation = null,
+    /// Borrowed validated JSON object replayed verbatim as this result part's
+    /// `providerOptions`, projected from the persisted result.
+    provider_options_json: ?[]const u8 = null,
 };
 
 pub const ToolExecutionStep = struct {
@@ -2860,6 +2867,8 @@ pub fn dupeToolCall(alloc: std.mem.Allocator, call: ToolCall) !ToolCall {
     errdefer if (provider_result) |result| alloc.free(result);
     const provider_options_json = if (call.provider_options_json) |options| try alloc.dupe(u8, options) else null;
     errdefer if (provider_options_json) |options| alloc.free(options);
+    const provider_result_options_json = if (call.provider_result_options_json) |options| try alloc.dupe(u8, options) else null;
+    errdefer if (provider_result_options_json) |options| alloc.free(options);
     return .{
         .id = id,
         .name = name,
@@ -2867,6 +2876,7 @@ pub fn dupeToolCall(alloc: std.mem.Allocator, call: ToolCall) !ToolCall {
         .argument_integrity = call.argument_integrity,
         .provisional_id = provisional_id,
         .provider_result = provider_result,
+        .provider_result_options_json = provider_result_options_json,
         .final_identity = call.final_identity,
         .provenance = call.provenance,
         .provider_options_json = provider_options_json,
@@ -2879,6 +2889,7 @@ pub fn freeToolCall(alloc: std.mem.Allocator, call: ToolCall) void {
     alloc.free(call.arguments_json);
     if (call.provisional_id) |provisional_id| alloc.free(provisional_id);
     if (call.provider_result) |provider_result| alloc.free(provider_result);
+    if (call.provider_result_options_json) |options| alloc.free(options);
     if (call.provider_options_json) |options| alloc.free(options);
 }
 

--- a/src/core/shared/types.zig
+++ b/src/core/shared/types.zig
@@ -744,6 +744,9 @@ pub const ToolCall = struct {
     provider_result: ?[]const u8 = null,
     final_identity: FinalToolIdentity = .valid,
     provenance: ToolExecutionProvenance = .fx_local,
+    /// Owned validated JSON object replayed verbatim as this call part's
+    /// `providerOptions` (for example per-call thought signatures).
+    provider_options_json: ?[]const u8 = null,
     /// Borrowed only for this action. Copies and durable/provider encodings omit it.
     resolved_skill: ?*const skill_contract.PreparedSkill = null,
 };
@@ -856,6 +859,9 @@ pub const PersistedToolResult = struct {
     stored_output_bytes: usize,
     truncated: bool = false,
     provider_native: bool = false,
+    /// Owned validated JSON object replayed verbatim as this result part's
+    /// `providerOptions`, captured from the provider-executed result event.
+    provider_options_json: ?[]u8 = null,
     created_at_ms: i64 = 0,
     permission_feedback: [][]u8 = &.{},
     committed_file_presentation: ?CommittedFilePresentation = null,
@@ -1025,11 +1031,15 @@ pub const ToolExecutionStep = struct {
     assistant: ?[]u8 = null,
     tool_calls: []ToolCall = &.{},
     tool_results: []PersistedToolResult = &.{},
+    /// Ordered replay parts for this step's assistant segment, owned with the step.
+    assistant_parts: ?[]AssistantPart = null,
 };
 
 pub const PersistedSteering = struct {
     text: []u8,
     assistant_prefix: ?[]u8 = null,
+    /// Ordered replay parts for the assistant prefix before this steering point.
+    assistant_prefix_parts: ?[]AssistantPart = null,
     after_tool_step_count: usize,
 };
 
@@ -1118,6 +1128,43 @@ pub const AssistantMessagePhase = enum {
     final_answer,
 };
 
+/// One text part of an ordered assistant response retained for replay.
+pub const AssistantTextPart = struct {
+    /// Exact text as returned by the provider; never a display projection.
+    text: []const u8,
+    /// Owned validated JSON object replayed verbatim as this part's
+    /// `providerOptions`. Opaque protocol state, not display prose.
+    provider_options: ?[]const u8 = null,
+};
+
+/// One reasoning part of an ordered assistant response retained for replay.
+/// Empty text is meaningful: metadata-only blocks still carry replay state.
+pub const AssistantReasoningPart = struct {
+    text: []const u8,
+    /// Owned validated JSON object replayed verbatim as this part's
+    /// `providerOptions` (for example provider signatures or encrypted state).
+    provider_options: ?[]const u8 = null,
+};
+
+/// Ordered reference to the canonical `ToolCall` with this final ID. The
+/// referenced call remains the single owner of execution identity and
+/// arguments; this sequence only fixes the call's position among text and
+/// reasoning parts. Never references a provisional ID.
+pub const AssistantToolCallRef = struct {
+    id: []const u8,
+};
+
+/// Ordered content of one assistant response segment. A present slice is
+/// authoritative for replay and is emitted exactly once; a null field means
+/// old, direct-provider, or synthetic content and keeps the existing
+/// text/tool projection. A present empty slice is explicit: it must not fall
+/// back to a display string.
+pub const AssistantPart = union(enum) {
+    text: AssistantTextPart,
+    reasoning: AssistantReasoningPart,
+    tool_call_ref: AssistantToolCallRef,
+};
+
 pub const ChatMessage = struct {
     role: ChatRole,
     content: ?[]const u8 = null,
@@ -1133,6 +1180,9 @@ pub const ChatMessage = struct {
     tool_result_status: ?PersistedToolStatus = null,
     tool_result_memory: ?ToolResultMemory = null,
     permission_feedback: bool = false,
+    /// Ordered assistant replay parts, borrowed like `tool_calls`. Present means
+    /// authoritative; null keeps the legacy text/tool projection.
+    assistant_parts: ?[]const AssistantPart = null,
 };
 
 pub const Usage = struct {
@@ -1237,6 +1287,9 @@ pub const ModelCompletion = struct {
     provider_state_json: ?[]const u8 = null,
     finish_reason: ?ProviderFinishReason = null,
     usage: Usage = .{},
+    /// Ordered assistant replay parts owned by this completion's allocator.
+    /// Null for direct-provider or synthetic completions.
+    assistant_parts: ?[]const AssistantPart = null,
 };
 
 pub fn parseGatewayTimestamp(text: []const u8) error{InvalidGatewayTimestamp}!i64 {
@@ -1796,6 +1849,8 @@ pub const AssistantHistoryTurn = struct {
     user: UserTurn,
     assistant: []u8,
     execution: ExecutionMemory = .{},
+    /// Ordered replay parts for the final assistant answer, owned with the turn.
+    assistant_parts: ?[]AssistantPart = null,
 };
 
 pub const InterruptedTerminalReason = enum {
@@ -1811,6 +1866,8 @@ pub const InterruptedHistoryTurn = struct {
     execution: ExecutionMemory = .{},
     cancelled_command: ?CancelledCommandPresentation = null,
     terminal_reason: InterruptedTerminalReason = .cancelled,
+    /// Ordered replay parts for the interrupted assistant segment, owned with the turn.
+    assistant_parts: ?[]AssistantPart = null,
 };
 
 pub const context_handoff_open = "<context_handoff>";
@@ -2110,6 +2167,7 @@ pub fn freeHistoryTurn(alloc: std.mem.Allocator, turn: HistoryTurn) void {
             freeUserTurn(alloc, entry.user);
             alloc.free(entry.assistant);
             freeExecutionMemory(alloc, entry.execution);
+            if (entry.assistant_parts) |parts| freeAssistantParts(alloc, parts);
         },
         .interrupted => |entry| {
             freeUserTurn(alloc, entry.user);
@@ -2120,6 +2178,7 @@ pub fn freeHistoryTurn(alloc: std.mem.Allocator, turn: HistoryTurn) void {
             if (entry.cancelled_command) |presentation| {
                 freeCancelledCommandPresentation(alloc, presentation);
             }
+            if (entry.assistant_parts) |parts| freeAssistantParts(alloc, parts);
         },
     }
 }
@@ -2168,10 +2227,18 @@ pub fn dupeHistoryTurn(alloc: std.mem.Allocator, turn: HistoryTurn) !HistoryTurn
             errdefer alloc.free(assistant);
 
             const execution = try dupeExecutionMemory(alloc, entry.execution);
+            errdefer freeExecutionMemory(alloc, execution);
+
+            const assistant_parts = if (entry.assistant_parts) |parts|
+                try dupeAssistantParts(alloc, parts)
+            else
+                null;
+
             break :blk .{ .assistant = .{
                 .user = user,
                 .assistant = assistant,
                 .execution = execution,
+                .assistant_parts = assistant_parts,
             } };
         },
         .interrupted => |entry| blk: {
@@ -2196,6 +2263,12 @@ pub fn dupeHistoryTurn(alloc: std.mem.Allocator, turn: HistoryTurn) !HistoryTurn
             };
 
             const execution = try dupeExecutionMemory(alloc, entry.execution);
+            errdefer freeExecutionMemory(alloc, execution);
+
+            const assistant_parts = if (entry.assistant_parts) |parts|
+                try dupeAssistantParts(alloc, parts)
+            else
+                null;
 
             break :blk .{ .interrupted = .{
                 .user = user,
@@ -2205,6 +2278,7 @@ pub fn dupeHistoryTurn(alloc: std.mem.Allocator, turn: HistoryTurn) !HistoryTurn
                 .execution = execution,
                 .cancelled_command = cancelled_command,
                 .terminal_reason = entry.terminal_reason,
+                .assistant_parts = assistant_parts,
             } };
         },
     };
@@ -2305,6 +2379,7 @@ pub fn dupePersistedSteering(
     errdefer for (copy[0..copied]) |item| {
         alloc.free(item.text);
         if (item.assistant_prefix) |prefix| alloc.free(prefix);
+        if (item.assistant_prefix_parts) |parts| freeAssistantParts(alloc, parts);
     };
     for (steering, copy) |item, *dest| {
         const text = try alloc.dupe(u8, item.text);
@@ -2314,9 +2389,15 @@ pub fn dupePersistedSteering(
         else
             null;
         errdefer if (assistant_prefix) |prefix| alloc.free(prefix);
+        const assistant_prefix_parts = if (item.assistant_prefix_parts) |parts|
+            try dupeAssistantParts(alloc, parts)
+        else
+            null;
+        errdefer if (assistant_prefix_parts) |parts| freeAssistantParts(alloc, parts);
         dest.* = .{
             .text = text,
             .assistant_prefix = assistant_prefix,
+            .assistant_prefix_parts = assistant_prefix_parts,
             .after_tool_step_count = item.after_tool_step_count,
         };
         copied += 1;
@@ -2328,8 +2409,114 @@ pub fn freePersistedSteering(alloc: std.mem.Allocator, steering: []PersistedStee
     for (steering) |item| {
         alloc.free(item.text);
         if (item.assistant_prefix) |prefix| alloc.free(prefix);
+        if (item.assistant_prefix_parts) |parts| freeAssistantParts(alloc, parts);
     }
     if (steering.len > 0) alloc.free(steering);
+}
+
+pub fn dupeAssistantParts(alloc: std.mem.Allocator, parts: []const AssistantPart) ![]AssistantPart {
+    if (parts.len == 0) return &.{};
+
+    const copy = try alloc.alloc(AssistantPart, parts.len);
+    errdefer alloc.free(copy);
+
+    var copied: usize = 0;
+    errdefer {
+        for (copy[0..copied]) |part| freeAssistantPart(alloc, part);
+    }
+
+    for (parts, 0..) |part, i| {
+        copy[i] = try dupeAssistantPart(alloc, part);
+        copied += 1;
+    }
+    return copy;
+}
+
+pub fn freeAssistantParts(alloc: std.mem.Allocator, parts: []const AssistantPart) void {
+    for (parts) |part| freeAssistantPart(alloc, part);
+    if (parts.len > 0) alloc.free(parts);
+}
+
+fn dupeAssistantPart(alloc: std.mem.Allocator, part: AssistantPart) !AssistantPart {
+    switch (part) {
+        .text => |text_part| {
+            const text = try alloc.dupe(u8, text_part.text);
+            errdefer alloc.free(text);
+            const provider_options = if (text_part.provider_options) |options|
+                try alloc.dupe(u8, options)
+            else
+                null;
+            return .{ .text = .{ .text = text, .provider_options = provider_options } };
+        },
+        .reasoning => |reasoning_part| {
+            const text = try alloc.dupe(u8, reasoning_part.text);
+            errdefer alloc.free(text);
+            const provider_options = if (reasoning_part.provider_options) |options|
+                try alloc.dupe(u8, options)
+            else
+                null;
+            return .{ .reasoning = .{ .text = text, .provider_options = provider_options } };
+        },
+        .tool_call_ref => |ref| {
+            return .{ .tool_call_ref = .{ .id = try alloc.dupe(u8, ref.id) } };
+        },
+    }
+}
+
+fn freeAssistantPart(alloc: std.mem.Allocator, part: AssistantPart) void {
+    switch (part) {
+        .text => |text_part| {
+            alloc.free(text_part.text);
+            if (text_part.provider_options) |options| alloc.free(options);
+        },
+        .reasoning => |reasoning_part| {
+            alloc.free(reasoning_part.text);
+            if (reasoning_part.provider_options) |options| alloc.free(options);
+        },
+        .tool_call_ref => |ref| alloc.free(ref.id),
+    }
+}
+
+/// Validates replay integrity: every tool-call reference resolves to exactly
+/// one surviving canonical call with a valid final identity, and no call is
+/// referenced twice. Text and reasoning parts carry their own payloads.
+pub fn validateAssistantParts(
+    parts: []const AssistantPart,
+    tool_calls: []const ToolCall,
+) error{InvalidAssistantParts}!void {
+    for (parts, 0..) |part, i| {
+        if (part != .tool_call_ref) continue;
+        const ref = part.tool_call_ref;
+        var matches: usize = 0;
+        for (tool_calls) |call| {
+            if (!std.mem.eql(u8, call.id, ref.id)) continue;
+            matches += 1;
+            if (call.final_identity != .valid) return error.InvalidAssistantParts;
+        }
+        if (matches != 1) return error.InvalidAssistantParts;
+        for (parts[i + 1 ..]) |other| {
+            if (other == .tool_call_ref and std.mem.eql(u8, other.tool_call_ref.id, ref.id)) {
+                return error.InvalidAssistantParts;
+            }
+        }
+    }
+}
+
+/// Validates the provider-metadata envelope: a JSON object mapping provider
+/// namespaces to objects. Unknown namespaces and nested values are retained
+/// as-is; the validated raw bytes, not a reserialization, are replayed.
+pub fn validateProviderOptionsJson(
+    alloc: std.mem.Allocator,
+    bytes: []const u8,
+) error{InvalidProviderOptions}!void {
+    const parsed = std.json.parseFromSlice(std.json.Value, alloc, bytes, .{}) catch {
+        return error.InvalidProviderOptions;
+    };
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidProviderOptions;
+    for (parsed.value.object.values()) |value| {
+        if (value != .object) return error.InvalidProviderOptions;
+    }
 }
 
 pub fn dupeToolExecutionSteps(alloc: std.mem.Allocator, steps: []const ToolExecutionStep) ![]ToolExecutionStep {
@@ -2363,11 +2550,17 @@ fn dupeToolExecutionStep(alloc: std.mem.Allocator, step: ToolExecutionStep) !Too
     errdefer freeToolCallSlice(alloc, tool_calls);
     const tool_results = try dupePersistedToolResults(alloc, step.tool_results);
     errdefer freePersistedToolResults(alloc, tool_results);
+    const assistant_parts = if (step.assistant_parts) |parts|
+        try dupeAssistantParts(alloc, parts)
+    else
+        null;
+    errdefer if (assistant_parts) |parts| freeAssistantParts(alloc, parts);
 
     return .{
         .assistant = assistant,
         .tool_calls = tool_calls,
         .tool_results = tool_results,
+        .assistant_parts = assistant_parts,
     };
 }
 
@@ -2375,6 +2568,7 @@ fn freeToolExecutionStep(alloc: std.mem.Allocator, step: ToolExecutionStep) void
     if (step.assistant) |assistant| alloc.free(assistant);
     freeToolCallSlice(alloc, step.tool_calls);
     freePersistedToolResults(alloc, step.tool_results);
+    if (step.assistant_parts) |parts| freeAssistantParts(alloc, parts);
 }
 
 pub fn dupeToolCallSlice(alloc: std.mem.Allocator, calls: []const ToolCall) ![]ToolCall {
@@ -2511,6 +2705,8 @@ fn dupePersistedToolResult(alloc: std.mem.Allocator, result: PersistedToolResult
     errdefer if (command_output_replay) |replay| freeCommandOutputReplay(alloc, replay);
     const tool_image_handle = if (result.tool_image_handle) |handle| try alloc.dupe(u8, handle) else null;
     errdefer if (tool_image_handle) |handle| alloc.free(handle);
+    const provider_options_json = if (result.provider_options_json) |options| try alloc.dupe(u8, options) else null;
+    errdefer if (provider_options_json) |options| alloc.free(options);
     const tool_images = try dupeToolImages(alloc, result.tool_images);
     return .{
         .tool_images = tool_images,
@@ -2525,6 +2721,7 @@ fn dupePersistedToolResult(alloc: std.mem.Allocator, result: PersistedToolResult
         .stored_output_bytes = result.stored_output_bytes,
         .truncated = result.truncated,
         .provider_native = result.provider_native,
+        .provider_options_json = provider_options_json,
         .created_at_ms = result.created_at_ms,
         .permission_feedback = permission_feedback,
         .committed_file_presentation = committed_file_presentation,
@@ -2547,6 +2744,7 @@ fn freePersistedToolResult(alloc: std.mem.Allocator, result: PersistedToolResult
         freeCommittedFilePresentation(alloc, presentation);
     }
     if (result.command_output_replay) |replay| freeCommandOutputReplay(alloc, replay);
+    if (result.provider_options_json) |options| alloc.free(options);
 }
 
 pub fn dupeCommandOutputReplay(
@@ -2660,6 +2858,8 @@ pub fn dupeToolCall(alloc: std.mem.Allocator, call: ToolCall) !ToolCall {
     errdefer if (provisional_id) |value| alloc.free(value);
     const provider_result = if (call.provider_result) |result| try alloc.dupe(u8, result) else null;
     errdefer if (provider_result) |result| alloc.free(result);
+    const provider_options_json = if (call.provider_options_json) |options| try alloc.dupe(u8, options) else null;
+    errdefer if (provider_options_json) |options| alloc.free(options);
     return .{
         .id = id,
         .name = name,
@@ -2669,6 +2869,7 @@ pub fn dupeToolCall(alloc: std.mem.Allocator, call: ToolCall) !ToolCall {
         .provider_result = provider_result,
         .final_identity = call.final_identity,
         .provenance = call.provenance,
+        .provider_options_json = provider_options_json,
     };
 }
 
@@ -2678,6 +2879,7 @@ pub fn freeToolCall(alloc: std.mem.Allocator, call: ToolCall) void {
     alloc.free(call.arguments_json);
     if (call.provisional_id) |provisional_id| alloc.free(provisional_id);
     if (call.provider_result) |provider_result| alloc.free(provider_result);
+    if (call.provider_options_json) |options| alloc.free(options);
 }
 
 test "dupeToolCall preserves argument integrity" {
@@ -3208,4 +3410,91 @@ test "public types remain constructible" {
     _ = decision;
     _ = action;
     _ = resolve_mode;
+}
+
+test "dupeAssistantParts deep-copies text, reasoning, metadata, and references" {
+    const alloc = std.testing.allocator;
+    const parts: []const AssistantPart = &.{
+        .{ .text = .{ .text = "Checking.", .provider_options = "{\"meta\":{\"k\":\"v\"}}" } },
+        .{ .reasoning = .{ .text = "Let me check.", .provider_options = "{\"anthropic\":{\"signature\":\"sig_1\"}}" } },
+        .{ .tool_call_ref = .{ .id = "call_1" } },
+        .{ .reasoning = .{ .text = "", .provider_options = "{\"anthropic\":{\"redactedData\":\"red_1\"}}" } },
+    };
+
+    const copy = try dupeAssistantParts(alloc, parts);
+    defer freeAssistantParts(alloc, copy);
+
+    try std.testing.expectEqual(@as(usize, 4), copy.len);
+    try std.testing.expectEqualStrings("Checking.", copy[0].text.text);
+    try std.testing.expect(copy[0].text.text.ptr != parts[0].text.text.ptr);
+    try std.testing.expectEqualStrings("{\"anthropic\":{\"signature\":\"sig_1\"}}", copy[1].reasoning.provider_options.?);
+    try std.testing.expect(copy[1].reasoning.provider_options.?.ptr != parts[1].reasoning.provider_options.?.ptr);
+    try std.testing.expectEqualStrings("call_1", copy[2].tool_call_ref.id);
+    try std.testing.expect(copy[2].tool_call_ref.id.ptr != parts[2].tool_call_ref.id.ptr);
+    try std.testing.expectEqualStrings("", copy[3].reasoning.text);
+    try std.testing.expectEqualStrings("{\"anthropic\":{\"redactedData\":\"red_1\"}}", copy[3].reasoning.provider_options.?);
+}
+
+test "dupeAssistantParts cleans up on allocation failure" {
+    const parts: []const AssistantPart = &.{
+        .{ .text = .{ .text = "alpha" } },
+        .{ .reasoning = .{ .text = "beta", .provider_options = "{\"a\":{\"b\":1}}" } },
+        .{ .tool_call_ref = .{ .id = "call_1" } },
+    };
+
+    var fail_index: usize = 0;
+    while (true) {
+        var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = fail_index });
+        const copy = dupeAssistantParts(failing.allocator(), parts) catch |err| {
+            try std.testing.expectEqual(error.OutOfMemory, err);
+            fail_index += 1;
+            continue;
+        };
+        freeAssistantParts(std.testing.allocator, copy);
+        break;
+    }
+    try std.testing.expect(fail_index > 0);
+}
+
+test "validateAssistantParts accepts resolving references and rejects drift" {
+    const calls: []const ToolCall = &.{
+        .{ .id = "call_1", .name = "lookup", .arguments_json = "{}" },
+        .{ .id = "call_2", .name = "read", .arguments_json = "{}" },
+    };
+
+    const valid: []const AssistantPart = &.{
+        .{ .reasoning = .{ .text = "thinking" } },
+        .{ .tool_call_ref = .{ .id = "call_1" } },
+        .{ .tool_call_ref = .{ .id = "call_2" } },
+    };
+    try validateAssistantParts(valid, calls);
+
+    const missing: []const AssistantPart = &.{.{ .tool_call_ref = .{ .id = "gone" } }};
+    try std.testing.expectError(error.InvalidAssistantParts, validateAssistantParts(missing, calls));
+
+    const duplicate: []const AssistantPart = &.{
+        .{ .tool_call_ref = .{ .id = "call_1" } },
+        .{ .tool_call_ref = .{ .id = "call_1" } },
+    };
+    try std.testing.expectError(error.InvalidAssistantParts, validateAssistantParts(duplicate, calls));
+
+    const provisional: []const AssistantPart = &.{.{ .tool_call_ref = .{ .id = "stream_1" } }};
+    const provisional_calls: []const ToolCall = &.{.{
+        .id = "call_9",
+        .name = "lookup",
+        .arguments_json = "{}",
+        .provisional_id = "stream_1",
+    }};
+    try std.testing.expectError(error.InvalidAssistantParts, validateAssistantParts(provisional, provisional_calls));
+}
+
+test "validateProviderOptionsJson enforces the two-level metadata envelope" {
+    const alloc = std.testing.allocator;
+    try validateProviderOptionsJson(alloc, "{\"anthropic\":{\"signature\":\"s\"}}");
+    try validateProviderOptionsJson(alloc, "{\"google\":{\"thoughtSignature\":\"t\",\"nested\":{\"x\":[1,null]}}}");
+    try validateProviderOptionsJson(alloc, "{}");
+
+    try std.testing.expectError(error.InvalidProviderOptions, validateProviderOptionsJson(alloc, "[]"));
+    try std.testing.expectError(error.InvalidProviderOptions, validateProviderOptionsJson(alloc, "{\"anthropic\":\"scalar\"}"));
+    try std.testing.expectError(error.InvalidProviderOptions, validateProviderOptionsJson(alloc, "{]"));
 }

--- a/src/core/shared/types.zig
+++ b/src/core/shared/types.zig
@@ -2526,6 +2526,54 @@ pub fn validateProviderOptionsJson(
     }
 }
 
+/// Concatenates the replay sequences of two joined assistant segments, in
+/// chronological order. Borrows both inputs' payloads; the caller owns only
+/// the returned slice. Returns null when both are absent.
+pub fn concatAssistantParts(
+    alloc: std.mem.Allocator,
+    first: ?[]const AssistantPart,
+    second: ?[]const AssistantPart,
+) !?[]const AssistantPart {
+    if (first == null) return second;
+    if (second == null) return first;
+    const joined = try alloc.alloc(AssistantPart, first.?.len + second.?.len);
+    @memcpy(joined[0..first.?.len], first.?);
+    @memcpy(joined[first.?.len..], second.?);
+    return joined;
+}
+
+/// Keeps a replay sequence in sync when calls are filtered after admission:
+/// text and reasoning parts always survive, and references to removed calls
+/// are dropped in the same pass. Returns null when nothing remains, so the
+/// caller falls back to the legacy projection instead of emitting an
+/// authoritative empty sequence for a step that still has filtered calls.
+/// The returned slice aliases the source parts' payloads; it owns only the
+/// array itself, which the caller frees.
+pub fn filterAssistantPartsToCalls(
+    alloc: std.mem.Allocator,
+    parts: ?[]const AssistantPart,
+    tool_calls: []const ToolCall,
+) !?[]AssistantPart {
+    const source = parts orelse return null;
+    var kept: std.ArrayList(AssistantPart) = .empty;
+    errdefer kept.deinit(alloc);
+    for (source) |part| {
+        const keep = switch (part) {
+            .text, .reasoning => true,
+            .tool_call_ref => |ref| for (tool_calls) |call| {
+                if (std.mem.eql(u8, call.id, ref.id)) break true;
+            } else false,
+        };
+        if (keep) {
+            kept.append(alloc, part) catch |err| {
+                return err;
+            };
+        }
+    }
+    if (kept.items.len == 0) return null;
+    return try kept.toOwnedSlice(alloc);
+}
+
 pub fn dupeToolExecutionSteps(alloc: std.mem.Allocator, steps: []const ToolExecutionStep) ![]ToolExecutionStep {
     if (steps.len == 0) return &.{};
 

--- a/src/gateway/client.zig
+++ b/src/gateway/client.zig
@@ -229,6 +229,7 @@ pub const StreamResult = struct {
             if (call.provisional_id) |provisional_id| alloc.free(provisional_id);
             if (call.provider_result) |provider_result| alloc.free(provider_result);
             if (call.provider_options_json) |options| alloc.free(options);
+            if (call.provider_result_options_json) |options| alloc.free(options);
         }
         if (self.completion.tool_calls.len > 0) alloc.free(self.completion.tool_calls);
         if (self.completion.provider_failure_detail) |detail| alloc.free(@constCast(detail));
@@ -646,7 +647,7 @@ pub fn postGatewayCompletion(
             .{ .name = "Accept", .value = "application/json" },
             .{ .name = vercel_gateway_extended_time_header, .value = vercel_gateway_extended_time_value },
             .{ .name = "ai-gateway-protocol-version", .value = "0.0.1" },
-            .{ .name = "ai-language-model-specification-version", .value = "4" },
+            .{ .name = "ai-language-model-specification-version", .value = "3" },
             .{ .name = "ai-language-model-id", .value = model },
             .{ .name = "ai-language-model-streaming", .value = "false" },
         };
@@ -1723,7 +1724,7 @@ fn gatewayExtraHeaders(
     len += 1;
     buf[len] = .{ .name = "ai-gateway-protocol-version", .value = "0.0.1" };
     len += 1;
-    buf[len] = .{ .name = "ai-language-model-specification-version", .value = "4" };
+    buf[len] = .{ .name = "ai-language-model-specification-version", .value = "3" };
     len += 1;
     buf[len] = .{ .name = "ai-language-model-id", .value = model };
     len += 1;
@@ -2260,14 +2261,141 @@ const SseStreamedToolInput = struct {
     arguments: std.ArrayList(u8),
     state: StreamedToolInputState = .open,
     label_sent: bool = false,
+    provider_options: ?[]u8 = null,
 
     fn deinit(self: *SseStreamedToolInput, alloc: std.mem.Allocator) void {
         self.id.deinit(alloc);
         self.name.deinit(alloc);
         self.arguments.deinit(alloc);
+        if (self.provider_options) |options| alloc.free(options);
         self.* = undefined;
     }
 };
+
+/// Bounds for retained replay state. Exceeding any of them discards the whole
+/// ordered part sequence explicitly; truncated signed content is never kept.
+const max_replay_part_count: usize = 1024;
+const max_part_metadata_bytes: usize = 256 * 1024;
+const max_replay_capture_bytes: usize = 16 * 1024 * 1024;
+
+const SseTextBlock = struct {
+    id: std.ArrayList(u8),
+    text: std.ArrayList(u8),
+    provider_options: ?[]u8 = null,
+    ended: bool = false,
+
+    fn deinit(self: *SseTextBlock, alloc: std.mem.Allocator) void {
+        self.id.deinit(alloc);
+        self.text.deinit(alloc);
+        if (self.provider_options) |options| alloc.free(options);
+        self.* = undefined;
+    }
+};
+
+const SseReasoningBlock = struct {
+    id: std.ArrayList(u8),
+    text: std.ArrayList(u8),
+    provider_options: ?[]u8 = null,
+    ended: bool = false,
+
+    fn deinit(self: *SseReasoningBlock, alloc: std.mem.Allocator) void {
+        self.id.deinit(alloc);
+        self.text.deinit(alloc);
+        if (self.provider_options) |options| alloc.free(options);
+        self.* = undefined;
+    }
+};
+
+const SsePartOrderEntry = union(enum) {
+    text: usize,
+    reasoning: usize,
+    tool_call: usize,
+};
+
+/// Ordered capture state for replayable assistant content. Parsed event values
+/// die with the per-event arena; retained text and metadata are copied into
+/// `alloc` here and moved into the completion on success.
+const SseReplayCapture = struct {
+    text_blocks: std.ArrayList(SseTextBlock) = .empty,
+    reasoning_blocks: std.ArrayList(SseReasoningBlock) = .empty,
+    order: std.ArrayList(SsePartOrderEntry) = .empty,
+    bytes: usize = 0,
+    overflowed: bool = false,
+    /// Content arrived that cannot be attributed to a tracked block; emitting
+    /// the partial sequence would silently drop it from the replay.
+    inconsistent: bool = false,
+
+    fn deinit(self: *SseReplayCapture, alloc: std.mem.Allocator) void {
+        for (self.text_blocks.items) |*block| block.deinit(alloc);
+        self.text_blocks.deinit(alloc);
+        for (self.reasoning_blocks.items) |*block| block.deinit(alloc);
+        self.reasoning_blocks.deinit(alloc);
+        self.order.deinit(alloc);
+        self.* = undefined;
+    }
+
+    fn active(self: *const SseReplayCapture) bool {
+        return !self.overflowed and !self.inconsistent;
+    }
+
+    fn noteBytes(self: *SseReplayCapture, n: usize) void {
+        self.bytes +|= n;
+        if (self.bytes > max_replay_capture_bytes) self.overflowed = true;
+    }
+
+    fn notePart(self: *SseReplayCapture) void {
+        if (self.order.items.len >= max_replay_part_count) {
+            self.overflowed = true;
+        }
+    }
+};
+
+fn findTextBlock(blocks: []SseTextBlock, id: []const u8) ?usize {
+    for (blocks, 0..) |*block, index| {
+        if (std.mem.eql(u8, block.id.items, id)) return index;
+    }
+    return null;
+}
+
+fn findReasoningBlock(blocks: []SseReasoningBlock, id: []const u8) ?usize {
+    for (blocks, 0..) |*block, index| {
+        if (std.mem.eql(u8, block.id.items, id)) return index;
+    }
+    return null;
+}
+
+/// Applies the SDK's latest-snapshot metadata rule: a present object snapshot
+/// replaces prior state, while a missing or nullish update keeps it. The
+/// retained bytes are owned by `alloc` and validated as the two-level
+/// provider-metadata envelope; unknown namespaces are preserved.
+fn capturePartMetadata(
+    alloc: std.mem.Allocator,
+    root: std.json.Value,
+    current: *?[]u8,
+    capture: *SseReplayCapture,
+) !void {
+    const metadata_value = root.object.get("providerMetadata") orelse return;
+    if (metadata_value == .null) return;
+    if (metadata_value != .object) {
+        traceStreamStateAnomaly(.invalid_part_metadata);
+        return;
+    }
+    const bytes = try stringifyJsonValueOwned(alloc, metadata_value);
+    errdefer alloc.free(bytes);
+    if (bytes.len > max_part_metadata_bytes) {
+        alloc.free(bytes);
+        capture.overflowed = true;
+        return;
+    }
+    types.validateProviderOptionsJson(alloc, bytes) catch {
+        alloc.free(bytes);
+        traceStreamStateAnomaly(.invalid_part_metadata);
+        return;
+    };
+    capture.noteBytes(bytes.len);
+    if (current.*) |old| alloc.free(old);
+    current.* = bytes;
+}
 
 const ProviderResultState = enum {
     none,
@@ -2283,6 +2411,8 @@ const SseToolCallAccumulator = struct {
     argument_integrity: types.ToolArgumentIntegrity = .valid,
     provider_result: ?[]u8 = null,
     provider_result_state: ProviderResultState = .none,
+    provider_options: ?[]u8 = null,
+    provider_result_options: ?[]u8 = null,
     final_identity: types.FinalToolIdentity = .valid,
     provenance: types.ToolExecutionProvenance = .fx_local,
 
@@ -2292,6 +2422,8 @@ const SseToolCallAccumulator = struct {
         self.arguments.deinit(alloc);
         self.provisional_id.deinit(alloc);
         if (self.provider_result) |result| alloc.free(result);
+        if (self.provider_options) |options| alloc.free(options);
+        if (self.provider_result_options) |options| alloc.free(options);
         self.* = undefined;
     }
 };
@@ -2307,6 +2439,7 @@ const StreamStateAnomaly = enum {
     late_start,
     unmatched_or_late_delta,
     unmatched_or_duplicate_end,
+    invalid_part_metadata,
 };
 
 var test_force_sse_preview_failure = false;
@@ -2534,6 +2667,7 @@ fn deinitGatewayCompletion(alloc: std.mem.Allocator, completion: *types.ModelCom
         if (call.provisional_id) |provisional_id| alloc.free(provisional_id);
         if (call.provider_result) |provider_result| alloc.free(provider_result);
         if (call.provider_options_json) |options| alloc.free(options);
+        if (call.provider_result_options_json) |options| alloc.free(options);
     }
     if (completion.tool_calls.len > 0) alloc.free(completion.tool_calls);
     if (completion.provider_failure_detail) |detail| alloc.free(@constCast(detail));
@@ -2692,6 +2826,8 @@ fn materializeToolCalls(
             alloc.free(call.arguments_json);
             if (call.provisional_id) |provisional_id| alloc.free(provisional_id);
             if (call.provider_result) |provider_result| alloc.free(provider_result);
+            if (call.provider_options_json) |options| alloc.free(options);
+            if (call.provider_result_options_json) |options| alloc.free(options);
         }
         alloc.free(calls);
     }
@@ -2713,6 +2849,13 @@ fn materializeToolCalls(
         else
             null;
         errdefer if (provider_result) |result| alloc.free(result);
+        const provider_options = if (acc.provider_options) |options| try alloc.dupe(u8, options) else null;
+        errdefer if (provider_options) |options| alloc.free(options);
+        const provider_result_options = if (acc.provider_result_state == .final)
+            if (acc.provider_result_options) |options| try alloc.dupe(u8, options) else null
+        else
+            null;
+        errdefer if (provider_result_options) |options| alloc.free(options);
 
         calls[i] = .{
             .id = id,
@@ -2721,13 +2864,87 @@ fn materializeToolCalls(
             .argument_integrity = acc.argument_integrity,
             .provisional_id = provisional_id,
             .provider_result = provider_result,
+            .provider_result_options_json = provider_result_options,
             .final_identity = acc.final_identity,
             .provenance = acc.provenance,
+            .provider_options_json = provider_options,
         };
         initialized += 1;
     }
 
     return calls;
+}
+
+/// Builds the ordered replay sequence from captured blocks and final tool
+/// calls. Returns null when nothing replayable was captured (legacy or
+/// non-lifecycle streams keep the existing text/tool projection) or when
+/// capture bounds were exceeded; signed content is never truncated to fit.
+fn buildAssistantReplayParts(
+    alloc: std.mem.Allocator,
+    capture: *const SseReplayCapture,
+    accumulators: []const SseToolCallAccumulator,
+) !?[]types.AssistantPart {
+    if (capture.overflowed) {
+        debug_trace.logf("sse", "event=replay_capture_discarded reason=overflow", .{});
+        return null;
+    }
+    if (capture.inconsistent) {
+        debug_trace.logf("sse", "event=replay_capture_discarded reason=inconsistent_lifecycle", .{});
+        return null;
+    }
+    if (capture.order.items.len == 0) return null;
+    for (accumulators) |acc| {
+        if (acc.final_identity != .valid) {
+            // A call without a valid final identity cannot be referenced; the
+            // existing identity-failure handling owns this completion instead.
+            debug_trace.logf("sse", "event=replay_capture_discarded reason=invalid_tool_identity", .{});
+            return null;
+        }
+    }
+
+    const parts = try alloc.alloc(types.AssistantPart, capture.order.items.len);
+    var initialized: usize = 0;
+    errdefer {
+        for (parts[0..initialized]) |part| {
+            switch (part) {
+                .text => |text_part| {
+                    alloc.free(text_part.text);
+                    if (text_part.provider_options) |options| alloc.free(options);
+                },
+                .reasoning => |reasoning_part| {
+                    alloc.free(reasoning_part.text);
+                    if (reasoning_part.provider_options) |options| alloc.free(options);
+                },
+                .tool_call_ref => |ref| alloc.free(ref.id),
+            }
+        }
+        alloc.free(parts);
+    }
+
+    for (capture.order.items, 0..) |entry, i| {
+        parts[i] = switch (entry) {
+            .text => |index| blk: {
+                const block = capture.text_blocks.items[index];
+                const text = try alloc.dupe(u8, block.text.items);
+                errdefer alloc.free(text);
+                const options = if (block.provider_options) |current| try alloc.dupe(u8, current) else null;
+                break :blk types.AssistantPart{ .text = .{ .text = text, .provider_options = options } };
+            },
+            .reasoning => |index| blk: {
+                const block = capture.reasoning_blocks.items[index];
+                const text = try alloc.dupe(u8, block.text.items);
+                errdefer alloc.free(text);
+                const options = if (block.provider_options) |current| try alloc.dupe(u8, current) else null;
+                break :blk types.AssistantPart{ .reasoning = .{ .text = text, .provider_options = options } };
+            },
+            .tool_call => |index| blk: {
+                const id = try alloc.dupe(u8, accumulators[index].id.items);
+                break :blk types.AssistantPart{ .tool_call_ref = .{ .id = id } };
+            },
+        };
+        initialized += 1;
+    }
+    return parts;
 }
 
 fn extractFirstJsonStringValue(args: []const u8) ?[]const u8 {
@@ -3120,6 +3337,9 @@ fn consumeSseStreamTraced(
         tool_accumulators.deinit(alloc);
     }
 
+    var replay_capture: SseReplayCapture = .{};
+    defer replay_capture.deinit(alloc);
+
     var finish_reason_holder: ?types.ProviderFinishReason = null;
     var finish_usage: types.Usage = .{};
     var finish_billing: ?types.ProviderBilling = null;
@@ -3237,6 +3457,34 @@ fn consumeSseStreamTraced(
         } else if (std.mem.eql(u8, event_type, "error")) {
             provider_failure_cause = provider_failure_cause orelse providerFailureCause(root);
             try captureProviderFailureDetail(alloc, &provider_failure_detail, root);
+        } else if (std.mem.eql(u8, event_type, "text-start")) {
+            if (!replay_capture.active()) continue;
+            const id = streamedToolInputId(root, .invalid_start) orelse {
+                replay_capture.inconsistent = true;
+                continue;
+            };
+            if (findTextBlock(replay_capture.text_blocks.items, id)) |_| {
+                traceStreamStateAnomaly(.conflicting_start);
+                replay_capture.inconsistent = true;
+                continue;
+            }
+            var block: SseTextBlock = .{ .id = .empty, .text = .empty };
+            block.id.appendSlice(alloc, id) catch |err| {
+                block.deinit(alloc);
+                return err;
+            };
+            replay_capture.notePart();
+            if (!replay_capture.active()) {
+                block.deinit(alloc);
+                continue;
+            }
+            replay_capture.text_blocks.append(alloc, block) catch |err| {
+                block.deinit(alloc);
+                return err;
+            };
+            // The block list owns the block from here on.
+            try replay_capture.order.append(alloc, .{ .text = replay_capture.text_blocks.items.len - 1 });
+            try capturePartMetadata(alloc, root, &replay_capture.text_blocks.items[replay_capture.text_blocks.items.len - 1].provider_options, &replay_capture);
         } else if (std.mem.eql(u8, event_type, "text-delta")) {
             if (root.object.get("delta")) |delta_val| {
                 if (delta_val == .string and delta_val.string.len > 0) {
@@ -3246,8 +3494,85 @@ fn consumeSseStreamTraced(
                         delta_val.string;
                     try content_buf.appendSlice(alloc, retained);
                     on_content_chunk(callback_ctx, delta_val.string);
+                    if (replay_capture.active()) {
+                        const id_value = root.object.get("id");
+                        const block_index = if (id_value != null and id_value.? == .string)
+                            findTextBlock(replay_capture.text_blocks.items, id_value.?.string)
+                        else
+                            null;
+                        if (block_index) |index| {
+                            const block = &replay_capture.text_blocks.items[index];
+                            if (block.ended) {
+                                traceStreamStateAnomaly(.unmatched_or_late_delta);
+                                replay_capture.inconsistent = true;
+                            } else {
+                                try block.text.appendSlice(alloc, delta_val.string);
+                                replay_capture.noteBytes(delta_val.string.len);
+                            }
+                        } else {
+                            // Text that cannot be attributed to a tracked block
+                            // would vanish from the replay sequence.
+                            replay_capture.inconsistent = true;
+                        }
+                    }
                 }
             }
+            if (replay_capture.active()) {
+                if (root.object.get("id")) |id_value| {
+                    if (id_value == .string) {
+                        if (findTextBlock(replay_capture.text_blocks.items, id_value.string)) |index| {
+                            try capturePartMetadata(alloc, root, &replay_capture.text_blocks.items[index].provider_options, &replay_capture);
+                        }
+                    }
+                }
+            }
+        } else if (std.mem.eql(u8, event_type, "text-end")) {
+            if (!replay_capture.active()) continue;
+            const id = streamedToolInputId(root, .unmatched_or_duplicate_end) orelse {
+                replay_capture.inconsistent = true;
+                continue;
+            };
+            const index = findTextBlock(replay_capture.text_blocks.items, id) orelse {
+                traceStreamStateAnomaly(.unmatched_or_duplicate_end);
+                replay_capture.inconsistent = true;
+                continue;
+            };
+            const block = &replay_capture.text_blocks.items[index];
+            if (block.ended) {
+                traceStreamStateAnomaly(.unmatched_or_duplicate_end);
+                replay_capture.inconsistent = true;
+                continue;
+            }
+            block.ended = true;
+            try capturePartMetadata(alloc, root, &block.provider_options, &replay_capture);
+        } else if (std.mem.eql(u8, event_type, "reasoning-start")) {
+            if (!replay_capture.active()) continue;
+            const id = streamedToolInputId(root, .invalid_start) orelse {
+                replay_capture.inconsistent = true;
+                continue;
+            };
+            if (findReasoningBlock(replay_capture.reasoning_blocks.items, id)) |_| {
+                traceStreamStateAnomaly(.conflicting_start);
+                replay_capture.inconsistent = true;
+                continue;
+            }
+            var block: SseReasoningBlock = .{ .id = .empty, .text = .empty };
+            block.id.appendSlice(alloc, id) catch |err| {
+                block.deinit(alloc);
+                return err;
+            };
+            replay_capture.notePart();
+            if (!replay_capture.active()) {
+                block.deinit(alloc);
+                continue;
+            }
+            replay_capture.reasoning_blocks.append(alloc, block) catch |err| {
+                block.deinit(alloc);
+                return err;
+            };
+            // The block list owns the block from here on.
+            try replay_capture.order.append(alloc, .{ .reasoning = replay_capture.reasoning_blocks.items.len - 1 });
+            try capturePartMetadata(alloc, root, &replay_capture.reasoning_blocks.items[replay_capture.reasoning_blocks.items.len - 1].provider_options, &replay_capture);
         } else if (std.mem.eql(u8, event_type, "reasoning-delta")) {
             if (on_reasoning_chunk) |callback| {
                 if (root.object.get("delta")) |delta_val| {
@@ -3256,6 +3581,52 @@ fn consumeSseStreamTraced(
                     }
                 }
             }
+            // Metadata arrives independently of text: an empty delta may carry
+            // the block's signature, and metadata-only blocks carry replay state
+            // with no text at all.
+            if (!replay_capture.active()) continue;
+            const id_value = root.object.get("id") orelse {
+                replay_capture.inconsistent = true;
+                continue;
+            };
+            if (id_value != .string) {
+                replay_capture.inconsistent = true;
+                continue;
+            }
+            const index = findReasoningBlock(replay_capture.reasoning_blocks.items, id_value.string) orelse {
+                replay_capture.inconsistent = true;
+                continue;
+            };
+            const block = &replay_capture.reasoning_blocks.items[index];
+            if (block.ended) {
+                traceStreamStateAnomaly(.unmatched_or_late_delta);
+                replay_capture.inconsistent = true;
+            } else if (root.object.get("delta")) |delta_val| {
+                if (delta_val == .string and delta_val.string.len > 0) {
+                    try block.text.appendSlice(alloc, delta_val.string);
+                    replay_capture.noteBytes(delta_val.string.len);
+                }
+            }
+            try capturePartMetadata(alloc, root, &block.provider_options, &replay_capture);
+        } else if (std.mem.eql(u8, event_type, "reasoning-end")) {
+            if (!replay_capture.active()) continue;
+            const id = streamedToolInputId(root, .unmatched_or_duplicate_end) orelse {
+                replay_capture.inconsistent = true;
+                continue;
+            };
+            const index = findReasoningBlock(replay_capture.reasoning_blocks.items, id) orelse {
+                traceStreamStateAnomaly(.unmatched_or_duplicate_end);
+                replay_capture.inconsistent = true;
+                continue;
+            };
+            const block = &replay_capture.reasoning_blocks.items[index];
+            if (block.ended) {
+                traceStreamStateAnomaly(.unmatched_or_duplicate_end);
+                replay_capture.inconsistent = true;
+                continue;
+            }
+            block.ended = true;
+            try capturePartMetadata(alloc, root, &block.provider_options, &replay_capture);
         } else if (std.mem.eql(u8, event_type, "tool-input-start")) {
             const id = streamedToolInputId(root, .invalid_start) orelse continue;
             const name = if (root.object.get("toolName")) |name_value|
@@ -3278,6 +3649,9 @@ fn consumeSseStreamTraced(
                 record.deinit(alloc);
                 return err;
             };
+            if (replay_capture.active()) {
+                try capturePartMetadata(alloc, root, &streamed_tool_inputs.items[streamed_tool_inputs.items.len - 1].provider_options, &replay_capture);
+            }
             if (name.len > 0) {
                 if (on_tool_start) |cb| cb(callback_ctx, id, name, null);
             }
@@ -3306,6 +3680,9 @@ fn consumeSseStreamTraced(
                 if (on_tool_input_chunk) |callback| callback(callback_ctx, delta_value.string);
             } else {
                 record.state = .ended;
+            }
+            if (replay_capture.active()) {
+                try capturePartMetadata(alloc, root, &record.provider_options, &replay_capture);
             }
         } else if (std.mem.eql(u8, event_type, "tool-call")) {
             var acc: SseToolCallAccumulator = .{
@@ -3459,10 +3836,29 @@ fn consumeSseStreamTraced(
                 }
             }
 
+            // The final tool-call event's metadata takes precedence over any
+            // metadata captured from the preliminary streamed-input events.
+            if (replay_capture.active()) {
+                try capturePartMetadata(alloc, root, &acc.provider_options, &replay_capture);
+                if (acc.provider_options == null) {
+                    if (stream_index) |index| {
+                        if (streamed_tool_inputs.items[index].provider_options) |inherited| {
+                            acc.provider_options = try alloc.dupe(u8, inherited);
+                        }
+                    }
+                }
+            }
+
             try tool_accumulators.append(alloc, acc);
             acc_owned = false;
             if (stream_index) |index| {
                 streamed_tool_inputs.items[index].state = .finalized;
+            }
+            if (replay_capture.active()) {
+                replay_capture.notePart();
+                if (replay_capture.active()) {
+                    try replay_capture.order.append(alloc, .{ .tool_call = tool_accumulators.items.len - 1 });
+                }
             }
         } else if (std.mem.eql(u8, event_type, "tool-result")) {
             const result_identity = finalToolIdentity(root.object.get("toolCallId"));
@@ -3542,6 +3938,11 @@ fn consumeSseStreamTraced(
             if (acc.provider_result) |old_result| alloc.free(old_result);
             acc.provider_result = owned_result;
             acc.provider_result_state = if (preliminary) .preliminary else .final;
+            // Only a final result's metadata is replay state; a preliminary
+            // result's metadata must not masquerade as final-result data.
+            if (!preliminary and replay_capture.active()) {
+                try capturePartMetadata(alloc, root, &acc.provider_result_options, &replay_capture);
+            }
         } else if (std.mem.eql(u8, event_type, "finish")) {
             provider_failure_cause = provider_failure_cause orelse providerFailureCause(root);
             const finish_event = parseSseFinishEvent(alloc, root, &provider_failure_detail) catch |err| {
@@ -3584,6 +3985,7 @@ fn consumeSseStreamTraced(
     }
 
     completion.tool_calls = try materializeToolCalls(alloc, tool_accumulators.items);
+    completion.assistant_parts = try buildAssistantReplayParts(alloc, &replay_capture, tool_accumulators.items);
 
     completion.provider_result_identity_failure = provider_result_identity_failure;
     completion.provider_failure_cause = provider_failure_cause;
@@ -3667,6 +4069,274 @@ test "consumeSseStream preserves provider finish_reason" {
 
     try std.testing.expectEqualStrings("Hola", completion.content.?);
     try std.testing.expectEqual(types.ProviderFinishReason.length, completion.finish_reason.?);
+}
+
+test "decode to replay preserves ordered reasoning parts and per-part metadata" {
+    const vercel_protocol = @import("vercel_protocol.zig");
+    const alloc = std.testing.allocator;
+
+    // Synthetic provider stream: text, a signed reasoning block (signature on an
+    // empty delta, replacing the start snapshot), one authoritative tool call,
+    // a metadata-only reasoning block, and trailing text with its own metadata.
+    const payload =
+        "data: {\"type\":\"text-start\",\"id\":\"t1\"}\n\n" ++
+        "data: {\"type\":\"text-delta\",\"id\":\"t1\",\"delta\":\"Checking the file.\"}\n\n" ++
+        "data: {\"type\":\"text-end\",\"id\":\"t1\"}\n\n" ++
+        "data: {\"type\":\"reasoning-start\",\"id\":\"r1\",\"providerMetadata\":{\"anthropic\":{\"signature\":\"sig_superseded\",\"note\":1}}}\n\n" ++
+        "data: {\"type\":\"reasoning-delta\",\"id\":\"r1\",\"delta\":\"Let me check.\"}\n\n" ++
+        "data: {\"type\":\"reasoning-delta\",\"id\":\"r1\",\"delta\":\"\",\"providerMetadata\":{\"anthropic\":{\"signature\":\"sig_1\"}}}\n\n" ++
+        "data: {\"type\":\"reasoning-end\",\"id\":\"r1\"}\n\n" ++
+        "data: {\"type\":\"tool-input-start\",\"id\":\"call_1\",\"toolName\":\"lookup\"}\n\n" ++
+        "data: {\"type\":\"tool-input-delta\",\"id\":\"call_1\",\"delta\":\"{\\\"query\\\":\"}\n\n" ++
+        "data: {\"type\":\"tool-input-delta\",\"id\":\"call_1\",\"delta\":\"\\\"example\\\"}\"}\n\n" ++
+        "data: {\"type\":\"tool-input-end\",\"id\":\"call_1\"}\n\n" ++
+        "data: {\"type\":\"tool-call\",\"toolCallId\":\"call_1\",\"toolName\":\"lookup\",\"input\":\"{\\\"query\\\":\\\"example\\\"}\",\"providerMetadata\":{\"google\":{\"thoughtSignature\":\"ts_1\"}}}\n\n" ++
+        "data: {\"type\":\"reasoning-start\",\"id\":\"r2\",\"providerMetadata\":{\"anthropic\":{\"redactedData\":\"red_1\"}}}\n\n" ++
+        "data: {\"type\":\"reasoning-end\",\"id\":\"r2\"}\n\n" ++
+        "data: {\"type\":\"text-start\",\"id\":\"t2\",\"providerMetadata\":{\"testprovider\":{\"note\":\"n1\"}}}\n\n" ++
+        "data: {\"type\":\"text-delta\",\"id\":\"t2\",\"delta\":\"Done checking.\"}\n\n" ++
+        "data: {\"type\":\"text-end\",\"id\":\"t2\"}\n\n" ++
+        "data: {\"type\":\"finish\",\"finishReason\":{\"unified\":\"tool-calls\",\"raw\":\"tool_use\"},\"usage\":{\"inputTokens\":{\"total\":10},\"outputTokens\":{\"total\":5}}}\n\n" ++
+        "data: [DONE]\n\n";
+
+    // Decode with no reasoning callback installed, into a releasable arena.
+    var source_arena = std.heap.ArenaAllocator.init(alloc);
+    var completion = blk: {
+        var reader = std.Io.Reader.fixed(payload);
+        var cancel_flag = std.atomic.Value(bool).init(false);
+        const Noop = struct {
+            fn chunk(_: *anyopaque, _: []const u8) void {}
+        };
+        break :blk try consumeSseStream(source_arena.allocator(), &reader, undefined, Noop.chunk, null, &cancel_flag);
+    };
+
+    // The accepted content is deep-cloned, then every decode-side buffer dies.
+    const parts = try types.dupeAssistantParts(alloc, completion.assistant_parts orelse &.{
+        .{ .text = .{ .text = "decode dropped the reasoning blocks" } },
+    });
+    defer types.freeAssistantParts(alloc, parts);
+    const calls = try types.dupeToolCallSlice(alloc, completion.tool_calls);
+    defer types.freeToolCallSlice(alloc, calls);
+    const content = if (completion.content) |text| try alloc.dupe(u8, text) else null;
+    defer if (content) |text| alloc.free(text);
+    completion = undefined;
+    source_arena.deinit();
+
+    try std.testing.expectEqual(@as(usize, 5), parts.len);
+    try std.testing.expectEqualStrings("Checking the file.", parts[0].text.text);
+    try std.testing.expect(parts[0].text.provider_options == null);
+    try std.testing.expectEqualStrings("Let me check.", parts[1].reasoning.text);
+    try std.testing.expectEqualStrings(
+        "{\"anthropic\":{\"signature\":\"sig_1\"}}",
+        parts[1].reasoning.provider_options.?,
+    );
+    try std.testing.expectEqualStrings("call_1", parts[2].tool_call_ref.id);
+    try std.testing.expectEqualStrings("", parts[3].reasoning.text);
+    try std.testing.expectEqualStrings(
+        "{\"anthropic\":{\"redactedData\":\"red_1\"}}",
+        parts[3].reasoning.provider_options.?,
+    );
+    try std.testing.expectEqualStrings("Done checking.", parts[4].text.text);
+    try std.testing.expectEqualStrings(
+        "{\"testprovider\":{\"note\":\"n1\"}}",
+        parts[4].text.provider_options.?,
+    );
+
+    try std.testing.expectEqual(@as(usize, 1), calls.len);
+    try std.testing.expectEqualStrings("{\"query\":\"example\"}", calls[0].arguments_json);
+    try std.testing.expectEqualStrings(
+        "{\"google\":{\"thoughtSignature\":\"ts_1\"}}",
+        calls[0].provider_options_json.?,
+    );
+    // The display/legacy projection derives from text, never from reasoning.
+    try std.testing.expectEqualStrings("Checking the file.Done checking.", content.?);
+
+    // Serialize the cloned state as history in the next request after the tool
+    // result, as the tool loop would.
+    const messages: []const types.ChatMessage = &.{
+        .{ .role = .user, .content = "Look up an example." },
+        .{
+            .role = .assistant,
+            .content = content,
+            .tool_calls = calls,
+            .assistant_parts = parts,
+        },
+        .{
+            .role = .tool,
+            .content = "found it",
+            .tool_call_id = "call_1",
+            .tool_name = "lookup",
+        },
+    };
+    const body = try vercel_protocol.buildGatewayRequestBody(alloc, "[]", messages);
+    defer alloc.free(body);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, alloc, body, .{});
+    defer parsed.deinit();
+    try std.testing.expect(parsed.value == .object);
+    // The unsupported top-level reasoning effort field is never emitted on v3.
+    try std.testing.expect(parsed.value.object.get("reasoning") == null);
+
+    const prompt = parsed.value.object.get("prompt").?;
+    try std.testing.expectEqual(@as(usize, 3), prompt.array.items.len);
+    const assistant = prompt.array.items[1];
+    try std.testing.expectEqualStrings("assistant", assistant.object.get("role").?.string);
+    const expected_content =
+        "[{\"type\":\"text\",\"text\":\"Checking the file.\"}," ++
+        "{\"type\":\"reasoning\",\"text\":\"Let me check.\",\"providerOptions\":{\"anthropic\":{\"signature\":\"sig_1\"}}}," ++
+        "{\"type\":\"tool-call\",\"toolCallId\":\"call_1\",\"toolName\":\"lookup\",\"input\":{\"query\":\"example\"},\"providerOptions\":{\"google\":{\"thoughtSignature\":\"ts_1\"}}}," ++
+        "{\"type\":\"reasoning\",\"text\":\"\",\"providerOptions\":{\"anthropic\":{\"redactedData\":\"red_1\"}}}," ++
+        "{\"type\":\"text\",\"text\":\"Done checking.\",\"providerOptions\":{\"testprovider\":{\"note\":\"n1\"}}}]";
+    var content_out: std.Io.Writer.Allocating = .init(alloc);
+    defer content_out.deinit();
+    try std.json.Stringify.value(assistant.object.get("content").?, .{}, &content_out.writer);
+    try std.testing.expectEqualStrings(expected_content, content_out.written());
+
+    const tool_message = prompt.array.items[2];
+    try std.testing.expectEqualStrings("tool", tool_message.object.get("role").?.string);
+    const tool_parts = tool_message.object.get("content").?.array.items;
+    try std.testing.expectEqual(@as(usize, 1), tool_parts.len);
+    try std.testing.expectEqualStrings("tool-result", tool_parts[0].object.get("type").?.string);
+    try std.testing.expectEqualStrings("call_1", tool_parts[0].object.get("toolCallId").?.string);
+    try std.testing.expectEqualStrings("lookup", tool_parts[0].object.get("toolName").?.string);
+}
+
+test "reasoning metadata arrives on end with latest snapshot semantics" {
+    const payload =
+        "data: {\"type\":\"reasoning-start\",\"id\":\"rs_1\",\"providerMetadata\":{\"openai\":{\"itemId\":\"rs_1\"}}}\n\n" ++
+        "data: {\"type\":\"reasoning-delta\",\"id\":\"rs_1\",\"delta\":\"thinking\"}\n\n" ++
+        "data: {\"type\":\"reasoning-delta\",\"id\":\"rs_1\",\"delta\":\" more\"}\n\n" ++
+        "data: {\"type\":\"reasoning-end\",\"id\":\"rs_1\",\"providerMetadata\":{\"openai\":{\"reasoningEncryptedContent\":\"enc_1\",\"itemId\":\"rs_1\"}}}\n\n" ++
+        "data: {\"type\":\"finish\",\"finishReason\":{\"unified\":\"stop\"}}\n\n" ++
+        "data: [DONE]\n\n";
+
+    var reader = std.Io.Reader.fixed(payload);
+    var cancel_flag = std.atomic.Value(bool).init(false);
+    const Noop = struct {
+        fn chunk(_: *anyopaque, _: []const u8) void {}
+    };
+
+    var completion = try consumeSseStream(std.testing.allocator, &reader, undefined, Noop.chunk, null, &cancel_flag);
+    defer deinitGatewayCompletion(std.testing.allocator, &completion);
+
+    const parts = completion.assistant_parts orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqual(@as(usize, 1), parts.len);
+    try std.testing.expectEqualStrings("thinking more", parts[0].reasoning.text);
+    // The end-event snapshot replaced the start snapshot, and the metadata-less
+    // deltas did not erase earlier state.
+    try std.testing.expectEqualStrings(
+        "{\"openai\":{\"reasoningEncryptedContent\":\"enc_1\",\"itemId\":\"rs_1\"}}",
+        parts[0].reasoning.provider_options.?,
+    );
+}
+
+test "incomplete reasoning block at EOF retains accumulated replay state" {
+    const payload =
+        "data: {\"type\":\"reasoning-start\",\"id\":\"r1\",\"providerMetadata\":{\"anthropic\":{\"signature\":\"sig_partial\"}}}\n\n" ++
+        "data: {\"type\":\"reasoning-delta\",\"id\":\"r1\",\"delta\":\"partial thought\"}\n\n";
+
+    var reader = std.Io.Reader.fixed(payload);
+    var cancel_flag = std.atomic.Value(bool).init(false);
+    const Noop = struct {
+        fn chunk(_: *anyopaque, _: []const u8) void {}
+    };
+
+    var completion = try consumeSseStream(std.testing.allocator, &reader, undefined, Noop.chunk, null, &cancel_flag);
+    defer deinitGatewayCompletion(std.testing.allocator, &completion);
+
+    const parts = completion.assistant_parts orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqual(@as(usize, 1), parts.len);
+    try std.testing.expectEqualStrings("partial thought", parts[0].reasoning.text);
+    try std.testing.expectEqualStrings(
+        "{\"anthropic\":{\"signature\":\"sig_partial\"}}",
+        parts[0].reasoning.provider_options.?,
+    );
+}
+
+test "malformed and unattributable lifecycle events discard replay capture explicitly" {
+    // A metadata snapshot with a scalar namespace value is dropped, not replayed.
+    const malformed_metadata =
+        "data: {\"type\":\"reasoning-start\",\"id\":\"r1\",\"providerMetadata\":{\"anthropic\":\"scalar\"}}\n\n" ++
+        "data: {\"type\":\"reasoning-delta\",\"id\":\"r1\",\"delta\":\"kept\"}\n\n" ++
+        "data: {\"type\":\"reasoning-end\",\"id\":\"r1\"}\n\n" ++
+        "data: {\"type\":\"finish\",\"finishReason\":{\"unified\":\"stop\"}}\n\n";
+    var reader = std.Io.Reader.fixed(malformed_metadata);
+    var cancel_flag = std.atomic.Value(bool).init(false);
+    const Noop = struct {
+        fn chunk(_: *anyopaque, _: []const u8) void {}
+    };
+    var completion = try consumeSseStream(std.testing.allocator, &reader, undefined, Noop.chunk, null, &cancel_flag);
+    defer deinitGatewayCompletion(std.testing.allocator, &completion);
+    const kept_parts = completion.assistant_parts orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqual(@as(usize, 1), kept_parts.len);
+    try std.testing.expect(kept_parts[0].reasoning.provider_options == null);
+    try std.testing.expectEqualStrings("kept", kept_parts[0].reasoning.text);
+
+    // A text delta that cannot be attributed to any tracked block discards the
+    // whole sequence rather than replaying an incomplete response.
+    const unattributable =
+        "data: {\"type\":\"reasoning-start\",\"id\":\"r1\"}\n\n" ++
+        "data: {\"type\":\"reasoning-delta\",\"id\":\"r1\",\"delta\":\"fine\"}\n\n" ++
+        "data: {\"type\":\"reasoning-end\",\"id\":\"r1\"}\n\n" ++
+        "data: {\"type\":\"text-delta\",\"id\":\"orphan\",\"delta\":\"lost text\"}\n\n" ++
+        "data: {\"type\":\"finish\",\"finishReason\":{\"unified\":\"stop\"}}\n\n";
+    var second_reader = std.Io.Reader.fixed(unattributable);
+    var second_completion = try consumeSseStream(std.testing.allocator, &second_reader, undefined, Noop.chunk, null, &cancel_flag);
+    defer deinitGatewayCompletion(std.testing.allocator, &second_completion);
+    try std.testing.expect(second_completion.assistant_parts == null);
+    try std.testing.expectEqualStrings("lost text", second_completion.content.?);
+}
+
+test "oversized part metadata discards replay capture without truncation" {
+    const alloc = std.testing.allocator;
+    const oversized_signature = "s" ** (max_part_metadata_bytes);
+    const payload = try std.fmt.allocPrint(alloc, "data: {{\"type\":\"reasoning-start\",\"id\":\"r1\",\"providerMetadata\":{{\"anthropic\":{{\"signature\":\"{s}\"}}}}}}\n\n" ++
+        "data: {{\"type\":\"reasoning-delta\",\"id\":\"r1\",\"delta\":\"thought\"}}\n\n" ++
+        "data: {{\"type\":\"finish\",\"finishReason\":{{\"unified\":\"stop\"}}}}\n\n", .{oversized_signature});
+    defer alloc.free(payload);
+
+    var reader = std.Io.Reader.fixed(payload);
+    var cancel_flag = std.atomic.Value(bool).init(false);
+    const Noop = struct {
+        fn chunk(_: *anyopaque, _: []const u8) void {}
+    };
+    var completion = try consumeSseStream(std.testing.allocator, &reader, undefined, Noop.chunk, null, &cancel_flag);
+    defer deinitGatewayCompletion(std.testing.allocator, &completion);
+    // Explicit unavailability: no truncated signature is labeled replay-safe.
+    try std.testing.expect(completion.assistant_parts == null);
+}
+
+test "replay capture survives allocation failure without leaks" {
+    const payload =
+        "data: {\"type\":\"text-start\",\"id\":\"t1\"}\n\n" ++
+        "data: {\"type\":\"text-delta\",\"id\":\"t1\",\"delta\":\"alpha\"}\n\n" ++
+        "data: {\"type\":\"text-end\",\"id\":\"t1\"}\n\n" ++
+        "data: {\"type\":\"reasoning-start\",\"id\":\"r1\",\"providerMetadata\":{\"anthropic\":{\"signature\":\"sig_1\"}}}\n\n" ++
+        "data: {\"type\":\"reasoning-delta\",\"id\":\"r1\",\"delta\":\"beta\"}\n\n" ++
+        "data: {\"type\":\"reasoning-end\",\"id\":\"r1\"}\n\n" ++
+        "data: {\"type\":\"tool-call\",\"toolCallId\":\"call_1\",\"toolName\":\"lookup\",\"input\":\"{}\",\"providerMetadata\":{\"google\":{\"thoughtSignature\":\"ts_1\"}}}\n\n" ++
+        "data: {\"type\":\"finish\",\"finishReason\":{\"unified\":\"tool-calls\"}}\n\n";
+
+    const Noop = struct {
+        fn chunk(_: *anyopaque, _: []const u8) void {}
+    };
+
+    var fail_index: usize = 0;
+    while (fail_index < 400) {
+        var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = fail_index });
+        var reader = std.Io.Reader.fixed(payload);
+        var cancel_flag = std.atomic.Value(bool).init(false);
+        var completion = consumeSseStream(failing.allocator(), &reader, undefined, Noop.chunk, null, &cancel_flag) catch |err| {
+            try std.testing.expectEqual(error.OutOfMemory, err);
+            fail_index += 1;
+            continue;
+        };
+        deinitGatewayCompletion(std.testing.allocator, &completion);
+        break;
+    } else {
+        return error.TestUnexpectedResult;
+    }
+    try std.testing.expect(fail_index > 0);
 }
 
 test "consumeSseStream captures generation identity metadata" {
@@ -4358,18 +5028,8 @@ test "consumeSseStream serializes tool-call input that arrives as an object" {
         fn chunk(_: *anyopaque, _: []const u8) void {}
     };
 
-    const completion = try consumeSseStream(std.testing.allocator, &reader, undefined, Noop.chunk, null, &cancel_flag);
-    defer {
-        if (completion.content) |c| std.testing.allocator.free(c);
-        for (completion.tool_calls) |tc| {
-            std.testing.allocator.free(tc.id);
-            std.testing.allocator.free(tc.name);
-            std.testing.allocator.free(tc.arguments_json);
-            if (tc.provisional_id) |id| std.testing.allocator.free(id);
-            if (tc.provider_result) |pr| std.testing.allocator.free(pr);
-        }
-        std.testing.allocator.free(completion.tool_calls);
-    }
+    var completion = try consumeSseStream(std.testing.allocator, &reader, undefined, Noop.chunk, null, &cancel_flag);
+    defer deinitGatewayCompletion(std.testing.allocator, &completion);
 
     try std.testing.expectEqual(@as(usize, 1), completion.tool_calls.len);
     try std.testing.expect(completion.tool_calls[0].arguments_json.len > 0);

--- a/src/gateway/client.zig
+++ b/src/gateway/client.zig
@@ -228,9 +228,11 @@ pub const StreamResult = struct {
             alloc.free(call.arguments_json);
             if (call.provisional_id) |provisional_id| alloc.free(provisional_id);
             if (call.provider_result) |provider_result| alloc.free(provider_result);
+            if (call.provider_options_json) |options| alloc.free(options);
         }
         if (self.completion.tool_calls.len > 0) alloc.free(self.completion.tool_calls);
         if (self.completion.provider_failure_detail) |detail| alloc.free(@constCast(detail));
+        if (self.completion.assistant_parts) |parts| types.freeAssistantParts(alloc, parts);
         const status = self.status;
         self.* = .{ .status = status };
     }
@@ -2531,9 +2533,11 @@ fn deinitGatewayCompletion(alloc: std.mem.Allocator, completion: *types.ModelCom
         alloc.free(call.arguments_json);
         if (call.provisional_id) |provisional_id| alloc.free(provisional_id);
         if (call.provider_result) |provider_result| alloc.free(provider_result);
+        if (call.provider_options_json) |options| alloc.free(options);
     }
     if (completion.tool_calls.len > 0) alloc.free(completion.tool_calls);
     if (completion.provider_failure_detail) |detail| alloc.free(@constCast(detail));
+    if (completion.assistant_parts) |parts| types.freeAssistantParts(alloc, parts);
     completion.* = .{};
 }
 

--- a/src/gateway/host_stream_provider.zig
+++ b/src/gateway/host_stream_provider.zig
@@ -87,7 +87,7 @@ fn stream(raw: ?*anyopaque, alloc: Allocator, request: stream_provider.ModelRequ
         .{ .name = "HTTP-Referer", .value = "https://github.com/vercel-labs/fx" },
         .{ .name = "X-Title", .value = "fx" },
         .{ .name = "ai-gateway-protocol-version", .value = "0.0.1" },
-        .{ .name = "ai-language-model-specification-version", .value = "4" },
+        .{ .name = "ai-language-model-specification-version", .value = "3" },
         .{ .name = "ai-language-model-id", .value = request.model },
         .{ .name = "ai-language-model-streaming", .value = "true" },
     });

--- a/src/gateway/vercel_protocol.zig
+++ b/src/gateway/vercel_protocol.zig
@@ -382,10 +382,9 @@ fn buildGatewayRequestBodyValidated(
         try out.writer.print(",\"maxOutputTokens\":{d}", .{value});
     }
 
-    if (options.reasoning) |*reasoning| {
-        try out.writer.writeAll(",\"reasoning\":");
-        try std.json.Stringify.value(reasoning.label(), .{}, &out.writer);
-    }
+    // The v3 call-options schema has no top-level reasoning effort field; the
+    // user's effort preferences stay available through supported provider
+    // options rather than a root field the route discards.
     try writeProviderOptions(&out.writer, options);
 
     try out.writer.writeByte('}');
@@ -643,6 +642,13 @@ fn write_tool_result_group(
     try writer.writeAll("]}");
 }
 
+fn findToolCallByFinalId(tool_calls: []const ToolCall, id: []const u8) ?*const ToolCall {
+    for (tool_calls) |*tool_call| {
+        if (std.mem.eql(u8, tool_call.id, id)) return tool_call;
+    }
+    return null;
+}
+
 fn write_tool_result_part(scratch_alloc: std.mem.Allocator, writer: *std.Io.Writer, message: ChatMessage, ids: *const tool_call_ids.Projection) !void {
     try writer.writeAll("{\"type\":\"tool-result\",\"toolCallId\":");
     try std.json.Stringify.value(ids.resolve(message.tool_call_id orelse ""), .{}, writer);
@@ -672,7 +678,9 @@ fn write_tool_result_part(scratch_alloc: std.mem.Allocator, writer: *std.Io.Writ
             try std.json.Stringify.value(image.mime_type, .{}, writer);
             try writer.writeByte('}');
         }
-        try writer.writeAll("]}}");
+        try writer.writeAll("]}");
+        try write_tool_result_provider_options(scratch_alloc, writer, message);
+        try writer.writeByte('}');
         return;
     }
     if (denied) {
@@ -683,7 +691,19 @@ fn write_tool_result_part(scratch_alloc: std.mem.Allocator, writer: *std.Io.Writ
         try writer.writeAll(",\"output\":{\"type\":\"text\",\"value\":");
     }
     try std.json.Stringify.value(content, .{}, writer);
-    try writer.writeAll("}}");
+    try writer.writeByte('}');
+    try write_tool_result_provider_options(scratch_alloc, writer, message);
+    try writer.writeByte('}');
+}
+
+fn write_tool_result_provider_options(scratch_alloc: std.mem.Allocator, writer: *std.Io.Writer, message: ChatMessage) !void {
+    const memory = message.tool_result_memory orelse return;
+    const options = memory.provider_options_json orelse return;
+    types.validateProviderOptionsJson(scratch_alloc, options) catch {
+        return error.InvalidGatewayHistory;
+    };
+    try writer.writeAll(",\"providerOptions\":");
+    try writer.writeAll(options);
 }
 
 fn writeChatMessageJsonInner(
@@ -753,25 +773,88 @@ fn writeChatMessageJsonInner(
         },
         .assistant => {
             try writer.writeAll(",\"content\":[");
-            var wrote_part = false;
-            if (message.content) |content| {
-                if (content.len > 0) {
-                    try writer.writeAll("{\"type\":\"text\",\"text\":");
-                    try std.json.Stringify.value(content, .{}, writer);
+            if (message.assistant_parts) |parts| {
+                // A present part sequence is authoritative and emitted exactly
+                // once. References must resolve to the surviving canonical
+                // calls; invalid replay state fails the build explicitly.
+                types.validateAssistantParts(parts, message.tool_calls) catch {
+                    return error.InvalidGatewayHistory;
+                };
+                for (parts, 0..) |part, index| {
+                    if (index > 0) try writer.writeByte(',');
+                    switch (part) {
+                        .text => |text_part| {
+                            try writer.writeAll("{\"type\":\"text\",\"text\":");
+                            try std.json.Stringify.value(text_part.text, .{}, writer);
+                            if (text_part.provider_options) |options| {
+                                types.validateProviderOptionsJson(scratch_alloc, options) catch {
+                                    return error.InvalidGatewayHistory;
+                                };
+                                try writer.writeAll(",\"providerOptions\":");
+                                try writer.writeAll(options);
+                            }
+                            try writer.writeByte('}');
+                        },
+                        .reasoning => |reasoning_part| {
+                            try writer.writeAll("{\"type\":\"reasoning\",\"text\":");
+                            try std.json.Stringify.value(reasoning_part.text, .{}, writer);
+                            if (reasoning_part.provider_options) |options| {
+                                types.validateProviderOptionsJson(scratch_alloc, options) catch {
+                                    return error.InvalidGatewayHistory;
+                                };
+                                try writer.writeAll(",\"providerOptions\":");
+                                try writer.writeAll(options);
+                            }
+                            try writer.writeByte('}');
+                        },
+                        .tool_call_ref => |ref| {
+                            const tool_call = findToolCallByFinalId(message.tool_calls, ref.id) orelse
+                                return error.InvalidGatewayHistory;
+                            try writer.writeAll("{\"type\":\"tool-call\",\"toolCallId\":");
+                            try std.json.Stringify.value(ids.resolve(tool_call.id), .{}, writer);
+                            try writer.writeAll(",\"toolName\":");
+                            try std.json.Stringify.value(tool_call.name, .{}, writer);
+                            try writer.writeAll(",\"input\":");
+                            try writer.writeAll(tool_call.arguments_json);
+                            if (tool_call.provider_options_json) |options| {
+                                types.validateProviderOptionsJson(scratch_alloc, options) catch {
+                                    return error.InvalidGatewayHistory;
+                                };
+                                try writer.writeAll(",\"providerOptions\":");
+                                try writer.writeAll(options);
+                            }
+                            try writer.writeByte('}');
+                        },
+                    }
+                }
+            } else {
+                var wrote_part = false;
+                if (message.content) |content| {
+                    if (content.len > 0) {
+                        try writer.writeAll("{\"type\":\"text\",\"text\":");
+                        try std.json.Stringify.value(content, .{}, writer);
+                        try writer.writeByte('}');
+                        wrote_part = true;
+                    }
+                }
+                for (message.tool_calls) |tool_call| {
+                    if (wrote_part) try writer.writeByte(',');
+                    try writer.writeAll("{\"type\":\"tool-call\",\"toolCallId\":");
+                    try std.json.Stringify.value(ids.resolve(tool_call.id), .{}, writer);
+                    try writer.writeAll(",\"toolName\":");
+                    try std.json.Stringify.value(tool_call.name, .{}, writer);
+                    try writer.writeAll(",\"input\":");
+                    try writer.writeAll(tool_call.arguments_json);
+                    if (tool_call.provider_options_json) |options| {
+                        types.validateProviderOptionsJson(scratch_alloc, options) catch {
+                            return error.InvalidGatewayHistory;
+                        };
+                        try writer.writeAll(",\"providerOptions\":");
+                        try writer.writeAll(options);
+                    }
                     try writer.writeByte('}');
                     wrote_part = true;
                 }
-            }
-            for (message.tool_calls) |tool_call| {
-                if (wrote_part) try writer.writeByte(',');
-                try writer.writeAll("{\"type\":\"tool-call\",\"toolCallId\":");
-                try std.json.Stringify.value(ids.resolve(tool_call.id), .{}, writer);
-                try writer.writeAll(",\"toolName\":");
-                try std.json.Stringify.value(tool_call.name, .{}, writer);
-                try writer.writeAll(",\"input\":");
-                try writer.writeAll(tool_call.arguments_json);
-                try writer.writeByte('}');
-                wrote_part = true;
             }
             try writer.writeByte(']');
         },
@@ -1209,6 +1292,130 @@ test "writeChatMessageJson maps tool result status to the Vercel output variant"
     }
 }
 
+test "writeChatMessageJson replays ordered assistant parts with per-part providerOptions" {
+    const calls = [_]ToolCall{.{
+        .id = "call_1",
+        .name = "lookup",
+        .arguments_json = "{\"query\":\"example\"}",
+        .provider_options_json = "{\"google\":{\"thoughtSignature\":\"ts_1\"}}",
+    }};
+    const parts = [_]types.AssistantPart{
+        .{ .text = .{ .text = "Checking.", .provider_options = "{\"testprovider\":{\"note\":\"n1\"}}" } },
+        .{ .reasoning = .{ .text = "Let me check.", .provider_options = "{\"anthropic\":{\"signature\":\"sig_1\"}}" } },
+        .{ .tool_call_ref = .{ .id = "call_1" } },
+        .{ .reasoning = .{ .text = "", .provider_options = "{\"anthropic\":{\"redactedData\":\"red_1\"}}" } },
+    };
+    var out: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer out.deinit();
+
+    // The display string derives from text and must not merge into or replace
+    // the authoritative part sequence.
+    try writeChatMessageJson(std.testing.allocator, &out.writer, .{
+        .role = .assistant,
+        .content = "Checking.",
+        .tool_calls = &calls,
+        .assistant_parts = &parts,
+    });
+
+    try std.testing.expectEqualStrings(
+        "{\"role\":\"assistant\",\"content\":[" ++
+            "{\"type\":\"text\",\"text\":\"Checking.\",\"providerOptions\":{\"testprovider\":{\"note\":\"n1\"}}}," ++
+            "{\"type\":\"reasoning\",\"text\":\"Let me check.\",\"providerOptions\":{\"anthropic\":{\"signature\":\"sig_1\"}}}," ++
+            "{\"type\":\"tool-call\",\"toolCallId\":\"call_1\",\"toolName\":\"lookup\",\"input\":{\"query\":\"example\"},\"providerOptions\":{\"google\":{\"thoughtSignature\":\"ts_1\"}}}," ++
+            "{\"type\":\"reasoning\",\"text\":\"\",\"providerOptions\":{\"anthropic\":{\"redactedData\":\"red_1\"}}}" ++
+            "]}",
+        out.written(),
+    );
+}
+
+test "writeChatMessageJson rejects stale and duplicate tool-call references" {
+    const calls = [_]ToolCall{.{ .id = "call_1", .name = "lookup", .arguments_json = "{}" }};
+    const stale = [_]types.AssistantPart{.{ .tool_call_ref = .{ .id = "gone" } }};
+    const duplicate = [_]types.AssistantPart{
+        .{ .tool_call_ref = .{ .id = "call_1" } },
+        .{ .tool_call_ref = .{ .id = "call_1" } },
+    };
+    const provisional_only = [_]types.AssistantPart{.{ .tool_call_ref = .{ .id = "call_1" } }};
+    const provisional_calls = [_]ToolCall{.{
+        .id = "call_1",
+        .name = "lookup",
+        .arguments_json = "{}",
+        .final_identity = .wrong_type,
+    }};
+
+    var out: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer out.deinit();
+    try std.testing.expectError(error.InvalidGatewayHistory, writeChatMessageJson(std.testing.allocator, &out.writer, .{
+        .role = .assistant,
+        .tool_calls = &calls,
+        .assistant_parts = &stale,
+    }));
+    try std.testing.expectError(error.InvalidGatewayHistory, writeChatMessageJson(std.testing.allocator, &out.writer, .{
+        .role = .assistant,
+        .tool_calls = &calls,
+        .assistant_parts = &duplicate,
+    }));
+    // A reference never resolves to a call without a valid final identity.
+    try std.testing.expectError(error.InvalidGatewayHistory, writeChatMessageJson(std.testing.allocator, &out.writer, .{
+        .role = .assistant,
+        .tool_calls = &provisional_calls,
+        .assistant_parts = &provisional_only,
+    }));
+}
+
+test "writeChatMessageJson emits a present empty part sequence without display fallback" {
+    var out: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer out.deinit();
+    try writeChatMessageJson(std.testing.allocator, &out.writer, .{
+        .role = .assistant,
+        .content = "Done.",
+        .assistant_parts = &.{},
+    });
+    try std.testing.expectEqualStrings("{\"role\":\"assistant\",\"content\":[]}", out.written());
+}
+
+test "writeChatMessageJson writes tool-result providerOptions for text, error, and denial outputs" {
+    const denial = "{\"error\":{\"type\":\"tool_permission_denied\",\"reason\":\"policy_denied\"}}";
+    const cases = [_]struct {
+        status: types.PersistedToolStatus,
+        content: []const u8,
+        output_type: []const u8,
+    }{
+        .{ .status = .success, .content = "ordinary result", .output_type = "text" },
+        .{ .status = .failure, .content = "ordinary failure", .output_type = "error-text" },
+        .{ .status = .failure, .content = denial, .output_type = "execution-denied" },
+    };
+    for (cases) |case| {
+        var out: std.Io.Writer.Allocating = .init(std.testing.allocator);
+        defer out.deinit();
+        try writeChatMessageJson(std.testing.allocator, &out.writer, .{
+            .role = .tool,
+            .content = case.content,
+            .tool_call_id = "call_1",
+            .tool_name = "terminal",
+            .tool_result_status = case.status,
+            .tool_result_memory = .{ .provider_options_json = "{\"gateway\":{\"resultNote\":\"rn_1\"}}" },
+        });
+        var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, out.written(), .{});
+        defer parsed.deinit();
+        const result = parsed.value.object.get("content").?.array.items[0].object;
+        try std.testing.expectEqualStrings(case.output_type, result.get("output").?.object.get("type").?.string);
+        const options = result.get("providerOptions").?.object;
+        try std.testing.expectEqualStrings("rn_1", options.get("gateway").?.object.get("resultNote").?.string);
+    }
+
+    // Malformed replay metadata fails the build explicitly.
+    var out: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer out.deinit();
+    try std.testing.expectError(error.InvalidGatewayHistory, writeChatMessageJson(std.testing.allocator, &out.writer, .{
+        .role = .tool,
+        .content = "ordinary result",
+        .tool_call_id = "call_1",
+        .tool_name = "terminal",
+        .tool_result_memory = .{ .provider_options_json = "[1,2]" },
+    }));
+}
+
 test "Gateway automatic caching preserves transient context and grouped tool results" {
     const alloc = std.testing.allocator;
     const calls = [_]ToolCall{
@@ -1274,7 +1481,9 @@ test "buildGatewayRequestBodyWithOptions keeps Anthropic default silent and name
     defer alloc.free(named_body);
     var named_parsed = try std.json.parseFromSlice(std.json.Value, alloc, named_body, .{});
     defer named_parsed.deinit();
-    try std.testing.expectEqualStrings("future-tier", named_parsed.value.object.get("reasoning").?.string);
+    // v3 has no top-level reasoning field: named effort is never emitted at
+    // the root of the request.
+    try std.testing.expect(named_parsed.value.object.get("reasoning") == null);
     try std.testing.expect(named_parsed.value.object.get("providerOptions") == null);
 }
 
@@ -1358,7 +1567,11 @@ test "pending tool review closes the exact assistant step with synthetic pending
     const user_index = std.mem.find(u8, body, "\"role\":\"user\"").?;
     try std.testing.expect(system_index < user_index);
     try std.testing.expect(std.mem.find(u8, body, "\"maxOutputTokens\":2048") != null);
-    try std.testing.expect(std.mem.find(u8, body, "\"reasoning\":\"minimal\"") != null);
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, body, .{});
+    defer parsed.deinit();
+    // v3 has no top-level reasoning field; part-level providerOptions are the
+    // only reasoning carrier, so a whole-body search would be incorrect.
+    try std.testing.expect(parsed.value.object.get("reasoning") == null);
     try std.testing.expectError(
         error.InvalidGatewayHistory,
         buildGatewayRequestBody(std.testing.allocator, "[]", &messages),
@@ -1468,7 +1681,7 @@ test "buildGatewayRequestBodyWithOptions serializes Gateway Fast provider option
 
     var parsed = try std.json.parseFromSlice(std.json.Value, alloc, body, .{});
     defer parsed.deinit();
-    try std.testing.expectEqualStrings("future-tier", parsed.value.object.get("reasoning").?.string);
+    try std.testing.expect(parsed.value.object.get("reasoning") == null);
     try std.testing.expect(parsed.value.object.get("fast") == null);
     const provider_options = parsed.value.object.get("providerOptions").?;
     const gateway = provider_options.object.get("gateway").?;

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -4027,8 +4027,8 @@ describe("cli: ask success", () => {
         expect(JSON.parse(result.stdout).output.trim()).toBe("portable ask complete");
         expect(gateway.requests).toHaveLength(1);
         const request = JSON.parse(gateway.requests[0]!.body);
+        expect(request).not.toHaveProperty("reasoning");
         expect(request).toMatchObject({
-          reasoning: "high",
           maxOutputTokens: 64_000,
         });
         expect(gateway.modelRequests).toHaveLength(1);
@@ -4037,7 +4037,7 @@ describe("cli: ask success", () => {
           gateway.requests[0]!.headers.get(
             "ai-language-model-specification-version",
           ),
-        ).toBe("4");
+        ).toBe("3");
       } finally {
         gateway.stop();
         rmSync(root, { recursive: true, force: true });

--- a/tests/e2e/config-persistence.test.ts
+++ b/tests/e2e/config-persistence.test.ts
@@ -1116,8 +1116,8 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
         expect(gateway.requests[1]!.headers.get("authorization")).toBe(
           "Bearer fake-capability-key",
         );
+        expect(JSON.parse(gateway.requests[1]!.body)).not.toHaveProperty("reasoning");
         expect(JSON.parse(gateway.requests[1]!.body)).toMatchObject({
-          reasoning: "max",
           providerOptions: { gateway: { speed: "fast" } },
         });
         expect(JSON.parse(gateway.requests[1]!.body)).not.toHaveProperty("fast");
@@ -1343,7 +1343,7 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
           gateway.requests[0]!.headers.get(
             "ai-language-model-specification-version",
           ),
-        ).toBe("4");
+        ).toBe("3");
         expect(JSON.parse(gateway.requests[0]!.body)).not.toHaveProperty("reasoning");
 
         await session.sendLiteral("/model new-reasoning");
@@ -1373,10 +1373,8 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
           gateway.requests[1]!.headers.get(
             "ai-language-model-specification-version",
           ),
-        ).toBe("4");
-        expect(JSON.parse(gateway.requests[1]!.body)).toMatchObject({
-          reasoning: "future-tier",
-        });
+        ).toBe("3");
+        expect(JSON.parse(gateway.requests[1]!.body)).not.toHaveProperty("reasoning");
         expect(JSON.parse(gateway.requests[1]!.body).providerOptions).toEqual({
           gateway: { caching: "auto" },
         });

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -740,6 +740,144 @@ describe("gateway stream lifecycle", () => {
     }
   }, 45_000);
 
+  test("gateway reasoning parts survive tool continuation and saved-session resume", async () => {
+    const root = createFixtureRoot("reasoning-replay");
+    writeFileSync(join(root.workspace, "note.txt"), "NOTE_CONTENT_SENTINEL\n");
+    const tracePath = join(root.root, "trace.log");
+
+    const SIGNATURE = "sig_step_1";
+    const REDACTED = "redacted_blob_1";
+    const THOUGHT_SIGNATURE = "thought_sig_1";
+    const ENCRYPTED = "enc_final_1";
+    const ITEM_ID = "rs_final_1";
+
+    // The tool continuation must carry the first response's ordered parts, and
+    // the resumed request must carry them again from durable history.
+    const expectStepParts = (body: string) => {
+      const request = gatewayRequest(body);
+      expect(request).not.toHaveProperty("reasoning");
+      const assistant = request.prompt.find((message) => message.role === "assistant");
+      expect(assistant).toBeDefined();
+      const content = assistant!.content as Array<Record<string, unknown>>;
+      expect(Array.isArray(content)).toBe(true);
+      expect(content.map((part) => part.type)).toEqual([
+        "text",
+        "reasoning",
+        "tool-call",
+        "reasoning",
+      ]);
+      expect(content[0]).toEqual({ type: "text", text: "Reading the note." });
+      expect(content[1]).toEqual({
+        type: "reasoning",
+        text: "The note has the answer.",
+        providerOptions: { anthropic: { signature: SIGNATURE } },
+      });
+      expect(content[2]).toMatchObject({
+        type: "tool-call",
+        toolCallId: "call_read_1",
+        toolName: "read_file",
+        input: { path: "note.txt" },
+        providerOptions: { google: { thoughtSignature: THOUGHT_SIGNATURE } },
+      });
+      expect(content[3]).toEqual({
+        type: "reasoning",
+        text: "",
+        providerOptions: { anthropic: { redactedData: REDACTED } },
+      });
+      expect(toolResultOutput(body, "call_read_1")).toContain("NOTE_CONTENT_SENTINEL");
+    };
+    // The final answer's parts, retained on the completed turn.
+    const expectFinalParts = (body: string) => {
+      const request = gatewayRequest(body);
+      const assistants = request.prompt.filter((message) => message.role === "assistant");
+      const last = assistants[assistants.length - 1]!;
+      const content = last.content as Array<Record<string, unknown>>;
+      expect(content.map((part) => part.type)).toEqual(["reasoning", "text"]);
+      expect(content[0]).toEqual({
+        type: "reasoning",
+        text: "The answer is known.",
+        providerOptions: { openai: { reasoningEncryptedContent: ENCRYPTED, itemId: ITEM_ID } },
+      });
+      expect(content[1]).toEqual({ type: "text", text: "The note says hello." });
+    };
+
+    let index = 0;
+    const gateway = startDynamicFakeGateway((body) => {
+      switch (index++) {
+        case 0:
+          return fakeGatewaySse([
+            { type: "text-start", id: "t1" },
+            { type: "text-delta", id: "t1", delta: "Reading the note." },
+            { type: "text-end", id: "t1" },
+            { type: "reasoning-start", id: "r1" },
+            { type: "reasoning-delta", id: "r1", delta: "The note has the answer." },
+            { type: "reasoning-delta", id: "r1", delta: "", providerMetadata: { anthropic: { signature: SIGNATURE } } },
+            { type: "reasoning-end", id: "r1" },
+            {
+              type: "tool-call",
+              toolCallId: "call_read_1",
+              toolName: "read_file",
+              input: { path: "note.txt" },
+              providerMetadata: { google: { thoughtSignature: THOUGHT_SIGNATURE } },
+            },
+            { type: "reasoning-start", id: "r2", providerMetadata: { anthropic: { redactedData: REDACTED } } },
+            { type: "reasoning-end", id: "r2" },
+            { type: "finish", finishReason: { unified: "tool-calls", raw: "tool_use" } },
+          ]);
+        case 1:
+          expectStepParts(body);
+          return fakeGatewaySse([
+            { type: "reasoning-start", id: "r3" },
+            { type: "reasoning-delta", id: "r3", delta: "The answer is known." },
+            { type: "reasoning-end", id: "r3", providerMetadata: { openai: { reasoningEncryptedContent: ENCRYPTED, itemId: ITEM_ID } } },
+            { type: "text-start", id: "t2" },
+            { type: "text-delta", id: "t2", delta: "The note says hello." },
+            { type: "text-end", id: "t2" },
+            { type: "finish", finishReason: { unified: "stop", raw: "stop" }, usage: { inputTokens: { total: 8 }, outputTokens: { total: 6 } } },
+          ]);
+        case 2:
+          expectStepParts(body);
+          expectFinalParts(body);
+          return fakeGatewayFinalText("Resumed answer.");
+        default:
+          return new Response("unexpected request", { status: 500 });
+      }
+    }, { models: [{ id: MODEL, type: "language", tags: ["tool-use"], context_window: 100_000 }] });
+
+    try {
+      const result = await runFx(["ask", "--auto", "--json", "Read note.txt and tell me what it says."], {
+        cwd: root.workspace, env: fixtureEnv(root, gateway, tracePath), timeoutMs: 30_000,
+      });
+      if (result.code !== 0) throw new Error(`Reasoning replay flow failed: ${result.stderr}\n${result.stdout}`);
+      const output = parseAskJson(result.stdout);
+      expect(output.exit_code).toBe(0);
+      expect(output.session_id).not.toBe("");
+      expect(output.tool_calls).toEqual([{ name: "read_file", status: "success" }]);
+      expect(gateway.requestCount()).toBe(2);
+      expect(result.stderr).not.toContain("panic");
+
+      const resumed = await runFx(["ask", "--auto", "--json", "--resume-id", output.session_id, "Tell me again."], {
+        cwd: root.workspace, env: fixtureEnv(root, gateway, tracePath), timeoutMs: 30_000,
+      });
+      if (resumed.code !== 0) throw new Error(`Reasoning replay resume failed: ${resumed.stderr}\n${resumed.stdout}`);
+      expect(resumed.code).toBe(0);
+      expect(parseAskJson(resumed.stdout).exit_code).toBe(0);
+      expect(gateway.requestCount()).toBe(3);
+
+      // The durable conversation log holds the parts for the next process.
+      const eventsLog = readFileSync(
+        join(root.home, ".fx", "sessions", output.session_id, "events.jsonl"),
+        "utf8",
+      );
+      expect(eventsLog).toContain(SIGNATURE);
+      expect(eventsLog).toContain(REDACTED);
+      expect(eventsLog).toContain(ENCRYPTED);
+    } finally {
+      gateway.stop();
+      rmSync(root.root, { recursive: true, force: true });
+    }
+  }, 45_000);
+
   test.skipIf(!tmuxAvailable())("explicit skill context survives cancellation and a fresh turn", async () => {
     const root = createFixtureRoot("skill-cancel-recover");
     const directory = join(root.workspace, ".agents", "skills", "cancel-workflow");

--- a/tests/e2e/web-search-fake-gateway.test.ts
+++ b/tests/e2e/web-search-fake-gateway.test.ts
@@ -793,8 +793,8 @@ describe("web_search Gateway fixture", () => {
         expect(gateway.requests[0].body).toContain('"name":"exa_search"');
         expect(gateway.requests[0].body).not.toContain('"name":"perplexity_search"');
         expect(gateway.requests[0].body).not.toContain('"name":"parallel_search"');
-        expect(JSON.parse(gateway.requests[0].body)).toMatchObject({ reasoning: "high" });
-        expect(JSON.parse(gateway.requests[1].body)).toMatchObject({ reasoning: "high" });
+        expect(JSON.parse(gateway.requests[0].body)).not.toHaveProperty("reasoning");
+        expect(JSON.parse(gateway.requests[1].body)).not.toHaveProperty("reasoning");
         expect(gateway.requests[0].body).not.toContain('"thinking"');
         expect(gateway.requests[1].body).not.toContain('"thinking"');
       } finally {


### PR DESCRIPTION
## Summary

On the `/v3/ai/language-model` endpoint, fx forwarded reasoning text to the display but dropped it from the conversation: reasoning blocks, their provider metadata (signatures, redacted or encrypted state, item IDs, thought signatures), and part ordering were lost after tool calls, on later user turns, and across save/resume. fx also sent specification header `4` to the v3 route and emitted a top-level `reasoning` field that the v3 call-options schema discards.

This change preserves supported assistant reasoning parts, their order, and their replay metadata through the v3 stream, the owned completion, the next tool-loop request, durable history, and resumed sessions.

## What changed

- **Decode:** the shared SSE decoder accumulates text/reasoning blocks by stream ID with latest-snapshot metadata semantics — including metadata-only blocks and signatures carried on empty deltas — and captures tool-call and final-result metadata at their own scopes. Retained state is bounded; oversized or unattributable capture discards the sequence explicitly rather than truncating signed content.
- **Serialize:** assistant messages emit the ordered parts with per-part `providerOptions` when present, and keep the existing text/tool projection otherwise. References to tool calls are validated against the surviving calls.
- **Runtime:** parts flow through tool loops, steering, stop-hook and silent continuations, and the final answer. Call filtering remaps ordered references with the selected calls in the same pass, and projections that rewrite calls or text detach signed state instead of replaying altered content. Response-language rejection clears parts with content. Failed, interrupted, or length-limited attempts do not retain partial replay state.
- **Persistence:** the conversation event log carries parts on assistant events (omitted when absent) and call/result metadata on their own events; the shared session codec, recovery checkpoints, kernel checkpoints, and the JS host store round-trip them as optional fields with no schema bump. Old records load with replay state absent; unknown envelope keys stay rejected; stale references fail strictly.
- **Retention policy:** provider signatures and ciphertext are opaque protocol state — retained exactly, never logged, never normalized. Any transform that would alter part content (secret masking, argument rewrites, compaction) marks the replay unit unavailable and the message falls back to the legacy projection.
- **Protocol:** native and host streaming and the retained non-streaming helper send specification header `3` on the v3 route; the unsupported top-level `reasoning` field is no longer emitted. Effort preferences are unchanged and remain available through supported provider options. Direct Codex/Grok paths are unchanged.

## Test plan

- New unit/integration coverage: a decode-to-replay fixture; decoder tests for metadata-only blocks, end-event metadata, malformed and unattributable lifecycle events, capture bounds, and allocation-failure cleanup; serializer tests for ordered replay, per-part option scopes, and stale/duplicate reference rejection; a runtime tool-loop test inspecting the continuation request body; redaction-collision policy tests; conversation-log and shared-codec round trips including old shapes; kernel-checkpoint round trip.
- New e2e in `tests/e2e/gateway-stream-lifecycle.test.ts` (inherits the file's existing PGSO classification): a tool loop whose continuation request carries the exact retained parts, followed by a fresh-process resume that sends them again.
- Updated header/effort assertions in `cli.test.ts`, `config-persistence.test.ts`, and `web-search-fake-gateway.test.ts`.
- Verified locally: focused `zig build test` scopes in Debug and ReleaseSafe, `zig build -Doptimize=ReleaseSafe`, `scripts/check-public-surface.sh`, and the lifecycle/CLI/web-search e2e files against the built binary.

Draft until Full CI passes on this exact commit on all four runners and the ship gate reports SHIP.
