### PR TITLE
Reject null libfx backend selectors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,12 @@ jobs:
           node --experimental-wasm-jspi sdk/tests/test-packed-example.mjs /tmp/libfx-package.tgz wasm esm
           node --experimental-wasm-jspi --no-experimental-require-module sdk/tests/test-packed-example.mjs /tmp/libfx-package.tgz wasm cjs
 
+      - name: Test package recovery and lifecycle boundaries
+        run: |
+          node sdk/tests/test-package-resilience.mjs --package /tmp/libfx-package.tgz \
+            --cheap-cycles 100 --tool-workflows 20 --duration-ms 5000 --concurrency 4 \
+            --json-out "${{ runner.temp }}/libfx-package-evidence/resilience.json"
+
       - name: Install Next fixture package manager
         run: npm install --global pnpm@11.1.1
 
@@ -210,12 +216,13 @@ jobs:
           LIBFX_TEST_ARTIFACT_ROOT: ${{ runner.temp }}/libfx-package-evidence
         run: node sdk/tests/test-next-package.mjs /tmp/libfx-package.tgz
 
-      - name: Retain Next package evidence
+      - name: Retain package qualification evidence
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: libfx-next-package-evidence
           path: |
+            ${{ runner.temp }}/libfx-package-evidence/resilience.json
             ${{ runner.temp }}/libfx-package-evidence/libfx-next-*/*.log
             ${{ runner.temp }}/libfx-package-evidence/libfx-next-*/results.json
           if-no-files-found: ignore

--- a/.github/workflows/publish-libfx.yml
+++ b/.github/workflows/publish-libfx.yml
@@ -304,6 +304,12 @@ jobs:
           node --experimental-wasm-jspi sdk/tests/test-backend-info.mjs
           node sdk/tests/test-term-demo-package.mjs
 
+      - name: Test package recovery and lifecycle boundaries
+        run: |
+          node sdk/tests/test-package-resilience.mjs --package libfx-package.tgz \
+            --cheap-cycles 100 --tool-workflows 20 --duration-ms 5000 --concurrency 4 \
+            --json-out "${{ runner.temp }}/libfx-package-evidence/resilience.json"
+
       - name: Test Next development, production and isolated output
         env:
           LIBFX_TEST_ARTIFACT_ROOT: ${{ runner.temp }}/libfx-package-evidence
@@ -315,6 +321,7 @@ jobs:
         with:
           name: libfx-package-evidence
           path: |
+            ${{ runner.temp }}/libfx-package-evidence/resilience.json
             ${{ runner.temp }}/libfx-package-evidence/libfx-next-*/*.log
             ${{ runner.temp }}/libfx-package-evidence/libfx-next-*/results.json
           if-no-files-found: ignore

--- a/sdk/NAPI.md
+++ b/sdk/NAPI.md
@@ -274,6 +274,11 @@ deployment output. Failed package qualification blocks publication. Next
 logs and structured results are retained as workflow artifacts, including
 on failure.
 
+CI and publication also run the package resilience matrix with a bounded
+lifecycle, tool, and concurrent workload. Longer soak runs remain manual.
+The Next and Vercel harnesses retain completed scenarios and structured errors
+when qualification fails, and report success only after cleanup succeeds.
+
 Live Vercel qualification is a separate release check. Run
 `node sdk/tests/test-vercel-package.mjs <tarball>` before publication, then run
 the same command with the immutable npm version afterward. Set

--- a/sdk/node.js
+++ b/sdk/node.js
@@ -246,11 +246,10 @@ function validateBackendInfoOptions(value) {
       throw new TypeError(`getBackendInfo() does not accept ${key}`);
     }
   }
-  const surface = options.surface ?? "agent";
+  const { surface = "agent", backend = "auto" } = options;
   if (!new Set(["agent", "terminal"]).has(surface)) {
     throw new TypeError('surface must be "agent" or "terminal"');
   }
-  const backend = options.backend ?? "auto";
   if (!new Set(["auto", "native", "wasm"]).has(backend)) {
     throw new TypeError('backend must be "auto", "native", or "wasm"');
   }

--- a/sdk/node.js
+++ b/sdk/node.js
@@ -240,22 +240,21 @@ function validateBackendInfoOptions(value) {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     throw new TypeError("getBackendInfo() options must be an object");
   }
-  const options = { ...value };
+  const { nativeAddon, backend = "auto", surface = "agent", ...options } = value;
   for (const key of Object.keys(options)) {
-    if (!new Set(["surface", "backend", "nativeAddon", "wasm"]).has(key)) {
+    if (key !== "wasm") {
       throw new TypeError(`getBackendInfo() does not accept ${key}`);
     }
   }
-  const { surface = "agent", backend = "auto" } = options;
   if (!new Set(["agent", "terminal"]).has(surface)) {
     throw new TypeError('surface must be "agent" or "terminal"');
   }
   if (!new Set(["auto", "native", "wasm"]).has(backend)) {
     throw new TypeError('backend must be "auto", "native", or "wasm"');
   }
-  if (Object.hasOwn(options, "nativeAddon") && options.nativeAddon !== undefined && options.nativeAddon !== false &&
-    typeof options.nativeAddon !== "string" && !(options.nativeAddon instanceof URL) &&
-    (typeof options.nativeAddon !== "object" || options.nativeAddon === null)) {
+  if (nativeAddon !== undefined && nativeAddon !== false &&
+    typeof nativeAddon !== "string" && !(nativeAddon instanceof URL) &&
+    (typeof nativeAddon !== "object" || nativeAddon === null)) {
     throw new TypeError("nativeAddon must be a module, path, URL, false, or undefined");
   }
   const validWasm = options.wasm === undefined || typeof options.wasm === "string" || options.wasm instanceof URL ||
@@ -264,7 +263,7 @@ function validateBackendInfoOptions(value) {
   if (Object.hasOwn(options, "wasm") && !validWasm) {
     throw new TypeError("wasm must be a URL, Response, ArrayBuffer, typed array, or WebAssembly.Module");
   }
-  return { ...options, surface, backend };
+  return { ...options, surface, backend, nativeAddon };
 }
 
 export async function getBackendInfo(value = {}) {

--- a/sdk/tests/package-report.mjs
+++ b/sdk/tests/package-report.mjs
@@ -1,0 +1,10 @@
+export function serializeError(error) {
+  if (error == null) return null;
+  return {
+    name: error.name,
+    code: error.code ?? null,
+    message: error.message,
+    stack: error.stack,
+    ...(error instanceof AggregateError ? { errors: error.errors.map(serializeError) } : {}),
+  };
+}

--- a/sdk/tests/test-backend-info.mjs
+++ b/sdk/tests/test-backend-info.mjs
@@ -40,9 +40,16 @@ const matchingTerminal = {
 };
 
 try {
-  for (const options of [null, [], 1, { surface: "browser" }, { backend: "other" }, { nativeAddon: true }]) {
+  for (const options of [null, [], 1, { surface: "browser" }, { surface: null }, { backend: "other" }, { backend: null }, { nativeAddon: true }]) {
     await assert.rejects(getBackendInfo(options), TypeError);
   }
+
+  const defaults = await getBackendInfo({ nativeAddon: matchingCore });
+  assert.deepEqual(await getBackendInfo({ surface: undefined, backend: undefined, nativeAddon: matchingCore }), defaults);
+  assert.deepEqual(await getBackendInfo({ surface: "agent", backend: "auto", nativeAddon: matchingCore }), defaults);
+  const backendError = { name: "TypeError", message: 'backend must be "auto", "native", or "wasm"' };
+  await assert.rejects(createFxAgent({ backend: null }), backendError);
+  await assert.rejects(createFxTerminal({ backend: null }), backendError);
 
   assert.deepEqual(await getBackendInfo({ backend: "native", nativeAddon: matchingCore }), {
     surface: "agent",

--- a/sdk/tests/test-next-package.mjs
+++ b/sdk/tests/test-next-package.mjs
@@ -9,6 +9,7 @@ import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { serializeError } from "./package-report.mjs";
 
 const tarball = resolve(process.argv[2]);
 const artifactRoot = process.env.LIBFX_TEST_ARTIFACT_ROOT || tmpdir();
@@ -21,6 +22,7 @@ const env = { ...process.env, NODE_OPTIONS: "", NODE_PATH: "", NEXT_TELEMETRY_DI
   LIBFX_LIVE: "0", LIBFX_SMOKE_TOKEN: token, LIBFX_TEST_MODEL: "" };
 const servers = new Set();
 const results = [];
+let failure;
 
 async function run(command, args, cwd, name) {
   const log = createWriteStream(resolve(root, `${name}.log`));
@@ -124,9 +126,19 @@ try {
   const standalone = await start(isolated, [resolve(isolated, "server.js")], "standalone");
   await exercise(standalone, "standalone");
   await stop(standalone);
-  await writeFile(resolve(root, "results.json"), JSON.stringify({ node: process.version, tarball, results }, null, 2));
-  console.log(`Next package integration passed: ${root}`);
+} catch (error) {
+  failure = error;
 } finally {
-  for (const server of servers) await stop(server);
+  for (const server of servers) {
+    try { await stop(server); }
+    catch (error) { failure = failure ? new AggregateError([failure, error], "Verification and cleanup failed") : error; }
+  }
+  await writeFile(resolve(root, "results.json"), JSON.stringify({
+    node: process.version, tarball, results,
+    status: failure ? "failed" : "passed",
+    error: serializeError(failure),
+  }, null, 2));
   console.log(`Next package evidence: ${root}`);
 }
+if (failure) throw failure;
+console.log(`Next package integration passed: ${root}`);

--- a/sdk/tests/test-packed-example.mjs
+++ b/sdk/tests/test-packed-example.mjs
@@ -38,15 +38,32 @@ if (process.argv[2] !== "--installed") {
   assert.equal(typeof createMcpAdapter, "function");
   assert.equal(typeof createSkillsAdapter, "function");
 
-  for (const invalid of [null, false, 0, "", "other"]) {
-    await assert.rejects(getBackendInfo({ backend: invalid }), TypeError);
-    await assert.rejects(getBackendInfo({ surface: invalid }), TypeError);
-    const backendError = { name: "TypeError", message: 'backend must be "auto", "native", or "wasm"' };
-    await assert.rejects(createFxAgent({ backend: invalid }), backendError);
-    await assert.rejects(createFxTerminal({ backend: invalid }), backendError);
+  for (const makeOptions of [
+    (key, value) => ({ [key]: value }),
+    (key, value) => Object.create({ [key]: value }),
+    (key, value) => Object.defineProperty({}, key, { value }),
+  ]) {
+    for (const invalid of [null, false, 0, "", "other"]) {
+      await assert.rejects(getBackendInfo(makeOptions("backend", invalid)), TypeError);
+      await assert.rejects(getBackendInfo(makeOptions("surface", invalid)), TypeError);
+      const backendError = { name: "TypeError", message: 'backend must be "auto", "native", or "wasm"' };
+      await assert.rejects(createFxAgent(makeOptions("backend", invalid)), backendError);
+      await assert.rejects(createFxTerminal(makeOptions("backend", invalid)), backendError);
+    }
+    for (const value of [undefined, "auto", "native", "wasm"]) {
+      assert.deepEqual(await getBackendInfo(makeOptions("backend", value)), await getBackendInfo({ backend: value }));
+    }
+    assert.deepEqual(await getBackendInfo(makeOptions("surface", undefined)), await getBackendInfo());
+    assert.deepEqual(await getBackendInfo(makeOptions("nativeAddon", false)), await getBackendInfo({ nativeAddon: false }));
   }
   assert.deepEqual(await getBackendInfo({ backend: undefined, surface: undefined }), await getBackendInfo());
   assert.deepEqual(await getBackendInfo({ backend: "auto", surface: "agent" }), await getBackendInfo());
+  for (const select of [getBackendInfo, createFxAgent, createFxTerminal]) {
+    let reads = 0;
+    const options = { backend: "native", get nativeAddon() { reads++; this.backend = null; } };
+    await assert.rejects(select(options), { name: "TypeError", message: 'backend must be "auto", "native", or "wasm"' });
+    assert.equal(reads, 1);
+  }
 
   let requestedAuthorization;
   let requestedModel;

--- a/sdk/tests/test-packed-example.mjs
+++ b/sdk/tests/test-packed-example.mjs
@@ -32,11 +32,21 @@ if (process.argv[2] !== "--installed") {
     await rm(temp, { recursive: true, force: true });
   }
 } else {
-  const { createFxAgent } = format === "cjs" ? createRequire(import.meta.url)("libfx") : await import("libfx");
+  const { createFxAgent, createFxTerminal, getBackendInfo } = format === "cjs" ? createRequire(import.meta.url)("libfx") : await import("libfx");
   const { createMcpAdapter } = await import("libfx/mcp");
   const { createSkillsAdapter } = await import("libfx/skills");
   assert.equal(typeof createMcpAdapter, "function");
   assert.equal(typeof createSkillsAdapter, "function");
+
+  for (const invalid of [null, false, 0, "", "other"]) {
+    await assert.rejects(getBackendInfo({ backend: invalid }), TypeError);
+    await assert.rejects(getBackendInfo({ surface: invalid }), TypeError);
+    const backendError = { name: "TypeError", message: 'backend must be "auto", "native", or "wasm"' };
+    await assert.rejects(createFxAgent({ backend: invalid }), backendError);
+    await assert.rejects(createFxTerminal({ backend: invalid }), backendError);
+  }
+  assert.deepEqual(await getBackendInfo({ backend: undefined, surface: undefined }), await getBackendInfo());
+  assert.deepEqual(await getBackendInfo({ backend: "auto", surface: "agent" }), await getBackendInfo());
 
   let requestedAuthorization;
   let requestedModel;

--- a/sdk/tests/test-vercel-package.mjs
+++ b/sdk/tests/test-vercel-package.mjs
@@ -7,6 +7,7 @@ import { cp, mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { serializeError } from "./package-report.mjs";
 
 const input = process.argv[2];
 assert.ok(input, "provide a published libfx version or local tarball");
@@ -20,6 +21,9 @@ const directory = await mkdtemp(resolve(artifactRoot, "libfx-vercel-"));
 const app = resolve(directory, "app");
 const secret = randomUUID();
 const tokenArgs = process.env.LIBFX_VERCEL_TOKEN ? ["--token", process.env.LIBFX_VERCEL_TOKEN] : [];
+const redact = (text) => [secret, process.env.AI_GATEWAY_API_KEY, process.env.LIBFX_VERCEL_TOKEN]
+  .filter(Boolean).reduce((value, credential) => value.replaceAll(credential, "[redacted]"), text);
+const results = [];
 let deployment;
 let deploymentRef;
 let failure;
@@ -33,8 +37,6 @@ async function run(command, args, name) {
   const timeout = setTimeout(() => child.kill("SIGKILL"), 300_000);
   try {
     const [code] = await once(child, "close");
-    const redact = (text) => [secret, process.env.AI_GATEWAY_API_KEY, process.env.LIBFX_VERCEL_TOKEN]
-      .filter(Boolean).reduce((value, credential) => value.replaceAll(credential, "[redacted]"), text);
     await writeFile(resolve(directory, `${name}.log`), redact(`${output}\n${errors}`));
     assert.equal(code, 0, `Vercel ${name} failed; see ${directory}/${name}.log`);
     return output;
@@ -79,7 +81,6 @@ try {
   await vercel(["inspect", deploymentRef, "--wait", "--timeout", "5m"], "inspect");
   const unauthorized = await fetch(`${deployment}/api/fx`);
   assert.equal(unauthorized.status, 401, "live tool endpoint must require its verification token");
-  const results = [];
   for (let round = 0; round < 3; round++) {
     for (const backend of ["native", "auto"]) {
       for (const scenario of ["host", "mcp"]) {
@@ -100,8 +101,6 @@ try {
       }
     }
   }
-  await writeFile(resolve(directory, "results.json"), JSON.stringify({ input, deployment, results }, null, 2));
-  console.log(`Live Vercel package verification passed: ${directory}`);
 } catch (error) {
   failure = error;
   if (deploymentRef) {
@@ -112,6 +111,12 @@ try {
     try { await vercel(["remove", deploymentRef, "--yes"], "cleanup"); }
     catch (error) { failure = failure ? new AggregateError([failure, error], "Verification and cleanup failed") : error; }
   }
+  await writeFile(resolve(directory, "results.json"), redact(JSON.stringify({
+    input, deployment, results,
+    status: failure ? "failed" : "passed",
+    error: serializeError(failure),
+  }, null, 2)));
   console.log(`Vercel package evidence: ${directory}`);
 }
 if (failure) throw failure;
+console.log(`Live Vercel package verification passed: ${directory}`);


### PR DESCRIPTION
getBackendInfo({ backend: null }) reported an available backend even though createFxAgent rejected that selector. The probe now defaults only omitted or undefined selectors and rejects explicit null for backend and surface. The probe also preserves inherited and non-enumerable selectors and reads them in factory order. Installed ESM and CommonJS tests cover the contract.

CI and publication now run the existing resilience matrix with a bounded workload. Next and Vercel qualification retain completed scenarios and structured errors on failure, including combined verification and cleanup failures; Vercel results redact credentials.

Verified the 100-repeat selector matrix, native/Wasm ESM/CJS package consumers, Next development/production/standalone with tools and concurrency, and controlled failure reporting. The original invalid-selector behavior and missing failure reports were reproduced before their repairs.

