### PR TITLE
Publish sessions only after initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ Older sessions that saved Vercel connection settings can be opened through `-r`,
 
 If a saved conversation is damaged, run `fx session recover <id>` to copy its validated prefix into a new session. Recovery preserves checkpoint boundaries and referenced result files, leaves the original unchanged, and prints the new session ID. Records after the damaged boundary are not included, and recovery does not rerun commands. Healthy conversations can be resumed without recovery.
 
+New sessions appear in resume selection only after their initial files are ready. Incomplete creation folders left by older builds do not block healthy conversations from resuming with `-c`; those folders remain available for diagnosis and are not deleted.
+
 Interactive terminal tabs show `fx v<version> | <folder>` using the running binary's version and current workspace folder name, for example `fx v0.0.7 | fx`. Renaming a session or switching models leaves the title unchanged. Resuming from another folder uses that folder's name. Exiting clears the fx-owned title. Noninteractive commands do not emit terminal-title controls.
 
 Run `/feedback` to open the feedback form at `fx.sh/feedback`. It does not create a diagnostic or change the clipboard.

--- a/src/core/session/session_log.zig
+++ b/src/core/session/session_log.zig
@@ -3193,18 +3193,24 @@ pub const Root = struct {
             return failLoadedWritableSession(error.SessionAlreadyExists);
         }
 
+        const random = randomIdentifier();
+        const suffix = std.fmt.bytesToHex(random, .lower);
+        const staging_name = try std.fmt.allocPrint(alloc, "creating+{s}", .{suffix});
+        defer alloc.free(staging_name);
         sessions.dir.createDir(
             io_mod.getIo(),
-            initial_state.id,
+            staging_name,
             private_dir_permissions,
-        ) catch |err| switch (err) {
-            error.PathAlreadyExists => return failLoadedWritableSession(error.SessionAlreadyExists),
-            else => return failLoadedWritableSession(error.SessionStartFailed),
+        ) catch return failLoadedWritableSession(error.SessionStartFailed);
+        var unpublished = true;
+        errdefer if (unpublished) {
+            debug_trace.logf("session", "session creation discarded unpublished state id={s}", .{initial_state.id});
+            sessions.dir.deleteTree(io_mod.getIo(), staging_name) catch |err| {
+                debug_trace.logf("session", "session creation cleanup retained id={s} err={s}", .{ initial_state.id, @errorName(err) });
+            };
         };
-        io_mod.syncVerifiedDir(sessions.dir) catch
-            return failLoadedWritableSession(error.SessionStartFailed);
 
-        var session_dir = try openSessionDir(sessions, initial_state.id, .writable);
+        var session_dir = try io_mod.openOrCreateVerifiedPrivateDir(sessions, staging_name);
         options.test_controls.lock(.session);
         var writer_lock = acquireLockWithDeadline(
             &session_dir,
@@ -3225,13 +3231,29 @@ pub const Root = struct {
             .writer_lock = writer_lock,
             .session_id = session_id,
         };
-        errdefer writable.deinit(alloc);
-        return createNativeSession(
+        var writable_owned = true;
+        errdefer if (writable_owned) writable.deinit(alloc);
+        var loaded = try createNativeSession(
             alloc,
             &writable,
             initial_state,
             options,
         );
+        writable_owned = false;
+        errdefer loaded.deinit(alloc);
+        try loaded.conversation_writer.file.sync(io_mod.getIo());
+        try io_mod.syncVerifiedDir(loaded.log.dir.dir);
+        publishSessionDirectory(sessions.dir, staging_name, initial_state.id) catch |err| {
+            if (err == error.PathAlreadyExists) return error.SessionAlreadyExists;
+            debug_trace.logf("session", "session creation publication failed id={s} err={s}", .{ initial_state.id, @errorName(err) });
+            return err;
+        };
+        unpublished = false;
+        io_mod.syncVerifiedDir(sessions.dir) catch |err| {
+            debug_trace.logf("session", "session creation retained published state id={s} durability=uncertain err={s}", .{ initial_state.id, @errorName(err) });
+            return error.SessionStartFailed;
+        };
+        return loaded;
     }
 
     pub fn resumeForWrite(
@@ -3369,6 +3391,34 @@ pub const Root = struct {
         return entryExists(&dir, name);
     }
 };
+
+fn publishSessionDirectory(parent: std.Io.Dir, staging: []const u8, target: []const u8) !void {
+    if (comptime @import("builtin").os.tag != .macos) {
+        return parent.renamePreserve(staging, parent, target, io_mod.getIo());
+    }
+    // Zig 0.16's Darwin preserve-rename uses hard links, which cannot publish directories.
+    const Darwin = struct {
+        extern "c" fn renameatx_np(c_int, [*:0]const u8, c_int, [*:0]const u8, c_uint) c_int;
+    };
+    var staging_buffer: [256]u8 = undefined;
+    var target_buffer: [256]u8 = undefined;
+    const staging_z = try std.fmt.bufPrintZ(&staging_buffer, "{s}", .{staging});
+    const target_z = try std.fmt.bufPrintZ(&target_buffer, "{s}", .{target});
+    while (true) {
+        try io_mod.getIo().checkCancel();
+        const err = std.posix.errno(Darwin.renameatx_np(parent.handle, staging_z, parent.handle, target_z, 0x4));
+        switch (err) {
+            .SUCCESS => return,
+            .INTR => continue,
+            .EXIST, .NOTEMPTY => return error.PathAlreadyExists,
+            .OPNOTSUPP, .NOSYS => return error.OperationUnsupported,
+            else => {
+                debug_trace.logf("session", "session directory publication failed errno={s}", .{@tagName(err)});
+                return error.SessionStartFailed;
+            },
+        }
+    }
+}
 
 fn validateLeaf(name: []const u8) !void {
     if (name.len == 0 or std.mem.eql(u8, name, ".") or
@@ -4383,6 +4433,105 @@ test "root starts a cache-free conversation session" {
     try std.testing.expect(saw_writer_lock);
     try std.testing.expect(saw_permissions);
     try std.testing.expect(saw_usage);
+}
+
+test "root session creation stays outside discovery while preparing" {
+    const alloc = std.testing.allocator;
+    var temp = try TempRoot.init(alloc);
+    defer temp.deinit(alloc);
+    var initial = try testState(alloc, "unpublished-session", 10);
+    defer initial.deinit(alloc);
+    const Probe = struct {
+        root: *Root,
+        observed: bool = false,
+        visible: bool = false,
+        failure: ?anyerror = null,
+
+        fn lock(context: ?*anyopaque, _: LockKind) void {
+            const self: *@This() = @ptrCast(@alignCast(context.?));
+            self.observed = true;
+            self.visible = entryExists(&self.root.sessions.?, "unpublished-session") catch |err| {
+                self.failure = err;
+                return;
+            };
+        }
+    };
+    var probe = Probe{ .root = &temp.root };
+    var loaded = try temp.root.startConversationSession(alloc, initial, .{
+        .test_controls = .{ .context = &probe, .lock_fn = Probe.lock },
+    });
+    defer loaded.deinit(alloc);
+    if (probe.failure) |err| return err;
+    try std.testing.expect(probe.observed);
+    try std.testing.expect(!probe.visible);
+    try std.testing.expect(try entryExists(&temp.root.sessions.?, initial.id));
+    try std.testing.expectEqualStrings(initial.id, loaded.active_id);
+    var saved = try temp.root.loadReadOnly(alloc, initial.id, .{});
+    defer saved.deinit(alloc);
+    try std.testing.expectEqualStrings(initial.id, saved.id);
+}
+
+test "root session creation never replaces a racing target" {
+    const alloc = std.testing.allocator;
+    var temp = try TempRoot.init(alloc);
+    defer temp.deinit(alloc);
+    var initial = try testState(alloc, "racing-session", 10);
+    defer initial.deinit(alloc);
+    const Probe = struct {
+        root: *Root,
+        created: bool = false,
+        failure: ?anyerror = null,
+
+        fn lock(context: ?*anyopaque, _: LockKind) void {
+            const self: *@This() = @ptrCast(@alignCast(context.?));
+            self.root.sessions.?.dir.createDir(std.testing.io, "racing-session", private_dir_permissions) catch |err| {
+                if (err != error.PathAlreadyExists) self.failure = err;
+                return;
+            };
+            self.created = true;
+        }
+    };
+    var probe = Probe{ .root = &temp.root };
+    if (temp.root.startConversationSession(alloc, initial, .{
+        .test_controls = .{ .context = &probe, .lock_fn = Probe.lock },
+    })) |value| {
+        var loaded = value;
+        loaded.deinit(alloc);
+        return error.ExpectedSessionCollision;
+    } else |err| try std.testing.expectEqual(error.SessionAlreadyExists, err);
+    if (probe.failure) |err| return err;
+    try std.testing.expect(probe.created);
+    var preserved = try openSessionDir(&temp.root.sessions.?, initial.id, .read_only);
+    defer preserved.close();
+    var entries = preserved.dir.iterate();
+    try std.testing.expect((try entries.next(std.testing.io)) == null);
+}
+
+test "root session creation allocation failures leave no published state" {
+    const alloc = std.testing.allocator;
+    var temp = try TempRoot.init(alloc);
+    defer temp.deinit(alloc);
+    var initial = try testState(alloc, "allocation-session", 10);
+    defer initial.deinit(alloc);
+    var measured = std.testing.FailingAllocator.init(alloc, .{});
+    var successful = try temp.root.startConversationSession(measured.allocator(), initial, .{});
+    successful.deinit(measured.allocator());
+    try temp.root.sessions.?.dir.deleteTree(std.testing.io, initial.id);
+    for (0..measured.alloc_index) |fail_index| {
+        var failing = std.testing.FailingAllocator.init(alloc, .{ .fail_index = fail_index });
+        if (temp.root.startConversationSession(failing.allocator(), initial, .{})) |value| {
+            var loaded = value;
+            loaded.deinit(failing.allocator());
+            return error.ExpectedAllocationFailure;
+        } else |err| {
+            try std.testing.expect(failing.has_induced_failure);
+            // Existing allocating JSON writers surface allocation loss as WriteFailed.
+            try std.testing.expect(err == error.OutOfMemory or err == error.WriteFailed);
+        }
+        try std.testing.expectEqual(failing.allocated_bytes, failing.freed_bytes);
+        var entries = temp.root.sessions.?.dir.iterate();
+        try std.testing.expect((try entries.next(std.testing.io)) == null);
+    }
 }
 
 test "conversation writer appends without duplicating live history" {

--- a/src/core/session/session_store.zig
+++ b/src/core/session/session_store.zig
@@ -2690,14 +2690,22 @@ pub const Store = struct {
         return loaded;
     }
 
-    fn only_unpublished_lock(session_dir: *io_mod.VerifiedDir) !bool {
+    fn only_unpublished_creation(session_dir: *io_mod.VerifiedDir, allow_metadata: bool) !bool {
+        if (try authority_module.entryExistsRelative(session_dir, "events.jsonl")) return false;
         var dir = try session_dir.dir.openDir(io_mod.getIo(), ".", .{ .iterate = true });
         defer dir.close(io_mod.getIo());
         var entries = dir.iterate();
         while (try entries.next(io_mod.getIo())) |entry| {
-            if (entry.kind != .file or !std.mem.eql(u8, entry.name, "session.lock")) return false;
+            if (entry.kind != .file) return false;
+            const is_lock = std.mem.eql(u8, entry.name, "session.lock");
+            const is_metadata = allow_metadata and std.mem.eql(u8, entry.name, "session.json");
+            const prefix = ".session.json.tmp.";
+            if (!is_lock and !is_metadata) {
+                if (entry.name.len != prefix.len + 32 or !std.mem.startsWith(u8, entry.name, prefix)) return false;
+                for (entry.name[prefix.len..]) |byte| if (!std.ascii.isHex(byte)) return false;
+            }
             const stat = try dir.statFile(io_mod.getIo(), entry.name, .{ .follow_symlinks = false });
-            if (stat.kind != .file or stat.size != 0 or stat.nlink != 1) return false;
+            if (stat.kind != .file or stat.nlink != 1 or (is_lock and stat.size != 0)) return false;
         }
         return true;
     }
@@ -2882,6 +2890,12 @@ pub const Store = struct {
         if (try session_log.readConversationMetadata(alloc, &session_dir)) |value| {
             var metadata = value;
             defer metadata.deinit();
+            if (std.mem.eql(u8, metadata.value.id, session_id) and
+                try only_unpublished_creation(&session_dir, true))
+            {
+                debug_trace.logf("session", "latest selection retained incomplete creation id={s} disposition=skipped", .{session_id});
+                return null;
+            }
             return try discovery.writable_conversation_candidate(
                 alloc,
                 &session_dir,
@@ -2905,7 +2919,10 @@ pub const Store = struct {
                     &session_dir,
                     session_id,
                 ) catch |err| {
-                    if (err == error.FileNotFound and try only_unpublished_lock(&session_dir)) return null;
+                    if (err == error.FileNotFound and try only_unpublished_creation(&session_dir, false)) {
+                        debug_trace.logf("session", "latest selection retained incomplete creation id={s} disposition=skipped", .{session_id});
+                        return null;
+                    }
                     return err;
                 };
                 defer candidate.deinit(alloc);
@@ -7182,6 +7199,61 @@ test "writable last skips only unpublished lock directories" {
     const retained = try readFixtureFile(alloc, ctx.store, "lock-only", "events.jsonl", 1024);
     defer alloc.free(retained);
     try std.testing.expectEqualStrings("unidentified saved data\n", retained);
+}
+
+test "writable last skips retained incomplete creation without weakening saved-data checks" {
+    const alloc = std.testing.allocator;
+    for ([_]struct { metadata: bool, temporary: bool }{
+        .{ .metadata = false, .temporary = true },
+        .{ .metadata = true, .temporary = false },
+        .{ .metadata = true, .temporary = true },
+    }) |shape| {
+        var tmp = std.testing.tmpDir(.{});
+        defer tmp.cleanup();
+        var ctx = try initTempStore(alloc, &tmp);
+        defer ctx.deinit(alloc);
+        try createHistoryPageFixture(alloc, ctx.store, "healthy", ctx.workspace, 1, "saved");
+        try ctx.store.canonical_root.sessions.?.dir.createDir(std.testing.io, "failed-start", .fromMode(0o700));
+        var incomplete_dir = try ctx.store.openSessionDir("failed-start");
+        defer incomplete_dir.close();
+        const lock_file = try incomplete_dir.dir.createFile(std.testing.io, "session.lock", .{ .permissions = .fromMode(0o600) });
+        lock_file.close(std.testing.io);
+        const temp_name = ".session.json.tmp.0123456789abcdef0123456789abcdef";
+        if (shape.temporary) try writeFixtureEntry(alloc, ctx.store, "failed-start", temp_name, "partial metadata");
+        if (shape.metadata) {
+            var healthy_dir = try ctx.store.openSessionDir("healthy");
+            defer healthy_dir.close();
+            var decoded = (try session_log.readConversationMetadata(alloc, &healthy_dir)).?;
+            defer decoded.deinit();
+            var metadata = decoded.value;
+            metadata.id = "failed-start";
+            const bytes = try session_codec.encodeSessionMetadata(alloc, metadata);
+            defer alloc.free(bytes);
+            try writeFixtureEntry(alloc, ctx.store, "failed-start", "session.json", bytes);
+        }
+        const retained_name = if (shape.metadata) "session.json" else temp_name;
+        const before = try readFixtureFile(alloc, ctx.store, "failed-start", retained_name, 4096);
+        defer alloc.free(before);
+        {
+            var resumed = try ctx.store.resumeTargetForWrite(alloc, .last, ctx.workspace, .{});
+            defer resumed.deinit(alloc);
+            try std.testing.expectEqualStrings("healthy", resumed.active_id);
+            try std.testing.expectEqualStrings("saved-0", resumed.state.history[0].assistant.user.text);
+        }
+        const retained = try readFixtureFile(alloc, ctx.store, "failed-start", retained_name, 4096);
+        defer alloc.free(retained);
+        try std.testing.expectEqualStrings(before, retained);
+        if (ctx.store.resumeForWrite(alloc, "failed-start")) |value| {
+            var loaded = value;
+            loaded.deinit(alloc);
+            return error.IncompleteSessionWasResumed;
+        } else |err| try std.testing.expect(err == error.FileNotFound or err == error.SessionNotFound);
+        try writeFixtureEntry(alloc, ctx.store, "failed-start", "permissions.json", "{}");
+        try std.testing.expectError(error.FileNotFound, ctx.store.resumeTargetForWrite(alloc, .last, ctx.workspace, .{}));
+        const controls = try readFixtureFile(alloc, ctx.store, "failed-start", "permissions.json", 1024);
+        defer alloc.free(controls);
+        try std.testing.expectEqualStrings("{}", controls);
+    }
 }
 
 test "writable last ignores unrelated conversation history" {

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -6810,6 +6810,67 @@ test.skipIf(!tmuxAvailable())(
 );
 
 test.skipIf(!tmuxAvailable())(
+  "latest and picker resume preserve conversations beside incomplete session creation",
+  async () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "fx-resume-incomplete-creation-")));
+    const home = join(root, "home"), workspace = join(root, "workspace");
+    mkdirSync(home); mkdirSync(workspace);
+    const gateway = startFakeGateway([
+      fakeGatewayFinalText("PUBLICATION_SAVED_HISTORY"),
+      fakeGatewayFinalText("LATEST_CONTINUATION_SAVED"),
+      fakeGatewayFinalText("PICKER_CONTINUATION_SAVED"),
+    ]);
+    const env = gatewayEnv(home, gateway);
+    let active: TmuxSession | null = null;
+    try {
+      const seed = await runFx(["ask", "--json", "Save the conversation."], { cwd: workspace, env });
+      expect(seed.code).toBe(0);
+      const id = JSON.parse(seed.stdout).session_id;
+      const sessions = join(home, ".fx", "sessions");
+      const eventsPath = join(sessions, id, "events.jsonl");
+      const before = readFileSync(eventsPath);
+      const metadata = JSON.parse(readFileSync(join(sessions, id, "session.json"), "utf8"));
+      const remnants: Array<[string, string]> = [];
+      for (const failedId of ["temporary-start", "metadata-start", "creating+unpublished"]) {
+        const directory = join(sessions, failedId);
+        mkdirSync(directory, { mode: 0o700 });
+        writeFileSync(join(directory, "session.lock"), "", { mode: 0o600 });
+        const path = join(directory, failedId === "metadata-start" ? "session.json" : ".session.json.tmp.0123456789abcdef0123456789abcdef");
+        const content = failedId === "metadata-start" ? JSON.stringify({ ...metadata, id: failedId }) : "partial metadata";
+        writeFileSync(path, content, { mode: 0o600 });
+        remnants.push([path, content]);
+      }
+      for (const [flag, reply] of [["-c", "LATEST_CONTINUATION_SAVED"], ["-r", "PICKER_CONTINUATION_SAVED"]] as const) {
+        const stderrPath = join(root, `${flag}.stderr`);
+        active = await TmuxSession.create({ cmd: `${shellQuote(FX_BIN)} ${flag}`, cwd: workspace, env, stderrPath, remainOnExit: true });
+        if (flag === "-r") {
+          await active.waitForText("Sessions 1", TIMEOUT);
+          await active.sendKeys("Enter");
+        }
+        await active.waitForText("PUBLICATION_SAVED_HISTORY", TIMEOUT);
+        await active.waitForStableComposer(TIMEOUT);
+        await active.sendText("Continue the saved conversation without tools.");
+        await active.waitForPane((pane) => pane.includes(reply) && hasEmptyComposer(pane), TIMEOUT);
+        const events = readFileSync(eventsPath, "utf8").trim().split("\n").map((line) => JSON.parse(line).event);
+        expect(events.filter((event) => event.assistant?.text === reply)).toHaveLength(1);
+        expect(readFileSync(eventsPath).subarray(0, before.length).equals(before)).toBe(true);
+        expect(await active.captureFullScrollback()).not.toContain("FileNotFound");
+        await active.sendText("/quit");
+        await active.waitForPane(() => paneExitMatches(active!.paneStatus(), 0), TIMEOUT);
+        expect(readFileSync(stderrPath, "utf8")).toBe("");
+        await active.kill(); active = null;
+      }
+      expect(gateway.requests).toHaveLength(3);
+      expect(gateway.requests[2]!.body).toContain("LATEST_CONTINUATION_SAVED");
+      for (const [path, bytes] of remnants) expect(readFileSync(path, "utf8")).toBe(bytes);
+    } finally {
+      await active?.kill(); gateway.stop(); rmSync(root, { recursive: true, force: true });
+    }
+  },
+  TIMEOUT * 3,
+);
+
+test.skipIf(!tmuxAvailable())(
   "manual compaction keeps earlier small-session messages visible after resume",
   async () => {
     const root = realpathSync(mkdtempSync(join(tmpdir(), "fx-resume-compacted-display-")));


### PR DESCRIPTION
## Summary

- Keep interrupted or failed session setup out of resume selection until initialization is complete.
- Resume healthy conversations beside older failed-start remnants without deleting those remnants.
- Prevent concurrent session creation from replacing an existing session.
- Retain complete published sessions if the final directory synchronization fails.
