### PR TITLE
Respect explicit credential sources in recovery guidance

### DIFF
--- a/src/core/auth/auth_runtime.zig
+++ b/src/core/auth/auth_runtime.zig
@@ -1406,12 +1406,29 @@ pub const StatusSnapshot = struct {
 
     pub fn missingHelp(self: StatusSnapshot, surface: MissingHelpSurface) ?[]const u8 {
         if (self.active_source != null) return null;
-        if (self.stored_key_status == .unavailable) return credentials.unreadable_store_message;
+        if (self.stored_key_status == .unavailable) {
+            if (self.required_source == .stored_key) return switch (surface) {
+                .cli => "The selected stored API key could not be read from " ++ credentials.stored_key_backend_label ++ ". Start fx and open /provider to choose an available credential; no other credential was selected.",
+                .interactive => "The selected stored API key could not be read from " ++ credentials.stored_key_backend_label ++ ". Run /provider to choose an available credential; no other credential was selected.",
+            };
+            return credentials.unreadable_store_message;
+        }
         if (self.failure) |failure| {
             if (preparationError(failure)) |err| return preparationFailureNotice(err);
         }
-        if (self.required_source == .fx_login) {
-            return switch (surface) {
+        const automatic_help: []const u8 = switch (surface) {
+            .cli => credentials.missing_credential_message,
+            .interactive => credentials.missing_interactive_credential_message,
+        };
+        const required_source = self.required_source orelse return automatic_help;
+        return switch (required_source) {
+            .vercel_oidc_token => "VERCEL_OIDC_TOKEN is selected but unavailable. Set VERCEL_OIDC_TOKEN before starting fx; no other credential was selected.",
+            .ai_gateway_api_key => "AI_GATEWAY_API_KEY is selected but unavailable. Set AI_GATEWAY_API_KEY before starting fx; no other credential was selected.",
+            .stored_key => switch (surface) {
+                .cli => "A stored API key is selected but unavailable. Start fx and open /provider to choose an available credential; no other credential was selected.",
+                .interactive => "A stored API key is selected but unavailable. Run /provider to choose an available credential; no other credential was selected.",
+            },
+            .fx_login => switch (surface) {
                 .cli => if (self.fx_login_status == .unavailable)
                     "The saved fx login could not be loaded. Run fx login to repair this source; no other credential was selected."
                 else
@@ -1420,23 +1437,16 @@ pub const StatusSnapshot = struct {
                     "The saved fx login could not be loaded. Run /login to repair this source; no other credential was selected."
                 else
                     "fx login is selected but unavailable. Run /login to reconnect; no other credential was selected.",
-            };
-        }
-        if (self.required_source == .chatgpt_subscription) {
-            return switch (surface) {
+            },
+            .chatgpt_subscription => switch (surface) {
                 .cli => credentials.missing_chatgpt_credential_message,
                 .interactive => credentials.missing_chatgpt_interactive_credential_message,
-            };
-        }
-        if (self.required_source == .grok_subscription) {
-            return switch (surface) {
+            },
+            .grok_subscription => switch (surface) {
                 .cli => credentials.missing_grok_credential_message,
                 .interactive => credentials.missing_grok_interactive_credential_message,
-            };
-        }
-        return switch (surface) {
-            .cli => credentials.missing_credential_message,
-            .interactive => credentials.missing_interactive_credential_message,
+            },
+            .host_managed => automatic_help,
         };
     }
 
@@ -3715,6 +3725,48 @@ test "auth status snapshot distinguishes an absent store from an unreadable one"
 
     const resolved = StatusSnapshot{ .active_source = .fx_login, .stored_key_status = .unavailable };
     try std.testing.expect(resolved.missingHelp(.cli) == null);
+}
+
+test "auth status names each explicit key source and its recovery" {
+    const cases = [_]struct {
+        source: credentials.Source,
+        label: []const u8,
+        cli_recovery: []const u8,
+        interactive_recovery: []const u8,
+    }{
+        .{ .source = .vercel_oidc_token, .label = "VERCEL_OIDC_TOKEN", .cli_recovery = "Set VERCEL_OIDC_TOKEN before starting fx", .interactive_recovery = "Set VERCEL_OIDC_TOKEN before starting fx" },
+        .{ .source = .ai_gateway_api_key, .label = "AI_GATEWAY_API_KEY", .cli_recovery = "Set AI_GATEWAY_API_KEY before starting fx", .interactive_recovery = "Set AI_GATEWAY_API_KEY before starting fx" },
+        .{ .source = .stored_key, .label = "stored API key", .cli_recovery = "Start fx and open /provider", .interactive_recovery = "Run /provider" },
+    };
+    for (cases) |case| {
+        const status = StatusSnapshot{ .required_source = case.source };
+        for ([_]MissingHelpSurface{ .cli, .interactive }) |surface| {
+            const help = status.missingHelp(surface).?;
+            try std.testing.expect(std.mem.find(u8, help, case.label) != null);
+            try std.testing.expect(std.mem.find(u8, help, if (surface == .cli) case.cli_recovery else case.interactive_recovery) != null);
+            try std.testing.expect(std.mem.find(u8, help, "no other credential was selected") != null);
+            if (case.source != .ai_gateway_api_key) try std.testing.expect(std.mem.find(u8, help, "AI_GATEWAY_API_KEY") == null);
+        }
+    }
+}
+
+test "auth status preserves selected stored-key read failure without suggesting an excluded key" {
+    var status = StatusSnapshot{
+        .required_source = .stored_key,
+        .stored_key_status = .unavailable,
+        .failure = classifyCredentialFailure(.stored_key, error.CredentialStorageUnavailable),
+    };
+    for ([_]MissingHelpSurface{ .cli, .interactive }) |surface| {
+        const help = status.missingHelp(surface).?;
+        try std.testing.expect(std.mem.find(u8, help, "could not be read") != null);
+        try std.testing.expect(std.mem.find(u8, help, credentials.stored_key_backend_label) != null);
+        try std.testing.expect(std.mem.find(u8, help, "/provider") != null);
+        try std.testing.expect(std.mem.find(u8, help, "AI_GATEWAY_API_KEY") == null);
+    }
+    status.required_source = null;
+    try std.testing.expectEqualStrings(credentials.unreadable_store_message, status.missingHelp(.cli).?);
+    status.active_source = .ai_gateway_api_key;
+    try std.testing.expect(status.missingHelp(.cli) == null);
 }
 
 test "auth status keeps an unavailable explicit fx login distinct from automatic absence" {

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -702,6 +702,9 @@ describe("cli: status", () => {
     { name: "Gateway with a stale Codex preference", provider: "gateway", source: "chatgpt_subscription", help: MISSING_AUTH_MESSAGE },
     { name: "Gateway with a stale Grok preference", provider: "gateway", source: "grok_subscription", help: MISSING_AUTH_MESSAGE },
     { name: "an exact Gateway login", provider: "gateway", source: "fx_login", help: "fx login is selected but unavailable. Run fx login to reconnect; no other credential was selected." },
+    { name: "an exact OIDC token", provider: "gateway", source: "vercel_oidc_token", help: "VERCEL_OIDC_TOKEN is selected but unavailable. Set VERCEL_OIDC_TOKEN before starting fx; no other credential was selected." },
+    { name: "an exact environment key", provider: "gateway", source: "ai_gateway_api_key", help: "AI_GATEWAY_API_KEY is selected but unavailable. Set AI_GATEWAY_API_KEY before starting fx; no other credential was selected." },
+    { name: "an exact stored key", provider: "gateway", source: "stored_key", help: "A stored API key is selected but unavailable. Start fx and open /provider to choose an available credential; no other credential was selected." },
     { name: "Codex", provider: "codex", source: undefined, help: "fx needs a Codex subscription login for this model. Run fx login codex." },
     { name: "Grok", provider: "grok", source: undefined, help: "fx needs a Grok subscription login for this model. Run fx login grok." },
   ]) {

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -2905,6 +2905,43 @@ for (const [provider, help] of [
   }, TIMEOUT);
 }
 
+for (const [source, help] of [
+  ["vercel_oidc_token", "VERCEL_OIDC_TOKEN is selected but unavailable."],
+  ["stored_key", "A stored API key is selected but unavailable."],
+] as const) {
+  tmuxTest(`/status retains ${source} until another credential is selected`, async () => {
+    home = mkdtempSync(join(tmpdir(), "fx-status-explicit-key-"));
+    stderrPath = join(home, "stderr.log");
+    writeFileSync(stderrPath, "");
+    mkdirSync(join(home, ".fx"));
+    const settingsPath = join(home, ".fx", "settings.json");
+    const settings = JSON.stringify({ provider: "gateway", credential_source: source });
+    writeFileSync(settingsPath, settings);
+    gateway = startFakeGateway([fakeGatewayFinalText("EXPLICIT_KEY_RECOVERED")]);
+    session = await startFx(home, stderrPath, gateway);
+    await session.waitForComposer(TIMEOUT);
+    await session.sendText("/status");
+    await session.waitForText("auth_help=", TIMEOUT);
+    const missing = await session.captureFullScrollback();
+    expect(missing).toContain(`auth_help=${help}`);
+    expect(missing).not.toContain("set AI_GATEWAY_API_KEY");
+    expect(gateway.requests).toHaveLength(0);
+    expect(readFileSync(settingsPath, "utf8")).toBe(settings);
+
+    await selectEnvKeyCredential(session);
+    await session.sendText("Verify the account with a greeting.");
+    await session.waitForText("EXPLICIT_KEY_RECOVERED", TIMEOUT);
+    await session.sendText("/status");
+    await session.waitForText("auth=AI_GATEWAY_API_KEY", TIMEOUT);
+    const scrollback = await session.captureFullScrollback();
+    expect(scrollback.slice(scrollback.lastIndexOf("● Status:"))).not.toContain("auth_help=");
+    expect(JSON.parse(readFileSync(settingsPath, "utf8")).credential_source).toBe("ai_gateway_api_key");
+    expect(gateway.requests).toHaveLength(1);
+    expect(gateway.requests[0].headers.get("authorization")).toBe(`Bearer ${ENV_TOKEN}`);
+    expect(readFileSync(stderrPath, "utf8")).toBe("");
+  }, TIMEOUT);
+}
+
 tmuxTest("/status preserves a missing selected login through explicit key recovery", async () => {
   home = mkdtempSync(join(tmpdir(), "fx-status-selected-login-"));
   stderrPath = join(home, "stderr.log");


### PR DESCRIPTION
## Summary

- Name selected OIDC and environment-key sources and point to the matching variable in missing-credential guidance.
- Direct missing or disabled stored-key selections to `/provider` for an explicit credential change.
- Keep stored-key read failures visible without recommending an excluded environment key.
