### PR TITLE
Preserve Node asset loading across async inputs and tracing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,7 @@ jobs:
           node sdk/tests/test-node-package.mjs
           node sdk/tests/test-term-demo-package.mjs
           node sdk/scripts/package-libfx.mjs sdk/dist/libfx
+          node --experimental-wasm-jspi sdk/tests/test-node-async-assets.mjs sdk/dist/libfx
           npm pack ./sdk/dist/libfx --ignore-scripts --json > /tmp/libfx-pack.json
           mv "$(node -p 'require("/tmp/libfx-pack.json")[0].filename')" /tmp/libfx-package.tgz
           node sdk/tests/test-packed-example.mjs /tmp/libfx-package.tgz native esm
@@ -225,6 +226,8 @@ jobs:
             ${{ runner.temp }}/libfx-package-evidence/resilience.json
             ${{ runner.temp }}/libfx-package-evidence/libfx-next-*/*.log
             ${{ runner.temp }}/libfx-package-evidence/libfx-next-*/results.json
+            ${{ runner.temp }}/libfx-package-evidence/libfx-trace-*/*.log
+            ${{ runner.temp }}/libfx-package-evidence/libfx-trace-*/results.json
           if-no-files-found: ignore
 
   sdk-browser-wasm:

--- a/.github/workflows/publish-libfx.yml
+++ b/.github/workflows/publish-libfx.yml
@@ -297,6 +297,7 @@ jobs:
 
       - name: Test installed package and diagnostics
         run: |
+          node --experimental-wasm-jspi sdk/tests/test-node-async-assets.mjs sdk/dist/libfx
           node sdk/tests/test-packed-example.mjs libfx-package.tgz native esm
           node --no-experimental-require-module sdk/tests/test-packed-example.mjs libfx-package.tgz native cjs
           node --experimental-wasm-jspi sdk/tests/test-packed-example.mjs libfx-package.tgz wasm esm
@@ -324,6 +325,8 @@ jobs:
             ${{ runner.temp }}/libfx-package-evidence/resilience.json
             ${{ runner.temp }}/libfx-package-evidence/libfx-next-*/*.log
             ${{ runner.temp }}/libfx-package-evidence/libfx-next-*/results.json
+            ${{ runner.temp }}/libfx-package-evidence/libfx-trace-*/*.log
+            ${{ runner.temp }}/libfx-package-evidence/libfx-trace-*/results.json
           if-no-files-found: ignore
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -420,4 +423,6 @@ jobs:
           path: |
             ${{ runner.temp }}/libfx-registry-evidence/libfx-next-*/*.log
             ${{ runner.temp }}/libfx-registry-evidence/libfx-next-*/results.json
+            ${{ runner.temp }}/libfx-registry-evidence/libfx-trace-*/*.log
+            ${{ runner.temp }}/libfx-registry-evidence/libfx-trace-*/results.json
           if-no-files-found: ignore

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -256,6 +256,11 @@ creates a separate WebAssembly instance for every Agent. Agent memory, history,
 tools, cancellation, and shutdown remain isolated. Workers and separate
 processes maintain their own module caches, as do the ESM and CommonJS entries.
 
+Node factories and `getBackendInfo()` also accept a `wasm` Promise resolving
+to an HTTP(S) URL string, a `Response`, Wasm bytes, or a compiled
+`WebAssembly.Module`. Asset resolver failures propagate from factories and
+appear as `LIBFX_WASM_LOAD_FAILED` in diagnostics.
+
 Node.js 20+ is supported. Browser WebAssembly requires a JSPI-capable browser.
 The Linux x64 and arm64 native addons require glibc 2.34 or newer. Native
 agents do not require JSPI or experimental Node flags.

--- a/sdk/node.js
+++ b/sdk/node.js
@@ -76,17 +76,22 @@ async function loadNativeCandidate(candidate) {
 }
 
 function defaultNativeCandidate() {
+  // Local path bindings let deployment tracers retain these assets in the generated CommonJS entry.
   if (process.platform === "linux" && process.arch === "x64") {
-    return new URL("./libfx.linux-x64.node", import.meta.url);
+    const path = fileURLToPath(new URL("./libfx.linux-x64.node", import.meta.url));
+    return path;
   }
   if (process.platform === "linux" && process.arch === "arm64") {
-    return new URL("./libfx.linux-arm64.node", import.meta.url);
+    const path = fileURLToPath(new URL("./libfx.linux-arm64.node", import.meta.url));
+    return path;
   }
   if (process.platform === "darwin" && process.arch === "x64") {
-    return new URL("./libfx.darwin-x64.node", import.meta.url);
+    const path = fileURLToPath(new URL("./libfx.darwin-x64.node", import.meta.url));
+    return path;
   }
   if (process.platform === "darwin" && process.arch === "arm64") {
-    return new URL("./libfx.darwin-arm64.node", import.meta.url);
+    const path = fileURLToPath(new URL("./libfx.darwin-arm64.node", import.meta.url));
+    return path;
   }
   return null;
 }
@@ -151,7 +156,7 @@ async function discoverNativeBackend() {
     return { backend: null, error: null, failure: "unsupported" };
   }
   try {
-    await access(fileURLToPath(candidate));
+    await access(candidate);
   } catch (error) {
     if (missingArtifact(error)) {
       return { backend: null, error: null, probeError: error, failure: "missing" };
@@ -297,7 +302,7 @@ export async function getBackendInfo(value = {}) {
   const defaultWasm = surface === "agent" ? defaultCoreWasm : defaultTermWasm;
   const wasmSource = wasm ?? defaultWasm;
   try {
-    await loadModule(wasmInput(wasmSource));
+    await loadModule(await wasmInput(wasmSource));
     attempts.push({ backend: "wasm-jspi", available: true, reason: null });
     return { surface, backend: "wasm-jspi", attempts };
   } catch (error) {
@@ -512,7 +517,7 @@ async function createWithFallback(surface, nativeMethod, wasmFactory, defaultWas
     throw jspiFallbackError(surface, nativeError);
   }
   const wasmSource = runtimeOptions.wasm ?? defaultWasm;
-  return wasmFactory({ ...runtimeOptions, wasm: wasmInput(wasmSource) });
+  return wasmFactory({ ...runtimeOptions, wasm: await wasmInput(wasmSource) });
 }
 
 export async function createFxAgent(options = {}) {

--- a/sdk/tests/test-next-package.mjs
+++ b/sdk/tests/test-next-package.mjs
@@ -6,8 +6,9 @@ import { once } from "node:events";
 import { createWriteStream } from "node:fs";
 import { cp, mkdir, mkdtemp, readFile, rename, writeFile } from "node:fs/promises";
 import { createServer } from "node:net";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { serializeError } from "./package-report.mjs";
 
@@ -107,6 +108,12 @@ try {
   manifest.dependencies.libfx = "file:./libfx.tgz";
   await writeFile(resolve(app, "package.json"), JSON.stringify(manifest, null, 2));
   await run(process.env.PNPM_BIN || "pnpm", ["install", "--no-frozen-lockfile", "--ignore-scripts"], app, "install");
+  const require = createRequire(resolve(app, "package.json"));
+  await run(process.execPath, [
+    fileURLToPath(new URL("./test-node-tracing.mjs", import.meta.url)),
+    dirname(require.resolve("libfx")),
+    require.resolve("next/dist/compiled/@vercel/nft"),
+  ], app, "node-tracing");
   const next = resolve(app, "node_modules/next/dist/bin/next");
   const dev = await start(app, [next, "dev"], "dev");
   await exercise(dev, "dev");

--- a/sdk/tests/test-node-async-assets.mjs
+++ b/sdk/tests/test-node-async-assets.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+import { strict as assert } from "node:assert";
+import { createRequire } from "node:module";
+import { readFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const directory = resolve(process.argv[2]);
+const entries = [
+  ["esm", await import(pathToFileURL(join(directory, "node.js")).href)],
+  ["cjs", createRequire(import.meta.url)(join(directory, "node.cjs"))],
+];
+const assets = {
+  agent: await readFile(join(directory, "fx-core.wasm")),
+  terminal: await readFile(join(directory, "fx-term.wasm")),
+};
+const requests = new Map();
+const corrupt = new Set();
+const server = createServer((request, response) => {
+  requests.set(request.url, (requests.get(request.url) ?? 0) + 1);
+  response.writeHead(200, { "content-type": "application/wasm" });
+  response.end(corrupt.has(request.url) ? Buffer.from("invalid Wasm") : assets[request.url.split("/")[1]]);
+});
+await new Promise((listen) => server.listen(0, "127.0.0.1", listen));
+const origin = `http://127.0.0.1:${server.address().port}`;
+const modelMethods = [];
+const modelFetch = async (_url, init) => {
+  const method = init?.method ?? "GET";
+  modelMethods.push(method);
+  if (method === "GET") return Response.json({ object: "list", data: [] });
+  assert.equal(method, "POST");
+  return new Response('data: {"type":"text-delta","delta":"async asset"}\n\ndata: {"type":"finish","finishReason":{"unified":"stop","raw":"stop"},"usage":{"inputTokens":{"total":1},"outputTokens":{"total":1}}}\n\ndata: [DONE]\n\n', {
+    headers: { "content-type": "text/event-stream" },
+  });
+};
+let completed = 0;
+let agentTurns = 0;
+const watchdog = setTimeout(() => { console.error("Node async asset test timed out"); process.exit(1); }, 60_000);
+watchdog.unref();
+
+async function exercise(sdk, surface, options) {
+  if (surface === "agent") {
+    const agent = await sdk.createFxAgent({ ...options, apiKey: "async-asset-key", model: "async/model", fetch: modelFetch });
+    try {
+      const turn = agent.prompt("hello");
+      let text = "";
+      for await (const event of turn) if (event.type === "text_delta") text += event.delta;
+      assert.equal(text, "async asset");
+      assert.equal((await turn.result).stopReason, "end_turn");
+      assert.ok((await agent.checkpoint()).length > 48);
+      agentTurns++;
+    }
+    finally { await agent.close(); }
+    return;
+  }
+  const data = new Set();
+  const resize = new Set();
+  let output = 0;
+  const terminal = {
+    cols: 80, rows: 24,
+    write(bytes) { output += bytes.byteLength; },
+    onData(listener) { data.add(listener); return () => data.delete(listener); },
+    onResize(listener) { resize.add(listener); return () => resize.delete(listener); },
+  };
+  let runtime;
+  try {
+    runtime = await sdk.createFxTerminal({ ...options, terminal, fetch: modelFetch,
+      env: { AI_GATEWAY_API_KEY: "async-asset-key", FX_SOUND: "0" } });
+    await runtime.interactive;
+    assert.ok(output > 0);
+  }
+  finally {
+    if (runtime) {
+      runtime.abort();
+      assert.equal(await runtime.exited, 130);
+    }
+    assert.equal(data.size, 0);
+    assert.equal(resize.size, 0);
+  }
+}
+
+try {
+  for (const [format, sdk] of entries) {
+    assert.equal(sdk.supportsJspi(), true, "run with --experimental-wasm-jspi");
+    for (const surface of ["agent", "terminal"]) {
+      for (const backend of ["wasm", "auto"]) {
+        for (const source of ["promise-url", "direct-url", "promise-response", "promise-bytes", "promise-module"]) {
+          const path = `/${surface}/${format}-${backend}-${source}.wasm`;
+          const url = `${origin}${path}`;
+          const wasm = source === "promise-url" ? Promise.resolve(url)
+            : source === "direct-url" ? url
+            : source === "promise-response" ? fetch(url)
+            : source === "promise-bytes" ? Promise.resolve(assets[surface])
+            : WebAssembly.compile(assets[surface]);
+          await exercise(sdk, surface, { backend, nativeAddon: false, wasm });
+          if (source.endsWith("url")) {
+            assert.equal(requests.get(path), 1, "cold URL inputs must fetch the selected asset");
+            const info = await sdk.getBackendInfo({ surface, backend, nativeAddon: false, wasm: Promise.resolve(url) });
+            assert.equal(info.backend, "wasm-jspi", JSON.stringify(info));
+            assert.equal(requests.get(path), 1, "probe and factory must reuse the resolved URL's module");
+          }
+          completed++;
+        }
+        const error = Object.assign(new Error("asset resolver failed"), { code: "ASSET_RESOLVER_FAILED" });
+        await assert.rejects(exercise(sdk, surface, { backend, nativeAddon: false, wasm: Promise.reject(error) }), (actual) => actual === error);
+        const info = await sdk.getBackendInfo({ surface, backend, nativeAddon: false, wasm: Promise.reject(error) });
+        assert.equal(info.backend, "unavailable");
+        assert.equal(info.attempts.at(-1).reason.code, "LIBFX_WASM_LOAD_FAILED");
+        assert.equal(info.attempts.at(-1).reason.causeCode, error.code);
+      }
+      const path = `/${surface}/${format}-repair.wasm`;
+      const wasm = Promise.resolve(`${origin}${path}`);
+      corrupt.add(path);
+      const failed = await sdk.getBackendInfo({ surface, backend: "wasm", wasm });
+      assert.equal(failed.backend, "unavailable");
+      assert.equal(failed.attempts[0].reason.code, "LIBFX_WASM_LOAD_FAILED");
+      assert.equal(requests.get(path), 1, "the failed probe must reach compilation of the requested asset");
+      corrupt.delete(path);
+      const info = await sdk.getBackendInfo({ surface, backend: "wasm", wasm });
+      assert.equal(info.backend, "wasm-jspi", JSON.stringify(info));
+      await exercise(sdk, surface, { backend: "wasm", wasm });
+      assert.equal(requests.get(path), 2, "failed modules must retry and repaired modules must remain cached");
+    }
+  }
+  assert.equal(modelMethods.filter((method) => method === "POST").length, agentTurns);
+  assert.equal(agentTurns, 22);
+  console.log(`Node async assets passed: ${completed} input/surface/backend/format cases, ${agentTurns} agent turns, resolver failures, and repair`);
+} finally {
+  clearTimeout(watchdog);
+  server.closeAllConnections();
+  await new Promise((close) => server.close(close));
+}

--- a/sdk/tests/test-node-tracing.mjs
+++ b/sdk/tests/test-node-tracing.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+import { strict as assert } from "node:assert";
+import { spawnSync } from "node:child_process";
+import { cp, mkdir, mkdtemp, rename, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve, sep } from "node:path";
+import { serializeError } from "./package-report.mjs";
+
+const packageDir = resolve(process.argv[2]);
+const { nodeFileTrace } = createRequire(import.meta.url)(resolve(process.argv[3]));
+const artifactRoot = process.env.LIBFX_TEST_ARTIFACT_ROOT || tmpdir();
+await mkdir(artifactRoot, { recursive: true });
+const root = await mkdtemp(join(artifactRoot, "libfx-trace-"));
+const results = [];
+let failure;
+
+async function exercise(sdk) {
+  const { strict: assert } = await import("node:assert");
+  const { createServer } = await import("node:http");
+  const { mkdir } = await import("node:fs/promises");
+  const { resolve } = await import("node:path");
+  const home = resolve("profile");
+  await mkdir(home, { recursive: true });
+  let modelCalls = 0;
+  const server = createServer((request, response) => {
+    request.resume();
+    request.on("end", () => {
+      if (request.method === "GET") {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end('{"object":"list","data":[]}');
+      } else {
+        modelCalls++;
+        response.writeHead(200, { "content-type": "text/event-stream" });
+        response.end('data: {"type":"text-delta","delta":"traced"}\n\ndata: {"type":"finish","finishReason":{"unified":"stop","raw":"stop"},"usage":{"inputTokens":{"total":1},"outputTokens":{"total":1}}}\n\ndata: [DONE]\n\n');
+      }
+    });
+  });
+  await new Promise((listen) => server.listen(0, "127.0.0.1", listen));
+  const origin = `http://127.0.0.1:${server.address().port}`;
+  const results = [];
+  try {
+    const info = await sdk.getBackendInfo({ backend: "native" });
+    assert.equal(info.backend, "native", JSON.stringify(info));
+    for (const backend of ["native", "auto"]) {
+      const agent = await sdk.createFxAgent({
+        backend, home, workspaceRoot: process.cwd(), apiKey: "trace-key", model: "trace/model",
+        gatewayChatUrl: `${origin}/chat`,
+        fetch(input, init) {
+          const url = init?.method === "GET" ? `${origin}/models` : String(input);
+          assert.equal(new URL(url).origin, origin);
+          return fetch(url, init);
+        },
+      });
+      try {
+        const turn = agent.prompt("hello");
+        let text = "";
+        for await (const event of turn) if (event.type === "text_delta") text += event.delta;
+        assert.equal(text, "traced");
+        assert.equal((await turn.result).stopReason, "end_turn");
+        const checkpointBytes = (await agent.checkpoint()).length;
+        assert.ok(checkpointBytes > 48);
+        results.push({ backend, checkpointBytes });
+      } finally { await agent.close(); }
+    }
+    assert.equal(modelCalls, 2);
+    console.log(JSON.stringify({ info, results }));
+  } finally {
+    server.closeAllConnections();
+    await new Promise((close) => server.close(close));
+  }
+}
+
+async function run(entry, cwd, name) {
+  const child = spawnSync(process.execPath, ["--no-experimental-require-module", entry], {
+    cwd, encoding: "utf8", timeout: 30_000,
+    env: { PATH: process.env.PATH, NODE_PATH: "", NODE_OPTIONS: "", FX_SOUND: "0", FX_DISABLE_KEYCHAIN: "1" },
+  });
+  await writeFile(join(root, `${name}.log`), `${child.stdout || ""}\n${child.stderr || ""}`);
+  if (child.error) throw child.error;
+  assert.equal(child.status, 0, `${name} failed; see ${root}/${name}.log`);
+  return JSON.parse(child.stdout.trim());
+}
+
+try {
+  for (const format of ["esm", "cjs"]) {
+    const source = join(root, `${format}-source`);
+    const isolated = join(root, `${format}-isolated`);
+    const entry = format === "esm" ? "entry.mjs" : "entry.cjs";
+    await cp(packageDir, join(source, "node_modules/libfx"), { recursive: true });
+    const load = format === "esm" ? 'import * as sdk from "libfx";' : 'const sdk = require("libfx");';
+    await writeFile(join(source, entry), `${load}\n(${exercise.toString()})(sdk).catch(error => { console.error(error); process.exitCode = 1; });\n`);
+    const result = { format, control: await run(entry, source, `${format}-control`) };
+    results.push(result);
+    const trace = await nodeFileTrace([join(source, entry)], { base: source, processCwd: source });
+    result.files = [...trace.fileList].sort();
+    result.warnings = [...trace.warnings].map(String);
+    if (format === "cjs") assert.ok(!result.files.includes("node_modules/libfx/node.js"), "CJS tracing must not be rescued by an ESM import");
+    for (const file of result.files) {
+      const from = resolve(source, file);
+      const to = resolve(isolated, file);
+      assert.ok(from.startsWith(source + sep) && to.startsWith(isolated + sep), `trace escaped its fixture: ${file}`);
+      await mkdir(dirname(to), { recursive: true });
+      await cp(from, to);
+    }
+    await rename(source, `${source}-unavailable`);
+    result.isolated = await run(entry, isolated, `${format}-isolated`);
+    assert.ok(result.files.some((file) => file.endsWith(`/libfx.${process.platform}-${process.arch}.node`)));
+    console.log(`${format} traced native and auto agent turns passed`);
+  }
+} catch (error) { failure = error; }
+finally {
+  await writeFile(join(root, "results.json"), JSON.stringify({
+    node: process.version, packageDir, status: failure ? "failed" : "passed", results, error: serializeError(failure),
+  }, null, 2));
+  console.log(`Node tracing evidence: ${root}`);
+}
+if (failure) throw failure;


### PR DESCRIPTION
Promises resolving to Wasm URL strings stopped working in Node after #721, and file tracing could silently omit the native addon from CommonJS deployments. Resolve asynchronous assets before the shared compiler handles them, and keep native file URLs in local path bindings that tracers recognize.

Add regressions for both agent and terminal factories, ESM/CommonJS, explicit Wasm and auto mode, resolver failures, cache repair, and isolated traced native/auto agent turns. Run these checks in CI and package qualification, including Next’s bundled tracer and registry verification.

Verified 1,000 promised-URL cases plus 3,000 controls, 100 isolated CommonJS runs plus matching ESM controls, Node 20/24 consumers, and Next development/production/standalone with tools and concurrency. Both original failures were reproduced before the fixes.
