### PR TITLE
Keep filtered tool turns resumable

### DIFF
--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -3357,6 +3357,102 @@ fn retainCompletedResultInTurnArena(result: *runtime_gateway_step.StreamResult) 
     }
 }
 
+fn discardCompletionProse(
+    arena: Allocator,
+    provider: agent_stream_provider.Provider,
+    source: model_provider.ProviderSelection,
+    completed: *agent_stream_provider.Completed,
+) !void {
+    const prior = completed.completion;
+    const replay: ?types.ProviderReplay = if (prior.provider_state_json) |parts|
+        .{ .source = source, .parts_json = parts }
+    else
+        null;
+    const selected = try provider.projectReplay(arena, replay, prior.tool_calls, false, true);
+    if (completed.ownership == .owned) {
+        if (prior.content) |content| arena.free(@constCast(content));
+        if (prior.provider_state_json) |parts| {
+            if (selected == null or selected.?.parts_json.ptr != parts.ptr) arena.free(@constCast(parts));
+        }
+    }
+    completed.completion.content = null;
+    completed.completion.provider_state_json = if (selected) |value| value.parts_json else null;
+}
+
+fn projectEmptyHistoryReplay(
+    arena: Allocator,
+    provider: agent_stream_provider.Provider,
+    selection: model_provider.ProviderSelection,
+    messages: []ChatMessage,
+) !void {
+    for (messages, 0..) |*message, index| {
+        if (message.role != .assistant) continue;
+        if (message.content) |content| if (content.len != 0) continue;
+        const replay = message.provider_replay orelse continue;
+        if (!replay.matches(selection)) continue;
+        const selected = try provider.projectReplay(arena, replay, message.tool_calls, false, true);
+        if (selected) |value| if (value.parts_json.ptr == replay.parts_json.ptr) continue;
+        debug_trace.logf("history", "empty_assistant_replay_projected message_index={d} prior_bytes={d} retained_bytes={d}", .{
+            index, replay.parts_json.len, if (selected) |value| value.parts_json.len else 0,
+        });
+        message.provider_replay = selected;
+    }
+}
+
+test "discarded completion prose preserves ownership and fails atomically" {
+    const Probe = struct {
+        fn project(alloc: Allocator, value: ?types.ProviderReplay, _: []const ToolCall, text: bool, reasoning: bool) !?types.ProviderReplay {
+            try std.testing.expect(!text and reasoning);
+            const replay = value.?;
+            if (std.mem.eql(u8, replay.parts_json, "fail")) return error.InvalidProviderState;
+            if (std.mem.eql(u8, replay.parts_json, "drop")) return null;
+            if (std.mem.eql(u8, replay.parts_json, "kept")) return replay;
+            return .{ .source = replay.source, .parts_json = try alloc.dupe(u8, "retained") };
+        }
+
+        fn run(alloc: Allocator) !void {
+            const provider: agent_stream_provider.Provider = .{
+                .stream_fn = agent_stream_provider.unavailable_provider.stream_fn,
+                .project_replay_fn = project,
+            };
+            for ([_]bool{ false, true }) |owned| {
+                for ([_]?[]const u8{ null, "kept", "replace", "drop", "fail" }) |state| {
+                    var original: agent_stream_provider.Result = .{ .completed = .{ .ownership = .owned } };
+                    defer original.deinit(alloc);
+                    original.completed.completion.content = try alloc.dupe(u8, "prose");
+                    if (state) |value| original.completed.completion.provider_state_json = try alloc.dupe(u8, value);
+                    var result = original;
+                    if (owned) original.completed.ownership = .borrowed else result.completed.ownership = .borrowed;
+                    defer result.deinit(alloc);
+                    defer if (!owned) {
+                        if (result.completed.completion.provider_state_json) |parts| {
+                            if (original.completed.completion.provider_state_json == null or
+                                parts.ptr != original.completed.completion.provider_state_json.?.ptr) alloc.free(@constCast(parts));
+                        }
+                    };
+                    const prior = result.completed.completion;
+                    discardCompletionProse(alloc, provider, .{ .provider = .gateway, .model = "fixture-model" }, &result.completed) catch |err| {
+                        try std.testing.expectEqual(prior.content.?.ptr, result.completed.completion.content.?.ptr);
+                        try std.testing.expectEqual(prior.provider_state_json.?.ptr, result.completed.completion.provider_state_json.?.ptr);
+                        if (err == error.InvalidProviderState) continue;
+                        return err;
+                    };
+                    try std.testing.expect(result.completed.completion.content == null);
+                    if (state == null or std.mem.eql(u8, state.?, "drop")) {
+                        try std.testing.expect(result.completed.completion.provider_state_json == null);
+                    } else if (std.mem.eql(u8, state.?, "kept")) {
+                        try std.testing.expectEqual(prior.provider_state_json.?.ptr, result.completed.completion.provider_state_json.?.ptr);
+                    } else {
+                        try std.testing.expectEqualStrings("retained", result.completed.completion.provider_state_json.?);
+                    }
+                }
+            }
+        }
+    };
+    try Probe.run(std.testing.allocator);
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, Probe.run, .{});
+}
+
 fn isRetryableModelFailure(kind: agent_stream_provider.FailureKind) bool {
     return switch (kind) {
         .rate_limited, .server_error, .bad_gateway, .unavailable, .gateway_timeout => true,
@@ -4312,6 +4408,7 @@ fn processQueuedPromptInner(
             0,
         );
     }
+    try projectEmptyHistoryReplay(arena, deps.agent_stream_provider, .{ .provider = job.provider, .model = job.model }, history_messages.items);
     const projected_roles = try runtime_telemetry.formatMessageRoles(arena, history_messages.items);
     debug_trace.eventf(
         "history",
@@ -4751,6 +4848,8 @@ pub fn prepareRetainedCompactionWindow(
     active: ?types.AssistantHistoryTurn,
     capabilities: model_capabilities.Capabilities,
     source_tokens: usize,
+    provider: agent_stream_provider.Provider,
+    provider_selection: model_provider.ProviderSelection,
 ) !RetainedCompactionWindow {
     var combined: std.ArrayList(HistoryTurn) = .empty;
     try combined.appendSlice(arena, history);
@@ -4783,6 +4882,7 @@ pub fn prepareRetainedCompactionWindow(
     const retained = try session_runtime.contextHistoryRange(arena, history, cut, null);
     var messages: std.ArrayList(ChatMessage) = .empty;
     try session_runtime.appendHistoryChatMessages(arena, &messages, retained);
+    try projectEmptyHistoryReplay(arena, provider, provider_selection, messages.items);
     return .{
         .source = source.items,
         .retained_history = retained,
@@ -4811,11 +4911,11 @@ test "retained context ends an unfinished turn at its completed exchange" {
         .execution = .{ .tool_steps = @constCast(&steps) },
     };
     const capabilities = model_capabilities.Capabilities{ .context_window = 4_000 };
-    const active = try prepareRetainedCompactionWindow(arena_state.allocator(), &.{}, turn, capabilities, 9_000);
+    const active = try prepareRetainedCompactionWindow(arena_state.allocator(), &.{}, turn, capabilities, 9_000, agent_stream_provider.unavailable_provider, .{ .provider = .gateway, .model = "fixture-model" });
     try std.testing.expectEqual(types.ContextHistoryCut{ .tool_steps = 1 }, active.cut);
     try std.testing.expectEqual(@as(usize, 3), active.source.len);
     try std.testing.expectEqual(@as(usize, 0), active.retained_messages.len);
-    const saved = try prepareRetainedCompactionWindow(arena_state.allocator(), &.{.{ .assistant = turn }}, null, capabilities, 9_000);
+    const saved = try prepareRetainedCompactionWindow(arena_state.allocator(), &.{.{ .assistant = turn }}, null, capabilities, 9_000, agent_stream_provider.unavailable_provider, .{ .provider = .gateway, .model = "fixture-model" });
     try std.testing.expectEqual(types.ContextHistoryCut{ .turns = 1 }, saved.cut);
     try std.testing.expectEqual(@as(usize, 0), saved.retained_messages.len);
 }
@@ -5713,7 +5813,7 @@ fn processQueuedPromptLoop(
                             .user = .{ .text = job.prompt, .images = job.images },
                             .assistant = @constCast(""),
                             .execution = prefix_execution,
-                        }, request_capabilities, request_cost.estimated_input_tokens);
+                        }, request_capabilities, request_cost.estimated_input_tokens, deps.agent_stream_provider, .{ .provider = job.provider, .model = job.model });
                         if (window.source.len == 0) {
                             if (context_overflow_recovery == .pending or request_cost.estimated_input_tokens > (runtime_prompt_context.usableInputTokens(request_capabilities) orelse std.math.maxInt(usize))) return error.ContextCapacityExceeded;
                             break :compact_attempt;
@@ -6664,7 +6764,7 @@ fn processQueuedPromptLoop(
                 }
             };
 
-            const attempt_completion = response_completion;
+            var attempt_completion = response_completion;
             const response_language_candidate = if (stream_ctx.raw_text.items.len > 0)
                 stream_ctx.raw_text.items
             else if (attempt_completion.content) |content|
@@ -6730,6 +6830,11 @@ fn processQueuedPromptLoop(
                 switch (language_decision) {
                     .accept, .undecidable => try stream_ctx.accept_staged_response_language(),
                     .accept_without_prose => {
+                        try discardCompletionProse(arena, deps.agent_stream_provider, .{
+                            .provider = job.provider,
+                            .model = gateway_model,
+                        }, &stream_result.completed);
+                        attempt_completion = stream_result.completed.completion;
                         debug_trace.eventf(
                             "agent",
                             "response_language_mismatch",
@@ -6744,9 +6849,6 @@ fn processQueuedPromptLoop(
                             },
                         );
                         stream_ctx.drop_staged_response_language_candidate();
-                        if (streamCompletionPtr(&stream_result)) |candidate| {
-                            candidate.content = null;
-                        }
                     },
                     .retry_once, .fail_without_commit => {
                         const observed = candidate_language.script.?;

--- a/src/core/agent/runtime/tests/gateway_flow.zig
+++ b/src/core/agent/runtime/tests/gateway_flow.zig
@@ -3404,6 +3404,64 @@ test "retained context automatic compaction continues with the exact recent para
     for (gateway.request_models.items) |requested_model| try std.testing.expectEqualStrings(model, requested_model);
 }
 
+test "retained context compaction preserves recovered historical replay" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const result_dir = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(result_dir);
+    const old_text = "OLDER_HISTORY_SENTINEL " ++ ("o" ** 52_000);
+    const recent_result = "RECENT_RECOVERED_RESULT\n" ++ ("r" ** 1_000);
+    const model = "provider/retained-recovery";
+    const state = "[{\"type\":\"reasoning\",\"text\":\"retained_reasoning\"},{\"type\":\"text\",\"offset\":0,\"length\":42,\"providerOptions\":{\"fixture\":{\"id\":\"discarded_text\"}}}]";
+    var calls = [_]ToolCall{toolCall("old_read", "read_file", "{\"path\":\"a.txt\"}")};
+    var results = [_]types.PersistedToolResult{.{
+        .tool_call_id = @constCast("old_read"),
+        .tool_name = @constCast("read_file"),
+        .status = .success,
+        .output = @constCast(recent_result),
+        .output_bytes = recent_result.len,
+        .stored_output_bytes = recent_result.len,
+    }};
+    var steps = [_]types.ToolExecutionStep{.{
+        .assistant = @constCast(""),
+        .tool_calls = &calls,
+        .tool_results = &results,
+        .provider_replay = .{ .source = .{ .provider = .gateway, .model = model }, .parts_json = state },
+    }};
+    var history = [_]HistoryTurn{
+        .{ .assistant = .{ .user = .{ .text = @constCast("earlier work") }, .assistant = @constCast(old_text) } },
+        .{ .assistant = .{ .user = .{ .text = @constCast("recent work") }, .assistant = @constCast(""), .execution = .{ .tool_steps = &steps } } },
+    };
+    const old_tokens = prompt_context.estimateCompactionSourceTokens(&.{.{ .role = .assistant, .content = old_text }});
+    const recent_tokens = prompt_context.estimateCompactionSourceTokens(&.{.{ .role = .tool, .content = recent_result }});
+    const capabilities = [_]ModelCapabilityOverride{.{ .model = model, .capabilities = .{ .context_window = @intCast((old_tokens + recent_tokens / 2) * 5 / 4) } }};
+    var gateway = FakeGateway.init(alloc, &.{
+        .{ .content = "Earlier work established the project facts." },
+        .{ .content = "The saved read result remains available." },
+    });
+    defer gateway.deinit();
+    var hooks = FakeAgentRuntimeDeps.init(alloc);
+    defer hooks.deinit();
+    hooks.available_capability_overrides = &capabilities;
+    var fixture = PromptFixture{};
+    var config = fixture.config();
+    config.tool_result_dir = result_dir;
+    var job = fixture.job();
+    job.model = @constCast(model);
+    job.history = &history;
+    try runFakePrompt(&gateway, &hooks, config, job);
+    try std.testing.expectEqual(@as(usize, 2), gateway.request_bodies.items.len);
+    try std.testing.expectEqual(@as(usize, 0), hooks.executed_names.items.len);
+    try expectBodyContains(&gateway, 0, "OLDER_HISTORY_SENTINEL");
+    try expectBodyContains(&gateway, 1, "context_handoff");
+    try expectBodyContains(&gateway, 1, "RECENT_RECOVERED_RESULT");
+    try expectBodyContains(&gateway, 1, "retained_reasoning");
+    try expectBodyNotContains(&gateway, 1, "discarded_text");
+    try expectBodyNotContains(&gateway, 1, "OLDER_HISTORY_SENTINEL");
+    try std.testing.expectEqualStrings(state, steps[0].provider_replay.?.parts_json);
+}
+
 test "processQueuedPrompt does not compact away its only recent exchange" {
     const alloc = std.testing.allocator;
     var gateway = FakeGateway.init(alloc, &.{
@@ -5069,6 +5127,134 @@ test "processQueuedPrompt does not language-retry a tool-bearing response" {
     try std.testing.expectEqual(@as(usize, 1), hooks.history_turns.items.len);
     try std.testing.expectEqual(@as(usize, 1), hooks.history_turns.items[0].assistant.execution.tool_steps.len);
     try std.testing.expect(hooks.history_turns.items[0].assistant.execution.tool_steps[0].assistant == null);
+}
+
+test "processQueuedPrompt discards prose replay without losing reasoning or tool metadata" {
+    const alloc = std.testing.allocator;
+    const prose = "我会先检查锁文件和依赖清单。";
+    const state = try std.fmt.allocPrint(
+        alloc,
+        "[{{\"type\":\"reasoning\",\"text\":\"retained_reasoning\"}},{{\"type\":\"text\",\"offset\":0,\"length\":{d},\"providerOptions\":{{\"fixture\":{{\"id\":\"discarded_text\"}}}}}},{{\"type\":\"tool-call\",\"toolCallId\":\"call_read\",\"providerOptions\":{{\"fixture\":{{\"id\":\"retained_tool\"}}}}}}]",
+        .{prose.len},
+    );
+    defer alloc.free(state);
+    const calls = [_]ToolCall{toolCall("call_read", "read_file", "{\"path\":\"a\"}")};
+    const completions = [_]FakeCompletion{
+        .{ .chunks = &.{prose}, .content = prose, .tool_calls = &calls, .provider_state_json = state },
+        .{ .content = "The notes are checked." },
+    };
+    var gateway = FakeGateway.init(alloc, &completions);
+    defer gateway.deinit();
+    var hooks = FakeAgentRuntimeDeps.init(alloc);
+    defer hooks.deinit();
+    var fixture = PromptFixture{};
+    var job = fixture.job();
+    job.prompt = @constCast("Please check the notes.");
+    try runFakePrompt(&gateway, &hooks, fixture.config(), job);
+    try std.testing.expectEqual(@as(usize, 2), gateway.request_bodies.items.len);
+    try std.testing.expectEqual(@as(usize, 1), hooks.executed_names.items.len);
+    try expectBodyNotContains(&gateway, 1, prose);
+    try expectBodyNotContains(&gateway, 1, "discarded_text");
+    try expectBodyContains(&gateway, 1, "retained_reasoning");
+    try expectBodyContains(&gateway, 1, "retained_tool");
+    const step = hooks.history_turns.items[0].assistant.execution.tool_steps[0];
+    try std.testing.expect(step.assistant == null);
+    try std.testing.expect(std.mem.find(u8, step.provider_replay.?.parts_json, "retained_reasoning") != null);
+    try std.testing.expect(std.mem.find(u8, step.provider_replay.?.parts_json, "retained_tool") != null);
+    try std.testing.expect(std.mem.find(u8, step.provider_replay.?.parts_json, "discarded_text") == null);
+}
+
+test "processQueuedPrompt recovers empty historical prose without changing source or repeating tools" {
+    const alloc = std.testing.allocator;
+    const state = "[{\"type\":\"reasoning\",\"text\":\"retained_reasoning\"},{\"type\":\"text\",\"offset\":0,\"length\":42,\"providerOptions\":{\"fixture\":{\"id\":\"discarded_text\"}}},{\"type\":\"tool-call\",\"toolCallId\":\"call_read\",\"providerOptions\":{\"fixture\":{\"id\":\"retained_tool\"}}}]";
+    var calls = [_]ToolCall{toolCall("call_read", "read_file", "{\"path\":\"a\"}")};
+    var results = [_]types.PersistedToolResult{.{
+        .tool_call_id = @constCast("call_read"),
+        .tool_name = @constCast("read_file"),
+        .status = .success,
+        .output = @constCast("retained_result"),
+        .output_bytes = 15,
+        .stored_output_bytes = 15,
+    }};
+    var steps = [_]types.ToolExecutionStep{.{
+        .assistant = @constCast(""),
+        .tool_calls = &calls,
+        .tool_results = &results,
+        .provider_replay = .{ .source = .{ .provider = .gateway, .model = "fixture-model" }, .parts_json = state },
+    }};
+    var history = [_]HistoryTurn{.{ .assistant = .{
+        .user = .{ .text = @constCast("Please read the notes.") },
+        .assistant = @constCast(""),
+        .execution = .{ .tool_steps = &steps },
+    } }};
+    for (0..2) |_| {
+        const completions = [_]FakeCompletion{.{ .content = "The saved result is intact." }};
+        var gateway = FakeGateway.init(alloc, &completions);
+        defer gateway.deinit();
+        var hooks = FakeAgentRuntimeDeps.init(alloc);
+        defer hooks.deinit();
+        var fixture = PromptFixture{};
+        var job = fixture.job();
+        job.model = @constCast("fixture-model");
+        job.history = &history;
+        try runFakePrompt(&gateway, &hooks, fixture.config(), job);
+        try std.testing.expectEqual(@as(usize, 1), gateway.request_bodies.items.len);
+        try std.testing.expectEqual(@as(usize, 0), hooks.executed_names.items.len);
+        try expectBodyContains(&gateway, 0, "retained_reasoning");
+        try expectBodyContains(&gateway, 0, "retained_tool");
+        try expectBodyContains(&gateway, 0, "retained_result");
+        try expectBodyNotContains(&gateway, 0, "discarded_text");
+        try std.testing.expectEqualStrings(state, steps[0].provider_replay.?.parts_json);
+        try std.testing.expectEqualStrings("", steps[0].assistant.?);
+    }
+}
+
+test "processQueuedPrompt empty history recovery preserves validation and source boundaries" {
+    const Case = struct {
+        content: []const u8 = "",
+        state: []const u8,
+        provider: model_provider.ProviderId = .gateway,
+        model: []const u8 = "fixture-model",
+        failure: bool = true,
+    };
+    const cases = [_]Case{
+        .{ .state = "{" },
+        .{ .state = "[42]" },
+        .{ .state = "[{\"type\":\"unknown\"}]" },
+        .{ .content = "x", .state = "[{\"type\":\"text\",\"offset\":0,\"length\":42}]" },
+        .{ .content = " ", .state = "[{\"type\":\"text\",\"offset\":0,\"length\":42}]" },
+        .{ .content = "kept", .state = "[{\"type\":\"text\",\"offset\":0,\"length\":4}]", .failure = false },
+        .{ .state = "[{\"type\":\"reasoning\",\"text\":\"kept\"}]", .failure = false },
+        .{ .state = "not-json", .provider = .codex, .failure = false },
+        .{ .state = "not-json", .model = "other-model", .failure = false },
+    };
+    const alloc = std.testing.allocator;
+    for (cases) |case| {
+        var history = [_]HistoryTurn{.{ .assistant = .{
+            .user = .{ .text = @constCast("Please check the notes.") },
+            .assistant = @constCast(case.content),
+            .provider_replay = .{ .source = .{ .provider = case.provider, .model = case.model }, .parts_json = case.state },
+        } }};
+        const completions = [_]FakeCompletion{.{ .content = "The saved result is intact." }};
+        var gateway = FakeGateway.init(alloc, &completions);
+        defer gateway.deinit();
+        var hooks = FakeAgentRuntimeDeps.init(alloc);
+        defer hooks.deinit();
+        var fixture = PromptFixture{};
+        var job = fixture.job();
+        job.model = @constCast("fixture-model");
+        job.history = &history;
+        if (case.failure) {
+            try std.testing.expectError(error.InvalidProviderState, runFakePrompt(&gateway, &hooks, fixture.config(), job));
+            try std.testing.expectEqual(@as(usize, 0), gateway.admitted_requests);
+        } else {
+            try runFakePrompt(&gateway, &hooks, fixture.config(), job);
+            try std.testing.expectEqual(@as(usize, 1), gateway.admitted_requests);
+        }
+        try std.testing.expectEqual(@as(usize, 0), hooks.executed_names.items.len);
+        try std.testing.expectEqualStrings(case.state, history[0].assistant.provider_replay.?.parts_json);
+        try std.testing.expectEqualStrings(case.content, history[0].assistant.assistant);
+    }
 }
 
 test "processQueuedPrompt reconciles provider error before tool execution" {

--- a/src/core/app/app_agent_runtime.zig
+++ b/src/core/app/app_agent_runtime.zig
@@ -1092,7 +1092,7 @@ pub fn Runtime(comptime App: type) type {
                 job.model,
                 capabilities,
             );
-            const window = try agent_runtime.prepareRetainedCompactionWindow(arena, job.history, null, capabilities, source_tokens);
+            const window = try agent_runtime.prepareRetainedCompactionWindow(arena, job.history, null, capabilities, source_tokens, deps.agent_stream_provider, .{ .provider = job.provider, .model = job.model });
             const continuation_messages = try arena.alloc(ChatMessage, continuation.request.messages.len + window.retained_messages.len);
             @memcpy(continuation_messages[0..continuation.request.messages.len], continuation.request.messages);
             @memcpy(continuation_messages[continuation.request.messages.len..], window.retained_messages);

--- a/src/gateway/responses_protocol.zig
+++ b/src/gateway/responses_protocol.zig
@@ -33,6 +33,7 @@ pub fn selectReplayParts(alloc: std.mem.Allocator, replay: ?types.ProviderReplay
         count += 1;
     }
     if (count == 0) return null;
+    if (count == parsed.value.array.items.len) return source;
     out.writer.writeByte(']') catch return error.OutOfMemory;
     return .{ .source = source.source, .parts_json = try out.toOwnedSlice() };
 }
@@ -301,6 +302,16 @@ test "Responses replay filtering cleans up allocation failures" {
         }
     };
     try std.testing.checkAllAllocationFailures(std.testing.allocator, Probe.run, .{});
+}
+
+test "Responses unchanged replay projection borrows reasoning state" {
+    const source: types.ProviderReplay = .{
+        .source = .{ .provider = .codex, .model = "fixture-model" },
+        .parts_json = "[ {\"type\":\"reasoning\",\"encrypted_content\":\"kept\"} ]",
+    };
+    const selected = (try selectReplayParts(std.testing.allocator, source, &.{}, false, true)).?;
+    try std.testing.expectEqual(source.parts_json.ptr, selected.parts_json.ptr);
+    try std.testing.expectEqualStrings(source.parts_json, selected.parts_json);
 }
 
 test "Responses request preserves assistant commentary phase" {

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -4870,6 +4870,78 @@ test("native final snapshots preserve completed items and reject conflicting kin
   }
 }, 60_000);
 
+test("native discarded prose keeps tool continuation and saved resume valid", async () => {
+  for (const provider of ["codex", "grok"] as const) for (const mismatch of [false, true]) for (const multiple of [false, true]) {
+    const profile = mkdtempSync(join(tmpdir(), "fx-discarded-prose-"));
+    const gateway = startFakeGateway([]);
+    const model = "fixture-model";
+    const prose = mismatch ? "我会先检查锁文件和依赖清单。" : "I will read the notes next.";
+    const reasoning = { type: "reasoning", id: "rs_filtered", summary: [], encrypted_content: "RETAINED_REASONING" };
+    const message = (id: string, text: string, phase?: string) => ({ type: "message", id, role: "assistant", status: "completed", ...(phase ? { phase } : {}), content: [{ type: "output_text", text, annotations: [] }] });
+    const messages = multiple ? [message("msg_first", prose), message("msg_second", prose)] : [message("msg_first", prose, "commentary")];
+    const call = { type: "function_call", id: "fc_filtered", call_id: "call_filtered", name: "read_file", arguments: JSON.stringify({ path: "notes.txt" }) };
+    const toolIndex = messages.length + 1;
+    const answer = (text: string) => fakeGatewaySse([
+      { type: "response.output_item.done", output_index: 0, item: message("msg_answer", text) },
+      { type: "response.completed", response: { status: "completed", output: null } },
+    ]);
+    const responses = [fakeGatewaySse([
+      { type: "response.output_item.done", output_index: 0, item: reasoning },
+      ...messages.map((item, index) => ({ type: "response.output_item.done", output_index: index + 1, item })),
+      { type: "response.output_item.added", output_index: toolIndex, item: { ...call, arguments: "" } },
+      { type: "response.function_call_arguments.done", output_index: toolIndex, item_id: call.id, arguments: call.arguments },
+      { type: "response.output_item.done", output_index: toolIndex, item: call },
+      { type: "response.completed", response: { status: "completed", output: [reasoning, ...messages, call] } },
+    ]), answer("The notes were checked."), answer("The saved session remains usable.")];
+    const direct = provider === "codex" ? startFakeCodexToolLoop({ model, responses }) : startFakeGrokToolLoop({ model, responses });
+    try {
+      if (provider === "codex") writeSeededChatGptLogin(profile, direct.accessToken);
+      else writeSeededGrokLogin(profile, direct.accessToken);
+      writeFileSync(join(profile, ".fx", "settings.json"), JSON.stringify({ provider, [provider + "_model"]: model }), { mode: 0o600 });
+      writeFileSync(join(profile, "notes.txt"), "FILTERED_READ_RESULT\n");
+      const tracePath = join(profile, "trace.log");
+      const env = {
+        HOME: profile, AI_GATEWAY_API_KEY: "fixture", VERCEL_OIDC_TOKEN: undefined, FX_MODEL: undefined,
+        FX_DISABLE_KEYCHAIN: "1", FX_AUTO_UPGRADE: "0", FX_SOUND: "0", FX_TRACE_LOG: tracePath, FX_TRACE_SCOPES: "agent,gateway,tool",
+        FX_GATEWAY_BASE_URL: gateway.baseUrl, FX_E2E_GATEWAY_MODELS_URL: gateway.baseUrl + "/coding-agent/v1/models",
+        FX_E2E_OPENAI_CODEX_RESPONSES_URL: direct.responsesUrl, FX_E2E_OPENAI_CODEX_MODELS_URL: direct.modelsUrl,
+        FX_E2E_XAI_GROK_RESPONSES_URL: direct.responsesUrl, FX_E2E_XAI_GROK_MODELS_URL: direct.modelsUrl,
+        FX_E2E_XAI_GROK_MODALITIES_URL: "modalitiesUrl" in direct ? direct.modalitiesUrl : undefined,
+      };
+      const first = await runFx(["ask", "--json", "--auto", "Please read the notes.txt file and explain the result."], { cwd: profile, env, timeoutMs: TIMEOUT });
+      expect(first.code, provider + "/" + mismatch + "/" + multiple + ": " + first.stdout + first.stderr).toBe(0);
+      expect(first.signal).toBeNull();
+      const result = JSON.parse(first.stdout);
+      expect(result.tool_calls).toEqual([{ name: "read_file", status: "success" }]);
+      expect(result.output).toBe(mismatch ? "The notes were checked." : messages.map(() => prose).join("\n\n") + "\n\nThe notes were checked.");
+      expect(direct.bodies).toHaveLength(2);
+      const trace = readFileSync(tracePath, "utf8");
+      expect(trace.includes("prose_discarded=true")).toBe(mismatch);
+      const detail = await runFx(["session", "--json", "--id", result.session_id], { cwd: profile, env });
+      expect(detail.code).toBe(0);
+      expect(JSON.parse(detail.stdout).history).toHaveLength(1);
+      const resumed = await runFx(["ask", "--json", "--auto", "--resume-id", result.session_id, "Please confirm the saved result without tools."], { cwd: profile, env, timeoutMs: TIMEOUT });
+      expect(resumed.code, resumed.stdout + resumed.stderr).toBe(0);
+      expect(resumed.stderr).toBe("");
+      expect(JSON.parse(resumed.stdout).tool_calls).toEqual([]);
+      expect(JSON.parse(resumed.stdout).output).toBe("The saved session remains usable.");
+      expect(direct.bodies).toHaveLength(3);
+      for (const body of direct.bodies.slice(1)) {
+        const input = JSON.parse(body).input;
+        expect(input.filter((item: { type?: string }) => item.type === "reasoning")).toEqual([reasoning]);
+        expect(input.filter((item: { type?: string }) => item.type === "function_call").map((item: { call_id: string }) => item.call_id)).toEqual([call.call_id]);
+        expect(input.filter((item: { type?: string }) => item.type === "function_call_output")).toHaveLength(1);
+        expect(body).toContain("FILTERED_READ_RESULT");
+        if (mismatch) expect(body).not.toContain(prose);
+      }
+      expect(gateway.requests).toHaveLength(0);
+    } finally {
+      direct.stop(); gateway.stop();
+      rmSync(profile, { recursive: true, force: true });
+    }
+  }
+}, 60_000);
+
 test("native terminal outcomes preserve recovery and incomplete warnings", async () => {
   for (const provider of ["gateway", "codex", "grok"] as const) for (const mode of ["transient", "partial", "tool", "rejected", "rejected-partial", "length", "length-with-status"]) {
     const native = provider !== "gateway";


### PR DESCRIPTION
## Summary

- Keep tool turns running when response-language filtering removes assistant prose.
- Resume saved turns with stale text replay metadata without repeating completed tools.
- Preserve recovered context through automatic and manual compaction.
