### PR TITLE
Preserve saved sessions across interruption and failure

### DIFF
--- a/src/acp/prompt.zig
+++ b/src/acp/prompt.zig
@@ -642,6 +642,11 @@ pub fn handlePrompt(
     const session = if (state.active_session) |*active| active else return .{
         .rpc_error = no_active_session_rpc_error,
     };
+    {
+        session.session_write_mutex.lockUncancelable(io_mod.getIo());
+        defer session.session_write_mutex.unlock(io_mod.getIo());
+        if (session.writable) |*loaded| try loaded.requireWritable();
+    }
     if (!try server.selectCredentialForProvider(state, session.provider)) {
         return .{ .rpc_error = .{
             .code = ErrorCode.invalid_request,
@@ -1962,7 +1967,7 @@ fn persistAcpHistoryTurn(
         return;
     };
     try writable.prepareHistoryTurnForCommit(alloc, &prepared);
-    _ = try writable.appendEvent(
+    _ = writable.appendEvent(
         alloc,
         .{ .history_turn_committed = .{
             .conversation_language = session.session_rt.languageSnapshot(),
@@ -1971,7 +1976,12 @@ fn persistAcpHistoryTurn(
             .turn = prepared,
         } },
         io_mod.milliTimestamp(),
-    );
+    ) catch |err| {
+        if (err == error.SessionPersistenceUncertain) {
+            if (current_prompt_input) |input| input.retainImageSnapshots();
+        }
+        return err;
+    };
     session.session_rt.commitPreparedHistoryEntry(alloc, prepared);
     prepared_owned = false;
     if (current_prompt_input) |prompt_input| prompt_input.retainImageSnapshots();
@@ -1991,7 +2001,12 @@ fn commitContextCompaction(
     var prepared_owned = true;
     defer if (prepared_owned) types.freeHistoryTurnSlice(ctx.alloc, prepared);
     if (session.writable) |*writable| {
-        _ = try writable.commitContextCompaction(ctx.alloc, summary, active_prefix, retained_from, io_mod.milliTimestamp());
+        _ = writable.commitContextCompaction(ctx.alloc, summary, active_prefix, retained_from, io_mod.milliTimestamp()) catch |err| {
+            if (err == error.SessionPersistenceUncertain and active_prefix != null) {
+                if (ctx.current_prompt_input) |input| input.retainImageSnapshots();
+            }
+            return err;
+        };
         if (active_prefix != null) {
             if (ctx.current_prompt_input) |input| input.retainImageSnapshots();
         }
@@ -2039,6 +2054,9 @@ fn setRecoveryCheckpoint(
     checkpoint: session_codec.RecoveryCheckpoint,
 ) !void {
     const ctx: *AcpContext = @ptrCast(@alignCast(raw_ctx));
+    errdefer |err| if (err == error.SessionPersistenceUncertain) {
+        if (ctx.current_prompt_input) |input| input.retainImageSnapshots();
+    };
     const session = if (ctx.state.active_session) |*value| value else return error.SessionPersistenceUnavailable;
     session.session_write_mutex.lockUncancelable(io_mod.getIo());
     defer session.session_write_mutex.unlock(io_mod.getIo());

--- a/src/core/agent/runtime/gateway_step.zig
+++ b/src/core/agent/runtime/gateway_step.zig
@@ -670,3 +670,61 @@ test "selected MCP schemas replace old definitions without duplicate names" {
     try std.testing.expect(properties.contains("new_value"));
     try std.testing.expect(!properties.contains("old_value"));
 }
+
+test "invalid writer at provider completion prevents delivery of executable tool calls" {
+    const Sink = struct {
+        calls: usize = 0,
+        fn persist(raw: *anyopaque, _: session_usage.Snapshot) !void {
+            const self: *@This() = @ptrCast(@alignCast(raw));
+            self.calls += 1;
+            if (self.calls == 2) return error.SessionPersistenceUncertain;
+        }
+    };
+    const Provider = struct {
+        fn stream(_: ?*anyopaque, alloc: Allocator, request: agent_stream_provider.ModelRequest) !agent_stream_provider.Result {
+            try request.admission.admit();
+            return .{ .completed = .{
+                .completion = .{ .tool_calls = try types.dupeToolCallSlice(alloc, &.{.{
+                    .id = "unsaved-tool",
+                    .name = "read_file",
+                    .arguments_json = "{}",
+                }}), .finish_reason = .tool_calls },
+                .ownership = .owned,
+            } };
+        }
+        fn event(_: *anyopaque, _: agent_stream_provider.Event) void {}
+    };
+    const alloc = std.testing.allocator;
+    var sink = Sink{};
+    var usage = session_usage.Usage.initFresh();
+    defer usage.deinit(alloc);
+    usage.configureCheckpointSink(.{ .context = &sink, .allocator = alloc, .persist = Sink.persist });
+    var cancel = std.atomic.Value(bool).init(false);
+    var delivery = DeliveryCertainty.init();
+    var evidence: AttemptEvidence = .{};
+    var callback_ctx: u8 = 0;
+    try std.testing.expectError(error.SessionPersistenceUncertain, streamModelCompletion(
+        .{ .stream_fn = Provider.stream },
+        alloc,
+        .{
+            .credential = .{ .direct = .{ .secret_bytes = "test-key" } },
+            .model = "test/model",
+            .retry_count = 1,
+            .messages = &.{},
+            .tool_choice = .auto,
+            .provider_options = .{},
+            .trace_ctx = .{},
+            .content_capture_limit = null,
+            .delivery = &delivery,
+            .attempt_evidence = &evidence,
+            .events = .{ .context = &callback_ctx, .emit_fn = Provider.event },
+            .cancel_flag = &cancel,
+        },
+        &usage,
+        alloc,
+    ));
+    try std.testing.expectEqual(@as(usize, 2), sink.calls);
+    try std.testing.expect(evidence.provider_admitted);
+    try std.testing.expect(usage.checkpoint_mutex.tryLock());
+    usage.checkpoint_mutex.unlock(io_mod.getIo());
+}

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -3888,6 +3888,8 @@ fn pushTerminalProviderFailureStatus(
 fn finishRecoveryPaused(
     deps: *const AgentRuntimeDeps,
     finalization: *TurnFinalizationGuard,
+    stream_ctx: *runtime_assistant_stream.StreamChunkContext,
+    arena: Allocator,
     finish_trace: *PromptFinishTrace,
     cause: model_response_recovery.FailureCause,
     consumed_attempts: usize,
@@ -3895,6 +3897,13 @@ fn finishRecoveryPaused(
     required_action: types.ModelRecoveryRequiredAction,
     diagnostic: ?types.ModelFailureDiagnostic,
 ) !void {
+    try stream_ctx.provisional_statuses.finishUnmatchedRecoveryStarts(
+        deps,
+        stream_ctx.alloc,
+        arena,
+        finalization.turn_id,
+        &.{},
+    );
     try pushRouteRecoveryStatus(deps, .{
         .kind = .terminal_provider_error,
         .failed_attempt = consumed_attempts,
@@ -5474,7 +5483,7 @@ fn processQueuedPromptLoop(
         var recovery_has_unexecuted_tool_start = false;
         var successful_recovery_strategy: ?model_response_recovery.Strategy = null;
         defer {
-            if (recovery_has_unexecuted_tool_start) {
+            if (recovery_has_unexecuted_tool_start and finalization.outcome != .paused) {
                 const settlement = if (config.cancel_flag.load(.seq_cst))
                     stream_ctx.provisional_statuses.finishTrackedCancelled(
                         deps,
@@ -5530,6 +5539,8 @@ fn processQueuedPromptLoop(
                 try finishRecoveryPaused(
                     deps,
                     finalization,
+                    &stream_ctx,
+                    arena,
                     &finish_trace,
                     recovery_cause,
                     semantic_attempt,
@@ -5564,6 +5575,8 @@ fn processQueuedPromptLoop(
                 try finishRecoveryPaused(
                     deps,
                     finalization,
+                    &stream_ctx,
+                    arena,
                     &finish_trace,
                     recovery_cause,
                     semantic_attempt,
@@ -6076,6 +6089,8 @@ fn processQueuedPromptLoop(
                     try finishRecoveryPaused(
                         deps,
                         finalization,
+                        &stream_ctx,
+                        arena,
                         &finish_trace,
                         failure_cause,
                         consumed_attempts,
@@ -6209,6 +6224,8 @@ fn processQueuedPromptLoop(
                     try finishRecoveryPaused(
                         deps,
                         finalization,
+                        &stream_ctx,
+                        arena,
                         &finish_trace,
                         failure_cause,
                         consumed_attempts,
@@ -6291,6 +6308,8 @@ fn processQueuedPromptLoop(
                     try finishRecoveryPaused(
                         deps,
                         finalization,
+                        &stream_ctx,
+                        arena,
                         &finish_trace,
                         failure_cause,
                         consumed_attempts,
@@ -6470,6 +6489,8 @@ fn processQueuedPromptLoop(
                 try finishRecoveryPaused(
                     deps,
                     finalization,
+                    &stream_ctx,
+                    arena,
                     &finish_trace,
                     recovery_cause,
                     semantic_attempt + 1,
@@ -6657,6 +6678,8 @@ fn processQueuedPromptLoop(
                     try finishRecoveryPaused(
                         deps,
                         finalization,
+                        &stream_ctx,
+                        arena,
                         &finish_trace,
                         cause,
                         semantic_attempt + 1,
@@ -6991,6 +7014,8 @@ fn processQueuedPromptLoop(
                     try finishRecoveryPaused(
                         deps,
                         finalization,
+                        &stream_ctx,
+                        arena,
                         &finish_trace,
                         cause,
                         semantic_attempt + 1,

--- a/src/core/agent/runtime/tests/gateway_flow.zig
+++ b/src/core/agent/runtime/tests/gateway_flow.zig
@@ -6881,6 +6881,35 @@ test "processQueuedPrompt pauses a local tool after assistant source when budget
     try std.testing.expectEqual(types.TurnPresentationOutcome.paused, hooks.finalized_outcome.?);
 }
 
+test "processQueuedPrompt settles retry tool starts before pausing" {
+    const alloc = std.testing.allocator;
+    const starts = [_]ToolCall{toolCall("interrupted-read", "read_file", "{}")};
+    const completions = [_]FakeCompletion{
+        .{ .streamed_tool_starts = &starts, .stream_error_after_tool_starts = error.ReadFailed },
+        .{ .stream_error_after_chunks = error.ReadFailed },
+    };
+    var gateway = FakeGateway.init(alloc, &completions);
+    defer gateway.deinit();
+    var hooks = FakeAgentRuntimeDeps.init(alloc);
+    defer hooks.deinit();
+    var fixture = PromptFixture{};
+    var config = fixture.config();
+    config.gateway_retry_count = 1;
+    config.max_provider_attempts = 2;
+    try runFakePrompt(&gateway, &hooks, config, fixture.job());
+    try std.testing.expectEqual(types.TurnPresentationOutcome.paused, hooks.finalized_outcome.?);
+    try std.testing.expectEqual(@as(usize, 0), hooks.executed_names.items.len);
+    const paused = logIndex(&hooks, "event:turn_finished").?;
+    var settled: usize = 0;
+    for (hooks.log.items, 0..) |entry, index| {
+        if (std.mem.startsWith(u8, entry, "status:finished:")) {
+            try std.testing.expect(index < paused);
+            settled += 1;
+        }
+    }
+    try std.testing.expectEqual(@as(usize, 1), settled);
+}
+
 test "processQueuedPrompt cancellation absorbs ReadFailed after published source" {
     const alloc = std.testing.allocator;
     const chunks = [_][]const u8{"partial cancelled"};
@@ -8142,4 +8171,44 @@ test "processQueuedPrompt trace emits one canonical result for tool execution er
     );
     try std.testing.expect(std.mem.find(u8, trace, "err=SystemResources") != null);
     try std.testing.expect(std.mem.find(u8, trace, "model_output_bytes=") != null);
+}
+
+test "processQueuedPrompt keeps provider uncertainty without tool terminals after pause" {
+    const alloc = std.testing.allocator;
+    const local = [_]ToolCall{toolCall("local-read", "read_file", "{}")};
+    const provider = [_]ToolCall{toolCall("provider-search", "web_search", "{}")};
+    const completions = [_]FakeCompletion{
+        .{ .streamed_tool_starts = &local, .stream_error_after_tool_starts = error.ReadFailed },
+        .{ .streamed_tool_starts = &provider, .stream_error_after_tool_starts = error.ReadFailed },
+        .{ .pause_before_output = true },
+    };
+    var pause_flag = std.atomic.Value(bool).init(false);
+    var gateway = FakeGateway.init(alloc, &completions);
+    gateway.recovery_pause_flag = &pause_flag;
+    defer gateway.deinit();
+    var hooks = FakeAgentRuntimeDeps.init(alloc);
+    hooks.enable_recovery_checkpoint = true;
+    defer hooks.deinit();
+    var fixture = PromptFixture{};
+    var config = fixture.config();
+    config.recovery_pause_flag = &pause_flag;
+    config.gateway_retry_count = 3;
+    config.max_provider_attempts = 4;
+    try runFakePrompt(&gateway, &hooks, config, fixture.job());
+    try std.testing.expectEqual(@as(usize, 3), gateway.request_models.items.len);
+    try std.testing.expectEqual(@as(usize, 0), hooks.executed_names.items.len);
+    try std.testing.expectEqual(types.TurnPresentationOutcome.paused, hooks.finalized_outcome.?);
+    const checkpoint = hooks.recovery_checkpoints.items[hooks.recovery_checkpoints.items.len - 1];
+    try std.testing.expectEqual(types.ModelRecoveryAction.paused, checkpoint.action);
+    try std.testing.expectEqual(.uncertain, checkpoint.tool_state);
+    const paused = logIndex(&hooks, "event:turn_finished").?;
+    var settled: usize = 0;
+    for (hooks.log.items, 0..) |entry, index| {
+        if (std.mem.startsWith(u8, entry, "status:finished:")) {
+            try std.testing.expect(index < paused);
+            settled += 1;
+        }
+    }
+    try std.testing.expectEqual(@as(usize, 1), settled);
+    try expectFailedLifecycleContains(hooks.lifecycle_events.items, "local-read", "before tool call ran");
 }

--- a/src/core/agent/worker_runtime.zig
+++ b/src/core/agent/worker_runtime.zig
@@ -506,7 +506,7 @@ pub const WorkerEvent = union(enum) {
 
 pub const WorkerEventBatch = struct {
     events: std.ArrayList(WorkerEvent),
-    cancel_requested: bool,
+    cancelled_turn_id: ?u64,
 };
 
 pub const WorkerRuntime = struct {
@@ -797,7 +797,7 @@ pub const WorkerRuntime = struct {
         self.worker_events = .empty;
         return .{
             .events = events,
-            .cancel_requested = self.worker_cancel_requested.load(.seq_cst),
+            .cancelled_turn_id = if (self.worker_cancel_requested.load(.seq_cst) and self.active_turn_id != 0) self.active_turn_id else null,
         };
     }
 
@@ -1806,6 +1806,11 @@ pub const WorkerRuntime = struct {
         max_history_turns: usize,
         publication: ?HistoryPublication,
     ) !void {
+        errdefer |err| if (err == error.SessionPersistenceUncertain) {
+            if (self.active_prompt_snapshot_ownership) |ownership| {
+                _ = ownership.preserve();
+            }
+        };
         if (self.queued_prompts.items.len == 0) {
             if (publication) |value| try value.commit();
             return;
@@ -1944,6 +1949,12 @@ pub const WorkerRuntime = struct {
         std.debug.assert(self.active_prompt_snapshot_ownership == ownership);
         self.active_prompt_snapshot_ownership = null;
         ownership.deinit();
+    }
+
+    pub fn preservePromptSnapshots(self: *WorkerRuntime, turn_id: u64, images: []const types.ImageAttachment) void {
+        self.worker_mutex.lockUncancelable(io_mod.getIo());
+        defer self.worker_mutex.unlock(io_mod.getIo());
+        _ = self.preservePromptSnapshotsLocked(turn_id, images);
     }
 
     fn preservePromptSnapshotsLocked(
@@ -4515,6 +4526,7 @@ test "takeEventBatch snapshots cancellation with detached events" {
     var runtime = WorkerRuntime{};
     defer runtime.deinit(alloc);
 
+    runtime.active_turn_id = 7;
     runtime.worker_cancel_requested.store(true, .seq_cst);
     runtime.worker_recovery_pause_requested.store(true, .seq_cst);
     try runtime.pushEvent(alloc, .{ .assistant_presentation = .{
@@ -4523,7 +4535,9 @@ test "takeEventBatch snapshots cancellation with detached events" {
 
     var batch = runtime.takeEventBatch();
     defer freeEventList(alloc, &batch.events);
-    try std.testing.expect(batch.cancel_requested);
+    runtime.active_turn_id = 8;
+    runtime.worker_cancel_requested.store(false, .seq_cst);
+    try std.testing.expectEqual(@as(?u64, 7), batch.cancelled_turn_id);
     try std.testing.expectEqual(@as(usize, 1), batch.events.items.len);
     try std.testing.expect(batch.events.items[0] == .assistant_presentation);
     try std.testing.expect(batch.events.items[0].assistant_presentation == .text);

--- a/src/core/app/app_agent_runtime.zig
+++ b/src/core/app/app_agent_runtime.zig
@@ -945,6 +945,11 @@ pub fn Runtime(comptime App: type) type {
             gateway_retry_count: usize,
             gateway_chat_url: []const u8,
         ) !void {
+            {
+                app.session_persistence.write_mutex.lockUncancelable(io_mod.getIo());
+                defer app.session_persistence.write_mutex.unlock(io_mod.getIo());
+                if (app.session_persistence.writable) |*loaded| try loaded.requireWritable();
+            }
             var job = queued_job;
             var fresh_history: ?worker_runtime.FreshPromptHistory = null;
             defer if (fresh_history) |*snapshot| snapshot.deinit(std.heap.c_allocator);

--- a/src/core/app/app_agent_runtime.zig
+++ b/src/core/app/app_agent_runtime.zig
@@ -945,17 +945,17 @@ pub fn Runtime(comptime App: type) type {
             gateway_retry_count: usize,
             gateway_chat_url: []const u8,
         ) !void {
-            {
-                app.session_persistence.write_mutex.lockUncancelable(io_mod.getIo());
-                defer app.session_persistence.write_mutex.unlock(io_mod.getIo());
-                if (app.session_persistence.writable) |*loaded| try loaded.requireWritable();
-            }
             var job = queued_job;
             var fresh_history: ?worker_runtime.FreshPromptHistory = null;
             defer if (fresh_history) |*snapshot| snapshot.deinit(std.heap.c_allocator);
             var snapshot_ownership = worker_runtime.ActivePromptSnapshotOwnership.init(job.images);
             app.worker.beginActivePromptSnapshots(&snapshot_ownership);
             defer app.worker.endActivePromptSnapshots(&snapshot_ownership);
+            {
+                app.session_persistence.write_mutex.lockUncancelable(io_mod.getIo());
+                defer app.session_persistence.write_mutex.unlock(io_mod.getIo());
+                if (app.session_persistence.writable) |*loaded| try loaded.requireWritable();
+            }
             if (job.recovery_checkpoint == null) {
                 if (try app_session_runtime.Runtime(App).snapshotFreshPromptBoundary(app, std.heap.c_allocator)) |value| {
                     var checkpoint = value;
@@ -3190,40 +3190,76 @@ test "subagent tool context uses immutable admission authority" {
     );
 }
 
-test "app agent runtime discards queued snapshots when tool projection preflight fails" {
+test "app agent runtime settles queued snapshot ownership when prompt admission fails" {
     const alloc = std.testing.allocator;
-    var tmp = std.testing.tmpDir(.{});
-    defer tmp.cleanup();
-    {
-        var file = try tmp.dir.createFile(std.testing.io, "queued-snapshot.bin", .{});
-        defer file.close(std.testing.io);
-        try file.writeStreamingAll(std.testing.io, "\x89PNG\r\n\x1a\nqueued");
+    const Admission = enum { projection_failure, invalid_writer, uncertain_checkpoint };
+    for ([_]Admission{ .projection_failure, .invalid_writer, .uncertain_checkpoint }) |admission| {
+        const invalid_writer = admission != .projection_failure;
+        var tmp = std.testing.tmpDir(.{});
+        defer tmp.cleanup();
+        {
+            var file = try tmp.dir.createFile(std.testing.io, "queued-snapshot.bin", .{});
+            defer file.close(std.testing.io);
+            try file.writeStreamingAll(std.testing.io, "\x89PNG\r\n\x1a\nqueued");
+        }
+        const snapshot_path = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "queued-snapshot.bin");
+        defer alloc.free(snapshot_path);
+
+        var app = try FakeApp.init(alloc);
+        defer app.deinit();
+        app.snapshot_tools_error = error.TestExpectedEqual;
+        const root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+        defer alloc.free(root);
+        defer app.session_persistence.deinit(alloc);
+        if (invalid_writer) {
+            app.session_persistence.store = try @import("../session/session_store.zig").Store.initFromHome(alloc, root, root);
+            app.session_persistence.writable = try app.session_persistence.store.?.startWritableSession(alloc, .{
+                .id = @constCast("rejected-images"),
+                .origin_workspace_root = @constCast(root),
+                .workspace_root = @constCast(root),
+                .created_at_ms = 1,
+                .updated_at_ms = 1,
+                .conversation_language = .literal("en"),
+                .history = &.{},
+                .total_input_tokens = 0,
+                .total_output_tokens = 0,
+                .preferences = .{ .model = @constCast("test-model"), .effort = .auto, .fast_mode = false },
+            });
+            app.session_persistence.writable.?.conversation_writer.failure = error.SessionCommitFailed;
+        }
+
+        var job = try makeQueuedPrompt(alloc);
+        defer worker_runtime.freeQueuedPrompt(alloc, job);
+        job.images = try types.dupeImageAttachmentSlice(alloc, &.{.{
+            .id = 1,
+            .path = @constCast("/tmp/source.png"),
+            .media_type = @constCast("image/png"),
+            .snapshot_path = snapshot_path,
+            .snapshot_sha256 = @constCast("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+        }});
+
+        if (admission == .uncertain_checkpoint) {
+            app.worker.active_turn_id = 41;
+            app.worker.preservePromptSnapshots(41, job.images);
+            app.session_persistence.writable.?.conversation_writer.failure = error.SessionPersistenceUncertain;
+        }
+        try std.testing.expectError(
+            switch (admission) {
+                .projection_failure => error.TestExpectedEqual,
+                .invalid_writer => error.SessionCommitFailed,
+                .uncertain_checkpoint => error.SessionPersistenceUncertain,
+            },
+            Runtime(FakeApp).processQueuedPrompt(&app, job, 1, test_gateway_chat_url),
+        );
+        if (admission == .uncertain_checkpoint) {
+            try std.Io.Dir.accessAbsolute(std.testing.io, snapshot_path, .{});
+        } else {
+            try std.testing.expectError(
+                error.FileNotFound,
+                std.Io.Dir.accessAbsolute(std.testing.io, snapshot_path, .{}),
+            );
+        }
     }
-    const snapshot_path = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "queued-snapshot.bin");
-    defer alloc.free(snapshot_path);
-
-    var app = try FakeApp.init(alloc);
-    defer app.deinit();
-    app.snapshot_tools_error = error.TestExpectedEqual;
-
-    var job = try makeQueuedPrompt(alloc);
-    defer worker_runtime.freeQueuedPrompt(alloc, job);
-    job.images = try types.dupeImageAttachmentSlice(alloc, &.{.{
-        .id = 1,
-        .path = @constCast("/tmp/source.png"),
-        .media_type = @constCast("image/png"),
-        .snapshot_path = snapshot_path,
-        .snapshot_sha256 = @constCast("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-    }});
-
-    try std.testing.expectError(
-        error.TestExpectedEqual,
-        Runtime(FakeApp).processQueuedPrompt(&app, job, 1, test_gateway_chat_url),
-    );
-    try std.testing.expectError(
-        error.FileNotFound,
-        std.Io.Dir.accessAbsolute(std.testing.io, snapshot_path, .{}),
-    );
 }
 
 test "app agent runtime discards every snapshot in a failed multi-image preflight" {

--- a/src/core/app/app_callbacks.zig
+++ b/src/core/app/app_callbacks.zig
@@ -268,6 +268,16 @@ test "full diff formatter renders unchanged review elisions" {
 
 pub fn Bindings(comptime App: type) type {
     return struct {
+        pub fn finishPromptPresentation(app: *App, finished: types.FinishedPrompt) !assistant_pacer.FinishResult {
+            try app_session_runtime.Runtime(App).appendFinishedPrompt(app, finished);
+            if (finished.summary) |summary| {
+                _ = app.shell.appendTurnSummaryEntry(app.alloc, summary) catch |err| {
+                    return .{ .presentation_failed = err };
+                };
+            }
+            return .committed;
+        }
+
         pub fn agentRuntimeDeps(app: *App) agent_runtime.AgentRuntimeDeps {
             var deps: agent_runtime.AgentRuntimeDeps = .{
                 .ctx = @ptrCast(app),
@@ -1300,10 +1310,10 @@ pub fn Bindings(comptime App: type) type {
             return app.worker.prepareFreshPrompt(std.heap.c_allocator, value);
         }
 
-        fn workerBridgeAppendHistoryTurn(ctx: *anyopaque, finished: types.FinishedPrompt) !void {
+        fn workerBridgeAppendHistoryTurn(ctx: *anyopaque, finished: types.FinishedPrompt) !app_worker_runtime.HistoryDelivery {
             const app: *App = @ptrCast(@alignCast(ctx));
-            if (try app.pacer.deferFinish(app.alloc, finished)) return;
-            try appendHistoryTurn(app, finished);
+            if (try app.pacer.deferFinish(app.alloc, finished)) return .retained;
+            return .{ .settled = try appendHistoryTurn(app, finished) };
         }
 
         fn workerBridgeSessionGrant(ctx: *anyopaque, grant: types.PermissionGrant) !void {
@@ -1316,17 +1326,21 @@ pub fn Bindings(comptime App: type) type {
             try app.writeDomainNotice(notice, true);
         }
 
-        fn appendHistoryTurn(app: *App, finished: types.FinishedPrompt) !void {
+        fn appendHistoryTurn(app: *App, finished: types.FinishedPrompt) !assistant_pacer.FinishResult {
+            if (comptime @hasDecl(App, "finishPromptPresentation")) {
+                return app.finishPromptPresentation(finished);
+            }
             if (comptime @hasDecl(App, "appendFinishedPrompt")) {
                 try app.appendFinishedPrompt(finished);
-                return;
+                return .committed;
             }
             if (comptime @hasDecl(App, "appendHistoryTurn")) {
                 try app.appendHistoryTurn(finished.turn);
                 if (finished.snapshot_file_ownership) |ownership| ownership.transfer();
-                return;
+                return .committed;
             }
             try app_session_runtime.Runtime(App).appendFinishedPrompt(app, finished);
+            return .committed;
         }
     };
 }
@@ -2452,7 +2466,7 @@ test "worker bridge deps forward UI operations" {
     try deps.diff_block(deps.ctx, .{
         .preview = try std.heap.c_allocator.dupe(u8, "diff preview"),
     });
-    try deps.append_history_turn(deps.ctx, .{ .turn = .{ .compacted_summary = .{
+    _ = try deps.append_history_turn(deps.ctx, .{ .turn = .{ .compacted_summary = .{
         .summary = @constCast("summary"),
         .removed_turn_count = 1,
         .compaction_count = 1,
@@ -2552,7 +2566,7 @@ test "worker bridge history append fallback updates runtime history" {
     const turn = try session_runtime.makeAssistantTurn(alloc, "persist me", "saved");
     defer session_runtime.freeHistoryTurn(alloc, turn);
 
-    try deps.append_history_turn(deps.ctx, .{ .turn = turn });
+    _ = try deps.append_history_turn(deps.ctx, .{ .turn = turn });
 
     try std.testing.expectEqual(@as(usize, 1), app.session.historyLen());
     try std.testing.expectEqualStrings(

--- a/src/core/app/app_entry_runtime.zig
+++ b/src/core/app/app_entry_runtime.zig
@@ -296,7 +296,15 @@ fn runInteractiveWithDeps(comptime App: type, comptime cooperative: bool, alloc:
         if (@hasDecl(App, "rebindAfterInit")) app.rebindAfterInit();
     }
     var app_needs_deinit = true;
-    defer if (app_needs_deinit) app.deinit();
+    defer if (app_needs_deinit) {
+        if (comptime cooperative) {
+            app.deinit();
+        } else {
+            var shutdown = app.deinitWithResumeHandoff();
+            defer shutdown.deinit(alloc);
+            if (shutdown.failure) |err| reportShutdownFailure(deps, err);
+        }
+    };
     if (comptime !cooperative and @hasField(App, "session") and
         @hasDecl(@TypeOf(app.session), "attachProfileUsagePublisher"))
     {
@@ -318,7 +326,20 @@ fn runInteractiveWithDeps(comptime App: type, comptime cooperative: bool, alloc:
 
     app.run() catch |err| {
         app.releaseTerminal();
-        if (err == error.TerminalInputClosed) return .returned;
+        if (err == error.TerminalInputClosed) {
+            app_needs_deinit = false;
+            if (comptime cooperative) {
+                app.deinit();
+            } else {
+                var shutdown = app.deinitWithResumeHandoff();
+                defer shutdown.deinit(alloc);
+                if (shutdown.failure) |failure| {
+                    reportShutdownFailure(deps, failure);
+                    return .{ .exit = 1 };
+                }
+            }
+            return .returned;
+        }
         reportUnexpectedInteractiveError(deps, err);
         return err;
     };
@@ -339,10 +360,19 @@ fn runInteractiveWithDeps(comptime App: type, comptime cooperative: bool, alloc:
     );
     defer graceful_exit_sigint_guard.deinit();
     app_needs_deinit = false;
-    const handoff_value = if (comptime cooperative) blk: {
+    const shutdown: app_session_runtime.ShutdownOutcome = if (comptime cooperative) blk: {
         app.deinit();
-        break :blk null;
+        break :blk .{};
     } else app.deinitWithResumeHandoff();
+    const handoff_value = shutdown.handoff;
+    if (shutdown.failure) |err| {
+        if (handoff_value) |value| {
+            var handoff = value;
+            handoff.deinit(alloc);
+        }
+        reportShutdownFailure(deps, err);
+        return .{ .exit = 1 };
+    }
     if (relaunch_request) |request| {
         if (handoff_value) |value| {
             var handoff = value;
@@ -384,6 +414,13 @@ fn runInteractiveWithDeps(comptime App: type, comptime cooperative: bool, alloc:
         deps.write_stdout(deps.stdout_ctx, message) catch {};
     }
     return .returned;
+}
+
+fn reportShutdownFailure(deps: RunDeps, err: anyerror) void {
+    var buffer: [256]u8 = undefined;
+    const text = std.fmt.bufPrint(&buffer, "fx: session save failed: {s}\n", .{@errorName(err)}) catch
+        "fx: session save failed\n";
+    writeStderr(deps, text);
 }
 
 fn replaceProcessDefault(
@@ -623,6 +660,7 @@ const TestCapture = struct {
     record_stderr_event: bool = false,
     record_stdout_event: bool = false,
     resume_handoff_id: ?[]const u8 = null,
+    shutdown_failure: ?anyerror = null,
     raise_sigint_during_deinit: bool = false,
     upgrade_relaunch_path: ?[]const u8 = null,
     upgrade_previous_revision: ?[]const u8 = null,
@@ -756,11 +794,11 @@ const TestApp = struct {
         self.* = undefined;
     }
 
-    fn deinitWithResumeHandoff(self: *TestApp) ?app_session_runtime.ResumeHandoff {
+    fn deinitWithResumeHandoff(self: *TestApp) app_session_runtime.ShutdownOutcome {
         const handoff: ?app_session_runtime.ResumeHandoff = if (active_capture.?.resume_handoff_id) |id| blk: {
             const session_id = std.testing.allocator.dupe(u8, id) catch {
                 self.deinit();
-                return null;
+                return .{ .failure = error.OutOfMemory };
             };
             break :blk .{ .session_id = session_id };
         } else null;
@@ -768,7 +806,7 @@ const TestApp = struct {
             _ = std.c.raise(std.posix.SIG.INT);
         }
         self.deinit();
-        return handoff;
+        return .{ .handoff = handoff, .failure = active_capture.?.shutdown_failure };
     }
 
     fn takeUpgradeRelaunchRequest(_: *TestApp) ?auto_upgrade.RelaunchRequest {
@@ -909,6 +947,21 @@ test "app entry runs interactive startup callbacks in active order" {
     try std.testing.expectEqual(RunOutcome.returned, outcome);
     try std.testing.expectEqual(@as(usize, 0), capture.stdout_calls);
     try expectEvents(&.{ "init:none", "mcp-discovery", "rebind-after-init", "auto-upgrade", "file-index", "worker-thread", "model-cache", "run", "terminal-release", "deinit" });
+}
+
+test "app entry reports persistence failure after teardown instead of a successful handoff" {
+    const alloc = std.testing.allocator;
+    var capture = TestCapture.init(.{ .interactive = .{} });
+    defer capture.deinit();
+    capture.resume_handoff_id = "session-123";
+    capture.shutdown_failure = error.InputOutput;
+    capture.record_stderr_event = true;
+    const outcome = try runWithDeps(TestApp, alloc, &.{}, testConfig(), capture.deps());
+    try std.testing.expectEqual(RunOutcome{ .exit = 1 }, outcome);
+    try std.testing.expectEqualStrings("fx: session save failed: InputOutput\n", capture.stderr.written());
+    try std.testing.expectEqual(@as(usize, 0), capture.stdout_calls);
+    try std.testing.expectEqualStrings("deinit", test_events[test_event_count - 2]);
+    try std.testing.expectEqualStrings("stderr-attempt", test_events[test_event_count - 1]);
 }
 
 test "app entry writes exact resume handoff after interactive teardown" {
@@ -1305,4 +1358,19 @@ test "app entry maps unavailable session state to one expected startup failure" 
         try std.testing.expectEqual(@as(usize, 1), capture.stderr_calls);
         try expectEvents(&.{"init:none"});
     }
+}
+
+test "app entry returns failure when terminal closure cannot save the session" {
+    var capture = TestCapture.init(.{ .interactive = .{} });
+    defer capture.deinit();
+    capture.run_error = error.TerminalInputClosed;
+    capture.shutdown_failure = error.InputOutput;
+    capture.resume_handoff_id = "session-123";
+    capture.record_stderr_event = true;
+    const outcome = try runWithDeps(TestApp, std.testing.allocator, &.{}, testConfig(), capture.deps());
+    try std.testing.expectEqual(RunOutcome{ .exit = 1 }, outcome);
+    try std.testing.expectEqualStrings("fx: session save failed: InputOutput\n", capture.stderr.written());
+    try std.testing.expectEqual(@as(usize, 0), capture.stdout_calls);
+    try std.testing.expectEqualStrings("deinit", test_events[test_event_count - 2]);
+    try std.testing.expectEqualStrings("stderr-attempt", test_events[test_event_count - 1]);
 }

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -355,6 +355,16 @@ pub const ResumeHandoff = struct {
     }
 };
 
+pub const ShutdownOutcome = struct {
+    handoff: ?ResumeHandoff = null,
+    failure: ?anyerror = null,
+
+    pub fn deinit(self: *ShutdownOutcome, alloc: Allocator) void {
+        if (self.handoff) |*handoff| handoff.deinit(alloc);
+        self.* = undefined;
+    }
+};
+
 pub const SessionPreferencePatch = struct {
     provider: ?model_provider.ProviderId = null,
     model: ?[]const u8 = null,
@@ -1037,12 +1047,13 @@ pub const Persistence = struct {
     image_snapshot_temp_dir: ?[]u8 = null,
     resume_handoff_intent: ResumeHandoffIntent = .none,
     pending_live_session_policy: ?BackgroundSessionPolicy = null,
+    shutdown_failure: ?anyerror = null,
 
     /// Fieldwise initialization avoids retaining undefined optional payloads
     /// in a static release-binary template.
     pub fn initInto(storage: *Persistence) void {
         comptime {
-            if (std.meta.fields(Persistence).len != 18) {
+            if (std.meta.fields(Persistence).len != 19) {
                 @compileError("update Persistence.initInto for the changed field set");
             }
         }
@@ -1065,6 +1076,7 @@ pub const Persistence = struct {
         storage.image_snapshot_temp_dir = null;
         storage.resume_handoff_intent = .none;
         storage.pending_live_session_policy = null;
+        storage.shutdown_failure = null;
     }
 
     pub fn deinit(self: *Persistence, alloc: Allocator) void {
@@ -1093,6 +1105,107 @@ pub const Persistence = struct {
         self.* = undefined;
     }
 };
+
+test "parking waits for an in-flight usage checkpoint before releasing the writer" {
+    const alloc = std.testing.allocator;
+    const ParkApp = struct {
+        alloc: Allocator,
+        session: session_runtime.SessionRuntime = .{ .max_history_turns = 8, .usage = session_usage.Usage.initFresh() },
+        session_persistence: Persistence = .{},
+        worker: worker_runtime.WorkerRuntime = .{},
+        pacer: @import("../../ui/assistant/pacer.zig").AssistantPacer = .{},
+        stream: struct { active: bool = false } = .{},
+    };
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(root);
+    var app = ParkApp{ .alloc = alloc };
+    defer app.session.deinit(alloc);
+    defer app.worker.deinit(std.heap.c_allocator);
+    defer app.pacer.deinit(alloc);
+    defer app.session_persistence.deinit(alloc);
+    app.session_persistence.store = try session_store.Store.initFromHome(alloc, root, root);
+    app.session_persistence.writable = try app.session_persistence.store.?.startWritableSession(alloc, .{
+        .id = @constCast("park-checkpoint"),
+        .origin_workspace_root = @constCast(root),
+        .workspace_root = @constCast(root),
+        .created_at_ms = 1,
+        .updated_at_ms = 1,
+        .conversation_language = .literal("en"),
+        .history = &.{},
+        .total_input_tokens = 0,
+        .total_output_tokens = 0,
+        .preferences = .{ .model = @constCast("test/model"), .effort = .auto, .fast_mode = false },
+    });
+    try app.pacer.enqueue(alloc, "pending presentation");
+    try std.testing.expect(!Runtime(ParkApp).tryBeginIdleSessionPark(&app));
+    app.pacer.clear(alloc);
+    try std.testing.expect(Runtime(ParkApp).tryBeginIdleSessionPark(&app));
+    app.worker.releaseTurnStartHold();
+    const Probe = struct {
+        app: *ParkApp,
+        entered: std.Io.Event = .unset,
+        park_started: std.Io.Event = .unset,
+        park_done: std.atomic.Value(bool) = .init(false),
+        checkpoint_ok: bool = false,
+        park_failure: ?anyerror = null,
+        calls: usize = 0,
+
+        fn persist(raw: *anyopaque, snapshot: session_usage.Snapshot) !void {
+            const self: *@This() = @ptrCast(@alignCast(raw));
+            self.calls += 1;
+            self.entered.set(std.testing.io);
+            self.park_started.waitUncancelable(std.testing.io);
+            const deadline = io_mod.milliTimestamp() + 250;
+            while (!self.park_done.load(.seq_cst) and io_mod.milliTimestamp() < deadline) {
+                io_mod.sleep(std.time.ns_per_ms);
+            }
+            if (self.park_done.load(.seq_cst)) return error.WriterReleasedBeforeCheckpoint;
+            if (!self.app.session_persistence.write_mutex.tryLock()) return error.WriterHeldWhileAwaitingCheckpoint;
+            defer self.app.session_persistence.write_mutex.unlock(std.testing.io);
+            _ = try self.app.session_persistence.writable.?.appendEvent(self.app.alloc, .{ .usage_checkpointed = .{ .usage = snapshot } }, 2);
+        }
+
+        fn checkpoint(self: *@This()) void {
+            self.checkpoint_ok = self.app.session.usage.persistCheckpoint();
+        }
+
+        fn park(self: *@This()) void {
+            self.park_started.set(std.testing.io);
+            defer self.park_done.store(true, .seq_cst);
+            Runtime(ParkApp).parkIdleWritableSession(self.app) catch |err| {
+                self.park_failure = err;
+            };
+        }
+    };
+    var probe = Probe{ .app = &app };
+    app.session.usage.configureCheckpointSink(.{ .context = &probe, .allocator = alloc, .persist = Probe.persist });
+    const checkpoint_thread = try std.Thread.spawn(.{}, Probe.checkpoint, .{&probe});
+    var checkpoint_joined = false;
+    defer if (!checkpoint_joined) {
+        probe.park_done.store(true, .seq_cst);
+        probe.park_started.set(std.testing.io);
+        checkpoint_thread.join();
+    };
+    const deadline = io_mod.milliTimestamp() + 3000;
+    while (!probe.entered.isSet()) {
+        if (io_mod.milliTimestamp() >= deadline) return error.CheckpointNotStarted;
+        io_mod.sleep(std.time.ns_per_ms);
+    }
+    const park_thread = try std.Thread.spawn(.{}, Probe.park, .{&probe});
+    park_thread.join();
+    checkpoint_thread.join();
+    checkpoint_joined = true;
+    if (probe.park_failure) |err| return err;
+    try std.testing.expect(probe.checkpoint_ok);
+    try std.testing.expect(app.session_persistence.writable.?.log.isParked());
+    try std.testing.expect(app.session.usage.persistCheckpoint());
+    try std.testing.expectEqual(@as(usize, 1), probe.calls);
+    var resumed = try app.session_persistence.store.?.resumeForWrite(alloc, "park-checkpoint");
+    defer resumed.deinit(alloc);
+    try std.testing.expectEqual(session_usage.Availability.complete, resumed.state.usage.?.billing);
+}
 
 test "persistence in-place initialization preserves empty ownership" {
     var persistence: Persistence = undefined;
@@ -2188,6 +2301,11 @@ pub fn Runtime(comptime App: type) type {
             app: *App,
             checkpoint: session_codec.RecoveryCheckpoint,
         ) !void {
+            errdefer |err| if (err == error.SessionPersistenceUncertain) {
+                if (comptime @hasDecl(@TypeOf(app.worker), "preservePromptSnapshots")) {
+                    app.worker.preservePromptSnapshots(checkpoint.turn_id, checkpoint.user.images);
+                }
+            };
             if (comptime !@hasField(App, "session_persistence")) {
                 return error.SessionPersistenceUnavailable;
             }
@@ -2469,6 +2587,10 @@ pub fn Runtime(comptime App: type) type {
                 } },
                 io_mod.milliTimestamp(),
             ) catch |err| {
+                if (err == error.SessionPersistenceUncertain) {
+                    if (snapshot_file_ownership) |ownership| ownership.transfer();
+                    return err;
+                }
                 return switch (mode) {
                     .strict => err,
                     .visual_epoch => blk: {
@@ -2754,6 +2876,25 @@ pub fn Runtime(comptime App: type) type {
             closeWritableSession(app);
         }
 
+        pub fn recordShutdownFailure(app: *App, err: anyerror) void {
+            if (app.session_persistence.shutdown_failure == null) {
+                app.session_persistence.shutdown_failure = err;
+            }
+            debug_trace.logf("session", "shutdown finished prompt persistence failed err={s}", .{@errorName(err)});
+        }
+
+        pub fn recordFailedHistoryDelivery(app: *App, err: anyerror) void {
+            recordShutdownFailure(app, err);
+            app.session_persistence.write_mutex.lockUncancelable(io_mod.getIo());
+            defer app.session_persistence.write_mutex.unlock(io_mod.getIo());
+            if (app.session_persistence.writable) |*loaded| {
+                // A missing finished turn cannot be followed by another saved turn.
+                if (loaded.conversation_writer.failure == null) {
+                    loaded.conversation_writer.failure = error.SessionCommitFailed;
+                }
+            }
+        }
+
         pub fn finalizePersistenceWithResumeHandoff(app: *App) ?ResumeHandoff {
             if (app.session_persistence.writable) |*loaded| {
                 if (loaded.log.isParked()) {
@@ -2795,12 +2936,13 @@ pub fn Runtime(comptime App: type) type {
             }
             defer app.worker.releaseTurnStartHold();
 
-            const loaded = &app.session_persistence.writable.?;
-            loaded.log.park();
+            const session_id = try app.alloc.dupe(u8, app.session_persistence.writable.?.active_id);
+            defer app.alloc.free(session_id);
+            try parkIdleWritableSession(app);
             debug_trace.logf(
                 "session",
                 "parked writer lock for suspend session={s}",
-                .{loaded.active_id},
+                .{session_id},
             );
 
             const lifecycle_result = app_lifecycle.suspendToJobControl(
@@ -2809,32 +2951,58 @@ pub fn Runtime(comptime App: type) type {
                 &app.metrics,
                 footer_rows,
             );
-            loaded.log.unpark() catch |err| {
+            abandonParkedWritableSession(app);
+            var loaded = loadResumeTargetForWrite(app, .{ .id = session_id }, .{
+                .session_lock_deadline_ms = 0,
+            }) catch |err| {
                 debug_trace.logf(
                     "session",
                     "unpark after suspend failed session={s} err={s}",
-                    .{ loaded.active_id, @errorName(err) },
+                    .{ session_id, @errorName(err) },
                 );
-                abandonParkedWritableSession(app);
                 app.worker.requestStop();
                 app.should_exit = true;
                 try lifecycle_result;
-                return;
+                return err;
             };
-
+            try installResumedSession(app, &loaded, .session);
+            app.permission_engine.clear(app.alloc);
+            requestSubagentBackgroundRecovery(app);
+            startResumedSessionReconciliation(app);
+            try app.finishLiveSessionResume();
             debug_trace.logf(
                 "session",
                 "unparked writer lock after suspend session={s}",
-                .{loaded.active_id},
+                .{session_id},
             );
             try lifecycle_result;
         }
 
+        /// The caller holds idle turn admission and has no running child work.
+        fn parkIdleWritableSession(app: *App) !void {
+            disableSubagentHost(app);
+            app.session.usage.cancelReconciliation();
+            app.session.usage.finishProfilePublicationsBeforeShutdown();
+            app.session.usage.configureCheckpointSink(null);
+            app.session_persistence.write_mutex.lockUncancelable(io_mod.getIo());
+            defer app.session_persistence.write_mutex.unlock(io_mod.getIo());
+            const loaded = &app.session_persistence.writable.?;
+            try settleDurableState(app, loaded);
+            loaded.log.park();
+        }
+
         fn tryBeginIdleSessionPark(app: *App) bool {
-            if (app.session_persistence.writable == null or app.stream.active) {
+            if (app.session_persistence.writable == null or app.stream.active or app.pacer.hasPending()) {
                 return false;
             }
-            return app.worker.tryHoldTurnStart();
+            if (!app.worker.tryHoldTurnStart()) return false;
+            if (app.session_persistence.subagent_host) |host| {
+                if (host.managed.hasRunningWork()) {
+                    app.worker.releaseTurnStartHold();
+                    return false;
+                }
+            }
+            return true;
         }
 
         /// Tear down a parked writable without converging or checkpointing.
@@ -4178,6 +4346,7 @@ pub fn Runtime(comptime App: type) type {
                 var settlement_failed = false;
                 settleDurableState(app, loaded) catch |err| {
                     settlement_failed = true;
+                    recordShutdownFailure(app, err);
                     debug_trace.logf(
                         "session",
                         "resume handoff boundary invalid session={s} err={s}",
@@ -4187,6 +4356,7 @@ pub fn Runtime(comptime App: type) type {
                 resume_boundary_valid = !settlement_failed;
             } else {
                 settleDurableState(app, loaded) catch |err| {
+                    recordShutdownFailure(app, err);
                     debug_trace.logf(
                         "session",
                         "final persistence settlement failed session={s} err={s}",
@@ -4337,6 +4507,7 @@ pub fn Runtime(comptime App: type) type {
             app: *App,
             loaded: *session_store.LoadedWritableSession,
         ) !void {
+            try loaded.requireWritable();
             const usage_dirty = if (comptime @hasField(@TypeOf(app.session), "usage"))
                 app.session.usage.isDirty()
             else
@@ -9712,4 +9883,62 @@ test "terminal title ignores long session and model context" {
     try Runtime(TestApp).setCachedSessionTitle(&app, "session-" ++ ("title" ** 20));
 
     try std.testing.expectEqualStrings("v" ++ build_options.app_version ++ " | workspace", app.terminalTitleLabelText());
+}
+
+test "failed history delivery rejects the current writer without poisoning a fresh session" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const paths = try testPaths(alloc, &tmp);
+    defer alloc.free(paths.home);
+    defer alloc.free(paths.workspace);
+    const home = try TestHome.install(alloc, paths.home);
+    defer home.deinit();
+    var app = try TestApp.init(alloc, paths.workspace);
+    defer app.deinit();
+    try configureTestPreferences(&app);
+    try Runtime(TestApp).initializePersistence(&app, true);
+    try Runtime(TestApp).beginFreshPersistedSession(&app);
+    Runtime(TestApp).recordFailedHistoryDelivery(&app, error.InputOutput);
+    const turn = try session_runtime.makeAssistantTurn(alloc, "request", "answer");
+    defer session_runtime.freeHistoryTurn(alloc, turn);
+    try std.testing.expectError(error.SessionCommitFailed, Runtime(TestApp).appendHistoryTurn(&app, turn));
+    try std.testing.expectEqual(@as(usize, 0), app.session.historyLen());
+    Runtime(TestApp).closeWritableSession(&app);
+    try Runtime(TestApp).beginFreshPersistedSession(&app);
+    try Runtime(TestApp).appendHistoryTurn(&app, turn);
+    try std.testing.expectEqual(@as(usize, 1), app.session.historyLen());
+    try std.testing.expectEqual(@as(?anyerror, error.InputOutput), app.session_persistence.shutdown_failure);
+}
+
+test "uncertain finished history preserves snapshot files and rejects later writes" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const paths = try testPaths(alloc, &tmp);
+    defer alloc.free(paths.home);
+    defer alloc.free(paths.workspace);
+    const home = try TestHome.install(alloc, paths.home);
+    defer home.deinit();
+    var app = try TestApp.init(alloc, paths.workspace);
+    defer app.deinit();
+    try configureTestPreferences(&app);
+    try Runtime(TestApp).initializePersistence(&app, true);
+    try Runtime(TestApp).beginFreshPersistedSession(&app);
+    const Fault = struct {
+        fn sync(_: ?*anyopaque, _: std.Io.File) !void {
+            return error.InputOutput;
+        }
+    };
+    app.session_persistence.writable.?.conversation_writer.test_sync_ops = .{ .sync_file = Fault.sync };
+    var ownership = SnapshotOwnershipProbe{};
+    const turn = try session_runtime.makeAssistantTurn(alloc, "request", "answer");
+    defer session_runtime.freeHistoryTurn(alloc, turn);
+    try std.testing.expectError(error.SessionPersistenceUncertain, Runtime(TestApp).appendFinishedPrompt(&app, .{
+        .turn = turn,
+        .snapshot_file_ownership = ownership.handle(),
+    }));
+    try std.testing.expectEqual(@as(usize, 1), ownership.transfers);
+    try std.testing.expectEqual(@as(usize, 0), app.session.historyLen());
+    try std.testing.expectError(error.SessionPersistenceUncertain, Runtime(TestApp).appendHistoryTurn(&app, turn));
 }

--- a/src/core/app/app_worker_runtime.zig
+++ b/src/core/app/app_worker_runtime.zig
@@ -61,6 +61,12 @@ fn unavailableFreshPrompt(_: *anyopaque, _: worker_runtime.FreshPromptPreparatio
 }
 fn discardCredentialRefresh(_: *anyopaque, _: credentials.Credential) !void {}
 
+/// A retained delivery owns its own payload; a settled delivery acknowledges history.
+pub const HistoryDelivery = union(enum) {
+    retained,
+    settled: assistant_pacer.FinishResult,
+};
+
 pub const WorkerEventHandlers = struct {
     ctx: *anyopaque,
     tool_lifecycle: activity_runtime.LifecyclePresenter,
@@ -79,7 +85,7 @@ pub const WorkerEventHandlers = struct {
     diff_block: *const fn (*anyopaque, diff_mod.DiffEntryPayload) anyerror!void,
     context_compaction: worker_runtime.ContextCompactionHandler = discardContextCompaction,
     prepare_fresh_prompt: worker_runtime.FreshPromptHandler = unavailableFreshPrompt,
-    append_history_turn: *const fn (*anyopaque, types.FinishedPrompt) anyerror!void,
+    append_history_turn: *const fn (*anyopaque, types.FinishedPrompt) anyerror!HistoryDelivery,
     session_grant: *const fn (*anyopaque, types.PermissionGrant) anyerror!void,
     error_text: *const fn (*anyopaque, types.SemanticNotice) anyerror!void,
 };
@@ -202,6 +208,7 @@ test "shutdown settles queued and pacer-owned finishes exactly once" {
             .assistant = @constCast("later answer"),
         } } } });
         app.worker.requestShutdown();
+        app_session_runtime.Runtime(ShutdownApp).recordShutdownFailure(&app, error.PreviousSessionSaveFailed);
         try std.testing.expectEqual(@as(usize, 0), app.session.historyLen());
         try std.testing.expect(app.session_persistence.writable.?.state.recovery_checkpoint != null);
 
@@ -264,6 +271,7 @@ const DetachedWorkerEventBatch = struct {
 
     fn deinit(self: *DetachedWorkerEventBatch) void {
         while (self.next_unvisited < self.events.items.len) : (self.next_unvisited += 1) {
+            debug_trace.logf("worker", "undelivered worker event discarded kind={s}", .{@tagName(self.events.items[self.next_unvisited])});
             worker_runtime.freeWorkerEvent(self.alloc, self.events.items[self.next_unvisited]);
         }
         self.events.deinit(self.alloc);
@@ -271,7 +279,7 @@ const DetachedWorkerEventBatch = struct {
     }
 };
 
-fn batchContainsInterruptedClosure(
+fn batchContainsTerminalClosure(
     events: []const WorkerEvent,
     id: types.ToolLifecycleId,
 ) bool {
@@ -282,12 +290,11 @@ fn batchContainsInterruptedClosure(
         };
         switch (lifecycle) {
             .terminal => |terminal| {
-                if (terminal.outcome.kind == .cancelled and
-                    terminal.id.turn_id == id.turn_id and
+                if (terminal.id.turn_id == id.turn_id and
                     std.mem.eql(u8, terminal.id.call_id, id.call_id)) return true;
             },
             .turn_finished => |finished| {
-                if (finished.outcome == .interrupted and finished.turn_id == id.turn_id) return true;
+                if (finished.turn_id == id.turn_id) return true;
             },
             .provisional, .authoritative_started, .progress => {},
         }
@@ -295,22 +302,30 @@ fn batchContainsInterruptedClosure(
     return false;
 }
 
-fn batchSegmentEndsInterrupted(events: []const WorkerEvent) bool {
-    for (events, 0..) |event, index| {
+fn batchSegmentIsInterrupted(events: []const WorkerEvent, cancelled_turn_id: ?u64) bool {
+    var turn_id: ?u64 = null;
+    scan: for (events, 0..) |event, index| {
         if (index > 0) switch (event) {
-            .begin_prompt, .begin_prompt_with_skill_bindings, .begin_presented_prompt => return false,
+            .begin_prompt, .begin_prompt_with_skill_bindings, .begin_presented_prompt => break :scan,
             else => {},
         };
-        const lifecycle = switch (event) {
-            .tool_lifecycle => |value| value,
-            else => continue,
-        };
-        switch (lifecycle) {
-            .turn_finished => |finished| if (finished.outcome == .interrupted) return true,
-            .provisional, .authoritative_started, .progress, .terminal => {},
+        switch (event) {
+            .begin_presented_prompt => |id| turn_id = id,
+            .turn_phase_update => |phase| turn_id = phase.turn_id,
+            .tool_lifecycle => |lifecycle| {
+                turn_id = switch (lifecycle) {
+                    .turn_finished => |finished| return finished.outcome == .interrupted,
+                    .provisional => |value| value.id.turn_id,
+                    .authoritative_started => |value| value.id.turn_id,
+                    .progress => |value| value.id.turn_id,
+                    .terminal => |value| value.id.turn_id,
+                };
+            },
+            else => {},
         }
     }
-    return false;
+    const cancelled = cancelled_turn_id orelse return false;
+    return turn_id == null or turn_id.? == cancelled;
 }
 
 pub fn Runtime(comptime App: type) type {
@@ -320,7 +335,7 @@ pub fn Runtime(comptime App: type) type {
             id: types.ToolLifecycleId,
             batch_events: []const WorkerEvent,
         ) CancelledEventAdmission {
-            if (batchContainsInterruptedClosure(batch_events, id)) return .admit;
+            if (batchContainsTerminalClosure(batch_events, id)) return .admit;
             if (id.turn_id <= presenter.snapshot().finalized_turn_watermark) return .drop;
             return .defer_until_closure;
         }
@@ -387,12 +402,7 @@ pub fn Runtime(comptime App: type) type {
         /// After the worker joins, persist finished turns without presenting output
         /// or admitting work. The pacer owns the finish preceding queued events.
         pub fn settleFinishedPromptsForShutdown(app: *App) !void {
-            if (app.pacer.deferred_turn) |finished| {
-                app.pacer.deferred_turn = null;
-                app.pacer.deferred_started_ns = null;
-                defer types.freeFinishedPrompt(app.alloc, finished);
-                try app_session_runtime.Runtime(App).appendFinishedPrompt(app, finished);
-            }
+            try settleDeferredFinish(app);
 
             var batch = DetachedWorkerEventBatch.init(
                 std.heap.c_allocator,
@@ -402,8 +412,49 @@ pub fn Runtime(comptime App: type) type {
             while (batch.claim()) |event| {
                 defer worker_runtime.freeWorkerEvent(batch.alloc, event);
                 switch (event) {
-                    .finish_prompt => |finished| try app_session_runtime.Runtime(App).appendFinishedPrompt(app, finished),
+                    .finish_prompt => |finished| try persistFinishedPrompt(app, finished),
                     else => debug_trace.logf("worker", "shutdown worker event dropped kind={s}", .{@tagName(event)}),
+                }
+            }
+        }
+
+        fn persistFinishedPrompt(app: *App, finished: types.FinishedPrompt) !void {
+            errdefer |err| app_session_runtime.Runtime(App).recordFailedHistoryDelivery(app, err);
+            if (comptime @hasField(App, "session")) {
+                try app_session_runtime.Runtime(App).appendFinishedPrompt(app, finished);
+            } else {
+                try app.appendFinishedPrompt(finished);
+            }
+        }
+
+        fn settleDeferredFinish(app: *App) !void {
+            if (comptime !@hasField(@TypeOf(app.pacer), "deferred_turn")) return;
+            if (app.pacer.deferred_turn) |finished| {
+                app.pacer.deferred_turn = null;
+                app.pacer.deferred_started_ns = null;
+                defer types.freeFinishedPrompt(app.alloc, finished);
+                try persistFinishedPrompt(app, finished);
+            }
+        }
+
+        fn preserveFinishedAfterDrainFailure(app: *App, batch: *DetachedWorkerEventBatch, may_persist: bool) void {
+            var can_persist = may_persist;
+            if (can_persist) settleDeferredFinish(app) catch {
+                can_persist = false;
+            };
+            while (batch.claim()) |event| {
+                defer worker_runtime.freeWorkerEvent(batch.alloc, event);
+                switch (event) {
+                    .finish_prompt => |finished| {
+                        if (can_persist) {
+                            persistFinishedPrompt(app, finished) catch {
+                                can_persist = false;
+                            };
+                        } else {
+                            debug_trace.logf("worker", "finished turn not persisted after earlier save failure", .{});
+                        }
+                    },
+                    else => debug_trace.logf("worker", "presentation failure discarded worker event kind={s}", .{@tagName(event)}),
                 }
             }
         }
@@ -821,15 +872,16 @@ pub fn Runtime(comptime App: type) type {
             };
             defer batch.deinit();
 
-            const cancel_requested = taken.cancel_requested;
-            var interrupted_segment = cancel_requested or batchSegmentEndsInterrupted(batch.events.items);
+            var can_persist_finished = true;
+            errdefer preserveFinishedAfterDrainFailure(app, &batch, can_persist_finished);
+
+            var interrupted_segment = batchSegmentIsInterrupted(batch.events.items, taken.cancelled_turn_id);
             var first_event = true;
 
             events: while (batch.claim()) |event| {
                 if (!first_event) switch (event) {
                     .begin_prompt, .begin_prompt_with_skill_bindings, .begin_presented_prompt => {
-                        interrupted_segment = cancel_requested or
-                            batchSegmentEndsInterrupted(batch.claimedAndRemaining());
+                        interrupted_segment = batchSegmentIsInterrupted(batch.claimedAndRemaining(), taken.cancelled_turn_id);
                     },
                     else => {},
                 };
@@ -1076,10 +1128,27 @@ pub fn Runtime(comptime App: type) type {
                         try applyToolLifecycle(app, handlers.tool_lifecycle, lifecycle);
                     },
                     .finish_prompt => |finished| {
+                        var accepted = false;
+                        errdefer if (!accepted) {
+                            settleDeferredFinish(app) catch {
+                                can_persist_finished = false;
+                            };
+                            if (can_persist_finished) persistFinishedPrompt(app, finished) catch {
+                                can_persist_finished = false;
+                            };
+                        };
                         try flushPendingCommandOutputAtTurnBoundary(app, handlers);
                         resetStream(app, false);
                         app.shell.render_requests.request(.footer);
-                        try handlers.append_history_turn(handlers.ctx, finished);
+                        const delivery = try handlers.append_history_turn(handlers.ctx, finished);
+                        accepted = true;
+                        switch (delivery) {
+                            .retained => {},
+                            .settled => |result| switch (result) {
+                                .committed => {},
+                                .presentation_failed => |err| return err,
+                            },
+                        }
                     },
                     .session_grant => |grant| {
                         try handlers.session_grant(handlers.ctx, grant);
@@ -1384,7 +1453,7 @@ const FakeWorker = struct {
         const cancel_requested = self.worker_cancel_requested.load(.seq_cst);
         return .{
             .events = self.takeEvents(),
-            .cancel_requested = cancel_requested,
+            .cancelled_turn_id = if (cancel_requested and self.active_turn_id != 0) self.active_turn_id else null,
         };
     }
 
@@ -1767,12 +1836,16 @@ const FakeApp = struct {
     attention_count: usize = 0,
     last_attention_turn_id: u64 = 0,
     last_attention_kind: ?@import("../hooks/hooks.zig").AttentionKind = null,
+    persisted_finishes: std.ArrayList(types.FinishedPrompt) = .empty,
+    finish_persistence_error: ?anyerror = null,
 
     fn init(alloc: std.mem.Allocator) FakeApp {
         return .{ .alloc = alloc };
     }
 
     fn deinit(self: *FakeApp) void {
+        for (self.persisted_finishes.items) |finished| types.freeFinishedPrompt(self.alloc, finished);
+        self.persisted_finishes.deinit(self.alloc);
         self.session_persistence.deinit(self.alloc);
         self.worker.deinit();
         self.approval_prompt.deinit(self.alloc);
@@ -1784,6 +1857,14 @@ const FakeApp = struct {
 
     fn pacerCallbacks(self: *FakeApp) void {
         _ = self;
+    }
+
+    pub fn appendFinishedPrompt(self: *FakeApp, finished: types.FinishedPrompt) !void {
+        if (self.finish_persistence_error) |err| return err;
+        const owned = try types.dupeFinishedPrompt(self.alloc, finished);
+        errdefer types.freeFinishedPrompt(self.alloc, owned);
+        try self.persisted_finishes.append(self.alloc, owned);
+        if (finished.snapshot_file_ownership) |ownership| ownership.transfer();
     }
 
     fn writeTranscript(self: *FakeApp, text: []const u8, record: bool) !void {
@@ -1860,7 +1941,9 @@ const NoopBridge = struct {
     fn diff(_: *anyopaque, payload: @import("../output/diff.zig").DiffEntryPayload) !void {
         @import("../output/diff.zig").freeDiffEntryPayload(std.heap.c_allocator, payload);
     }
-    fn history(_: *anyopaque, _: types.FinishedPrompt) !void {}
+    fn history(_: *anyopaque, _: types.FinishedPrompt) !HistoryDelivery {
+        return .{ .settled = .committed };
+    }
     fn grant(_: *anyopaque, _: types.PermissionGrant) !void {}
     fn err(_: *anyopaque, _: types.SemanticNotice) !void {}
 
@@ -2024,11 +2107,12 @@ const PacedTranscriptBridge = struct {
         self.notice_count += 1;
     }
 
-    fn appendHistoryTurn(raw: *anyopaque, finished: types.FinishedPrompt) !void {
+    fn appendHistoryTurn(raw: *anyopaque, finished: types.FinishedPrompt) !HistoryDelivery {
         const self: *PacedTranscriptBridge = @ptrCast(@alignCast(raw));
         self.history_count += 1;
-        if (try self.pacer.deferFinish(self.app.alloc, finished)) return;
+        if (try self.pacer.deferFinish(self.app.alloc, finished)) return .retained;
         self.finish_count += 1;
+        return .{ .settled = .committed };
     }
 
     fn emit(raw: *anyopaque, text: []const u8) !void {
@@ -2040,10 +2124,11 @@ const PacedTranscriptBridge = struct {
         );
     }
 
-    fn finish(raw: *anyopaque, _: types.FinishedPrompt) !void {
+    fn finish(raw: *anyopaque, _: types.FinishedPrompt) !assistant_pacer.FinishResult {
         const self: *PacedTranscriptBridge = @ptrCast(@alignCast(raw));
         self.finish_count += 1;
         self.record('F');
+        return .committed;
     }
 };
 
@@ -2624,11 +2709,12 @@ test "core.app_worker_runtime summary append clears recovered route status witho
     } } });
 
     const Capture = struct {
-        fn history(ctx: *anyopaque, finished: types.FinishedPrompt) !void {
+        fn history(ctx: *anyopaque, finished: types.FinishedPrompt) !HistoryDelivery {
             const inner: *FakeApp = @ptrCast(@alignCast(ctx));
             if (finished.summary) |summary| {
                 _ = try inner.shell.lifecycle.appendTurnSummaryEntry(inner.alloc, summary);
             }
+            return .{ .settled = .committed };
         }
     };
     var handlers = NoopBridge.handlers(&app);
@@ -3278,9 +3364,10 @@ test "core.app_worker_runtime cancellation suppresses payloads but retains turn 
             self.text_count += 1;
         }
 
-        fn history(raw: *anyopaque, _: types.FinishedPrompt) !void {
+        fn history(raw: *anyopaque, _: types.FinishedPrompt) !HistoryDelivery {
             const self: *@This() = @ptrCast(@alignCast(raw));
             self.history_count += 1;
+            return .{ .settled = .committed };
         }
     };
     var capture = Capture{};
@@ -3977,13 +4064,14 @@ test "core.app_worker_runtime split batches finalize lifecycle before history" {
         history_count: usize = 0,
         saw_finalized_fence: bool = false,
 
-        fn history(raw: *anyopaque, _: types.FinishedPrompt) !void {
+        fn history(raw: *anyopaque, _: types.FinishedPrompt) !HistoryDelivery {
             const self: *@This() = @ptrCast(@alignCast(raw));
             self.history_count += 1;
             self.saw_finalized_fence =
                 self.app.shell.finalizedToolTurnWatermark() == 1 and
                 self.app.shell.toolActivityRecordCount() == 0 and
                 self.app.shell.lifecyclePinCount() == 0;
+            return .{ .settled = .committed };
         }
     };
     var capture = Capture{ .app = &app };
@@ -4070,6 +4158,54 @@ test "core.app_worker_runtime reducer error settles batch and skips suffix" {
     const record = app.shell.toolActivityRecord(.{ .turn_id = 1, .call_id = "call" }).?;
     try std.testing.expectEqual(activity_runtime.ToolLifecyclePhase.authoritative, record.phase);
     try std.testing.expectEqual(@as(usize, 1), app.shell.lifecyclePinCount());
+}
+
+test "core.app_worker_runtime cancellation leaves an earlier completed segment drainable" {
+    var app = FakeApp.init(std.testing.allocator);
+    defer app.deinit();
+    app.worker.processing = true;
+    app.worker.active_turn_id = 2;
+    app.worker.worker_cancel_requested.store(true, .seq_cst);
+    try queueToolStart(&app, 1, "completed-call", "read_file");
+    try queueToolTerminal(&app, 1, "completed-call", .completed, "Read");
+    try app.worker.pushEvent(std.heap.c_allocator, .{ .assistant_presentation = .{ .text = @constCast("earlier completed answer") } });
+    try queueTurnFinished(&app, 1, .completed);
+    try app.worker.pushEvent(std.heap.c_allocator, .{ .begin_prompt = .{ .text = @constCast("later request") } });
+    try app.worker.pushEvent(std.heap.c_allocator, .{ .turn_phase_update = .{ .turn_id = 2, .step_id = 1, .phase = .thinking } });
+    try app.worker.pushEvent(std.heap.c_allocator, .{ .assistant_presentation = .{ .text = @constCast("cancelled later answer") } });
+    try queueTurnFinished(&app, 2, .interrupted);
+    const Capture = struct {
+        fn text(raw: *anyopaque, bytes: []const u8) !void {
+            const target: *FakeApp = @ptrCast(@alignCast(raw));
+            try target.transcript.appendSlice(target.alloc, bytes);
+        }
+    };
+    var handlers = NoopBridge.handlers(&app);
+    handlers.ctx = &app;
+    handlers.append_text = Capture.text;
+    try Runtime(FakeApp).tick(&app, handlers);
+    try std.testing.expectEqual(@as(usize, 0), app.worker.events.items.len);
+    try std.testing.expect(std.mem.find(u8, app.transcript.items, "earlier completed answer") != null);
+    try std.testing.expect(std.mem.find(u8, app.transcript.items, "cancelled later answer") == null);
+}
+
+test "core.app_worker_runtime reducer failure preserves a completed turn in the suffix" {
+    var app = FakeApp.init(std.testing.allocator);
+    defer app.deinit();
+    app.worker.processing = true;
+    try queueToolStart(&app, 1, "call", "read_file");
+    try queueLifecycle(&app, .{ .progress = .{
+        .id = .{ .turn_id = 1, .call_id = "call" },
+        .text = "Reading",
+    } });
+    try app.worker.pushEvent(std.heap.c_allocator, .{ .finish_prompt = .{ .turn = .{ .assistant = .{
+        .user = .{ .text = @constCast("accepted request") },
+        .assistant = @constCast("completed answer"),
+    } } } });
+    app.shell.fail_next_update = true;
+    try std.testing.expectError(error.InjectedTranscriptUpdateFailure, tickNoop(&app));
+    try std.testing.expectEqual(@as(usize, 1), app.persisted_finishes.items.len);
+    try std.testing.expectEqualStrings("completed answer", app.persisted_finishes.items[0].turn.assistant.assistant);
 }
 
 test "core.app_worker_runtime failed turn terminalizes tool lifecycle before error text" {
@@ -4322,7 +4458,9 @@ test "core.app_worker_runtime drains diff block through bridge handler" {
             self.payload = payload;
             try self.preview_buf.appendSlice(std.testing.allocator, payload.preview);
         }
-        fn history(_: *anyopaque, _: types.FinishedPrompt) !void {}
+        fn history(_: *anyopaque, _: types.FinishedPrompt) !HistoryDelivery {
+            return .{ .settled = .committed };
+        }
         fn grant(_: *anyopaque, _: types.PermissionGrant) !void {}
         fn err(_: *anyopaque, _: types.SemanticNotice) !void {}
     };
@@ -4740,7 +4878,9 @@ test "core.app_worker_runtime cancelled drain skips diff block" {
             defer @import("../output/diff.zig").freeDiffEntryPayload(std.heap.c_allocator, payload);
             self.diff_count += 1;
         }
-        fn history(_: *anyopaque, _: types.FinishedPrompt) !void {}
+        fn history(_: *anyopaque, _: types.FinishedPrompt) !HistoryDelivery {
+            return .{ .settled = .committed };
+        }
         fn grant(_: *anyopaque, _: types.PermissionGrant) !void {}
         fn err(_: *anyopaque, _: types.SemanticNotice) !void {}
     };
@@ -4763,4 +4903,61 @@ test "core.app_worker_runtime cancelled drain skips diff block" {
     });
 
     try std.testing.expectEqual(@as(usize, 0), capture.diff_count);
+}
+
+test "worker finish delivery separates unaccepted work from committed presentation failure" {
+    for ([_]bool{ false, true }) |committed| {
+        var app = FakeApp.init(std.testing.allocator);
+        defer app.deinit();
+        app.worker.processing = true;
+        const Capture = struct {
+            app: *FakeApp,
+            committed: bool,
+            fn history(raw: *anyopaque, finished: types.FinishedPrompt) !HistoryDelivery {
+                const self: *@This() = @ptrCast(@alignCast(raw));
+                if (!self.committed) return error.InjectedDeliveryFailure;
+                try self.app.appendFinishedPrompt(finished);
+                return .{ .settled = .{ .presentation_failed = error.InjectedDeliveryFailure } };
+            }
+        };
+        var capture = Capture{ .app = &app, .committed = committed };
+        var handlers = NoopBridge.handlers(&app);
+        handlers.ctx = &capture;
+        handlers.append_history_turn = Capture.history;
+        for ([_][]const u8{ "first answer", "second answer" }) |answer| {
+            try app.worker.pushEvent(std.heap.c_allocator, .{ .finish_prompt = .{ .turn = .{ .assistant = .{
+                .user = .{ .text = @constCast("request") },
+                .assistant = @constCast(answer),
+            } } } });
+        }
+        try std.testing.expectError(error.InjectedDeliveryFailure, Runtime(FakeApp).tick(&app, handlers));
+        try std.testing.expectEqual(@as(usize, 2), app.persisted_finishes.items.len);
+        try std.testing.expectEqualStrings("first answer", app.persisted_finishes.items[0].turn.assistant.assistant);
+        try std.testing.expectEqualStrings("second answer", app.persisted_finishes.items[1].turn.assistant.assistant);
+        try std.testing.expectEqual(@as(?anyerror, null), app.session_persistence.shutdown_failure);
+    }
+}
+
+test "unaccepted worker finish records save failure and stops the detached suffix" {
+    var app = FakeApp.init(std.testing.allocator);
+    defer app.deinit();
+    app.worker.processing = true;
+    app.finish_persistence_error = error.InputOutput;
+    const Capture = struct {
+        fn history(_: *anyopaque, _: types.FinishedPrompt) !HistoryDelivery {
+            return error.InjectedDeliveryFailure;
+        }
+    };
+    var handlers = NoopBridge.handlers(&app);
+    handlers.append_history_turn = Capture.history;
+    for (0..2) |_| {
+        try app.worker.pushEvent(std.heap.c_allocator, .{ .finish_prompt = .{ .turn = .{ .assistant = .{
+            .user = .{ .text = @constCast("request") },
+            .assistant = @constCast("answer"),
+        } } } });
+    }
+    try std.testing.expectError(error.InjectedDeliveryFailure, Runtime(FakeApp).tick(&app, handlers));
+    try std.testing.expectEqual(@as(?anyerror, error.InputOutput), app.session_persistence.shutdown_failure);
+    try std.testing.expectEqual(@as(usize, 0), app.persisted_finishes.items.len);
+    try std.testing.expectEqual(@as(usize, 0), app.worker.events.items.len);
 }

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -2852,7 +2852,7 @@ fn propagateHistoryTurn(raw_ctx: *anyopaque, turn: HistoryTurn) !void {
         return;
     };
     try writable.prepareHistoryTurnForCommit(ctx.alloc, &prepared);
-    _ = try writable.appendEvent(
+    _ = writable.appendEvent(
         ctx.alloc,
         .{ .history_turn_committed = .{
             .conversation_language = ctx.session.languageSnapshot(),
@@ -2861,7 +2861,10 @@ fn propagateHistoryTurn(raw_ctx: *anyopaque, turn: HistoryTurn) !void {
             .turn = prepared,
         } },
         io_mod.milliTimestamp(),
-    );
+    ) catch |err| {
+        if (err == error.SessionPersistenceUncertain) ctx.prompt_snapshot_committed = true;
+        return err;
+    };
     ctx.session.commitPreparedHistoryEntry(ctx.alloc, prepared);
     prepared_owned = false;
     ctx.prompt_snapshot_committed = true;
@@ -2879,7 +2882,10 @@ fn commitContextCompaction(
     const prepared = try session_runtime.prepareCompactedHistory(ctx.alloc, ctx.session.agent.history.items, summary, retained_from orelse .{ .turns = session_runtime.rawHistoryTurnCount(ctx.session.agent.history.items) });
     errdefer types.freeHistoryTurnSlice(ctx.alloc, prepared);
     if (ctx.writable) |*writable| {
-        _ = try writable.commitContextCompaction(ctx.alloc, summary, active_prefix, retained_from, io_mod.milliTimestamp());
+        _ = writable.commitContextCompaction(ctx.alloc, summary, active_prefix, retained_from, io_mod.milliTimestamp()) catch |err| {
+            if (err == error.SessionPersistenceUncertain and active_prefix != null) ctx.prompt_snapshot_committed = true;
+            return err;
+        };
         if (active_prefix != null) ctx.prompt_snapshot_committed = true;
     }
     ctx.session.commitCompactedHistory(ctx.alloc, prepared);
@@ -2890,6 +2896,9 @@ fn setRecoveryCheckpoint(
     checkpoint: session_codec.RecoveryCheckpoint,
 ) !void {
     const ctx: *AskContext = @ptrCast(@alignCast(raw_ctx));
+    errdefer |err| if (err == error.SessionPersistenceUncertain) {
+        ctx.prompt_snapshot_committed = true;
+    };
     ctx.session_write_mutex.lockUncancelable(io_mod.getIo());
     defer ctx.session_write_mutex.unlock(io_mod.getIo());
     const writable = if (ctx.writable) |*value| value else return error.SessionPersistenceUnavailable;

--- a/src/core/session/session_child_store.zig
+++ b/src/core/session/session_child_store.zig
@@ -551,6 +551,37 @@ pub const SessionChildCapability = struct {
             route.setPermissions(io_mod.getIo(), private_dir_permissions) catch
                 return error.PrivateStatePermissionsUnsupported;
         }
+        return initOpenedLegacyRoute(alloc, route, route_path, kind, mode);
+    }
+
+    /// Reads only an existing control route; legacy session parents need not
+    /// have acquired current-format directory permissions before discovery.
+    pub fn initLegacySubagentControl(
+        alloc: Allocator,
+        session_dir: std.Io.Dir,
+        display_session_path: []const u8,
+    ) !?SessionChildCapability {
+        var route = session_dir.openDir(io_mod.getIo(), "subagent", .{
+            .iterate = true,
+            .follow_symlinks = false,
+        }) catch |err| switch (err) {
+            error.FileNotFound => return null,
+            error.NotDir, error.SymLinkLoop => return error.SessionPathUnsafe,
+            else => return err,
+        };
+        errdefer route.close(io_mod.getIo());
+        const display = try std.fs.path.join(alloc, &.{ display_session_path, "subagent" });
+        defer alloc.free(display);
+        return try initOpenedLegacyRoute(alloc, route, display, .subagent_control, .read_only);
+    }
+
+    fn initOpenedLegacyRoute(
+        alloc: Allocator,
+        route: std.Io.Dir,
+        route_path: []const u8,
+        kind: ManagedChildKind,
+        mode: Mode,
+    ) !SessionChildCapability {
         try verifyPrivateDirectory(route);
 
         var retained = try route.openDir(io_mod.getIo(), ".", .{

--- a/src/core/session/session_discovery.zig
+++ b/src/core/session/session_discovery.zig
@@ -73,6 +73,7 @@ pub const WritableCandidate = struct {
     updated_at_ms: i64,
     storage: CandidateStorage,
     projection_state: ProjectionState,
+    subagent_child: ?bool = null,
 
     pub fn deinit(self: *WritableCandidate, alloc: Allocator) void {
         alloc.free(self.id);
@@ -430,7 +431,9 @@ pub fn writable_conversation_candidate(
             offset = line.next_offset;
         }
     }
-    return dupeWritableCandidate(alloc, metadata.id, metadata.workspace_root, updated_at_ms, .conversation, .current);
+    var candidate = try dupeWritableCandidate(alloc, metadata.id, metadata.workspace_root, updated_at_ms, .conversation, .current);
+    candidate.subagent_child = metadata.subagent_child;
+    return candidate;
 }
 
 /// Identifies a fenced candidate without recovering it. Caller owns the candidate.
@@ -440,7 +443,12 @@ pub fn fenced_legacy_writable_candidate(
     session_id: []const u8,
     fallback_workspace: []const u8,
 ) !WritableCandidate {
-    const name: []const u8 = if (try entryExistsRelative(session_dir, "session.legacy.json")) "session.legacy.json" else "session.json";
+    const name: []const u8 = if (try entryExistsRelative(session_dir, "session.legacy.json"))
+        "session.legacy.json"
+    else if (try entryExistsRelative(session_dir, "session.json"))
+        "session.json"
+    else
+        return error.SessionAuthorityBoundaryUnavailable;
     const path_stat = try session_dir.dir.statFile(io_mod.getIo(), name, .{ .follow_symlinks = false });
     if (path_stat.kind != .file or path_stat.nlink != 1) return error.SessionPathUnsafe;
     var file = try openSessionFile(session_dir, name, .read_only);

--- a/src/core/session/session_log.zig
+++ b/src/core/session/session_log.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const debug_trace = @import("../shared/debug_trace.zig");
 const io_mod = @import("../shared/io.zig");
 const profile_paths = @import("../shared/profile_paths.zig");
@@ -118,6 +119,8 @@ pub const ConversationWriter = struct {
     latest_checkpoint_coverage: u64 = 0,
     turn_open: bool = false,
     pending_tool_calls: std.ArrayList(session_event.PendingToolCall) = .empty,
+    failure: ?error{ SessionWriterChanged, SessionPersistenceUncertain, SessionCommitFailed } = null,
+    test_sync_ops: if (builtin.is_test) io_mod.DurableOps else void = if (builtin.is_test) .{} else {},
 
     /// Takes ownership of `file` only on success.
     pub fn init(alloc: Allocator, file: std.Io.File) !ConversationWriter {
@@ -216,6 +219,7 @@ pub const ConversationWriter = struct {
         timestamp_ms: i64,
         event: session_event.ConversationEvent,
     ) !u64 {
+        if (self.failure) |err| return err;
         const seq = std.math.add(u64, self.last_seq, 1) catch
             return error.ConversationSequenceOverflow;
         const envelope = session_event.ConversationEnvelope{
@@ -254,14 +258,7 @@ pub const ConversationWriter = struct {
 
         const frame = try session_event.encodeConversationFrame(alloc, envelope);
         defer alloc.free(frame);
-        if (try self.file.length(io_mod.getIo()) != self.committed_bytes) {
-            try self.file.setLength(io_mod.getIo(), self.committed_bytes);
-            try self.file.sync(io_mod.getIo());
-        }
-        try self.file.writePositionalAll(io_mod.getIo(), frame, self.committed_bytes);
-        try self.file.sync(io_mod.getIo());
-        self.committed_bytes = std.math.add(u64, self.committed_bytes, frame.len) catch
-            return error.ConversationSizeOverflow;
+        try self.writePrepared(frame);
         self.last_seq = seq;
         self.turn_open = turn_open;
 
@@ -444,6 +441,7 @@ pub const ConversationWriter = struct {
         timestamp_ms: i64,
         events: []const session_event.ConversationEvent,
     ) !void {
+        if (self.failure) |err| return err;
         if (events.len == 0) return;
         if (self.pending_tool_calls.items.len != 0) return error.UnresolvedToolCall;
 
@@ -492,24 +490,48 @@ pub const ConversationWriter = struct {
             try out.writer.writeAll(frame);
         }
         if (pending.items.len != 0) return error.UnresolvedToolCall;
-        if (try self.file.length(io_mod.getIo()) != self.committed_bytes) {
-            try self.file.setLength(io_mod.getIo(), self.committed_bytes);
-            try self.file.sync(io_mod.getIo());
-        }
-        try self.file.writePositionalAll(
-            io_mod.getIo(),
-            out.written(),
-            self.committed_bytes,
-        );
-        try self.file.sync(io_mod.getIo());
-        self.committed_bytes = std.math.add(
-            u64,
-            self.committed_bytes,
-            out.written().len,
-        ) catch return error.ConversationSizeOverflow;
+        try self.writePrepared(out.written());
         self.last_seq = seq;
         self.latest_checkpoint_coverage = checkpoint_coverage;
         self.turn_open = turn_open;
+    }
+
+    fn writePrepared(self: *ConversationWriter, bytes: []const u8) !void {
+        if (self.failure) |err| return err;
+        const next_bytes = std.math.add(u64, self.committed_bytes, bytes.len) catch
+            return error.ConversationSizeOverflow;
+        if (try self.file.length(io_mod.getIo()) != self.committed_bytes) {
+            self.failure = error.SessionWriterChanged;
+            debug_trace.logf("session", "conversation writer changed outside ownership offset={d}", .{self.committed_bytes});
+            return error.SessionWriterChanged;
+        }
+        self.file.writePositionalAll(io_mod.getIo(), bytes, self.committed_bytes) catch |err| {
+            return self.rollbackAppend(err);
+        };
+        self.syncAppend() catch |err| return self.rollbackAppend(err);
+        self.committed_bytes = next_bytes;
+    }
+
+    fn syncAppend(self: *ConversationWriter) !void {
+        if (comptime builtin.is_test) {
+            return self.test_sync_ops.sync_file(self.test_sync_ops.ctx, self.file);
+        }
+        try self.file.sync(io_mod.getIo());
+    }
+
+    fn rollbackAppend(self: *ConversationWriter, original: anyerror) anyerror {
+        self.failure = error.SessionPersistenceUncertain;
+        self.file.setLength(io_mod.getIo(), self.committed_bytes) catch |err| {
+            debug_trace.logf("session", "conversation append rollback failed offset={d} append_err={s} rollback_err={s}", .{ self.committed_bytes, @errorName(original), @errorName(err) });
+            return error.SessionPersistenceUncertain;
+        };
+        self.syncAppend() catch |err| {
+            debug_trace.logf("session", "conversation append rollback sync failed offset={d} append_err={s} rollback_err={s}", .{ self.committed_bytes, @errorName(original), @errorName(err) });
+            return error.SessionPersistenceUncertain;
+        };
+        self.failure = null;
+        debug_trace.logf("session", "conversation append rolled back offset={d} err={s}", .{ self.committed_bytes, @errorName(original) });
+        return original;
     }
 
     fn clearPendingToolCalls(self: *ConversationWriter) void {
@@ -812,10 +834,11 @@ fn load_conversation_state_at_boundary(
     else
         null;
     errdefer if (last_work_id) |work_id| alloc.free(work_id);
-    var usage = try session_usage_sidecar.load(
+    var usage: ?session_usage.Snapshot = try session_usage_sidecar.loadConversation(
         alloc,
         dir,
         expected_session_id,
+        metadata.value.updated_at_ms,
     );
     errdefer if (usage) |*snapshot| snapshot.deinit(alloc);
     var permission_state = try loadConversationPermissionState(alloc, dir);
@@ -2430,21 +2453,12 @@ pub const WritableSessionDir = struct {
         return self.writer_lock == null;
     }
 
-    /// Release `session.lock` while keeping the session directory open for a
-    /// later `unpark` in the same process (idle job-control suspend).
+    /// Release `session.lock`. The loaded session must be retired before
+    /// acquiring another writer, since its state may no longer match storage.
     pub fn park(self: *WritableSessionDir) void {
         const lock = &(self.writer_lock orelse return);
         lock.release();
         self.writer_lock = null;
-    }
-
-    /// Reacquire `session.lock` after `park`. Fails with `SessionBusy` when
-    /// another process already owns the writer lock.
-    pub fn unpark(self: *WritableSessionDir) !void {
-        if (self.writer_lock != null) return;
-        self.writer_lock = acquireLock(&self.dir, session_lock_file, true) catch |err| {
-            return mapSessionLockError(err);
-        };
     }
 
     pub fn eventLogLengthForTest(self: *WritableSessionDir) !u64 {
@@ -2478,6 +2492,19 @@ pub const LoadedWritableSession = struct {
     external_prompt_origin: ExternalPromptOrigin = .root,
     external_root_user_messages: [][]u8 = &.{},
     external_root_user_evidence_complete: bool = false,
+
+    pub fn requireWritable(self: *const LoadedWritableSession) !void {
+        if (self.log.isParked()) return error.SessionWriterParked;
+        if (self.conversation_writer.failure) |err| return err;
+    }
+
+    fn recordWriteFailure(self: *LoadedWritableSession, err: anyerror) anyerror {
+        if (err == error.DurableReplacePostRenameFailed) {
+            self.conversation_writer.failure = error.SessionPersistenceUncertain;
+            return error.SessionPersistenceUncertain;
+        }
+        return err;
+    }
 
     pub fn deinit(self: *LoadedWritableSession, alloc: Allocator) void {
         self.conversation_writer.deinit();
@@ -2521,6 +2548,7 @@ pub const LoadedWritableSession = struct {
         alloc: Allocator,
         turn: *session.HistoryTurn,
     ) !void {
+        try self.requireWritable();
         try externalizeConversationTurnResults(
             alloc,
             turn,
@@ -2533,6 +2561,7 @@ pub const LoadedWritableSession = struct {
         alloc: Allocator,
         title: []const u8,
     ) !bool {
+        try self.requireWritable();
         const bytes = try readManagedFileAlloc(
             alloc,
             &self.log.dir,
@@ -2557,12 +2586,12 @@ pub const LoadedWritableSession = struct {
             .subagent_child = metadata.value.subagent_child,
         });
         defer alloc.free(encoded);
-        try io_mod.durableReplaceVerified(
+        io_mod.durableReplaceVerified(
             alloc,
             &self.log.dir,
             manifest_file,
             encoded,
-        );
+        ) catch |err| return self.recordWriteFailure(err);
         return true;
     }
 
@@ -2591,7 +2620,8 @@ pub const LoadedWritableSession = struct {
         event: SessionUpdate,
         timestamp_ms: i64,
     ) !CommitPosition {
-        return switch (event) {
+        try self.requireWritable();
+        const result = switch (event) {
             .history_turn_committed => self.appendConversationHistoryEvent(
                 alloc,
                 event,
@@ -2613,6 +2643,7 @@ pub const LoadedWritableSession = struct {
                 timestamp_ms,
             ),
         };
+        return result catch |err| self.recordWriteFailure(err);
     }
 
     pub fn commitContextCompaction(
@@ -2623,6 +2654,7 @@ pub const LoadedWritableSession = struct {
         retained_from: ?types.ContextHistoryCut,
         timestamp_ms: i64,
     ) !CommitPosition {
+        try self.requireWritable();
         var prepared: ?session.HistoryTurn = if (active_prefix) |prefix|
             try session.dupeHistoryTurn(alloc, .{ .assistant = prefix })
         else
@@ -2637,6 +2669,7 @@ pub const LoadedWritableSession = struct {
             retained_from,
         );
         if (prepared) |turn| self.writeFirstConversationTitle(alloc, turn);
+        if (self.conversation_writer.failure) |err| return err;
         return self.finishConversationCommit(alloc, timestamp_ms);
     }
 
@@ -2650,7 +2683,7 @@ pub const LoadedWritableSession = struct {
             .history_turn_committed => |value| value,
             else => return error.InvalidConversationEvent,
         };
-        const work_id = if (payload.work_id) |value|
+        var work_id = if (payload.work_id) |value|
             try alloc.dupe(u8, value)
         else
             null;
@@ -2661,14 +2694,26 @@ pub const LoadedWritableSession = struct {
             payload.turn,
         );
         self.writeFirstConversationTitle(alloc, payload.turn);
+        if (self.conversation_writer.failure) |err| return err;
         if (work_id) |value| {
             if (self.state.last_subagent_work_id) |old| alloc.free(old);
             self.state.last_subagent_work_id = value;
+            work_id = null;
         }
+        const language_changed = !std.mem.eql(u8, self.state.conversation_language.view(), payload.conversation_language.view());
         self.state.conversation_language = payload.conversation_language;
         self.state.total_input_tokens = payload.total_input_tokens;
         self.state.total_output_tokens = payload.total_output_tokens;
-        return self.finishConversationCommit(alloc, timestamp_ms);
+        const position = self.finishConversationCommit(alloc, timestamp_ms);
+        if (language_changed) {
+            writeConversationMetadata(alloc, &self.log.dir, self.state) catch |err| {
+                self.conversation_writer.failure = error.SessionPersistenceUncertain;
+                debug_trace.logf("session", "history committed but language metadata failed session={s} err={s}", .{ self.active_id, @errorName(err) });
+                return error.SessionPersistenceUncertain;
+            };
+        }
+        if (self.conversation_writer.failure) |err| return err;
+        return position;
     }
 
     fn writeFirstConversationTitle(self: *LoadedWritableSession, alloc: Allocator, turn: session.HistoryTurn) void {
@@ -2827,16 +2872,17 @@ pub const LoadedWritableSession = struct {
         permission_state: session_permission_state.State,
         timestamp_ms: i64,
     ) !void {
+        try self.requireWritable();
         var next = try session_permission_state.dupe(alloc, permission_state);
         errdefer next.deinit(alloc);
         const bytes = try session_codec.encodePermissionState(alloc, next);
         defer alloc.free(bytes);
-        try io_mod.durableReplaceVerified(
+        io_mod.durableReplaceVerified(
             alloc,
             &self.log.dir,
             permission_state_file,
             bytes,
-        );
+        ) catch |err| return self.recordWriteFailure(err);
         self.state.permission_state.deinit(alloc);
         self.state.permission_state = next;
         self.state.updated_at_ms = timestamp_ms;
@@ -3305,14 +3351,11 @@ pub const Root = struct {
             session_id,
             options.session_lock_deadline_ms,
         );
+        errdefer writable.deinit(alloc);
         if (!try hasConversationMetadata(alloc, &writable.dir)) {
-            writable.deinit(alloc);
             return error.SessionMigrationRequired;
         }
-        return openConversationWritableSession(alloc, &writable) catch |err| {
-            writable.deinit(alloc);
-            return err;
-        };
+        return openConversationWritableSession(alloc, &writable);
     }
 
     pub fn loadReadOnly(
@@ -3851,6 +3894,187 @@ test "conversation writer appends one durable line per event" {
     try std.testing.expectEqual(@as(usize, 3), std.mem.count(u8, bytes, "\n"));
     try std.testing.expect(std.mem.find(u8, bytes, "commit.pending") == null);
     try std.testing.expect(std.mem.find(u8, bytes, "state_replacement") == null);
+}
+
+test "conversation writer preserves a suffix written outside its ownership" {
+    const alloc = std.testing.allocator;
+    for ([_]bool{ false, true }) |checkpoint| {
+        var tmp = std.testing.tmpDir(.{});
+        defer tmp.cleanup();
+        const file = try tmp.dir.createFile(std.testing.io, "events.jsonl", .{ .read = true });
+        var writer = try ConversationWriter.init(alloc, file);
+        defer writer.deinit();
+        try writer.appendHistoryTurn(alloc, 1, .{ .assistant = .{
+            .user = .{ .text = @constCast("accepted request") },
+            .assistant = @constCast("accepted answer"),
+        } });
+        const external = try session_event.encodeConversationFrame(alloc, .{
+            .seq = writer.last_seq + 1,
+            .timestamp_ms = 2,
+            .event = .{ .context_checkpoint = .{
+                .covers_through_seq = writer.last_seq,
+                .summary = "another writer's accepted context",
+            } },
+        });
+        defer alloc.free(external);
+        try file.writePositionalAll(std.testing.io, external, writer.committed_bytes);
+        try file.sync(std.testing.io);
+        const before = try alloc.alloc(u8, @intCast(try file.length(std.testing.io)));
+        defer alloc.free(before);
+        try std.testing.expectEqual(before.len, try file.readPositionalAll(std.testing.io, before, 0));
+        const turn: types.HistoryTurn = if (checkpoint)
+            .{ .compacted_summary = .{ .summary = @constCast("stale checkpoint"), .removed_turn_count = 1, .compaction_count = 1 } }
+        else
+            .{ .assistant = .{ .user = .{ .text = @constCast("stale request") }, .assistant = @constCast("stale answer") } };
+        try std.testing.expectError(error.SessionWriterChanged, writer.appendHistoryTurn(alloc, 3, turn));
+        try std.testing.expectEqual(before.len, try file.length(std.testing.io));
+        const after = try alloc.alloc(u8, before.len);
+        defer alloc.free(after);
+        try std.testing.expectEqual(after.len, try file.readPositionalAll(std.testing.io, after, 0));
+        try std.testing.expectEqualSlices(u8, before, after);
+    }
+}
+
+test "conversation writer rolls back failed sync and refuses uncertain continuation" {
+    const alloc = std.testing.allocator;
+    for ([_]bool{ false, true }) |checkpoint| {
+        for ([_]bool{ false, true }) |fail_rollback| {
+            var tmp = std.testing.tmpDir(.{});
+            defer tmp.cleanup();
+            const file = try tmp.dir.createFile(std.testing.io, "events.jsonl", .{ .read = true });
+            var writer = try ConversationWriter.init(alloc, file);
+            defer writer.deinit();
+            try writer.appendHistoryTurn(alloc, 10, .{ .assistant = .{
+                .user = .{ .text = @constCast("accepted request") },
+                .assistant = @constCast("accepted answer"),
+            } });
+            const prior = try writer.readAllForTest(alloc);
+            defer alloc.free(prior);
+            const SyncFault = struct {
+                calls: usize = 0,
+                fail_rollback: bool,
+
+                fn sync(ctx: ?*anyopaque, target: std.Io.File) !void {
+                    const self: *@This() = @ptrCast(@alignCast(ctx.?));
+                    self.calls += 1;
+                    if (self.calls == 1 or (self.fail_rollback and self.calls == 2)) return error.InjectedSyncFailure;
+                    try target.sync(std.testing.io);
+                }
+            };
+            var fault = SyncFault{ .fail_rollback = fail_rollback };
+            writer.test_sync_ops = .{ .ctx = &fault, .sync_file = SyncFault.sync };
+            const turn: types.HistoryTurn = if (checkpoint)
+                .{ .compacted_summary = .{ .summary = @constCast("failed summary"), .removed_turn_count = 1, .compaction_count = 1 } }
+            else
+                .{ .assistant = .{ .user = .{ .text = @constCast("failed request") }, .assistant = @constCast("failed answer") } };
+            try std.testing.expectError(
+                if (fail_rollback) error.SessionPersistenceUncertain else error.InjectedSyncFailure,
+                writer.appendHistoryTurn(alloc, 11, turn),
+            );
+            try std.testing.expectEqual(@as(usize, 2), fault.calls);
+            try std.testing.expectEqual(prior.len, try file.length(std.testing.io));
+            try std.testing.expectEqual(@as(u64, 3), writer.last_seq);
+            const after = try writer.readAllForTest(alloc);
+            defer alloc.free(after);
+            try std.testing.expectEqualSlices(u8, prior, after);
+            if (fail_rollback) {
+                try std.testing.expectError(error.SessionPersistenceUncertain, writer.appendHistoryTurn(alloc, 12, turn));
+                try std.testing.expectEqual(@as(usize, 2), fault.calls);
+            } else {
+                try writer.appendHistoryTurn(alloc, 12, turn);
+                try std.testing.expect(writer.committed_bytes > prior.len);
+            }
+        }
+    }
+}
+
+test "parked session refuses history and control mutations" {
+    const alloc = std.testing.allocator;
+    var temp = try TempRoot.init(alloc);
+    defer temp.deinit(alloc);
+    var initial = try testState(alloc, "parked-writes", 10);
+    defer initial.deinit(alloc);
+    var loaded = try temp.root.startConversationSession(alloc, initial, .{});
+    defer loaded.deinit(alloc);
+    loaded.log.park();
+    try std.testing.expectError(error.SessionWriterParked, loaded.appendEvent(alloc, .{ .history_turn_committed = .{
+        .conversation_language = initial.conversation_language,
+        .total_input_tokens = 0,
+        .total_output_tokens = 0,
+        .turn = .{ .assistant = .{ .user = .{ .text = @constCast("request") }, .assistant = @constCast("answer") } },
+    } }, 2));
+    try std.testing.expectError(error.SessionWriterParked, loaded.appendEvent(alloc, .{ .preferences_changed = .{ .fast_mode = true } }, 2));
+    try std.testing.expectError(error.SessionWriterParked, loaded.commitContextCompaction(alloc, .{ .summary = @constCast("summary"), .removed_turn_count = 1, .compaction_count = 1 }, null, null, 2));
+}
+
+test "writable resume releases ownership when metadata allocation fails" {
+    const alloc = std.testing.allocator;
+    var temp = try TempRoot.init(alloc);
+    defer temp.deinit(alloc);
+    var initial = try testState(alloc, "resume-allocation", 10);
+    defer initial.deinit(alloc);
+    var started = try temp.root.startConversationSession(alloc, initial, .{});
+    started.deinit(alloc);
+    var failing = std.testing.FailingAllocator.init(alloc, .{ .fail_index = 1 });
+    try std.testing.expectError(error.OutOfMemory, temp.root.resumeForWrite(failing.allocator(), initial.id, .{ .session_lock_deadline_ms = 0 }));
+    try std.testing.expectEqual(failing.allocated_bytes, failing.freed_bytes);
+    var resumed = try temp.root.resumeForWrite(alloc, initial.id, .{ .session_lock_deadline_ms = 0 });
+    defer resumed.deinit(alloc);
+    try std.testing.expectEqualStrings(initial.id, resumed.active_id);
+}
+
+test "committed conversation language survives reopening" {
+    const alloc = std.testing.allocator;
+    var temp = try TempRoot.init(alloc);
+    defer temp.deinit(alloc);
+    var initial = try testState(alloc, "language-roundtrip", 10);
+    defer initial.deinit(alloc);
+    {
+        var loaded = try temp.root.startConversationSession(alloc, initial, .{});
+        defer loaded.deinit(alloc);
+        _ = try loaded.appendEvent(alloc, .{ .history_turn_committed = .{
+            .conversation_language = .literal("fr"),
+            .total_input_tokens = 0,
+            .total_output_tokens = 0,
+            .turn = .{ .assistant = .{ .user = .{ .text = @constCast("Bonjour") }, .assistant = @constCast("Salut") } },
+        } }, 20);
+    }
+    var restored = try temp.root.loadReadOnly(alloc, initial.id, .{});
+    defer restored.deinit(alloc);
+    try std.testing.expectEqualStrings("fr", restored.conversation_language.view());
+    try std.testing.expectEqual(@as(usize, 1), restored.history.len);
+}
+
+test "conversation load retains history and qualifies missing or corrupt accounting" {
+    const alloc = std.testing.allocator;
+    for ([_]bool{ false, true }) |missing| {
+        var temp = try TempRoot.init(alloc);
+        defer temp.deinit(alloc);
+        var initial = try testState(alloc, "accounting-recovery", 10);
+        defer initial.deinit(alloc);
+        initial.history = try alloc.alloc(session.HistoryTurn, 1);
+        initial.history[0] = try session.makeAssistantTurn(alloc, "saved request", "saved answer");
+        var loaded = try temp.root.startConversationSession(alloc, initial, .{});
+        loaded.deinit(alloc);
+        var dir = try openSessionDir(&temp.root.sessions.?, initial.id, .read_only);
+        defer dir.close();
+        if (missing) {
+            try dir.dir.deleteFile(std.testing.io, session_usage_sidecar.sidecar_file);
+        } else {
+            try io_mod.durableReplaceVerified(alloc, &dir, session_usage_sidecar.sidecar_file, "{broken accounting");
+        }
+        var restored = try temp.root.loadReadOnly(alloc, initial.id, .{});
+        defer restored.deinit(alloc);
+        try std.testing.expectEqualStrings("saved answer", restored.history[0].assistant.assistant);
+        try std.testing.expect(restored.usage != null);
+        try std.testing.expectEqual(session_usage.Availability.incomplete, restored.usage.?.billing);
+        try std.testing.expectEqual(@as(usize, 1), restored.usage.?.incidents.len);
+        if (!missing) {
+            const retained = try readManagedFileAlloc(alloc, &dir, session_usage_sidecar.sidecar_file, 1024);
+            defer alloc.free(retained);
+            try std.testing.expectEqualStrings("{broken accounting", retained);
+        }
+    }
 }
 
 test "conversation writer repairs only a partial final record and continues" {
@@ -5673,4 +5897,26 @@ test "cache-free resume loads only the latest checkpoint and suffix" {
     const bytes = try io_mod.readFileToEnd(alloc, &event_file, 1024 * 1024);
     defer alloc.free(bytes);
     try std.testing.expect(std.mem.find(u8, bytes, "old question") != null);
+}
+
+test "language metadata failure retains ownership of the committed work identity" {
+    const alloc = std.testing.allocator;
+    var temp = try TempRoot.init(alloc);
+    defer temp.deinit(alloc);
+    var initial = try testState(alloc, "language-work-failure", 10);
+    defer initial.deinit(alloc);
+    var loaded = try temp.root.startConversationSession(alloc, initial, .{});
+    defer loaded.deinit(alloc);
+    loaded.freshly_started = false;
+    try loaded.log.dir.dir.deleteFile(std.testing.io, "session.json");
+    try loaded.log.dir.dir.createDir(std.testing.io, "session.json", private_dir_permissions);
+    try std.testing.expectError(error.SessionPersistenceUncertain, loaded.appendEvent(alloc, .{ .history_turn_committed = .{
+        .work_id = @constCast("committed-work"),
+        .conversation_language = .literal("fr"),
+        .total_input_tokens = 0,
+        .total_output_tokens = 0,
+        .turn = .{ .assistant = .{ .user = .{ .text = @constCast("Bonjour") }, .assistant = @constCast("Salut") } },
+    } }, 20));
+    try std.testing.expectEqualStrings("committed-work", loaded.state.last_subagent_work_id.?);
+    try std.testing.expectError(error.SessionPersistenceUncertain, loaded.requireWritable());
 }

--- a/src/core/session/session_store.zig
+++ b/src/core/session/session_store.zig
@@ -1397,6 +1397,20 @@ pub const Store = struct {
     }
 
     /// Opens verified read-only storage restricted to subagent control files.
+    /// The caller has already classified the session; no history is replayed.
+    pub fn openListedSubagentControlReadOnly(
+        self: Store,
+        alloc: Allocator,
+        session_id: []const u8,
+    ) !?session_child_store.SessionChildCapability {
+        var session_dir = try self.openSessionDir(session_id);
+        defer session_dir.close();
+        const display = try sessionDirPath(alloc, self.sessions_dir, session_id);
+        defer alloc.free(display);
+        return session_child_store.SessionChildCapability.initLegacySubagentControl(alloc, session_dir.dir, display);
+    }
+
+    /// Opens verified read-only storage restricted to subagent control files.
     pub fn openSubagentControlCapabilityReadOnly(
         self: Store,
         alloc: Allocator,
@@ -1786,6 +1800,7 @@ pub const Store = struct {
         writable: *const LoadedWritableSession,
         snapshot: session_usage.Snapshot,
     ) !UsageRecoveryCheckpoint {
+        try writable.requireWritable();
         const now_ms = @max(io_mod.milliTimestamp(), 0);
         const timestamp_ms = if (now_ms > writable.state.updated_at_ms)
             now_ms
@@ -2750,6 +2765,7 @@ pub const Store = struct {
         var scan = RankingScan{ .cache = try catalog_cache.Loaded.load(alloc, sessions, null) };
         defer scan.deinit(alloc);
         var selected: ?WritableCandidate = null;
+        var candidate_error: ?anyerror = null;
         defer if (selected) |*candidate| candidate.deinit(alloc);
         var dir = try sessions.dir.openDir(io_mod.getIo(), ".", .{ .iterate = true, .follow_symlinks = false });
         defer dir.close(io_mod.getIo());
@@ -2774,7 +2790,9 @@ pub const Store = struct {
                     null,
                     err,
                 );
-                return err;
+                if (err == error.OutOfMemory or err == error.Cancelled) return err;
+                candidate_error = err;
+                continue;
             } orelse continue;
             if (!std.mem.eql(u8, candidate.workspace_root, workspace_root)) {
                 logDiscovery(
@@ -2786,6 +2804,27 @@ pub const Store = struct {
                     .skipped,
                     null,
                 );
+                candidate.deinit(alloc);
+                continue;
+            }
+            const child_identity = candidate.subagent_child orelse switch (candidate.storage) {
+                .legacy_v1, .legacy_v2 => false,
+                .schema_v3, .conversation => null,
+            };
+            const internal = subagent_child_state.isDiscoveredManagedChildSession(
+                self,
+                alloc,
+                candidate.id,
+                child_identity,
+            ) catch |err| {
+                logDiscoveryError(.workspace_writable_last, candidate.id, candidate.storage, candidate.projection_state, err);
+                candidate.deinit(alloc);
+                if (err == error.OutOfMemory or err == error.Cancelled) return err;
+                candidate_error = err;
+                continue;
+            };
+            if (internal) {
+                debug_trace.logf("session", "latest selection excluded internal child id={s}", .{candidate.id});
                 candidate.deinit(alloc);
                 continue;
             }
@@ -2805,8 +2844,7 @@ pub const Store = struct {
                 candidate.deinit(alloc);
             }
         }
-        // No cache publication is reachable from an incomplete or failed scan.
-        scan.publish(self, alloc);
+        if (candidate_error == null) scan.publish(self, alloc);
         if (selected) |candidate| {
             logDiscovery(
                 .workspace_writable_last,
@@ -2819,6 +2857,7 @@ pub const Store = struct {
             );
             return try alloc.dupe(u8, candidate.id);
         }
+        if (candidate_error) |err| return err;
         return null;
     }
 
@@ -2873,6 +2912,10 @@ pub const Store = struct {
         if (try session_log.readConversationMetadata(alloc, &session_dir)) |value| {
             var metadata = value;
             defer metadata.deinit();
+            if (metadata.value.subagent_child and std.mem.eql(u8, metadata.value.id, session_id)) {
+                debug_trace.logf("session", "latest selection excluded internal child id={s}", .{session_id});
+                return null;
+            }
             if (std.mem.eql(u8, metadata.value.id, session_id) and
                 try only_unpublished_creation(&session_dir, true))
             {
@@ -7156,7 +7199,7 @@ test "classifies conversation and legacy candidates" {
     );
 }
 
-test "writable last skips only unpublished lock directories" {
+test "writable last preserves unidentified data without blocking a healthy session" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -7172,13 +7215,15 @@ test "writable last skips only unpublished lock directories" {
         try std.testing.expectEqualStrings("local", resumed.active_id);
     }
     try writeFixtureEntry(alloc, ctx.store, "lock-only", "events.jsonl", "unidentified saved data\n");
-    try std.testing.expectError(error.FileNotFound, ctx.store.resumeTargetForWrite(alloc, .last, ctx.workspace, .{}));
+    var resumed = try ctx.store.resumeTargetForWrite(alloc, .last, ctx.workspace, .{});
+    defer resumed.deinit(alloc);
+    try std.testing.expectEqualStrings("local", resumed.active_id);
     const retained = try readFixtureFile(alloc, ctx.store, "lock-only", "events.jsonl", 1024);
     defer alloc.free(retained);
     try std.testing.expectEqualStrings("unidentified saved data\n", retained);
 }
 
-test "writable last skips retained incomplete creation without weakening saved-data checks" {
+test "writable last preserves incomplete creation and exact resume diagnostics" {
     const alloc = std.testing.allocator;
     for ([_]struct { metadata: bool, temporary: bool }{
         .{ .metadata = false, .temporary = true },
@@ -7226,10 +7271,63 @@ test "writable last skips retained incomplete creation without weakening saved-d
             return error.IncompleteSessionWasResumed;
         } else |err| try std.testing.expect(err == error.FileNotFound or err == error.SessionNotFound);
         try writeFixtureEntry(alloc, ctx.store, "failed-start", "permissions.json", "{}");
-        try std.testing.expectError(error.FileNotFound, ctx.store.resumeTargetForWrite(alloc, .last, ctx.workspace, .{}));
+        var resumed = try ctx.store.resumeTargetForWrite(alloc, .last, ctx.workspace, .{});
+        defer resumed.deinit(alloc);
+        try std.testing.expectEqualStrings("healthy", resumed.active_id);
         const controls = try readFixtureFile(alloc, ctx.store, "failed-start", "permissions.json", 1024);
         defer alloc.free(controls);
         try std.testing.expectEqualStrings("{}", controls);
+    }
+}
+
+test "writable last retains a pending authority directory without a manifest" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var ctx = try initTempStore(alloc, &tmp);
+    defer ctx.deinit(alloc);
+    try createHistoryPageFixture(alloc, ctx.store, "healthy", ctx.workspace, 1, "saved");
+    try ctx.store.canonical_root.sessions.?.dir.createDir(std.testing.io, "pending", .fromMode(0o700));
+    try writeFixtureEntry(alloc, ctx.store, "pending", "authority.pending.json", "pending authority");
+    try writeFixtureEntry(alloc, ctx.store, "pending", "events.jsonl", "retained event data\n");
+    var resumed = try ctx.store.resumeTargetForWrite(alloc, .last, ctx.workspace, .{});
+    defer resumed.deinit(alloc);
+    try std.testing.expectEqualStrings("healthy", resumed.active_id);
+    const retained = try readFixtureFile(alloc, ctx.store, "pending", "events.jsonl", 1024);
+    defer alloc.free(retained);
+    try std.testing.expectEqualStrings("retained event data\n", retained);
+}
+
+test "writable last excludes newer child metadata and legacy owner markers" {
+    const alloc = std.testing.allocator;
+    for ([_]bool{ false, true }) |legacy_marker| {
+        var tmp = std.testing.tmpDir(.{});
+        defer tmp.cleanup();
+        var ctx = try initTempStore(alloc, &tmp);
+        defer ctx.deinit(alloc);
+        try createHistoryPageFixture(alloc, ctx.store, "parent", ctx.workspace, 1, "parent");
+        if (legacy_marker) {
+            try writeLegacyFixture(alloc, ctx.store, "child", ctx.workspace, std.math.maxInt(i64) - 1);
+            var dir = try ctx.store.openSessionDir("child");
+            defer dir.close();
+            try dir.dir.createDir(std.testing.io, "subagent", .fromMode(0o700));
+            try dir.dir.writeFile(std.testing.io, .{ .sub_path = "subagent/owner.json", .data = "{}", .flags = .{ .permissions = .fromMode(0o600) } });
+        } else {
+            try createHistoryPageFixture(alloc, ctx.store, "child", ctx.workspace, 1, "child");
+            var dir = try ctx.store.openSessionDir("child");
+            defer dir.close();
+            var decoded = (try session_log.readConversationMetadata(alloc, &dir)).?;
+            defer decoded.deinit();
+            var metadata = decoded.value;
+            metadata.subagent_child = true;
+            metadata.updated_at_ms = std.math.maxInt(i64) - 1;
+            const bytes = try session_codec.encodeSessionMetadata(alloc, metadata);
+            defer alloc.free(bytes);
+            try writeFixtureEntry(alloc, ctx.store, "child", "session.json", bytes);
+        }
+        var resumed = try ctx.store.resumeTargetForWrite(alloc, .last, ctx.workspace, .{});
+        defer resumed.deinit(alloc);
+        try std.testing.expectEqualStrings("parent", resumed.active_id);
     }
 }
 

--- a/src/core/session/session_usage.zig
+++ b/src/core/session/session_usage.zig
@@ -526,8 +526,9 @@ pub const Usage = struct {
         outcome: DeliveryOutcome,
     ) !void {
         self.checkpoint_mutex.lockUncancelable(io_mod.getIo());
+        errdefer self.checkpoint_mutex.unlock(io_mod.getIo());
         self.finishInvocation(sequence, duration_ms, outcome);
-        _ = self.persistCheckpointBestEffortLocked();
+        _ = try self.persistCheckpointForContinuationLocked();
         self.checkpoint_mutex.unlock(io_mod.getIo());
         self.flushProfilePublications();
     }
@@ -543,6 +544,7 @@ pub const Usage = struct {
         team: ?[]const u8,
     ) !bool {
         self.checkpoint_mutex.lockUncancelable(io_mod.getIo());
+        errdefer self.checkpoint_mutex.unlock(io_mod.getIo());
         const accepted = self.finishObservedInvocationAccepted(
             alloc,
             sequence,
@@ -553,7 +555,7 @@ pub const Usage = struct {
             team,
         ) catch |err| {
             self.markBillingIncomplete();
-            _ = self.persistCheckpointBestEffortLocked();
+            _ = try self.persistCheckpointForContinuationLocked();
             debug_trace.logf(
                 "session",
                 "usage generation checkpointed incomplete reason={s}",
@@ -563,7 +565,7 @@ pub const Usage = struct {
             self.flushProfilePublications();
             return false;
         };
-        _ = self.persistCheckpointBestEffortLocked();
+        _ = try self.persistCheckpointForContinuationLocked();
         self.checkpoint_mutex.unlock(io_mod.getIo());
         return accepted;
     }
@@ -577,6 +579,7 @@ pub const Usage = struct {
         reference: stream_provider.DeferredUsageReference,
     ) !bool {
         self.checkpoint_mutex.lockUncancelable(io_mod.getIo());
+        errdefer self.checkpoint_mutex.unlock(io_mod.getIo());
         const accepted = self.finishDeferredInvocationAccepted(
             alloc,
             sequence,
@@ -585,7 +588,7 @@ pub const Usage = struct {
             reference,
         ) catch |err| {
             self.markBillingIncomplete();
-            _ = self.persistCheckpointBestEffortLocked();
+            _ = try self.persistCheckpointForContinuationLocked();
             debug_trace.logf(
                 "session",
                 "usage generation checkpointed incomplete reason={s}",
@@ -595,7 +598,7 @@ pub const Usage = struct {
             self.flushProfilePublications();
             return false;
         };
-        _ = self.persistCheckpointBestEffortLocked();
+        _ = try self.persistCheckpointForContinuationLocked();
         self.checkpoint_mutex.unlock(io_mod.getIo());
         return accepted;
     }
@@ -661,6 +664,7 @@ pub const Usage = struct {
         };
 
         self.checkpoint_mutex.lockUncancelable(io_mod.getIo());
+        errdefer self.checkpoint_mutex.unlock(io_mod.getIo());
         const durable_bridge = self.checkpoint_sink != null;
         const accepted = self.finishExactInvocationAccepted(
             alloc,
@@ -673,7 +677,7 @@ pub const Usage = struct {
             durable_bridge,
         ) catch |err| {
             self.markBillingIncomplete();
-            _ = self.persistCheckpointBestEffortLocked();
+            _ = try self.persistCheckpointForContinuationLocked();
             self.checkpoint_mutex.unlock(io_mod.getIo());
             debug_trace.logf(
                 "session",
@@ -683,11 +687,11 @@ pub const Usage = struct {
             return false;
         };
         if (!accepted) {
-            _ = self.persistCheckpointBestEffortLocked();
+            _ = try self.persistCheckpointForContinuationLocked();
             self.checkpoint_mutex.unlock(io_mod.getIo());
             return false;
         }
-        if (durable_bridge and !self.persistCheckpointBestEffortLocked()) {
+        if (durable_bridge and !(try self.persistCheckpointForContinuationLocked())) {
             self.checkpoint_mutex.unlock(io_mod.getIo());
             return false;
         }
@@ -741,6 +745,10 @@ pub const Usage = struct {
     }
 
     fn persistCheckpointBestEffortLocked(self: *Usage) bool {
+        return self.persistCheckpointForContinuationLocked() catch false;
+    }
+
+    fn persistCheckpointForContinuationLocked(self: *Usage) error{ SessionPersistenceUncertain, SessionWriterChanged, SessionWriterParked, SessionCommitFailed }!bool {
         const sink = self.checkpoint_sink orelse return true;
         var persisted = self.snapshotCurrent(sink.allocator) catch |err| {
             self.markBillingIncomplete();
@@ -759,6 +767,14 @@ pub const Usage = struct {
                 "usage checkpoint unavailable; billing marked incomplete reason={s}",
                 .{@errorName(err)},
             );
+            switch (err) {
+                error.SessionPersistenceUncertain,
+                error.SessionWriterChanged,
+                error.SessionWriterParked,
+                error.SessionCommitFailed,
+                => return @errorCast(err),
+                else => {},
+            }
             return false;
         };
         self.markClean(persisted);
@@ -5881,4 +5897,34 @@ test "host-managed reconciliation records authority without credential bytes" {
         credential_authority.derive(.host_managed, null).?,
     ));
     try std.testing.expect(!usage.reconciliation_credential_blocked);
+}
+
+test "terminal checkpoint writer failure stops invocation completion and releases its lock" {
+    const Reject = struct {
+        calls: usize = 0,
+        fn persist(raw: *anyopaque, _: Snapshot) !void {
+            const self: *@This() = @ptrCast(@alignCast(raw));
+            self.calls += 1;
+            if (self.calls == 2) return error.SessionPersistenceUncertain;
+        }
+    };
+    const alloc = std.testing.allocator;
+    for ([_]bool{ false, true }) |deferred| {
+        var reject = Reject{};
+        var usage = Usage.initFresh();
+        defer usage.deinit(alloc);
+        usage.configureCheckpointSink(.{ .context = &reject, .allocator = alloc, .persist = Reject.persist });
+        const observation = try InvocationObservation.begin(&usage);
+        try std.testing.expectError(error.SessionPersistenceUncertain, observation.complete(
+            alloc,
+            .{ .generation_id = "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV" },
+            if (deferred) testGatewayUsageOutcome("gen_01ARZ3NDEKTSV4RRFFQ69G5FAV", false) else .{ .unavailable = .unbilled },
+        ));
+        try std.testing.expectEqual(@as(usize, 2), reject.calls);
+        try std.testing.expect(usage.checkpoint_mutex.tryLock());
+        usage.checkpoint_mutex.unlock(io_mod.getIo());
+        var snapshot = try usage.snapshot(alloc);
+        defer snapshot.deinit(alloc);
+        try std.testing.expectEqual(Availability.incomplete, snapshot.billing);
+    }
 }

--- a/src/core/session/session_usage_sidecar.zig
+++ b/src/core/session/session_usage_sidecar.zig
@@ -88,13 +88,7 @@ pub fn writeEncoded(
     );
 }
 
-pub fn load(
-    alloc: Allocator,
-    session_dir: *io_mod.VerifiedDir,
-    session_id: []const u8,
-) !?session_usage.Snapshot {
-    var captured = try capture(alloc, session_dir);
-    defer captured.deinit(alloc);
+fn loadCaptured(alloc: Allocator, captured: Captured, session_id: []const u8) !?session_usage.Snapshot {
     const bytes = switch (captured) {
         .missing => return null,
         .invalid => return error.InvalidUsageSidecar,
@@ -109,6 +103,57 @@ pub fn load(
     const snapshot = decoded.snapshot;
     alloc.free(decoded.session_id);
     decoded_owned = false;
+    return snapshot;
+}
+
+/// A conversation remains usable when its accounting snapshot is damaged.
+/// File access and private-path failures still prevent admission.
+pub fn loadConversation(
+    alloc: Allocator,
+    session_dir: *io_mod.VerifiedDir,
+    session_id: []const u8,
+    continuity_at_ms: i64,
+) !session_usage.Snapshot {
+    var captured = try capture(alloc, session_dir);
+    defer captured.deinit(alloc);
+    if (captured == .invalid) {
+        const reason = captured.invalid;
+        if (!std.mem.eql(u8, reason, "empty") and !std.mem.eql(u8, reason, "oversized")) {
+            return error.InvalidUsageSidecar;
+        }
+    }
+    const loaded = loadCaptured(alloc, captured, session_id) catch |err| blk: {
+        if (err == error.OutOfMemory) return err;
+        traceInvalid(err);
+        break :blk null;
+    };
+    if (loaded) |snapshot| return snapshot;
+    debug_trace.logf("session", "conversation accounting unavailable session={s} completeness=incomplete", .{session_id});
+    var snapshot = session_usage.Snapshot{
+        .billing = .incomplete,
+        .api_duration_complete = false,
+        .wall_duration_complete = false,
+        .code_complete = false,
+        .next_sequence = 1,
+        .settled_through_sequence = 0,
+        .api_duration_ms = 0,
+        .wall_duration_ms = 0,
+        .total_cost = 0,
+        .input_tokens = 0,
+        .output_tokens = 0,
+        .cache_read_tokens = 0,
+        .cache_write_tokens = 0,
+        .billable_web_search_calls = 0,
+        .lines_added = 0,
+        .lines_removed = 0,
+        .models = &.{},
+        .pending = &.{},
+    };
+    errdefer snapshot.deinit(alloc);
+    try session_usage.appendIncidentOwned(alloc, &snapshot, .{
+        .occurred_at_ms = @max(continuity_at_ms, 0),
+        .completeness = .incomplete,
+    });
     return snapshot;
 }
 
@@ -347,6 +392,21 @@ fn openTestVerifiedDir(dir: std.Io.Dir) !io_mod.VerifiedDir {
             .{ .iterate = true, .follow_symlinks = false },
         ),
     };
+}
+
+test "conversation accounting recovery refuses unsafe storage" {
+    const alloc = std.testing.allocator;
+    var temp = std.testing.tmpDir(.{});
+    defer temp.cleanup();
+    var verified = try openTestVerifiedDir(temp.dir);
+    defer verified.close();
+    try temp.dir.createDir(std.testing.io, sidecar_file, .fromMode(0o700));
+    try std.testing.expectError(error.InvalidUsageSidecar, loadConversation(alloc, &verified, "session", 10));
+    try temp.dir.deleteDir(std.testing.io, sidecar_file);
+    var file = try temp.dir.createFile(std.testing.io, sidecar_file, .{ .permissions = .fromMode(0o644) });
+    defer file.close(std.testing.io);
+    try file.writeStreamingAll(std.testing.io, "{corrupt but not private");
+    try std.testing.expectError(error.InvalidUsageSidecar, loadConversation(alloc, &verified, "session", 10));
 }
 
 test "usage sidecar restores rich fields only for its bound session and projection" {

--- a/src/core/subagent/child_state.zig
+++ b/src/core/subagent/child_state.zig
@@ -3,7 +3,6 @@ const domain = @import("domain.zig");
 const io_mod = @import("../shared/io.zig");
 const session_child_store = @import("../session/session_child_store.zig");
 const session_store = @import("../session/session_store.zig");
-const session_discovery = @import("../session/session_discovery.zig");
 const types = @import("../shared/types.zig");
 const text_utils = @import("../shared/text_utils.zig");
 
@@ -514,20 +513,23 @@ pub fn isManagedChildSession(
 }
 
 /// Reuses discovery's validated identity while retaining all child-marker checks.
-pub fn isListedManagedChildSession(
+pub fn isDiscoveredManagedChildSession(
     sessions: session_store.Store,
     alloc: Allocator,
-    candidate: *const session_discovery.ReadOnlyCandidate,
+    session_id: []const u8,
+    subagent_child: ?bool,
 ) !bool {
-    if (candidate.subagent_child == true) return true;
-    var capability = sessions.openListedChildCapabilityReadOnly(alloc, candidate.summary.id) catch |err| switch (err) {
+    if (subagent_child == true) return true;
+    var capability = sessions.openListedSubagentControlReadOnly(alloc, session_id) catch |err| switch (err) {
         error.SessionNotFound => return false,
         else => return err,
     };
-    defer capability.deinit();
-    if (try capabilityHasManagedChildMarker(alloc, &capability)) return true;
-    if (candidate.subagent_child) |identity| return identity;
-    return sessions.loadSubagentChildIdentity(alloc, candidate.summary.id) catch |err| switch (err) {
+    defer if (capability) |*value| value.deinit();
+    if (capability) |*value| {
+        if (try capabilityHasManagedChildMarker(alloc, value)) return true;
+    }
+    if (subagent_child) |identity| return identity;
+    return sessions.loadSubagentChildIdentity(alloc, session_id) catch |err| switch (err) {
         error.SessionNotFound => false,
         else => return err,
     };

--- a/src/core/subagent/managed_owner.zig
+++ b/src/core/subagent/managed_owner.zig
@@ -48,6 +48,15 @@ pub const Owner = struct {
     slots: std.ArrayList(*Slot) = .empty,
     closed: bool = false,
 
+    pub fn hasRunningWork(self: *Owner) bool {
+        self.mutex.lockUncancelable(io_mod.getIo());
+        defer self.mutex.unlock(io_mod.getIo());
+        for (self.slots.items) |slot| {
+            if (slot.completion == .running) return true;
+        }
+        return false;
+    }
+
     pub fn start(self: *Owner, child_id: []const u8) StartError!StartResult {
         while (true) {
             const finished = blk: {

--- a/src/core/subagent/resume_admission.zig
+++ b/src/core/subagent/resume_admission.zig
@@ -105,7 +105,7 @@ const CatalogWorker = struct {
             if (is_active and !candidate.summary.hasResumableContent()) continue;
             if (self.read.cancelled.load(.acquire)) return error.Cancelled;
             var cacheable = candidate.storage == .conversation;
-            const managed = if (!candidate.summary.hasResumableContent()) true else child_state.isListedManagedChildSession(self.read.store, self.alloc, &candidate) catch |err| switch (err) {
+            const managed = if (!candidate.summary.hasResumableContent()) true else child_state.isDiscoveredManagedChildSession(self.read.store, self.alloc, candidate.summary.id, candidate.subagent_child) catch |err| switch (err) {
                 error.OutOfMemory => return err,
                 else => blk: {
                     cacheable = false;

--- a/src/main.zig
+++ b/src/main.zig
@@ -813,7 +813,7 @@ const App = struct {
     }
 
     /// Returns an owned handoff only after all interactive state is torn down.
-    pub fn deinitWithResumeHandoff(self: *App) ?app_session_runtime.ResumeHandoff {
+    pub fn deinitWithResumeHandoff(self: *App) app_session_runtime.ShutdownOutcome {
         return self.deinitImpl(true);
     }
 
@@ -829,7 +829,7 @@ const App = struct {
         return ui_render.formatResumeHandoff(buffer, session_id, terminal_cols);
     }
 
-    fn deinitImpl(self: *App, capture_resume_handoff: bool) ?app_session_runtime.ResumeHandoff {
+    fn deinitImpl(self: *App, capture_resume_handoff: bool) app_session_runtime.ShutdownOutcome {
         self.auth.stopProviderPreparation();
         // Client.deinit releases the herdr pane (clear agent + label) when enabled.
         self.herdr.deinit();
@@ -844,7 +844,7 @@ const App = struct {
         self.releaseTerminal();
         if (self.worker_thread) |thread| thread.join();
         WorkerAppRuntime.settleFinishedPromptsForShutdown(self) catch |err| {
-            debug_trace.logf("session", "shutdown finished prompt persistence failed err={s}", .{@errorName(err)});
+            SessionAppRuntime.recordShutdownFailure(self, err);
         };
         self.terminal_client.deinit();
         self.managed_executions.deinit();
@@ -857,6 +857,7 @@ const App = struct {
             SessionAppRuntime.finalizePersistence(self);
             break :blk null;
         };
+        const shutdown_failure = self.session_persistence.shutdown_failure;
         self.worker.deinit(std.heap.c_allocator);
         self.web_fetch_runtime.deinit(self.alloc);
         self.web_search_runtime.deinit();
@@ -892,7 +893,7 @@ const App = struct {
         WorkspaceAppRuntime.deinit(self);
         self.workspace_identity.deinit(self.alloc);
         if (self.workspace_root.len > 0) self.alloc.free(self.workspace_root);
-        return resume_handoff;
+        return .{ .handoff = resume_handoff, .failure = shutdown_failure };
     }
 
     pub fn releaseTerminal(self: *App) void {
@@ -2591,17 +2592,15 @@ const App = struct {
         return SessionAppRuntime.fastModeModelBound(self);
     }
 
-    pub fn appendFinishedPrompt(self: *App, finished: types.FinishedPrompt) !void {
-        try SessionAppRuntime.appendFinishedPrompt(self, finished);
-        if (finished.summary) |summary| {
-            _ = try self.shell.appendTurnSummaryEntry(self.alloc, summary);
-        }
+    pub fn finishPromptPresentation(self: *App, finished: types.FinishedPrompt) !assistant_pacer.FinishResult {
+        return app_callbacks.Bindings(App).finishPromptPresentation(self, finished);
     }
 
-    pub fn pacerFinish(ctx: *anyopaque, finished: types.FinishedPrompt) anyerror!void {
+    pub fn pacerFinish(ctx: *anyopaque, finished: types.FinishedPrompt) anyerror!assistant_pacer.FinishResult {
         const self: *App = @ptrCast(@alignCast(ctx));
-        try self.appendFinishedPrompt(finished);
-        self.notificationPresentationFinished();
+        const result = try app_callbacks.Bindings(App).finishPromptPresentation(self, finished);
+        if (result == .committed) self.notificationPresentationFinished();
+        return result;
     }
 
     pub fn pacerCallbacks(self: *App) assistant_pacer.TickCallbacks {

--- a/src/ui/assistant/pacer.zig
+++ b/src/ui/assistant/pacer.zig
@@ -8,7 +8,13 @@ const HistoryTurn = types.HistoryTurn;
 const FinishedPrompt = types.FinishedPrompt;
 
 pub const EmitFn = *const fn (*anyopaque, []const u8) anyerror!void;
-pub const FinishFn = *const fn (*anyopaque, FinishedPrompt) anyerror!void;
+pub const FinishResult = union(enum) {
+    committed,
+    presentation_failed: anyerror,
+};
+
+// A result acknowledges history. An error retains the finish for settlement.
+pub const FinishFn = *const fn (*anyopaque, FinishedPrompt) anyerror!FinishResult;
 
 pub const DeferredFinishCommit = enum {
     uncommitted,
@@ -211,7 +217,8 @@ pub const AssistantPacer = struct {
             self.deferred_started_ns = now_ns;
         }
 
-        if (try self.emitPendingBlock(cb) == .drained) {
+        if (try self.emitPendingBlock(cb) == .drained or self.deferred_turn != null) {
+            if (self.pending.items.len > 0) try self.neutralizeIncompleteTail(cb);
             try self.fireDeferredFinish(alloc, now_ns, cb);
         }
     }
@@ -272,9 +279,7 @@ pub const AssistantPacer = struct {
 
     fn fireDeferredFinish(self: *AssistantPacer, alloc: Allocator, now_ns: i128, cb: TickCallbacks) !void {
         if (self.deferred_turn) |finished| {
-            self.deferred_turn = null;
             const started_ns = self.deferred_started_ns;
-            self.deferred_started_ns = null;
             var callback_finished = finished;
             if (callback_finished.summary) |*summary| {
                 const started = started_ns orelse now_ns;
@@ -282,8 +287,14 @@ pub const AssistantPacer = struct {
                     summary.turn_duration_ms += @intCast(@divFloor(now_ns - started, std.time.ns_per_ms));
                 }
             }
-            defer types.freeFinishedPrompt(alloc, callback_finished);
-            try cb.finish_fn(cb.finish_ctx, callback_finished);
+            const result = try cb.finish_fn(cb.finish_ctx, callback_finished);
+            self.deferred_turn = null;
+            self.deferred_started_ns = null;
+            types.freeFinishedPrompt(alloc, finished);
+            switch (result) {
+                .committed => {},
+                .presentation_failed => |err| return err,
+            }
         }
     }
 
@@ -376,10 +387,11 @@ const TestCapture = struct {
         try self.emitted.appendSlice(std.testing.allocator, text);
     }
 
-    fn finish(ctx: *anyopaque, finished: FinishedPrompt) anyerror!void {
+    fn finish(ctx: *anyopaque, finished: FinishedPrompt) anyerror!FinishResult {
         const self: *TestCapture = @ptrCast(@alignCast(ctx));
         self.finish_count += 1;
         self.finish_summary = finished.summary;
+        return .committed;
     }
 
     fn callbacks(self: *TestCapture) TickCallbacks {
@@ -568,7 +580,9 @@ test "presentation boundary preserves callback errors and pending bytes" {
             return error.InjectedEmitFailure;
         }
 
-        fn finish(_: *anyopaque, _: FinishedPrompt) anyerror!void {}
+        fn finish(_: *anyopaque, _: FinishedPrompt) anyerror!FinishResult {
+            return .committed;
+        }
     };
     var ctx: u8 = 0;
     const callbacks: TickCallbacks = .{
@@ -583,6 +597,66 @@ test "presentation boundary preserves callback errors and pending bytes" {
         pacer.flushPresentationAtBoundary(alloc, 0, callbacks),
     );
     try std.testing.expectEqualStrings("\x1b[1", pacer.pending.items);
+}
+
+test "deferred finish retains unacknowledged history without retrying committed presentation" {
+    const alloc = std.testing.allocator;
+    for ([_]bool{ false, true }) |committed| {
+        var pacer = AssistantPacer{};
+        defer pacer.deinit(alloc);
+        var cap = TestCapture{};
+        defer cap.deinit();
+        const Finish = struct {
+            committed: bool,
+            fail: bool = true,
+            commits: usize = 0,
+
+            fn run(raw: *anyopaque, _: FinishedPrompt) !FinishResult {
+                const self: *@This() = @ptrCast(@alignCast(raw));
+                if (self.fail and !self.committed) return error.InjectedPersistenceFailure;
+                self.commits += 1;
+                if (self.fail) return .{ .presentation_failed = error.InjectedPresentationFailure };
+                return .committed;
+            }
+        };
+        var finish = Finish{ .committed = committed };
+        var callbacks = cap.callbacks();
+        callbacks.finish_ctx = &finish;
+        callbacks.finish_fn = Finish.run;
+        try pacer.enqueue(alloc, "tail");
+        const turn = try makeAssistantTurn(alloc);
+        defer types.freeHistoryTurn(alloc, turn);
+        try std.testing.expect(try pacer.deferFinish(alloc, .{ .turn = turn }));
+        try std.testing.expectError(
+            if (committed) error.InjectedPresentationFailure else error.InjectedPersistenceFailure,
+            pacer.tick(alloc, 0, callbacks),
+        );
+        try std.testing.expectEqual(!committed, pacer.deferred_turn != null);
+        finish.fail = false;
+        try pacer.tick(alloc, 1, callbacks);
+        try std.testing.expectEqual(@as(usize, 1), finish.commits);
+        try std.testing.expect(!pacer.hasPending());
+    }
+}
+
+test "finished presentation closes an incomplete text tail" {
+    const alloc = std.testing.allocator;
+    var pacer = AssistantPacer{};
+    defer pacer.deinit(alloc);
+    var cap = TestCapture{};
+    defer cap.deinit();
+    try pacer.enqueue(alloc, "body \xe2\x82");
+    try pacer.tick(alloc, 0, cap.callbacks());
+    try std.testing.expect(pacer.hasPending());
+    const turn = try makeAssistantTurn(alloc);
+    defer types.freeHistoryTurn(alloc, turn);
+    try std.testing.expect(try pacer.deferFinish(alloc, .{ .turn = turn }));
+    try pacer.tick(alloc, 1, cap.callbacks());
+    try std.testing.expectEqual(@as(usize, 1), cap.finish_count);
+    try std.testing.expect(!pacer.hasPending());
+    try std.testing.expect(std.unicode.utf8ValidateSlice(cap.emitted.items));
+    try pacer.tick(alloc, 2, cap.callbacks());
+    try std.testing.expectEqual(@as(usize, 1), cap.finish_count);
 }
 
 test "deferFinish defers and fires when buffer drains" {

--- a/tests/e2e/session-recovery.test.ts
+++ b/tests/e2e/session-recovery.test.ts
@@ -113,6 +113,82 @@ async function continueSession(
 }
 
 const LEGACY_TITLE = "Synthetic legacy recovery conversation";
+
+test("latest resume preserves an unrelated pending authority directory", async () => {
+  const fixture = createFixture("fx-latest-pending-");
+  const gateway = startFakeGateway([
+    fakeGatewayFinalText("SAVED_PARENT_CONTEXT"),
+    fakeGatewayFinalText("CONTINUED_PARENT_CONTEXT"),
+  ]);
+  try {
+    const id = await createSavedSession(fixture, gateway);
+    const orphan = join(fixture.home, ".fx", "sessions", "pending-authority");
+    mkdirSync(orphan, { mode: 0o700 });
+    writeFileSync(join(orphan, "authority.pending.json"), "pending", { mode: 0o600 });
+    writeFileSync(join(orphan, "events.jsonl"), "unidentified saved data\n", { mode: 0o600 });
+    const resumed = await continueSession(fixture, gateway, id, true);
+    expect(resumed.code).toBe(0);
+    expect(resumed.stderr).toBe("");
+    expect(JSON.parse(resumed.stdout).session_id).toBe(id);
+    expect(gateway.requests.at(-1)?.body).toContain("SAVED_PARENT_CONTEXT");
+    expect(readFileSync(join(orphan, "events.jsonl"), "utf8")).toBe("unidentified saved data\n");
+    expect(readFileSync(join(orphan, "authority.pending.json"), "utf8")).toBe("pending");
+  } finally {
+    gateway.stop();
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+}, TIMEOUT);
+
+test("resume keeps conversation history when accounting is damaged", async () => {
+  const fixture = createFixture("fx-accounting-resume-");
+  const gateway = startFakeGateway([
+    fakeGatewayFinalText("ACCOUNTING_HISTORY_RETAINED"),
+    fakeGatewayFinalText("ACCOUNTING_RESUME_COMPLETED"),
+  ]);
+  try {
+    const id = await createSavedSession(fixture, gateway);
+    const dir = join(fixture.home, ".fx", "sessions", id);
+    const events = join(dir, "events.jsonl");
+    const before = readFileSync(events);
+    writeFileSync(join(dir, "usage-v2.json"), "{broken accounting", { mode: 0o600 });
+    const resumed = await continueSession(fixture, gateway, id);
+    expect(resumed.code).toBe(0);
+    expect(resumed.stderr).toBe("");
+    expect(JSON.parse(resumed.stdout).session_id).toBe(id);
+    expect(gateway.requests.at(-1)?.body).toContain("ACCOUNTING_HISTORY_RETAINED");
+    expect(readFileSync(events).subarray(0, before.length).equals(before)).toBe(true);
+    expect(JSON.parse(readFileSync(join(dir, "usage-v2.json"), "utf8")).snapshot.billing).toBe("incomplete");
+  } finally {
+    gateway.stop();
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+}, TIMEOUT);
+
+test("conversation language survives an ordinary saved turn and resume", async () => {
+  const fixture = createFixture("fx-language-resume-");
+  const gateway = startFakeGateway([
+    fakeGatewayFinalText("こんにちは。"),
+    fakeGatewayFinalText("完了しました。"),
+  ]);
+  try {
+    const seeded = await runFx(["ask", "--json", "こんにちは。日本語で返答してください。"], {
+      cwd: fixture.workspace, env: gatewayEnv(fixture, gateway), timeoutMs: TIMEOUT,
+    });
+    expect(seeded.code).toBe(0);
+    const id = JSON.parse(seeded.stdout).session_id;
+    const metadata = join(fixture.home, ".fx", "sessions", id, "session.json");
+    expect(JSON.parse(readFileSync(metadata, "utf8")).conversation_language).toBe("ja");
+    const resumed = await runFx(["ask", "--json", "--resume-id", id, "👍"], {
+      cwd: fixture.workspace, env: gatewayEnv(fixture, gateway), timeoutMs: TIMEOUT,
+    });
+    expect(resumed.code).toBe(0);
+    expect(resumed.stderr).toBe("");
+    expect(JSON.parse(readFileSync(metadata, "utf8")).conversation_language).toBe("ja");
+  } finally {
+    gateway.stop();
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+}, TIMEOUT);
 const LEGACY_ANSWER = "LEGACY_COMMITTED_ANSWER";
 const LEGACY_PARTIAL = "LEGACY_PARTIAL_EVIDENCE";
 const LEGACY_TOOL_CALL_ID = "legacy-recorded-read";

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -1384,6 +1384,36 @@ async function launchRouteRecoveryTui(
 }
 
 describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
+  test("retry exhaustion settles a streamed tool start and permits a later prompt", async () => {
+    const { queuedGateway, stderrPath } = await launchRouteRecoveryTui(
+      "fx-tui-retry-settlement-",
+      [
+        () => new Response(
+          'data: {"type":"tool-input-start","id":"interrupted-read","toolName":"read_file"}\n\n' +
+          'data: {"type":"tool-input-delta","id":"interrupted-read","delta":"{\\"path\\":\\"notes"}\n\n',
+          { headers: { "content-type": "text/event-stream" } },
+        ),
+        ...Array.from({ length: 9 }, () => () => retryAfterUnavailable(0)),
+        () => fakeGatewayFinalText("AFTER_NETWORK_RECOVERY"),
+      ],
+    );
+    await session!.sendText("Read the notes and continue after a connection failure.");
+    await session!.waitForText("recovery paused", TIMEOUT);
+    await session!.waitForStableComposer(TIMEOUT);
+    expect(queuedGateway.requests).toHaveLength(10);
+    const scrollback = await session!.captureFullScrollback();
+    expect(scrollback).toContain("Connection interrupted before");
+    expect(scrollback).not.toContain("UnknownToolLifecycleIdentity");
+    expect(readFileSync(stderrPath, "utf8")).toBe("");
+    await session!.sendText("Confirm a later prompt is still usable.");
+    await session!.waitForText("AFTER_NETWORK_RECOVERY", TIMEOUT);
+    await session!.waitForStableComposer(TIMEOUT);
+    expect(queuedGateway.requests).toHaveLength(11);
+    await session!.sendText("/quit");
+    expect(await session!.waitForSessionEnd(TIMEOUT)).toBe(true);
+    expect(readFileSync(stderrPath, "utf8")).toBe("");
+  }, TIMEOUT * 2);
+
   test("file edits keep earlier instruction bytes stable", async () => {
     const { queuedGateway, stderrPath } = await launchRouteRecoveryTui(
       "fx-tui-stable-verification-",

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -289,6 +289,65 @@ async function waitForPersistedSessionMarker(
   }, `persisted session marker ${marker}`, timeout);
 }
 
+test.skipIf(!tmuxAvailable())("suspension preserves another writer's acknowledged turn after foreground", async () => {
+  const root = mkdtempSync(join(tmpdir(), "fx-foreground-history-"));
+  const home = join(root, "home"), workspace = join(root, "workspace");
+  mkdirSync(home, { mode: 0o700 });
+  mkdirSync(workspace, { mode: 0o700 });
+  const trace = join(root, "trace.log"), stderr = join(root, "stderr.log");
+  const gateway = startFakeGateway([
+    fakeGatewayFinalText("FIRST_ACCEPTED_TURN"),
+    fakeGatewayFinalText("OTHER_WRITER_ACCEPTED_TURN"),
+    fakeGatewayFinalText("AFTER_FOREGROUND_TURN"),
+    fakeGatewayFinalText("COLD_REOPEN_TURN"),
+  ]);
+  const env = { ...gatewayEnv(home, gateway), FX_SOUND: "0", FX_DISABLE_KEYCHAIN: "1", FX_E2E_DISABLE_DOTENV: "1" };
+  let tui: TmuxSession | undefined;
+  try {
+    const seeded = await runFx(["ask", "--json", "Remember the original turn."], { cwd: workspace, env, timeoutMs: TIMEOUT });
+    expect(seeded.code).toBe(0);
+    const id = JSON.parse(seeded.stdout).session_id;
+    const events = join(home, ".fx", "sessions", id, "events.jsonl");
+    tui = await TmuxSession.create({
+      cmd: "/bin/sh -i", cwd: workspace, isolated: true, remainOnExit: true, width: 110, height: 36,
+      env: { ...env, PS1: "HANDOFF_SHELL> ", FX_TRACE_LOG: trace, FX_TRACE_SCOPES: "session,worker" },
+    });
+    await tui.waitForText("HANDOFF_SHELL>", TIMEOUT);
+    await tui.sendText(`${shellQuote(FX_BIN)} --resume ${shellQuote(id)} 2>${shellQuote(stderr)}`);
+    await tui.waitForText("FIRST_ACCEPTED_TURN", TIMEOUT);
+    await tui.waitForStableComposer(TIMEOUT);
+    await tui.sendKeys("C-z");
+    await waitForCondition(() => existsSync(trace) && readFileSync(trace, "utf8").includes("parked writer lock for suspend"), "writer park");
+    await tui.waitForPane(pane => /stopped|suspended/i.test(pane), TIMEOUT);
+    const other = await runFx(["ask", "--json", "--resume-id", id, "Remember the second writer's turn."], { cwd: workspace, env, timeoutMs: TIMEOUT });
+    expect(other.code).toBe(0);
+    const accepted = readFileSync(events);
+    expect(accepted.toString()).toContain("OTHER_WRITER_ACCEPTED_TURN");
+    await tui.sendText("fg");
+    await waitForCondition(() => readFileSync(trace, "utf8").includes("unparked writer lock after suspend"), "foreground reload");
+    await tui.waitForStableComposer(TIMEOUT);
+    await tui.sendText("Continue with the current conversation.");
+    await tui.waitForText("AFTER_FOREGROUND_TURN", TIMEOUT);
+    await tui.waitForStableComposer(TIMEOUT);
+    expect(gateway.requests.at(-1)?.body).toContain("OTHER_WRITER_ACCEPTED_TURN");
+    expect(readFileSync(events).subarray(0, accepted.length).equals(accepted)).toBe(true);
+    const scrollback = await tui.captureFullScrollback();
+    expect(scrollback).toContain("OTHER_WRITER_ACCEPTED_TURN");
+    expect(scrollback).not.toContain("InvalidTranscriptTransition");
+    await tui.sendText("/quit");
+    await tui.waitForPane(pane => pane.trimEnd().endsWith("HANDOFF_SHELL>"), TIMEOUT);
+    const cold = await runFx(["ask", "--json", "--resume-id", id, "Read the saved conversation."], { cwd: workspace, env, timeoutMs: TIMEOUT });
+    expect(cold.code).toBe(0);
+    expect(gateway.requests.at(-1)?.body).toContain("OTHER_WRITER_ACCEPTED_TURN");
+    expect(gateway.requests.at(-1)?.body).toContain("AFTER_FOREGROUND_TURN");
+    expect(readFileSync(stderr, "utf8")).toBe("");
+  } finally {
+    await tui?.kill();
+    gateway.stop();
+    rmSync(root, { recursive: true, force: true });
+  }
+}, TIMEOUT * 3);
+
 async function waitForSessionPicker(session: TmuxSession): Promise<string> {
   return session.waitForPane(
     (pane) => {


### PR DESCRIPTION
## Summary

- Preserve turns saved by another process when a suspended session returns to the foreground.
- Preserve existing history after failed writes and stop continued work when the write outcome is uncertain.
- Keep latest-session resume usable when an unrelated session is incomplete.
- Exclude internal child sessions when selecting the latest session to resume.
- Pause exhausted network recovery without publishing late tool events that crash the transcript.
- Keep earlier completed output visible when a later turn is cancelled.
- Save completed turns even when transcript rendering fails or a streamed tail is incomplete.
- Report session-save failures with a nonzero exit on quit or terminal input closure.
- Preserve the conversation language across saved turns and resume.
- Resume valid conversation history with explicitly incomplete accounting when its usage file is missing or corrupt.
