### PR TITLE
Restore legacy sessions with incompatible usage totals

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Saved conversations preserve original assistant replies and compatible provider 
 
 In saved sessions, oversized `read_tool_result` responses keep a complete terminal-safe backing copy even when the inline response is clipped. Compaction and later retrieval preserve that copy without masking the explicitly requested text again.
 
-Resuming an older session upgrades its saved permissions and skips empty legacy file-change entries while keeping the conversation and tool results. Cancelled tools remain recorded as failures and do not prevent later compaction. If the model returns an empty compaction summary, fx retries the summary once without repeating tools. Cancellation or another failed summary leaves the previous context intact.
+Resuming an older session upgrades its saved permissions and skips empty legacy file-change entries while keeping the conversation and tool results. Historical cache-token accounting no longer prevents an otherwise valid older session from resuming; incompatible usage totals are marked unavailable. Cancelled tools remain recorded as failures and do not prevent later compaction. If the model returns an empty compaction summary, fx retries the summary once without repeating tools. Cancellation or another failed summary leaves the previous context intact.
 
 Use `fx ask` for a single request:
 

--- a/src/core/session/session_codec.zig
+++ b/src/core/session/session_codec.zig
@@ -4486,6 +4486,31 @@ test "permission state schema two round trips before activation" {
     try std.testing.expectEqual(session_permission_state.StateDecision.deny, session_permission_state.decide(decoded, key));
 }
 
+test "durable state usage remains strict and releases partial allocations" {
+    const alloc = std.testing.allocator;
+    const state_json =
+        \\{"id":"usage-state","origin_workspace_root":"/workspace","workspace_root":"/workspace","created_at_ms":1,"updated_at_ms":2,
+        \\"conversation_language":"en","preferences":{"model":"test/model","effort":"auto","fast_mode":false},"history":[],"total_input_tokens":0,"total_output_tokens":0,
+        \\"usage":{"billing":"complete","api_duration_complete":true,"wall_duration_complete":true,"code_complete":true,"next_sequence":2,"settled_through_sequence":1,
+        \\"api_duration_ms":10,"wall_duration_ms":20,"total_cost":1,"input_tokens":10,"output_tokens":3,"cache_read_tokens":2,"cache_write_tokens":0,"billable_web_search_calls":0,"lines_added":0,"lines_removed":0,
+        \\"models":[{"model":"test/model","first_sequence":1,"total_cost":1,"input_tokens":10,"output_tokens":3,"cache_read_tokens":2,"cache_write_tokens":0,"billable_web_search_calls":0}],"pending":[]},
+        \\"last_subagent_work_id":"legacy-work"}
+    ;
+    try std.testing.checkAllAllocationFailures(alloc, struct {
+        fn check(a: Allocator, bytes: []const u8) !void {
+            var source = std.Io.Reader.fixed(bytes);
+            var decoded = try decodeState(a, &source, .{});
+            defer decoded.deinit(a);
+            try std.testing.expectEqual(@as(u64, 10), decoded.usage.?.input_tokens);
+            try std.testing.expectEqualStrings("legacy-work", decoded.last_subagent_work_id.?);
+        }
+    }.check, .{state_json});
+    const incompatible = try std.mem.replaceOwned(u8, alloc, state_json, "\"cache_read_tokens\":2", "\"cache_read_tokens\":11");
+    defer alloc.free(incompatible);
+    var strict_source = std.Io.Reader.fixed(incompatible);
+    try std.testing.expectError(error.InvalidSessionFormat, decodeState(alloc, &strict_source, .{}));
+}
+
 test "durable session optional fields handle fuzzed ownership paths" {
     try std.testing.fuzz({}, fuzzDurableSessionOptionalFields, .{ .corpus = &.{
         "{\"id\":\"session\",\"origin_workspace_root\":\"/tmp/origin\",\"workspace_root\":\"/tmp/current\",\"created_at_ms\":1,\"updated_at_ms\":1,\"conversation_language\":\"en\",\"preferences\":{\"model\":\"test/model\",\"effort\":\"auto\",\"fast_mode\":false},\"history\":[],\"total_input_tokens\":0,\"total_output_tokens\":0}",

--- a/src/core/session/session_codec.zig
+++ b/src/core/session/session_codec.zig
@@ -525,7 +525,17 @@ pub fn encodeState(state: DurableSessionState, writer: *std.Io.Writer) !EncodeSu
 }
 
 pub fn decodeState(alloc: Allocator, source: *std.Io.Reader, limits: DecodeLimits) !DurableSessionState {
-    return decodeStateImpl(alloc, source, limits) catch |err| switch (err) {
+    return decodeStateWithUsageContract(alloc, source, limits, false);
+}
+
+/// Reads an old persisted state without requiring modern cache-token totals.
+/// Caller owns the state; all non-usage validation remains unchanged.
+pub fn decodeLegacyState(alloc: Allocator, source: *std.Io.Reader, limits: DecodeLimits) !DurableSessionState {
+    return decodeStateWithUsageContract(alloc, source, limits, true);
+}
+
+fn decodeStateWithUsageContract(alloc: Allocator, source: *std.Io.Reader, limits: DecodeLimits, legacy_usage: bool) !DurableSessionState {
+    return decodeStateImpl(alloc, source, limits, legacy_usage) catch |err| switch (err) {
         error.OutOfMemory => return error.OutOfMemory,
         error.InvalidDurableField => return error.InvalidDurableField,
         error.InvalidDurableBytes => return error.InvalidDurableBytes,
@@ -1047,7 +1057,7 @@ pub fn writeRecoveryCheckpoint(writer: *std.Io.Writer, checkpoint: RecoveryCheck
     });
 }
 
-fn decodeStateImpl(alloc: Allocator, source: *std.Io.Reader, limits: DecodeLimits) !DurableSessionState {
+fn decodeStateImpl(alloc: Allocator, source: *std.Io.Reader, limits: DecodeLimits, legacy_usage: bool) !DurableSessionState {
     var json_reader = std.json.Reader.init(alloc, source);
     defer json_reader.deinit();
 
@@ -1117,6 +1127,7 @@ fn decodeStateImpl(alloc: Allocator, source: *std.Io.Reader, limits: DecodeLimit
     errdefer permission_state.deinit(alloc);
     var permission_state_seen = false;
     var usage: ?session_usage.Snapshot = null;
+    errdefer if (usage) |*snapshot| snapshot.deinit(alloc);
     var usage_seen = false;
     var last_subagent_work_id: ?[]u8 = null;
     errdefer if (last_subagent_work_id) |work_id| alloc.free(work_id);
@@ -1162,7 +1173,10 @@ fn decodeStateImpl(alloc: Allocator, source: *std.Io.Reader, limits: DecodeLimit
                 .allocate = .alloc_always,
                 .parse_numbers = false,
             });
-            usage = try session_usage.parseSnapshotValue(alloc, value);
+            usage = if (legacy_usage)
+                try session_usage.parseLegacySnapshotValue(alloc, value)
+            else
+                try session_usage.parseSnapshotValue(alloc, value);
             usage_seen = true;
         } else if (std.mem.eql(u8, key, "last_subagent_work_id")) {
             if (last_subagent_work_id != null or subagent_child_seen or recovery_checkpoint != null) return error.InvalidSessionFormat;
@@ -1184,7 +1198,6 @@ fn decodeStateImpl(alloc: Allocator, source: *std.Io.Reader, limits: DecodeLimit
             recovery_checkpoint = try parseRecoveryCheckpoint(alloc, value);
         } else return error.InvalidSessionFormat;
     }
-    errdefer if (usage) |*snapshot| snapshot.deinit(alloc);
     try expectToken(try json_reader.next(), .object_end);
     try expectToken(try json_reader.next(), .end_of_document);
 

--- a/src/core/session/session_event.zig
+++ b/src/core/session/session_event.zig
@@ -1044,7 +1044,7 @@ fn reduceReplacement(
     );
     defer chunk_reader.deinit();
 
-    var decoded = session_codec.decodeState(alloc, &chunk_reader.interface, .{}) catch |err| {
+    var decoded = session_codec.decodeLegacyState(alloc, &chunk_reader.interface, .{}) catch |err| {
         if (chunk_reader.truncated) return .{ .state = null };
         if (chunk_reader.failure) |failure| return failure;
         return err;
@@ -1670,7 +1670,7 @@ fn parsePayload(alloc: Allocator, kind: Kind, value: std.json.Value) !Event {
                 owned.deinit(alloc);
             }
             var usage = if (object.get("usage")) |usage_value|
-                session_usage.parseSnapshotValue(alloc, usage_value) catch |err| switch (err) {
+                session_usage.parseLegacySnapshotValue(alloc, usage_value) catch |err| switch (err) {
                     error.OutOfMemory => return error.OutOfMemory,
                     else => return error.InvalidEventFrame,
                 }
@@ -1765,7 +1765,7 @@ fn parsePayload(alloc: Allocator, kind: Kind, value: std.json.Value) !Event {
         },
         .usage_checkpointed => blk: {
             const object = try exactObject(value, &.{"usage"});
-            var usage = session_usage.parseSnapshotValue(
+            var usage = session_usage.parseLegacySnapshotValue(
                 alloc,
                 object.get("usage") orelse return error.InvalidEventFrame,
             ) catch |err| switch (err) {
@@ -2864,6 +2864,94 @@ test "history provenance replay frees every partial allocation" {
         checkHistoryProvenanceReplayAllocationFailures,
         .{},
     );
+}
+
+test "legacy cache accounting remains readable without invented totals" {
+    const alloc = std.testing.allocator;
+    const frame = "{\"schema_version\":1,\"log_generation\":\"01010101010101010101010101010101\",\"seq\":2," ++
+        "\"event_id\":\"02020202020202020202020202020202\",\"timestamp_ms\":20,\"kind\":\"usage_checkpointed\",\"payload\":{\"usage\":{" ++
+        "\"billing\":\"complete\",\"api_duration_complete\":true,\"wall_duration_complete\":true,\"code_complete\":true,\"next_sequence\":2,\"settled_through_sequence\":1," ++
+        "\"api_duration_ms\":10,\"wall_duration_ms\":20,\"total_cost\":1,\"input_tokens\":1,\"output_tokens\":3,\"cache_read_tokens\":2,\"cache_write_tokens\":0,\"billable_web_search_calls\":0,\"lines_added\":0,\"lines_removed\":0," ++
+        "\"models\":[{\"model\":\"test/model\",\"first_sequence\":1,\"total_cost\":1,\"input_tokens\":1,\"output_tokens\":3,\"cache_read_tokens\":2,\"cache_write_tokens\":0,\"billable_web_search_calls\":0}],\"pending\":[]}}}\n";
+    var decoded = try decodeFrame(alloc, frame);
+    defer decoded.deinit(alloc);
+    const usage = decoded.event.usage_checkpointed.usage;
+    try session_usage.validateSnapshot(usage);
+    try std.testing.expectEqual(session_usage.Availability.legacy, usage.billing);
+    try std.testing.expectEqual(@as(usize, 0), usage.models.len);
+    try std.testing.expectEqual(@as(usize, 0), usage.pending.len);
+    try std.testing.expect(!usage.api_duration_complete);
+    try std.testing.expectEqual(@as(u64, 2), decoded.seq);
+}
+
+test "legacy usage replacement retains framing and checksum validation" {
+    const alloc = std.testing.allocator;
+    const usage_json = "{\"billing\":\"complete\",\"api_duration_complete\":true,\"wall_duration_complete\":true,\"code_complete\":true,\"next_sequence\":2,\"settled_through_sequence\":1," ++
+        "\"api_duration_ms\":0,\"wall_duration_ms\":0,\"total_cost\":0,\"input_tokens\":1,\"output_tokens\":0,\"cache_read_tokens\":2,\"cache_write_tokens\":0,\"billable_web_search_calls\":0,\"lines_added\":0,\"lines_removed\":0," ++
+        "\"models\":[{\"model\":\"test/model\",\"first_sequence\":1,\"total_cost\":0,\"input_tokens\":1,\"output_tokens\":0,\"cache_read_tokens\":2,\"cache_write_tokens\":0,\"billable_web_search_calls\":0}],\"pending\":[]}";
+    const common = "\"id\":\"legacy-replacement\",\"origin_workspace_root\":\"/workspace\",\"workspace_root\":\"/workspace\",\"created_at_ms\":1,\"updated_at_ms\":2,\"conversation_language\":\"en\",\"preferences\":{\"model\":\"test/model\",\"effort\":\"auto\",\"fast_mode\":false}";
+    const state_json = "{" ++ common ++ ",\"history\":[],\"total_input_tokens\":7,\"total_output_tokens\":3,\"usage\":" ++ usage_json ++ "}";
+    const started = "{\"schema_version\":1,\"log_generation\":\"01010101010101010101010101010101\",\"seq\":1,\"event_id\":\"01010101010101010101010101010101\",\"timestamp_ms\":1,\"kind\":\"session_started\",\"payload\":{" ++
+        "\"id\":\"legacy-replacement\",\"created_at_ms\":1,\"origin_workspace_root\":\"/workspace\",\"workspace_root\":\"/workspace\",\"conversation_language\":\"en\",\"preferences\":{\"model\":\"test/model\",\"effort\":\"auto\",\"fast_mode\":false},\"usage\":" ++ usage_json ++ "}}\n";
+    const replacement_id = [_]u8{9} ** 16;
+    const digest = sha256(state_json);
+    for ([_]bool{ false, true }) |corrupt| {
+        var declared_digest = digest;
+        if (corrupt) declared_digest[0] ^= 1;
+        const transaction = [_]Event{
+            .{ .state_replacement_started = .{ .replacement_id = replacement_id, .reason = .compaction, .encoded_bytes = state_json.len, .sha256 = declared_digest, .chunk_count = 1 } },
+            .{ .state_replacement_chunk = .{ .replacement_id = replacement_id, .chunk_index = 0, .raw_bytes = state_json.len, .chunk_sha256 = digest, .bytes = @constCast(state_json) } },
+            .{ .state_replacement_committed = .{ .replacement_id = replacement_id, .encoded_bytes = state_json.len, .sha256 = declared_digest, .chunk_count = 1 } },
+        };
+        var log: std.Io.Writer.Allocating = .init(alloc);
+        defer log.deinit();
+        try log.writer.writeAll(started);
+        for (transaction, 2..) |event, seq| {
+            const frame = try encodeLegacyFixtureFrame(alloc, .{
+                .log_generation = [_]u8{1} ** 16,
+                .seq = seq,
+                .event_id = [_]u8{@intCast(seq)} ** 16,
+                .timestamp_ms = 2,
+                .event = event,
+            });
+            defer alloc.free(frame);
+            try log.writer.writeAll(frame);
+        }
+        var source = std.Io.Reader.fixed(log.written());
+        if (corrupt) {
+            try std.testing.expectError(error.InvalidReplacement, reduceJsonl(alloc, &source, null));
+        } else {
+            var reduced = try reduceJsonl(alloc, &source, null);
+            defer reduced.deinit(alloc);
+            try std.testing.expectEqualStrings("legacy-replacement", reduced.state.id);
+            try std.testing.expectEqual(@as(u64, 4), reduced.through.?.seq);
+            try std.testing.expectEqual(log.written().len, reduced.bytes_consumed);
+            try std.testing.expectEqual(@as(u64, 7), reduced.state.total_input_tokens);
+            try std.testing.expectEqual(session_usage.Availability.legacy, reduced.state.usage.?.billing);
+            try std.testing.expect(reduced.truncate_from == null);
+
+            var known = session_usage.Usage.initFresh();
+            defer known.deinit(alloc);
+            try known.recordCommittedLines(6, 2);
+            var snapshot = try known.snapshot(alloc);
+            defer snapshot.deinit(alloc);
+            const later_frame = try encodeLegacyFixtureFrame(alloc, .{
+                .log_generation = [_]u8{1} ** 16,
+                .seq = 5,
+                .event_id = [_]u8{5} ** 16,
+                .timestamp_ms = 3,
+                .event = .{ .usage_checkpointed = .{ .usage = snapshot } },
+            });
+            defer alloc.free(later_frame);
+            try log.writer.writeAll(later_frame);
+            var later_source = std.Io.Reader.fixed(log.written());
+            var later = try reduceJsonl(alloc, &later_source, null);
+            defer later.deinit(alloc);
+            try std.testing.expectEqual(session_usage.Availability.complete, later.state.usage.?.billing);
+            try std.testing.expectEqual(@as(u64, 6), later.state.usage.?.lines_added);
+            try std.testing.expectEqual(@as(u64, 5), later.through.?.seq);
+        }
+    }
 }
 
 test "usage checkpoint event decodes a cumulative snapshot" {

--- a/src/core/session/session_log.zig
+++ b/src/core/session/session_log.zig
@@ -4357,6 +4357,9 @@ test "legacy import preserves published events and active recovery after metadat
     defer temp.deinit(alloc);
     var initial = try testState(alloc, "legacy-metadata-sync-failure", 10);
     defer initial.deinit(alloc);
+    var legacy_usage = session_usage.Usage.initLegacy();
+    defer legacy_usage.deinit(alloc);
+    initial.usage = try legacy_usage.snapshot(alloc);
     const history = try alloc.alloc(session.HistoryTurn, 1);
     history[0] = try session.makeAssistantTurn(alloc, "saved request", "saved answer");
     initial.history = history;
@@ -4401,6 +4404,7 @@ test "legacy import preserves published events and active recovery after metadat
     try std.testing.expectEqual(@as(usize, 1), resumed.state.history.len);
     try std.testing.expectEqualStrings("saved answer", resumed.state.history[0].assistant.assistant);
     try std.testing.expectEqual(@as(u64, 7), resumed.state.recovery_checkpoint.?.turn_id);
+    try std.testing.expectEqual(session_usage.Availability.legacy, resumed.state.usage.?.billing);
 }
 
 test "conversation storage creates only metadata and event log" {

--- a/src/core/session/session_migration.zig
+++ b/src/core/session/session_migration.zig
@@ -222,6 +222,9 @@ pub fn loadSchemaV3ReadOnly(
     {
         return error.InvalidSessionFormat;
     }
+    if (replayed.state.usage) |usage| if (usage.billing == .legacy) {
+        @import("../shared/debug_trace.zig").logf("session", "legacy usage unavailable session_id={s} source_schema=3", .{session_id});
+    };
     if (try replayed.state.archive_legacy_recovery(alloc)) {
         @import("../shared/debug_trace.zig").logf("session", "legacy recovery archived session_id={s} reason=unverifiable_route_authority", .{session_id});
     }

--- a/src/core/session/session_projection.zig
+++ b/src/core/session/session_projection.zig
@@ -368,7 +368,7 @@ fn decodeCheckpointImpl(alloc: Allocator, bytes: []const u8) !Checkpoint {
         &state_json.writer,
     );
     var state_source = std.Io.Reader.fixed(state_json.written());
-    var state = session_codec.decodeState(alloc, &state_source, .{}) catch |err| switch (err) {
+    var state = session_codec.decodeLegacyState(alloc, &state_source, .{}) catch |err| switch (err) {
         error.OutOfMemory => return error.OutOfMemory,
         else => return error.InvalidCheckpoint,
     };
@@ -709,6 +709,74 @@ test "event stat fingerprint detects same-size replacement and metadata-only cha
     var wrong_size = original;
     wrong_size.size += 1;
     try std.testing.expectError(error.InvalidEventFileStat, eventFileStatFingerprint(wrong_size, 4096));
+}
+
+test "legacy checkpoint usage stays unavailable without weakening current state reads" {
+    const usage = @import("session_usage.zig");
+    const alloc = std.testing.allocator;
+    var runtime = usage.Usage.initFresh();
+    defer runtime.deinit(alloc);
+    var empty = try runtime.snapshot(alloc);
+    defer empty.deinit(alloc);
+    var models = [_]usage.ModelAggregate{.{
+        .model = @constCast("test/model"),
+        .first_sequence = 1,
+        .input_tokens = 10,
+    }};
+    var accounting = empty;
+    accounting.models = &models;
+    accounting.next_sequence = 2;
+    accounting.settled_through_sequence = 1;
+    accounting.input_tokens = 10;
+    accounting.reasoning_tokens = null;
+    accounting.request_count = null;
+    const state = session_codec.DurableSessionState{
+        .id = @constCast("legacy-usage"),
+        .origin_workspace_root = @constCast("/workspace"),
+        .workspace_root = @constCast("/workspace"),
+        .created_at_ms = 1,
+        .updated_at_ms = 2,
+        .conversation_language = session.ConversationLanguage.literal("en"),
+        .preferences = .{ .model = @constCast("test/model"), .effort = .auto, .fast_mode = false },
+        .history = &.{},
+        .total_input_tokens = 0,
+        .total_output_tokens = 0,
+        .usage = accounting,
+        .last_subagent_work_id = @constCast("legacy-work"),
+    };
+    var state_json: std.Io.Writer.Allocating = .init(alloc);
+    defer state_json.deinit();
+    _ = try session_codec.encodeState(state, &state_json.writer);
+    try std.testing.checkAllAllocationFailures(alloc, struct {
+        fn check(a: Allocator, bytes: []const u8) !void {
+            var source = std.Io.Reader.fixed(bytes);
+            var decoded = try session_codec.decodeState(a, &source, .{});
+            defer decoded.deinit(a);
+            try std.testing.expectEqual(@as(u64, 10), decoded.usage.?.input_tokens);
+        }
+    }.check, .{state_json.written()});
+    const old_state = try std.mem.replaceOwned(u8, alloc, state_json.written(), "\"cache_read_tokens\":0", "\"cache_read_tokens\":11");
+    defer alloc.free(old_state);
+    var strict_source = std.Io.Reader.fixed(old_state);
+    try std.testing.expectError(error.InvalidSessionFormat, session_codec.decodeState(alloc, &strict_source, .{}));
+
+    const encoded = try encodeCheckpoint(alloc, .{
+        .session_id = state.id,
+        .log_generation = testIdentifier(1),
+        .through_seq = 2,
+        .through_event_id = testIdentifier(2),
+        .through_event_log_bytes = 1024,
+        .state = state,
+    });
+    defer alloc.free(encoded);
+    const old_checkpoint = try std.mem.replaceOwned(u8, alloc, encoded, "\"cache_read_tokens\":0", "\"cache_read_tokens\":11");
+    defer alloc.free(old_checkpoint);
+    var decoded = try decodeCheckpoint(alloc, old_checkpoint);
+    defer decoded.deinit(alloc);
+    try std.testing.expectEqualStrings(state.id, decoded.state.id);
+    try std.testing.expectEqual(@as(u64, 2), decoded.through_seq);
+    try std.testing.expectEqual(usage.Availability.legacy, decoded.state.usage.?.billing);
+    try usage.validateSnapshot(decoded.state.usage.?);
 }
 
 test "checkpoint validation rejects stale corrupt and non-semantic boundaries" {

--- a/src/core/session/session_projection.zig
+++ b/src/core/session/session_projection.zig
@@ -368,7 +368,7 @@ fn decodeCheckpointImpl(alloc: Allocator, bytes: []const u8) !Checkpoint {
         &state_json.writer,
     );
     var state_source = std.Io.Reader.fixed(state_json.written());
-    var state = session_codec.decodeLegacyState(alloc, &state_source, .{}) catch |err| switch (err) {
+    var state = session_codec.decodeState(alloc, &state_source, .{}) catch |err| switch (err) {
         error.OutOfMemory => return error.OutOfMemory,
         else => return error.InvalidCheckpoint,
     };
@@ -709,74 +709,6 @@ test "event stat fingerprint detects same-size replacement and metadata-only cha
     var wrong_size = original;
     wrong_size.size += 1;
     try std.testing.expectError(error.InvalidEventFileStat, eventFileStatFingerprint(wrong_size, 4096));
-}
-
-test "legacy checkpoint usage stays unavailable without weakening current state reads" {
-    const usage = @import("session_usage.zig");
-    const alloc = std.testing.allocator;
-    var runtime = usage.Usage.initFresh();
-    defer runtime.deinit(alloc);
-    var empty = try runtime.snapshot(alloc);
-    defer empty.deinit(alloc);
-    var models = [_]usage.ModelAggregate{.{
-        .model = @constCast("test/model"),
-        .first_sequence = 1,
-        .input_tokens = 10,
-    }};
-    var accounting = empty;
-    accounting.models = &models;
-    accounting.next_sequence = 2;
-    accounting.settled_through_sequence = 1;
-    accounting.input_tokens = 10;
-    accounting.reasoning_tokens = null;
-    accounting.request_count = null;
-    const state = session_codec.DurableSessionState{
-        .id = @constCast("legacy-usage"),
-        .origin_workspace_root = @constCast("/workspace"),
-        .workspace_root = @constCast("/workspace"),
-        .created_at_ms = 1,
-        .updated_at_ms = 2,
-        .conversation_language = session.ConversationLanguage.literal("en"),
-        .preferences = .{ .model = @constCast("test/model"), .effort = .auto, .fast_mode = false },
-        .history = &.{},
-        .total_input_tokens = 0,
-        .total_output_tokens = 0,
-        .usage = accounting,
-        .last_subagent_work_id = @constCast("legacy-work"),
-    };
-    var state_json: std.Io.Writer.Allocating = .init(alloc);
-    defer state_json.deinit();
-    _ = try session_codec.encodeState(state, &state_json.writer);
-    try std.testing.checkAllAllocationFailures(alloc, struct {
-        fn check(a: Allocator, bytes: []const u8) !void {
-            var source = std.Io.Reader.fixed(bytes);
-            var decoded = try session_codec.decodeState(a, &source, .{});
-            defer decoded.deinit(a);
-            try std.testing.expectEqual(@as(u64, 10), decoded.usage.?.input_tokens);
-        }
-    }.check, .{state_json.written()});
-    const old_state = try std.mem.replaceOwned(u8, alloc, state_json.written(), "\"cache_read_tokens\":0", "\"cache_read_tokens\":11");
-    defer alloc.free(old_state);
-    var strict_source = std.Io.Reader.fixed(old_state);
-    try std.testing.expectError(error.InvalidSessionFormat, session_codec.decodeState(alloc, &strict_source, .{}));
-
-    const encoded = try encodeCheckpoint(alloc, .{
-        .session_id = state.id,
-        .log_generation = testIdentifier(1),
-        .through_seq = 2,
-        .through_event_id = testIdentifier(2),
-        .through_event_log_bytes = 1024,
-        .state = state,
-    });
-    defer alloc.free(encoded);
-    const old_checkpoint = try std.mem.replaceOwned(u8, alloc, encoded, "\"cache_read_tokens\":0", "\"cache_read_tokens\":11");
-    defer alloc.free(old_checkpoint);
-    var decoded = try decodeCheckpoint(alloc, old_checkpoint);
-    defer decoded.deinit(alloc);
-    try std.testing.expectEqualStrings(state.id, decoded.state.id);
-    try std.testing.expectEqual(@as(u64, 2), decoded.through_seq);
-    try std.testing.expectEqual(usage.Availability.legacy, decoded.state.usage.?.billing);
-    try usage.validateSnapshot(decoded.state.usage.?);
 }
 
 test "checkpoint validation rejects stale corrupt and non-semantic boundaries" {

--- a/src/core/session/session_usage.zig
+++ b/src/core/session/session_usage.zig
@@ -2241,6 +2241,11 @@ const ReconciliationAuthority = struct {
 };
 
 pub fn validateSnapshot(snapshot: Snapshot) !void {
+    _ = try validateSnapshotContract(snapshot, false);
+}
+
+fn validateSnapshotContract(snapshot: Snapshot, allow_legacy_cache: bool) !bool {
+    var cache_totals_valid = true;
     if (snapshot.next_sequence == 0) return error.InvalidUsageSnapshot;
     if (snapshot.settled_through_sequence >= snapshot.next_sequence) {
         return error.InvalidUsageSnapshot;
@@ -2307,7 +2312,8 @@ pub fn validateSnapshot(snapshot: Snapshot) !void {
         if (model.cache_read_tokens > model.input_tokens or
             model.cache_write_tokens > model.input_tokens)
         {
-            return error.InvalidUsageSnapshot;
+            if (!allow_legacy_cache) return error.InvalidUsageSnapshot;
+            cache_totals_valid = false;
         }
         if (model.reasoning_tokens) |reasoning| {
             if (reasoning > model.output_tokens) return error.InvalidUsageSnapshot;
@@ -2402,6 +2408,7 @@ pub fn validateSnapshot(snapshot: Snapshot) !void {
         }
     }
     if (identifier_bytes > max_identifier_bytes) return error.UsageCapacityExceeded;
+    return cache_totals_valid;
 }
 
 pub fn appendIncidentOwned(
@@ -2735,10 +2742,51 @@ fn writePendingAuthority(writer: *std.Io.Writer, pending: PendingGeneration) !vo
 
 /// Parses either the rollback-readable or current usage snapshot schema.
 pub fn parseSnapshotValue(alloc: Allocator, value: std.json.Value) !Snapshot {
+    var snapshot = try parseSnapshotFields(alloc, value);
+    errdefer snapshot.deinit(alloc);
+    try validateSnapshot(snapshot);
+    return snapshot;
+}
+
+/// Caller owns the result. Only historical separate-cache accounting may
+/// become unavailable; malformed or versioned snapshots remain errors.
+pub fn parseLegacySnapshotValue(alloc: Allocator, value: std.json.Value) !Snapshot {
+    var snapshot = try parseSnapshotFields(alloc, value);
+    errdefer snapshot.deinit(alloc);
+    if (try validateSnapshotContract(snapshot, isUnversionedSnapshot(value))) return snapshot;
+
+    snapshot.deinit(alloc);
+    return .{
+        .billing = .legacy,
+        .api_duration_complete = false,
+        .wall_duration_complete = false,
+        .code_complete = false,
+        .next_sequence = 1,
+        .settled_through_sequence = 0,
+        .api_duration_ms = 0,
+        .wall_duration_ms = 0,
+        .total_cost = 0,
+        .input_tokens = 0,
+        .output_tokens = 0,
+        .cache_read_tokens = 0,
+        .cache_write_tokens = 0,
+        .billable_web_search_calls = 0,
+        .lines_added = 0,
+        .lines_removed = 0,
+        .models = &.{},
+        .pending = &.{},
+    };
+}
+
+fn isUnversionedSnapshot(value: std.json.Value) bool {
+    return value == .object and value.object.count() == 18;
+}
+
+fn parseSnapshotFields(alloc: Allocator, value: std.json.Value) !Snapshot {
     if (value != .object) {
         return error.InvalidUsageSnapshot;
     }
-    const legacy = value.object.count() == 18;
+    const legacy = isUnversionedSnapshot(value);
     const schema_version = if (legacy)
         @as(u64, 1)
     else
@@ -3010,7 +3058,6 @@ pub fn parseSnapshotValue(alloc: Allocator, value: std.json.Value) !Snapshot {
         .publication_backlog = publication_backlog,
         .incidents = incidents,
     };
-    try validateSnapshot(snapshot);
     return snapshot;
 }
 
@@ -4183,6 +4230,138 @@ test "fresh usage aggregates authoritative generations in invocation order" {
     snapshot.input_tokens -= 1;
     snapshot.total_cost += 1;
     try std.testing.expectError(error.InvalidUsageSnapshot, validateSnapshot(snapshot));
+}
+
+fn legacyUsageForTest(alloc: Allocator) !std.json.Parsed(std.json.Value) {
+    return std.json.parseFromSlice(std.json.Value, alloc,
+        \\{"billing":"complete","api_duration_complete":true,"wall_duration_complete":true,"code_complete":true,"next_sequence":2,"settled_through_sequence":1,
+        \\"api_duration_ms":10,"wall_duration_ms":20,"total_cost":1,"input_tokens":10,"output_tokens":3,"cache_read_tokens":2,"cache_write_tokens":0,"billable_web_search_calls":0,"lines_added":0,"lines_removed":0,
+        \\"models":[{"model":"test/model","first_sequence":1,"total_cost":1,"input_tokens":10,"output_tokens":3,"cache_read_tokens":2,"cache_write_tokens":0,"billable_web_search_calls":0}],"pending":[]}
+    , .{});
+}
+
+test "legacy usage compatibility preserves valid snapshots and strict parsing" {
+    const alloc = std.testing.allocator;
+    var parsed = try legacyUsageForTest(alloc);
+    defer parsed.deinit();
+    var strict = try parseSnapshotValue(alloc, parsed.value);
+    defer strict.deinit(alloc);
+    var compatible = try parseLegacySnapshotValue(alloc, parsed.value);
+    defer compatible.deinit(alloc);
+    try std.testing.expect(snapshotEql(strict, compatible));
+
+    for ([_][]const u8{ "cache_read_tokens", "cache_write_tokens" }) |field| {
+        const global = parsed.value.object.getPtr(field).?;
+        const model = parsed.value.object.getPtr("models").?.array.items[0].object.getPtr(field).?;
+        const saved = global.*;
+        global.* = .{ .integer = 11 };
+        model.* = global.*;
+        var unavailable = try parseLegacySnapshotValue(alloc, parsed.value);
+        defer unavailable.deinit(alloc);
+        try validateSnapshot(unavailable);
+        try std.testing.expectEqual(Availability.legacy, unavailable.billing);
+        try std.testing.expectEqual(@as(usize, 0), unavailable.models.len);
+        try std.testing.expectEqual(@as(usize, 0), unavailable.pending.len);
+        try std.testing.expectError(error.InvalidUsageSnapshot, parseSnapshotValue(alloc, parsed.value));
+        global.* = saved;
+        model.* = saved;
+    }
+
+    var encoded: std.Io.Writer.Allocating = .init(alloc);
+    defer encoded.deinit();
+    try writeRichSnapshot(&encoded.writer, strict);
+    var rich = try std.json.parseFromSlice(std.json.Value, alloc, encoded.written(), .{});
+    defer rich.deinit();
+    var rich_copy = try parseLegacySnapshotValue(alloc, rich.value);
+    defer rich_copy.deinit(alloc);
+    try std.testing.expect(snapshotEql(strict, rich_copy));
+    rich.value.object.getPtr("cache_read_tokens").?.* = .{ .integer = 11 };
+    rich.value.object.getPtr("models").?.array.items[0].object.getPtr("cache_read_tokens").?.* = .{ .integer = 11 };
+    try std.testing.expectError(error.InvalidUsageSnapshot, parseLegacySnapshotValue(alloc, rich.value));
+}
+
+test "legacy usage compatibility does not hide malformed accounting" {
+    const alloc = std.testing.allocator;
+    var parsed = try legacyUsageForTest(alloc);
+    defer parsed.deinit();
+    parsed.value.object.getPtr("cache_read_tokens").?.* = .{ .integer = 11 };
+    const model = &parsed.value.object.getPtr("models").?.array.items[0];
+    model.object.getPtr("cache_read_tokens").?.* = .{ .integer = 11 };
+
+    const cases = [_]struct {
+        field: []const u8,
+        value: std.json.Value,
+        want: error{ InvalidGenerationRecord, InvalidUsageSnapshot },
+    }{
+        .{ .field = "total_cost", .value = .{ .float = -1 }, .want = error.InvalidGenerationRecord },
+        .{ .field = "total_cost", .value = .{ .float = std.math.inf(f64) }, .want = error.InvalidGenerationRecord },
+        .{ .field = "input_tokens", .value = .{ .integer = 9 }, .want = error.InvalidUsageSnapshot },
+        .{ .field = "next_sequence", .value = .{ .integer = 0 }, .want = error.InvalidUsageSnapshot },
+    };
+    for (cases) |case| {
+        const field = parsed.value.object.getPtr(case.field).?;
+        const saved = field.*;
+        field.* = case.value;
+        try std.testing.expectError(case.want, parseLegacySnapshotValue(alloc, parsed.value));
+        try std.testing.expectError(case.want, parseSnapshotValue(alloc, parsed.value));
+        field.* = saved;
+    }
+    model.object.getPtr("first_sequence").?.* = .{ .integer = 0 };
+    try std.testing.expectError(error.InvalidUsageSnapshot, parseLegacySnapshotValue(alloc, parsed.value));
+    model.object.getPtr("first_sequence").?.* = .{ .integer = 1 };
+    const models = parsed.value.object.getPtr("models").?;
+    try models.array.append(models.array.items[0]);
+    const totals = [_]struct { field: []const u8, original: i64, doubled: i64 }{
+        .{ .field = "total_cost", .original = 1, .doubled = 2 },
+        .{ .field = "input_tokens", .original = 10, .doubled = 20 },
+        .{ .field = "output_tokens", .original = 3, .doubled = 6 },
+        .{ .field = "cache_read_tokens", .original = 11, .doubled = 22 },
+    };
+    for (totals) |field| parsed.value.object.getPtr(field.field).?.* = .{ .integer = field.doubled };
+    try std.testing.expectError(error.InvalidUsageSnapshot, parseLegacySnapshotValue(alloc, parsed.value));
+    models.array.items.len = 1;
+    for (totals) |field| parsed.value.object.getPtr(field.field).?.* = .{ .integer = field.original };
+
+    var pending = try std.json.parseFromSlice(std.json.Value, alloc, "[{\"id\":\"gen_01ARZ3NDEKTSV4RRFFQ69G5FAV\",\"sequence\":0,\"origin\":\"https://ai-gateway.vercel.sh\",\"team\":null}]", .{});
+    defer pending.deinit();
+    const pending_field = parsed.value.object.getPtr("pending").?;
+    const old_pending = pending_field.*;
+    pending_field.* = pending.value;
+    parsed.value.object.getPtr("billing").?.* = .{ .string = "pending" };
+    try std.testing.expectError(error.InvalidUsageSnapshot, parseLegacySnapshotValue(alloc, parsed.value));
+    pending_field.* = old_pending;
+    parsed.value.object.getPtr("billing").?.* = .{ .string = "complete" };
+    try parsed.value.object.put(parsed.arena.allocator(), "unknown", .null);
+    try std.testing.expectError(error.InvalidGenerationRecord, parseLegacySnapshotValue(alloc, parsed.value));
+    try std.testing.expectError(error.InvalidUsageSnapshot, parseLegacySnapshotValue(alloc, .null));
+}
+
+test "legacy usage compatibility releases rejected and unavailable allocations" {
+    const alloc = std.testing.allocator;
+    var parsed = try legacyUsageForTest(alloc);
+    defer parsed.deinit();
+    parsed.value.object.getPtr("cache_read_tokens").?.* = .{ .integer = 11 };
+    parsed.value.object.getPtr("models").?.array.items[0].object.getPtr("cache_read_tokens").?.* = .{ .integer = 11 };
+    const Check = struct {
+        fn run(a: Allocator, value: std.json.Value, reject: bool) !void {
+            if (reject) {
+                if (parseLegacySnapshotValue(a, value)) |result| {
+                    var owned = result;
+                    owned.deinit(a);
+                    return error.ExpectedInvalidUsage;
+                } else |err| switch (err) {
+                    error.InvalidUsageSnapshot => return,
+                    else => return err,
+                }
+            }
+            var snapshot = try parseLegacySnapshotValue(a, value);
+            defer snapshot.deinit(a);
+            try std.testing.expectEqual(Availability.legacy, snapshot.billing);
+        }
+    };
+    try std.testing.checkAllAllocationFailures(alloc, Check.run, .{ parsed.value, false });
+    parsed.value.object.getPtr("input_tokens").?.* = .{ .integer = 9 };
+    try std.testing.checkAllAllocationFailures(alloc, Check.run, .{ parsed.value, true });
 }
 
 test "usage deduplicates terminal and generation callbacks" {

--- a/tests/e2e/session-recovery.test.ts
+++ b/tests/e2e/session-recovery.test.ts
@@ -279,6 +279,89 @@ function expectLegacyRequest(request: { body: string; headers: Headers }) {
 }
 
 describe("session recovery", () => {
+  test.skipIf(!tmuxAvailable())("legacy cache usage resumes through latest and exact session flows", async () => {
+    const fixture = createFixture("fx-session-legacy-cache-");
+    const gateway = startFakeGateway([
+      fakeGatewayFinalText("HEALTHY_LATEST_USAGE"),
+      fakeGatewayFinalText("LEGACY_USAGE_CONTINUED"),
+    ], LEGACY_GATEWAY_OPTIONS);
+    let tui: TmuxSession | undefined;
+    try {
+      const legacy = createLegacySession(fixture, 4);
+      const eventPath = join(legacy.source, "events.jsonl");
+      const records = readFileSync(eventPath, "utf8").trimEnd().split("\n").map(JSON.parse);
+      records.push({
+        schema_version: 1, log_generation: records[0].log_generation,
+        seq: 4, event_id: "04".repeat(16), timestamp_ms: 40, kind: "usage_checkpointed",
+        payload: { usage: {
+          billing: "complete", api_duration_complete: true, wall_duration_complete: true,
+          code_complete: true, next_sequence: 2, settled_through_sequence: 1,
+          api_duration_ms: 10, wall_duration_ms: 20, total_cost: 1,
+          input_tokens: 1, output_tokens: 3, cache_read_tokens: 2, cache_write_tokens: 0,
+          billable_web_search_calls: 0, lines_added: 0, lines_removed: 0,
+          models: [{ model: "test/model", first_sequence: 1, total_cost: 1,
+            input_tokens: 1, output_tokens: 3, cache_read_tokens: 2, cache_write_tokens: 0,
+            billable_web_search_calls: 0 }], pending: [],
+        } },
+      });
+      const events = records.map(record => JSON.stringify(record) + "\n").join("");
+      writeFileSync(eventPath, events, { mode: 0o600 });
+      const metadataPath = join(legacy.source, "session.json");
+      const metadata = JSON.parse(readFileSync(metadataPath, "utf8"));
+      writeFileSync(metadataPath, JSON.stringify({ ...metadata, updated_at_ms: 40,
+        last_event_seq: 4, event_log_bytes: Buffer.byteLength(events) }), { mode: 0o600 });
+      const watermark = JSON.parse(readFileSync(legacy.watermarkPath, "utf8"));
+      writeFileSync(legacy.watermarkPath, JSON.stringify({ ...watermark, through_seq: 4,
+        through_event_id: records.at(-1).event_id, through_event_log_bytes: Buffer.byteLength(events) }), { mode: 0o600 });
+      const oldHashes = savedFileHashes(legacy.source);
+      const healthyId = await createSavedSession(fixture, gateway);
+      const env = { ...legacyGatewayEnv(fixture, gateway), FX_SOUND: "0", FX_SKIP_ONBOARDING: "1" };
+      const quote = (value: string) => `'${value.replaceAll("'", "'\\''")}'`;
+      async function resume(args: string[], marker: string, label: string) {
+        const stderrPath = join(fixture.root, `${label}.stderr`);
+        tui = await TmuxSession.create({
+          cmd: [FX_BIN, ...args].map(quote).join(" "), cwd: fixture.workspace,
+          isolated: true, remainOnExit: true, width: 110, height: 40, stderrPath,
+          env: { ...env, FX_RECORD: join(fixture.root, `${label}.fxtape`) },
+        });
+        await tui.waitForPane(pane => tui!.paneStatus().dead || pane.includes(marker), TIMEOUT);
+        expect(readFileSync(stderrPath, "utf8")).toBe("");
+        expect(tui.paneStatus().dead).toBe(false);
+        await tui.waitForStableComposer(TIMEOUT);
+        expect(await tui.captureFullScrollback()).toContain(marker);
+        await tui.sendText("/quit");
+        await tui.waitForPane(() => tui!.paneStatus().dead, TIMEOUT);
+        expect(tui.paneStatus().status).toBe(0);
+        expect(readFileSync(stderrPath, "utf8")).toBe("");
+        await tui.kill(); tui = undefined;
+      }
+      await resume(["-c"], "HEALTHY_LATEST_USAGE", "latest");
+      expect(savedFileHashes(legacy.source)).toEqual(oldHashes);
+      expect(gateway.requests).toHaveLength(1);
+      expect(existsSync(join(fixture.home, ".fx", "sessions", healthyId))).toBe(true);
+
+      await resume(["--resume", legacy.id], LEGACY_ANSWER, "legacy");
+      expectLegacyArchive(legacy.source);
+      const usage = JSON.parse(readFileSync(join(legacy.source, "usage-v2.json"), "utf8"));
+      expect(usage.session_id).toBe(legacy.id);
+      expect(usage.snapshot.billing).toBe("legacy");
+      expect(usage.snapshot.models).toEqual([]);
+      expect(gateway.requests).toHaveLength(1);
+      const continued = await continueSession(fixture, gateway, legacy.id);
+      expect(continued.code).toBe(0);
+      expect(continued.stderr).toBe("");
+      expect(JSON.parse(continued.stdout).session_id).toBe(legacy.id);
+      expect(continued.stdout).toContain("LEGACY_USAGE_CONTINUED");
+      expectLegacyArchive(legacy.source);
+      expect(gateway.requests).toHaveLength(2);
+      expectLegacyRequest(gateway.requests[1]!);
+    } finally {
+      await tui?.kill();
+      gateway.stop();
+      rmSync(fixture.root, { recursive: true, force: true });
+    }
+  }, TIMEOUT * 3);
+
   test("healthy current conversation needs no recovery or migration", async () => {
     const fixture = createFixture("fx-session-current-healthy-");
     const gateway = startFakeGateway([fakeGatewayFinalText("SAVED_HEALTHY")]);


### PR DESCRIPTION
## Summary

- Allow latest and exact-ID resume when an older session contains separate-cache token accounting.
- Mark incompatible historical usage as unavailable while preserving the conversation and tool results through conversion and restart.
- Release decoded usage if loading a later session-state field fails.