### PR TITLE
Restore scoped instructions before continued turns

### DIFF
--- a/src/acp/prompt.zig
+++ b/src/acp/prompt.zig
@@ -4073,7 +4073,7 @@ test "ACP registry callbacks preserve snapshot bytes before transient context" {
     defer messages.deinit(arena);
     try messages.append(arena, .{ .role = .system, .content = "base system" });
 
-    try deps.append_static_context.?(deps.ctx, arena, &messages);
+    try deps.append_static_context.?(deps.ctx, arena, null, &messages);
     try deps.append_runtime_context(deps.ctx, arena, &messages);
 
     try std.testing.expectEqual(@as(usize, 4), messages.items.len);
@@ -4251,7 +4251,7 @@ test "ACP prompt projection configures web search then blocks native execution" 
     defer messages.deinit(arena);
     const deps = agentRuntimeDeps(&ctx);
     const append_static = deps.append_static_context orelse return error.TestExpectedEqual;
-    try append_static(deps.ctx, arena, &messages);
+    try append_static(deps.ctx, arena, null, &messages);
     try deps.append_runtime_context(deps.ctx, arena, &messages);
 
     try std.testing.expectEqualStrings("stale-key", state.web_search_runtime.api_key);

--- a/src/acp/prompt.zig
+++ b/src/acp/prompt.zig
@@ -1465,10 +1465,10 @@ fn appendRuntimeContext(raw_ctx: *anyopaque, arena: Allocator, messages: *std.Ar
     }, arena, messages);
 }
 
-fn appendStaticContext(raw_ctx: *anyopaque, arena: Allocator, messages: *std.ArrayList(ChatMessage)) !void {
+fn appendStaticContext(raw_ctx: *anyopaque, arena: Allocator, project_context: ?[]const u8, messages: *std.ArrayList(ChatMessage)) !void {
     const ctx: *AcpContext = @ptrCast(@alignCast(raw_ctx));
     try ctx.state.cfg.context_registry.appendDefaultStatic(.{
-        .project_context = ctx.modelVisibleProjectContext(),
+        .project_context = project_context orelse ctx.modelVisibleProjectContext(),
     }, arena, messages);
     if (ctx.state.cfg.minimal_kernel) return;
     const active_session = if (ctx.state.active_session) |*session| session else null;

--- a/src/builtins/context.zig
+++ b/src/builtins/context.zig
@@ -90,6 +90,39 @@ const RuleLoad = union(enum) {
     omitted: context_contract.OmissionReason,
 };
 
+const ReconstructionBudget = struct {
+    const candidate_limit = 128;
+    const read_limit = 64 * 1024 * 1024;
+    const Admission = enum { admitted, duplicate, exhausted };
+
+    // Source paths borrow selection-arena storage, including missing candidates.
+    sources: [candidate_limit][]const u8 = undefined,
+    candidate_count: usize = 0,
+    admitted_read_bytes: usize = 0,
+
+    fn admit_candidate(self: *ReconstructionBudget, source: []const u8) Admission {
+        if (containsString(self.sources[0..self.candidate_count], source)) return .duplicate;
+        if (self.candidate_count == candidate_limit) {
+            debug_trace.logf("context", "reconstruction_work_omitted reason=selection_cap candidates={d}", .{self.candidate_count});
+            return .exhausted;
+        }
+        self.sources[self.candidate_count] = source;
+        self.candidate_count += 1;
+        return .admitted;
+    }
+
+    fn admit_reads(self: *ReconstructionBudget, validation_bytes: usize, prefix_bytes: usize) bool {
+        const remaining = read_limit - self.admitted_read_bytes;
+        if (validation_bytes > remaining or prefix_bytes > remaining - validation_bytes) {
+            debug_trace.logf("context", "reconstruction_work_omitted reason=oversized admitted_read_bytes={d} validation_bytes={d} prefix_bytes={d}", .{ self.admitted_read_bytes, validation_bytes, prefix_bytes });
+            return false;
+        }
+        // Reserve both reads before validation. Failed or blank files do not refund work.
+        self.admitted_read_bytes += validation_bytes + prefix_bytes;
+        return true;
+    }
+};
+
 const SelectionOptions = struct {
     workspace_root: []const u8,
     targets: []const context_contract.ApplicableTarget,
@@ -99,12 +132,14 @@ const SelectionOptions = struct {
     initial_omission_summary: ?context_contract.ContextOmissionSummary = null,
     home: ?[]const u8 = null,
     initial: bool,
+    bounded_reconstruction: bool = false,
     load_project_instruction_files: bool = true,
     context_limits: context_limits.Values = .{},
 };
 
 const SelectionScratch = struct {
     arena: Allocator,
+    work_budget: ?ReconstructionBudget = null,
     candidates: std.ArrayList(RuleCandidate) = .empty,
     ranking_endpoints: std.ArrayList([]const u8) = .empty,
     delivered_sources: std.ArrayList([]const u8) = .empty,
@@ -182,6 +217,7 @@ fn gatherProjectContextWithHome(
         .initial_omission_summary = input.omission_summary,
         .home = home,
         .initial = true,
+        .bounded_reconstruction = input.bounded_reconstruction,
         .load_project_instruction_files = loadsProjectInstructionFiles(),
         .context_limits = input.context_limits,
     });
@@ -203,7 +239,10 @@ fn selectProjectContext(alloc: Allocator, options: SelectionOptions) context_con
     var arena_state = std.heap.ArenaAllocator.init(alloc);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
-    var scratch: SelectionScratch = .{ .arena = arena };
+    var scratch: SelectionScratch = .{
+        .arena = arena,
+        .work_budget = if (options.bounded_reconstruction) .{} else null,
+    };
 
     for (options.initial_omissions) |omission| {
         try scratch.addOmission(omission.source, omission.reason);
@@ -221,6 +260,7 @@ fn selectProjectContext(alloc: Allocator, options: SelectionOptions) context_con
 
     if (options.load_project_instruction_files) {
         if (options.initial) {
+            var launch_home: ?[]const u8 = null;
             if (options.home) |home| {
                 const canonical_home: ?[]u8 = io_mod.realpathAlloc(arena, home) catch |err| blk: {
                     if (err == error.OutOfMemory) return error.OutOfMemory;
@@ -231,7 +271,11 @@ fn selectProjectContext(alloc: Allocator, options: SelectionOptions) context_con
                     global_source_path = try std.fs.path.join(arena, &.{ home_root, ".fx", "AGENTS.md" });
                     global_rule = try loadRuleForSelection(arena, &scratch, global_source_path.?, options.context_limits.project_instruction_file_bytes);
                     if (pathing.pathInside(home_root, options.workspace_root)) {
-                        try collectLaunchAncestorCandidates(arena, &scratch, home_root, options.workspace_root, options.delivered_sources);
+                        if (options.bounded_reconstruction) {
+                            launch_home = home_root;
+                        } else {
+                            try collectLaunchAncestorCandidates(arena, &scratch, home_root, options.workspace_root, options.delivered_sources);
+                        }
                     } else {
                         try scratch.addOmission(options.workspace_root, .home_outside_workspace);
                     }
@@ -250,6 +294,10 @@ fn selectProjectContext(alloc: Allocator, options: SelectionOptions) context_con
             } else {
                 try scratch.addOmission(options.workspace_root, .unsafe_target);
             }
+            // Admit the explicit global and workspace sources before bounded ancestor work.
+            if (launch_home) |home_root| {
+                try collectLaunchAncestorCandidates(arena, &scratch, home_root, options.workspace_root, options.delivered_sources);
+            }
         }
 
         for (options.targets) |target| {
@@ -259,7 +307,7 @@ fn selectProjectContext(alloc: Allocator, options: SelectionOptions) context_con
 
     var usable: std.ArrayList(*RuleCandidate) = .empty;
     for (scratch.candidates.items) |*candidate| {
-        switch (try loadRule(arena, candidate.source, options.context_limits.project_instruction_file_bytes)) {
+        switch (try loadRuleWithBudget(arena, candidate.source, options.context_limits.project_instruction_file_bytes, if (scratch.work_budget) |*budget| budget else null)) {
             .body => |body| {
                 candidate.body = body.text;
                 candidate.observed_bytes = body.observed_bytes;
@@ -348,7 +396,11 @@ fn selectProjectContext(alloc: Allocator, options: SelectionOptions) context_con
         }
     }
     result.delivered_sources = try dupeOwnedStringSlice(alloc, scratch.delivered_sources.items);
-    result.evaluated_endpoints = try dupeOwnedStringSlice(alloc, scratch.evaluated_endpoints.items);
+    // A bounded reconstruction may leave ancestors unread. Only delivered rules
+    // may suppress live discovery, not completion of these directory scans.
+    if (!options.bounded_reconstruction) {
+        result.evaluated_endpoints = try dupeOwnedStringSlice(alloc, scratch.evaluated_endpoints.items);
+    }
     result.notices = try dupeOwnedStringSlice(alloc, scratch.notices.items);
     return result;
 }
@@ -359,7 +411,17 @@ fn loadRuleForSelection(
     source: []const u8,
     limit: context_limits.Resolved,
 ) !?LoadedRule {
-    switch (try loadRule(arena, source, limit)) {
+    if (scratch.work_budget) |*budget| {
+        switch (budget.admit_candidate(source)) {
+            .admitted => {},
+            .duplicate => return null,
+            .exhausted => {
+                try scratch.addOmission(source, .selection_cap);
+                return null;
+            },
+        }
+    }
+    switch (try loadRuleWithBudget(arena, source, limit, if (scratch.work_budget) |*budget| budget else null)) {
         .body => |body| {
             try scratch.addDelivered(source);
             return .{ .source = source, .body = body.text, .observed_bytes = body.observed_bytes };
@@ -383,7 +445,7 @@ fn collectLaunchAncestorCandidates(
     while (current) |scope| : (current = std.fs.path.dirname(scope)) {
         if (std.mem.eql(u8, scope, home)) break;
         if (!pathing.pathInside(home, scope)) break;
-        try appendRuleCandidate(arena, scratch, scope, .ancestor, prior_delivered);
+        if (!try appendRuleCandidate(arena, scratch, scope, .ancestor, prior_delivered)) break;
     }
 }
 
@@ -413,7 +475,7 @@ fn collectTargetCandidates(
     while (current) |scope| : (current = std.fs.path.dirname(scope)) {
         if (std.mem.eql(u8, scope, options.workspace_root)) break;
         if (!pathing.pathInside(options.workspace_root, scope)) break;
-        try appendRuleCandidate(arena, scratch, scope, .target, options.delivered_sources);
+        if (!try appendRuleCandidate(arena, scratch, scope, .target, options.delivered_sources)) break;
     }
 }
 
@@ -423,20 +485,42 @@ fn appendRuleCandidate(
     scope: []const u8,
     class: CandidateClass,
     prior_delivered: []const []const u8,
-) !void {
+) !bool {
     const source = try std.fs.path.join(arena, &.{ scope, "AGENTS.md" });
-    if (containsString(prior_delivered, source) or containsString(scratch.delivered_sources.items, source)) return;
+    if (containsString(prior_delivered, source) or containsString(scratch.delivered_sources.items, source)) return true;
     for (scratch.candidates.items) |candidate| {
-        if (std.mem.eql(u8, candidate.source, source)) return;
+        // A previous walk already covered these ancestors, or stopped at the work cap.
+        if (std.mem.eql(u8, candidate.source, source)) return scratch.work_budget == null;
+    }
+    if (scratch.work_budget) |*budget| {
+        switch (budget.admit_candidate(source)) {
+            .admitted => {},
+            // Initial global/workspace probes need not have walked this scope's ancestors.
+            .duplicate => return true,
+            .exhausted => {
+                try scratch.addOmission(source, .selection_cap);
+                return false;
+            },
+        }
     }
     try scratch.candidates.append(arena, .{
         .source = source,
         .scope = scope,
         .class = class,
     });
+    return true;
 }
 
 fn loadRule(arena: Allocator, path: []const u8, limit: context_limits.Resolved) Allocator.Error!RuleLoad {
+    return loadRuleWithBudget(arena, path, limit, null);
+}
+
+fn loadRuleWithBudget(
+    arena: Allocator,
+    path: []const u8,
+    limit: context_limits.Resolved,
+    work_budget: ?*ReconstructionBudget,
+) Allocator.Error!RuleLoad {
     const stat = std.Io.Dir.cwd().statFile(io_mod.getIo(), path, .{ .follow_symlinks = false }) catch |err| {
         return switch (err) {
             error.FileNotFound, error.NotDir => .missing,
@@ -490,13 +574,16 @@ fn loadRule(arena: Allocator, path: []const u8, limit: context_limits.Resolved) 
     const observed_bytes = std.math.cast(usize, opened_stat.size) orelse return .{ .omitted = .oversized };
     if (observed_bytes > context_limits.emergency_ceiling_bytes) return .{ .omitted = .oversized };
 
-    const has_content = validateRuleUtf8(&file, observed_bytes) catch
-        return .{ .omitted = .unreadable };
-    if (!has_content) return .blank;
     const read_len = @min(
         observed_bytes,
         @min(limit.effectiveBytes() +| 3, context_limits.emergency_ceiling_bytes),
     );
+    if (work_budget) |budget| {
+        if (!budget.admit_reads(observed_bytes, read_len)) return .{ .omitted = .oversized };
+    }
+    const has_content = validateRuleUtf8(&file, observed_bytes) catch
+        return .{ .omitted = .unreadable };
+    if (!has_content) return .blank;
     const content = try arena.alloc(u8, read_len);
     const bytes_read = file.readPositionalAll(io_mod.getIo(), content, 0) catch
         return .{ .omitted = .unreadable };
@@ -908,6 +995,68 @@ fn createSymlinkOrSkip(dir: std.Io.Dir, target_path: []const u8, link_path: []co
         if (err == error.AccessDenied or err == error.FileSystem) return error.SkipZigTest;
         return err;
     };
+}
+
+test "reconstruction budget bounds distinct candidates and both file reads" {
+    var budget = ReconstructionBudget{};
+    var names: [129][8]u8 = undefined;
+    for (&names, 0..) |*name, index| {
+        const source = try std.fmt.bufPrint(name, "r{d}", .{index});
+        try std.testing.expectEqual(if (index < 128) ReconstructionBudget.Admission.admitted else .exhausted, budget.admit_candidate(source));
+    }
+    try std.testing.expectEqual(ReconstructionBudget.Admission.duplicate, budget.admit_candidate("r0"));
+    try std.testing.expect(budget.admit_reads(ReconstructionBudget.read_limit - 4, 3));
+    try std.testing.expect(!budget.admit_reads(1, 1));
+    try std.testing.expectEqual(ReconstructionBudget.read_limit - 1, budget.admitted_read_bytes);
+    try std.testing.expect(budget.admit_reads(1, 0));
+}
+
+test "reconstruction budget omits file before validation and does not deliver it" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeTestFile(tmp.dir, "AGENTS.md", "RULE");
+    const source = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "AGENTS.md");
+    defer alloc.free(source);
+    var arena_state = std.heap.ArenaAllocator.init(alloc);
+    defer arena_state.deinit();
+    var scratch = SelectionScratch{
+        .arena = arena_state.allocator(),
+        .work_budget = .{ .admitted_read_bytes = ReconstructionBudget.read_limit - 7 },
+    };
+    try std.testing.expectEqual(@as(?LoadedRule, null), try loadRuleForSelection(scratch.arena, &scratch, source, (context_limits.Values{}).project_instruction_file_bytes));
+    try std.testing.expectEqual(@as(usize, 0), scratch.delivered_sources.items.len);
+    try std.testing.expectEqual(@as(usize, 1), scratch.omissions.items.len);
+    try std.testing.expectEqual(context_contract.OmissionReason.oversized, scratch.omissions.items[0].reason);
+    try std.testing.expectEqual(ReconstructionBudget.read_limit - 7, scratch.work_budget.?.admitted_read_bytes);
+}
+
+test "reconstruction budget keeps live discovery eligible while retaining delivered rules" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeTestFile(tmp.dir, "workspace/nested/AGENTS.md", "BOUNDED_RULE");
+    const workspace = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "workspace");
+    defer alloc.free(workspace);
+    const nested = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "workspace/nested");
+    defer alloc.free(nested);
+    var reconstructed = try gatherProjectContextWithHome(alloc, .{
+        .workspace_root = workspace,
+        .targets = &.{.{ .path = nested, .kind = .directory }},
+        .bounded_reconstruction = true,
+    }, null);
+    defer reconstructed.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 0), reconstructed.evaluated_endpoints.len);
+    try std.testing.expectEqual(@as(usize, 1), reconstructed.delivered_sources.len);
+    var later = try selectApplicableProjectContext(alloc, .{
+        .workspace_root = workspace,
+        .targets = &.{.{ .path = nested, .kind = .directory }},
+        .delivered_sources = reconstructed.delivered_sources,
+        .evaluated_endpoints = reconstructed.evaluated_endpoints,
+    });
+    defer later.deinit(alloc);
+    try std.testing.expect(later.content == null);
+    try std.testing.expectEqual(@as(usize, 1), later.evaluated_endpoints.len);
 }
 
 test "context formatting preserves section order and separators" {

--- a/src/core/agent/runtime/deps.zig
+++ b/src/core/agent/runtime/deps.zig
@@ -202,7 +202,7 @@ pub const AgentRuntimeDeps = struct {
     prepare_parent_turn_context: ?*const fn (ctx: *anyopaque, arena: Allocator) anyerror!?PreparedParentTurnContext = null,
     acknowledge_parent_turn_context: ?*const fn (ctx: *anyopaque, arena: Allocator, acknowledgements: []const ParentTurnDeliveryAck) void = null,
     append_runtime_context: *const fn (ctx: *anyopaque, arena: Allocator, messages: *std.ArrayList(ChatMessage)) anyerror!void,
-    append_static_context: ?*const fn (ctx: *anyopaque, arena: Allocator, messages: *std.ArrayList(ChatMessage)) anyerror!void = null,
+    append_static_context: ?*const fn (ctx: *anyopaque, arena: Allocator, project_context: ?[]const u8, messages: *std.ArrayList(ChatMessage)) anyerror!void = null,
     validate_tool_call: ?*const fn (ctx: *anyopaque, arena: Allocator, call: ToolCall) anyerror!ToolCallValidationResult = null,
     snapshot_mcp_definition: ?*const fn (*anyopaque, Allocator, []const u8, types.McpToolBinding) anyerror!@import("../../tooling/tool_mcp_runtime.zig").DefinitionSnapshot = null,
     prepare_skill_call: ?*const fn (ctx: *anyopaque, arena: Allocator, call: ToolCall, locations: ?*const skill_contract.Locations) anyerror!skill_contract.CallPreparation = null,

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -4815,7 +4815,11 @@ fn processQueuedPromptInner(
             if (explicit_section.?.load_notice) |notice| try push_notice(deps.ctx, notice);
         }
     }
-    try appendStablePromptContext(arena, deps, config, if (skill_section) |section| section.text else null, &stable_prefix);
+    var reconstructed_context = try reconstructProjectContext(arena, deps, config, job);
+    defer if (reconstructed_context) |*snapshot| snapshot.deinit(arena);
+    var prepared_job = job;
+    if (reconstructed_context) |snapshot| prepared_job.context_snapshot = snapshot;
+    try appendStablePromptContext(arena, deps, config, if (skill_section) |section| section.text else null, if (reconstructed_context) |snapshot| snapshot.modelVisibleBytes() else null, &stable_prefix);
     const active_history = job.history;
     const history_messages_before = stable_prefix.items.len;
     const interrupted_turns = runtime_interruption.countInterruptedHistory(active_history);
@@ -4871,7 +4875,7 @@ fn processQueuedPromptInner(
         semantic_presentation,
         lifecycle,
         config,
-        job,
+        prepared_job,
         .{ .catalog = if (skill_section) |*section| section else null, .explicit = if (explicit_section) |*section| section else null },
         request_capabilities,
         base_nested_terminal_advertised,
@@ -5225,11 +5229,55 @@ fn commitContextCompaction(
     return deps.propagate_history_turn(deps.ctx, .{ .compacted_summary = summary });
 }
 
+fn reconstructProjectContext(
+    alloc: Allocator,
+    deps: *const AgentRuntimeDeps,
+    config: Config,
+    job: QueuedPrompt,
+) !?context_contract.GatheredContextSnapshot {
+    if (!deps.context_enabled) return null;
+    const registry = deps.context_registry orelse return error.ContextRegistryUnavailable;
+    var retained = try tool_preparation.retainedContextTargets(
+        alloc,
+        job.history,
+        if (job.recovery_checkpoint) |checkpoint| checkpoint.execution else null,
+        config.workspace_root,
+        deps.tool_registry,
+        config.cancel_flag,
+    );
+    defer retained.deinit(alloc);
+    if (retained.items.len == 0) return null;
+    var targets: std.ArrayList(context_contract.ApplicableTarget) = .empty;
+    defer targets.deinit(alloc);
+    const prior = job.context_snapshot.evaluated_endpoints;
+    for (prior[0..@min(prior.len, 128)]) |endpoint| {
+        try targets.append(alloc, .{ .path = endpoint, .kind = .directory });
+    }
+    const image_targets = try context_contract.applicableTargetsForImages(alloc, job.images);
+    defer if (image_targets.len > 0) alloc.free(image_targets);
+    try targets.appendSlice(alloc, image_targets[0..@min(image_targets.len, 32)]);
+    try targets.appendSlice(alloc, retained.items);
+    if (config.cancel_flag.load(.seq_cst)) return error.Cancelled;
+    var snapshot = try registry.gatherDefaultSnapshot(alloc, .{
+        .workspace_root = config.workspace_root,
+        .access_scope = config.access_scope,
+        .targets = targets.items,
+        .bounded_reconstruction = true,
+        .context_limits = config.context_limits,
+    });
+    errdefer snapshot.deinit(alloc);
+    if (config.cancel_flag.load(.seq_cst)) return error.Cancelled;
+    for (snapshot.notices) |notice| try deps.pushContextNotice(notice);
+    debug_trace.logf("context", "reconstructed retained_targets={d} delivered_sources={d} bytes={d}", .{ retained.items.len, snapshot.delivered_sources.len, snapshot.modelVisibleBytes().len });
+    return snapshot;
+}
+
 fn appendStablePromptContext(
     alloc: Allocator,
     deps: *const AgentRuntimeDeps,
     config: Config,
     skill_catalog_text: ?[]const u8,
+    project_context: ?[]const u8,
     messages: *std.ArrayList(ChatMessage),
 ) !void {
     for ([_][]const u8{
@@ -5243,7 +5291,7 @@ fn appendStablePromptContext(
     if (config.model_prompt_overlay) |overlay| {
         try messages.append(alloc, .{ .role = .system, .content = overlay });
     }
-    if (deps.append_static_context) |append| try append(deps.ctx, alloc, messages);
+    if (deps.append_static_context) |append| try append(deps.ctx, alloc, project_context, messages);
 }
 
 const CompactionContinuation = struct {
@@ -5366,7 +5414,7 @@ pub fn prepareManualCompactionContinuation(
 ) !CompactionContinuation {
     var stable_prefix: std.ArrayList(ChatMessage) = .empty;
     const skill_section = try prepareSkillCatalog(arena, deps, config, capabilities.context_window);
-    try appendStablePromptContext(arena, deps, config, if (skill_section) |section| section.text else null, &stable_prefix);
+    try appendStablePromptContext(arena, deps, config, if (skill_section) |section| section.text else null, null, &stable_prefix);
     var overlay: std.ArrayList(ChatMessage) = .empty;
     try deps.append_runtime_context(deps.ctx, arena, &overlay);
     const projection = try build_provider_prompt_with_response_language_control(

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -5236,7 +5236,6 @@ fn reconstructProjectContext(
     job: QueuedPrompt,
 ) !?context_contract.GatheredContextSnapshot {
     if (!deps.context_enabled) return null;
-    const registry = deps.context_registry orelse return error.ContextRegistryUnavailable;
     var retained = try tool_preparation.retainedContextTargets(
         alloc,
         job.history,
@@ -5247,6 +5246,7 @@ fn reconstructProjectContext(
     );
     defer retained.deinit(alloc);
     if (retained.items.len == 0) return null;
+    const registry = deps.context_registry orelse return error.ContextRegistryUnavailable;
     var targets: std.ArrayList(context_contract.ApplicableTarget) = .empty;
     defer targets.deinit(alloc);
     const prior = job.context_snapshot.evaluated_endpoints;
@@ -5291,7 +5291,12 @@ fn appendStablePromptContext(
     if (config.model_prompt_overlay) |overlay| {
         try messages.append(alloc, .{ .role = .system, .content = overlay });
     }
-    if (deps.append_static_context) |append| try append(deps.ctx, alloc, project_context, messages);
+    if (deps.append_static_context) |append| {
+        try append(deps.ctx, alloc, project_context, messages);
+    } else if (project_context) |content| {
+        const registry = deps.context_registry orelse return error.ContextRegistryUnavailable;
+        try registry.appendDefaultStatic(.{ .project_context = content }, alloc, messages);
+    }
 }
 
 const CompactionContinuation = struct {

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -4815,7 +4815,30 @@ fn processQueuedPromptInner(
             if (explicit_section.?.load_notice) |notice| try push_notice(deps.ctx, notice);
         }
     }
-    var reconstructed_context = try reconstructProjectContext(arena, deps, config, job);
+    var reconstructed_context = reconstruct: while (true) {
+        const snapshot = reconstructProjectContext(arena, deps, config, job) catch |err| {
+            if (err != error.Cancelled or !config.cancel_flag.load(.seq_cst)) return err;
+            if (try append_immediate_steering_after_cancel(deps, arena, &within_turn_suffix, turn_id, "")) continue :reconstruct;
+            runtime_telemetry.traceCancelObserved(finish_trace.ctx, false);
+            var terminal_materializing = false;
+            try runtime_interruption.persistInterruptedTurnOnce(
+                deps,
+                finalization,
+                job,
+                null,
+                null,
+                completed_tool_names.items,
+                &interrupted_persisted,
+                finish_trace.ctx,
+                within_turn_suffix.items,
+                null,
+                &terminal_materializing,
+            );
+            finish_trace.finish("interrupted");
+            return;
+        };
+        break :reconstruct snapshot;
+    };
     defer if (reconstructed_context) |*snapshot| snapshot.deinit(arena);
     var prepared_job = job;
     if (reconstructed_context) |snapshot| prepared_job.context_snapshot = snapshot;

--- a/src/core/agent/runtime/tests/support.zig
+++ b/src/core/agent/runtime/tests/support.zig
@@ -942,9 +942,9 @@ pub const FakeAgentRuntimeDeps = struct {
         }
     }
 
-    fn appendStaticContext(raw: *anyopaque, arena: Allocator, messages: *std.ArrayList(ChatMessage)) !void {
+    fn appendStaticContext(raw: *anyopaque, arena: Allocator, project_context: ?[]const u8, messages: *std.ArrayList(ChatMessage)) !void {
         const self: *FakeAgentRuntimeDeps = @ptrCast(@alignCast(raw));
-        if (self.static_context_text) |text| {
+        if (project_context orelse self.static_context_text) |text| {
             try messages.append(arena, .{ .role = .system, .content = try arena.dupe(u8, text) });
         }
     }

--- a/src/core/agent/runtime/tests/tool_flow.zig
+++ b/src/core/agent/runtime/tests/tool_flow.zig
@@ -3171,6 +3171,20 @@ test "modern cancellation during later context selection stops before context or
     try std.testing.expectEqual(types.TurnPresentationOutcome.interrupted, hooks.finalized_outcome.?);
 }
 
+test "retained project context leaves empty history host context unchanged" {
+    const alloc = std.testing.allocator;
+    const completions = [_]FakeCompletion{.{ .content = "Final" }};
+    var gateway = FakeGateway.init(alloc, &completions);
+    defer gateway.deinit();
+    var hooks = FakeAgentRuntimeDeps.init(alloc);
+    defer hooks.deinit();
+    hooks.context_enabled = true;
+    hooks.static_context_text = "HOST_ONLY_CONTEXT";
+    var fixture = PromptFixture{};
+    try runFakePrompt(&gateway, &hooks, fixture.config(), fixture.job());
+    try expectBodyContains(&gateway, 0, "HOST_ONLY_CONTEXT");
+}
+
 test "retained project context refreshes queued rules before a repeated shell call" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
@@ -3217,6 +3231,22 @@ test "retained project context refreshes queued rules before a repeated shell ca
     try std.testing.expectEqual(@as(usize, 1), second_hooks.executed_names.items.len);
     try std.testing.expectEqual(@as(usize, 1), second_hooks.permission_names.items.len);
     try std.testing.expectEqual(@as(usize, 2), second_gateway.request_bodies.items.len);
+
+    const bare_final = [_]FakeCompletion{.{ .content = "Core context delivered" }};
+    var bare_gateway = FakeGateway.init(alloc, &bare_final);
+    defer bare_gateway.deinit();
+    var bare_hooks = FakeAgentRuntimeDeps.init(alloc);
+    defer bare_hooks.deinit();
+    bare_hooks.context_enabled = true;
+    bare_hooks.context_registry = registry;
+    var bare_deps = bare_hooks.deps();
+    bare_deps.append_static_context = null;
+    bare_deps.agent_stream_provider = bare_gateway.provider();
+    var agent: @import("../agent.zig").Agent = .{};
+    defer agent.deinit(alloc);
+    try agent.restoreHistory(alloc, job.history);
+    try runtime_orchestrator.processAgentPrompt(&agent, &bare_deps, null, testLifecycleContext(lifecycle_hooks.RuntimeView.empty(), alloc, workspace), fixture.config(), job);
+    try expectBodyContains(&bare_gateway, 0, "RETAINED_CURRENT_RULE");
 
     try tmp.dir.deleteFile(std.testing.io, "nested/AGENTS.md");
     const final = [_]FakeCompletion{.{ .content = "No stale rule" }};

--- a/src/core/agent/runtime/tests/tool_flow.zig
+++ b/src/core/agent/runtime/tests/tool_flow.zig
@@ -3171,6 +3171,76 @@ test "modern cancellation during later context selection stops before context or
     try std.testing.expectEqual(types.TurnPresentationOutcome.interrupted, hooks.finalized_outcome.?);
 }
 
+test "retained project context refreshes queued rules before a repeated shell call" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(std.testing.io, "nested");
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "nested/AGENTS.md", .data = "RETAINED_OLD_RULE" });
+    const workspace = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(workspace);
+    const nested = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "nested");
+    defer alloc.free(nested);
+    const registry = context_contract.Registry{ .default_provider = builtin_context.provider };
+    const calls = [_]ToolCall{toolCall("scoped_shell", "shell", "{\"action\":\"run\",\"command\":\"pwd\",\"cwd\":\"nested\"}")};
+    const completions = [_]FakeCompletion{ .{ .tool_calls = &calls }, .{ .content = "Final" } };
+    var first_gateway = FakeGateway.init(alloc, &completions);
+    defer first_gateway.deinit();
+    var first_hooks = FakeAgentRuntimeDeps.init(alloc);
+    defer first_hooks.deinit();
+    first_hooks.context_enabled = true;
+    first_hooks.context_registry = registry;
+    var fixture = PromptFixture{ .workspace_root = workspace };
+    try runFakePrompt(&first_gateway, &first_hooks, fixture.config(), fixture.job());
+    try std.testing.expectEqual(@as(usize, 0), first_hooks.executed_names.items.len);
+    try expectBodyContains(&first_gateway, 1, types.context_deferred_tool_result_output);
+
+    var queued_snapshot = try registry.gatherDefaultSnapshot(alloc, .{
+        .workspace_root = workspace,
+        .targets = &.{.{ .path = nested, .kind = .directory }},
+    });
+    defer queued_snapshot.deinit(alloc);
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "nested/AGENTS.md", .data = "RETAINED_CURRENT_RULE" });
+    var job = fixture.job();
+    job.history = first_hooks.history_turns.items;
+    job.context_snapshot = queued_snapshot;
+    var second_gateway = FakeGateway.init(alloc, &completions);
+    defer second_gateway.deinit();
+    var second_hooks = FakeAgentRuntimeDeps.init(alloc);
+    defer second_hooks.deinit();
+    second_hooks.context_enabled = true;
+    second_hooks.context_registry = registry;
+    second_hooks.static_context_text = queued_snapshot.modelVisibleBytes();
+    try runFakePrompt(&second_gateway, &second_hooks, fixture.config(), job);
+    try expectBodyContains(&second_gateway, 0, "RETAINED_CURRENT_RULE");
+    try expectBodyNotContains(&second_gateway, 0, "RETAINED_OLD_RULE");
+    try std.testing.expectEqual(@as(usize, 1), second_hooks.executed_names.items.len);
+    try std.testing.expectEqual(@as(usize, 1), second_hooks.permission_names.items.len);
+    try std.testing.expectEqual(@as(usize, 2), second_gateway.request_bodies.items.len);
+
+    try tmp.dir.deleteFile(std.testing.io, "nested/AGENTS.md");
+    const final = [_]FakeCompletion{.{ .content = "No stale rule" }};
+    var deleted_gateway = FakeGateway.init(alloc, &final);
+    defer deleted_gateway.deinit();
+    var deleted_hooks = FakeAgentRuntimeDeps.init(alloc);
+    defer deleted_hooks.deinit();
+    deleted_hooks.context_enabled = true;
+    deleted_hooks.context_registry = registry;
+    deleted_hooks.static_context_text = queued_snapshot.modelVisibleBytes();
+    try runFakePrompt(&deleted_gateway, &deleted_hooks, fixture.config(), job);
+    try expectBodyNotContains(&deleted_gateway, 0, "RETAINED_OLD_RULE");
+    try expectBodyNotContains(&deleted_gateway, 0, "RETAINED_CURRENT_RULE");
+
+    var disabled_gateway = FakeGateway.init(alloc, &final);
+    defer disabled_gateway.deinit();
+    var disabled_hooks = FakeAgentRuntimeDeps.init(alloc);
+    defer disabled_hooks.deinit();
+    disabled_hooks.static_context_text = "HOST_CONTEXT_UNCHANGED";
+    try runFakePrompt(&disabled_gateway, &disabled_hooks, fixture.config(), job);
+    try expectBodyContains(&disabled_gateway, 0, "HOST_CONTEXT_UNCHANGED");
+    try expectBodyNotContains(&disabled_gateway, 0, "RETAINED_OLD_RULE");
+}
+
 test "modern context delta defers effectful call exactly once" {
     const alloc = std.testing.allocator;
     defer ApplicableContextDelta.reset("", null);

--- a/src/core/agent/runtime/tests/tool_flow.zig
+++ b/src/core/agent/runtime/tests/tool_flow.zig
@@ -262,6 +262,7 @@ const ApplicableContextDelta = struct {
         _: std.mem.Allocator,
         _: context_contract.InitialContextInput,
     ) context_contract.ProviderError!context_contract.ProviderContext {
+        if (cancel_flag) |flag| flag.store(true, .seq_cst);
         return .{};
     }
 
@@ -3169,6 +3170,39 @@ test "modern cancellation during later context selection stops before context or
     try std.testing.expectEqualStrings("candidate_read", interrupted.tool_call.?.id);
     try std.testing.expectEqual(@as(usize, 1), hooks.finalization_count);
     try std.testing.expectEqual(types.TurnPresentationOutcome.interrupted, hooks.finalized_outcome.?);
+}
+
+test "retained project context cancellation preserves an interrupted turn" {
+    const alloc = std.testing.allocator;
+    defer ApplicableContextDelta.reset("", null);
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const workspace = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(workspace);
+    const calls = [_]ToolCall{toolCall("prior_read", "read_file", "{\"path\":\"prior.txt\"}")};
+    const steps = [_]types.ToolExecutionStep{.{ .tool_calls = @constCast(&calls) }};
+    const history = [_]types.HistoryTurn{.{ .assistant = .{
+        .user = .{ .text = @constCast("prior") },
+        .assistant = @constCast("prior result"),
+        .execution = .{ .tool_steps = @constCast(&steps) },
+    } }};
+    var gateway = FakeGateway.init(alloc, &.{});
+    defer gateway.deinit();
+    var hooks = FakeAgentRuntimeDeps.init(alloc);
+    defer hooks.deinit();
+    hooks.context_enabled = true;
+    hooks.context_registry = ApplicableContextDelta.registry;
+    var fixture = PromptFixture{ .workspace_root = workspace };
+    var job = fixture.job();
+    job.history = @constCast(&history);
+    ApplicableContextDelta.reset("", &fixture.cancel_flag);
+    try runFakePrompt(&gateway, &hooks, fixture.config(), job);
+    try std.testing.expect(fixture.cancel_flag.load(.seq_cst));
+    try std.testing.expectEqual(@as(usize, 0), gateway.request_bodies.items.len);
+    try std.testing.expectEqual(@as(usize, 0), hooks.executed_names.items.len);
+    try std.testing.expectEqual(types.TurnPresentationOutcome.interrupted, hooks.finalized_outcome.?);
+    try std.testing.expectEqual(@as(usize, 1), hooks.history_turns.items.len);
+    try std.testing.expect(hooks.history_turns.items[0] == .interrupted);
 }
 
 test "retained project context leaves empty history host context unchanged" {

--- a/src/core/agent/tool_preparation.zig
+++ b/src/core/agent/tool_preparation.zig
@@ -7,6 +7,9 @@ const file_mutation_contract = @import("../tooling/file_mutation_contract.zig");
 const tool_admission = @import("../tooling/tool_admission.zig");
 const tool_dispatch = @import("../tooling/tool_dispatch.zig");
 const workspace_access = @import("../workspace/workspace_access.zig");
+const pathing = @import("../workspace/pathing.zig");
+const debug_trace = @import("../shared/debug_trace.zig");
+const tool_args = @import("../tooling/tool_args.zig");
 
 const Allocator = std.mem.Allocator;
 const ToolCall = types.ToolCall;
@@ -478,6 +481,139 @@ fn freeApplicableTargets(alloc: Allocator, targets: []context_contract.Applicabl
     if (targets.len > 0) alloc.free(targets);
 }
 
+/// Owns only freshly resolved discovery hints, never delivery or permission state.
+pub const RetainedContextTargets = struct {
+    items: []context_contract.ApplicableTarget,
+
+    pub fn deinit(self: *RetainedContextTargets, alloc: Allocator) void {
+        freeApplicableTargets(alloc, self.items);
+        self.* = undefined;
+    }
+};
+
+pub fn retainedContextTargets(
+    alloc: Allocator,
+    history: []const types.HistoryTurn,
+    recovery_execution: ?types.ExecutionMemory,
+    workspace_root: []const u8,
+    registry: tool_dispatch.Registry,
+    cancel_flag: ?*std.atomic.Value(bool),
+) (Allocator.Error || error{Cancelled})!RetainedContextTargets {
+    var collector = RetainedTargetCollector{
+        .alloc = alloc,
+        .workspace_root = workspace_root,
+        .registry = registry,
+        .cancel_flag = cancel_flag,
+    };
+    errdefer {
+        for (collector.targets.items) |target| alloc.free(@constCast(target.path));
+        collector.targets.deinit(alloc);
+    }
+    try checkCancellation(cancel_flag);
+    if (recovery_execution) |execution| try collector.collect(execution);
+    var index = history.len;
+    const first = history.len - @min(history.len, 128);
+    while (index > first and !collector.full()) {
+        index -= 1;
+        const execution = switch (history[index]) {
+            .assistant => |turn| turn.execution,
+            .interrupted => |turn| turn.execution,
+            .compacted_summary => continue,
+        };
+        try collector.collect(execution);
+    }
+    if (index > 0 or collector.full()) {
+        debug_trace.logf("context", "retained_targets_bounded targets={d} steps={d} calls={d}", .{ collector.targets.items.len, collector.steps, collector.calls });
+    }
+    return .{ .items = try collector.targets.toOwnedSlice(alloc) };
+}
+
+const RetainedTargetCollector = struct {
+    alloc: Allocator,
+    workspace_root: []const u8,
+    registry: tool_dispatch.Registry,
+    cancel_flag: ?*std.atomic.Value(bool),
+    targets: std.ArrayList(context_contract.ApplicableTarget) = .empty,
+    steps: usize = 0,
+    calls: usize = 0,
+
+    fn full(self: *const RetainedTargetCollector) bool {
+        return self.targets.items.len == 32 or self.steps == 128 or self.calls == 128;
+    }
+
+    fn collect(self: *RetainedTargetCollector, execution: types.ExecutionMemory) (Allocator.Error || error{Cancelled})!void {
+        var step_index = execution.tool_steps.len;
+        while (step_index > 0 and !self.full()) {
+            step_index -= 1;
+            self.steps += 1;
+            const calls = execution.tool_steps[step_index].tool_calls;
+            var call_index = calls.len;
+            while (call_index > 0 and self.calls < 128 and self.targets.items.len < 32) {
+                call_index -= 1;
+                self.calls += 1;
+                try checkCancellation(self.cancel_flag);
+                try self.collectCall(calls[call_index]);
+            }
+        }
+    }
+
+    fn collectCall(self: *RetainedTargetCollector, call: ToolCall) Allocator.Error!void {
+        if (call.provenance == .provider_executed or call.argument_integrity != .valid or call.arguments_json.len > 64 * 1024) return;
+        const tool = self.registry.lookup(call.name) orelse return;
+        const is_directory = switch (tool.executor_kind) {
+            .glob_files, .grep_files, .terminal, .run_command => true,
+            .read_file, .write_file, .edit_file => false,
+            else => return,
+        };
+        var parsed = std.json.parseFromSlice(std.json.Value, self.alloc, call.arguments_json, .{}) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            else => return,
+        };
+        defer parsed.deinit();
+        if (parsed.value != .object) return;
+        var args = parsed.value.object;
+        const is_command = tool.executor_kind == .terminal or tool.executor_kind == .run_command;
+        if (tool.executor_kind == .terminal) {
+            if (args.get("request")) |request| {
+                if (request != .object) return;
+                args = request.object;
+            }
+            const expected_action = tool.captured_command_action orelse return;
+            const action = tool_args.optionalStringArg(args, "action") orelse return;
+            if (!std.mem.eql(u8, action, expected_action)) return;
+        }
+        const field = if (is_command) "cwd" else "path";
+        const raw_path = if (args.get(field)) |value| switch (value) {
+            .string => if (tool_args.isNullPlaceholderText(value.string) and is_directory) "." else value.string,
+            .null => if (is_directory) "." else return,
+            else => return,
+        } else if (is_directory) "." else return;
+        var path_arena = std.heap.ArenaAllocator.init(self.alloc);
+        defer path_arena.deinit();
+        const resolved = (if (is_directory)
+            pathing.resolveWorkspaceOrExternalPath(path_arena.allocator(), self.workspace_root, raw_path)
+        else
+            pathing.resolveWorkspaceOrExternalCreatePath(path_arena.allocator(), self.workspace_root, raw_path)) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            else => {
+                debug_trace.logf("context", "retained_target_skipped reason={s}", .{@errorName(err)});
+                return;
+            },
+        };
+        if (!pathing.pathInside(self.workspace_root, resolved)) {
+            debug_trace.logf("context", "retained_target_skipped reason=outside_primary_workspace", .{});
+            return;
+        }
+        const directory = if (is_directory) resolved else std.fs.path.dirname(resolved) orelse return;
+        for (self.targets.items) |target| {
+            if (std.mem.eql(u8, target.path, directory)) return;
+        }
+        const owned = try self.alloc.dupe(u8, directory);
+        errdefer self.alloc.free(owned);
+        try self.targets.append(self.alloc, .{ .path = owned, .kind = .directory });
+    }
+};
+
 fn testNoClassification(_: ?*anyopaque, _: Allocator, _: ToolCall) anyerror!?CallbackTerminal {
     return null;
 }
@@ -487,6 +623,57 @@ const test_classifiers: Classifiers = .{
     .validation = testNoClassification,
     .availability = testNoClassification,
 };
+
+fn checkRetainedTargetsAllocations(alloc: Allocator, history: []const types.HistoryTurn, workspace: []const u8, registry: tool_dispatch.Registry) !void {
+    var targets = try retainedContextTargets(alloc, history, null, workspace, registry, null);
+    defer targets.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 2), targets.items.len);
+}
+
+test "retained context targets use bounded typed history without executing calls" {
+    const alloc = std.testing.allocator;
+    const tools = @import("../../builtins/tools.zig");
+    const registry = tool_dispatch.Registry{ .tools = &.{ tools.read_file, tools.write_file, tools.grep_files, tools.shell } };
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(std.testing.io, "nested");
+    const workspace = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(workspace);
+    const calls = [_]ToolCall{
+        .{ .id = "read", .name = "read_file", .arguments_json = "{\"path\":\"nested/missing.txt\"}" },
+        .{ .id = "write", .name = "write_file", .arguments_json = "{\"path\":\"nested/new.txt\"}" },
+        .{ .id = "search", .name = "grep_files", .arguments_json = "{\"query\":\"not a path\"}" },
+        .{ .id = "shell", .name = "shell", .arguments_json = "{\"request\":{\"action\":\"run\",\"command\":\"never execute\",\"cwd\":\"nested\"}}" },
+        .{ .id = "bad", .name = "shell", .arguments_json = "[]" },
+        .{ .id = "external", .name = "read_file", .arguments_json = "{\"path\":\"/tmp/outside.txt\"}" },
+    };
+    const steps = [_]types.ToolExecutionStep{.{ .tool_calls = @constCast(&calls) }};
+    const history = [_]types.HistoryTurn{.{ .assistant = .{
+        .user = .{ .text = @constCast("inspect") },
+        .assistant = @constCast(""),
+        .execution = .{ .tool_steps = @constCast(&steps) },
+    } }};
+    try checkRetainedTargetsAllocations(alloc, &history, workspace, registry);
+    try std.testing.checkAllAllocationFailures(alloc, checkRetainedTargetsAllocations, .{ &history, workspace, registry });
+    var cancelled = std.atomic.Value(bool).init(true);
+    try std.testing.expectError(error.Cancelled, retainedContextTargets(alloc, &history, null, workspace, registry, &cancelled));
+
+    var duplicates = try retainedContextTargets(alloc, &history, history[0].assistant.execution, workspace, registry, null);
+    defer duplicates.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 2), duplicates.items.len);
+}
+
+test "retained context target call budget prevents old target reads" {
+    const alloc = std.testing.allocator;
+    const tools = @import("../../builtins/tools.zig");
+    const registry = tool_dispatch.Registry{ .tools = &.{tools.read_file} };
+    var calls: [129]ToolCall = @splat(.{ .id = "unknown", .name = "unknown", .arguments_json = "{}" });
+    calls[0] = .{ .id = "old", .name = "read_file", .arguments_json = "{\"path\":\"old.txt\"}" };
+    const steps = [_]types.ToolExecutionStep{.{ .tool_calls = &calls }};
+    var targets = try retainedContextTargets(alloc, &.{}, .{ .tool_steps = @constCast(&steps) }, "/tmp", registry, null);
+    defer targets.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 0), targets.items.len);
+}
 
 test "advertised dynamic calls stay opaque while unsupported calls are terminal" {
     const alloc = std.testing.allocator;

--- a/src/core/app/app_agent_runtime.zig
+++ b/src/core/app/app_agent_runtime.zig
@@ -795,6 +795,7 @@ pub fn Runtime(comptime App: type) type {
         pub fn appendStaticContextMessage(
             app: *App,
             arena: Allocator,
+            project_context: ?[]const u8,
             messages: *std.ArrayList(ChatMessage),
             ignored_list_entries: []const []const u8,
             max_list_entries: usize,
@@ -814,7 +815,7 @@ pub fn Runtime(comptime App: type) type {
             _ = gateway_retry_count;
             _ = gateway_chat_url;
             try app.contextRegistry().appendDefaultStatic(.{
-                .project_context = modelVisibleProjectContext(app),
+                .project_context = project_context orelse modelVisibleProjectContext(app),
             }, arena, messages);
             var snapshot = if (comptime @hasDecl(App, "snapshotMcpModelCatalog"))
                 try app.snapshotMcpModelCatalog(
@@ -2077,7 +2078,7 @@ test "app prompt projection configures web search then blocks native execution" 
     const arena = arena_state.allocator();
     var messages: std.ArrayList(ChatMessage) = .empty;
     defer messages.deinit(arena);
-    try Runtime(FakeApp).appendStaticContextMessage(&app, arena, &messages, &test_ignored_list_entries, 100, 1024, 40, 120, 2048, 2, test_gateway_chat_url);
+    try Runtime(FakeApp).appendStaticContextMessage(&app, arena, null, &messages, &test_ignored_list_entries, 100, 1024, 40, 120, 2048, 2, test_gateway_chat_url);
     try app.appendRuntimeContextMessage(arena, &messages);
 
     try std.testing.expectEqualStrings("stale-key", app.web_search_runtime.api_key);
@@ -2550,7 +2551,7 @@ test "app agent runtime appends static and transient context through configured 
     defer messages.deinit(arena);
     app.permission_engine.mode = .auto;
 
-    try Runtime(FakeApp).appendStaticContextMessage(&app, arena, &messages, &test_ignored_list_entries, 100, 1024, 40, 120, 2048, 2, test_gateway_chat_url);
+    try Runtime(FakeApp).appendStaticContextMessage(&app, arena, null, &messages, &test_ignored_list_entries, 100, 1024, 40, 120, 2048, 2, test_gateway_chat_url);
     try Runtime(FakeApp).appendTransientRuntimeContextMessage(&app, arena, &messages, &test_ignored_list_entries, 100, 1024, 40, 120, 2048, 2, test_gateway_chat_url);
 
     try std.testing.expectEqual(@as(usize, 3), messages.items.len);
@@ -2575,7 +2576,7 @@ test "app agent runtime prefers active queued project context snapshot" {
     var messages: std.ArrayList(ChatMessage) = .empty;
     defer messages.deinit(arena);
 
-    try Runtime(FakeApp).appendStaticContextMessage(&app, arena, &messages, &test_ignored_list_entries, 100, 1024, 40, 120, 2048, 2, test_gateway_chat_url);
+    try Runtime(FakeApp).appendStaticContextMessage(&app, arena, null, &messages, &test_ignored_list_entries, 100, 1024, 40, 120, 2048, 2, test_gateway_chat_url);
 
     try std.testing.expectEqual(@as(usize, 2), messages.items.len);
     try std.testing.expectEqualStrings("provider static:queued project context", messages.items[0].content.?);

--- a/src/core/app/app_callbacks.zig
+++ b/src/core/app/app_callbacks.zig
@@ -684,10 +684,10 @@ pub fn Bindings(comptime App: type) type {
             return result;
         }
 
-        fn agentAppendStaticContext(ctx: *anyopaque, arena: Allocator, messages: *std.ArrayList(ChatMessage)) !void {
+        fn agentAppendStaticContext(ctx: *anyopaque, arena: Allocator, project_context: ?[]const u8, messages: *std.ArrayList(ChatMessage)) !void {
             const app: *App = @ptrCast(@alignCast(ctx));
             if (comptime @hasDecl(App, "appendStaticContextMessage")) {
-                try app.appendStaticContextMessage(arena, messages);
+                try app.appendStaticContextMessage(arena, project_context, messages);
             }
         }
 

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -4634,7 +4634,7 @@ const TestContextRegistryFixture = struct {
         defer messages.deinit(arena);
 
         const append_static = deps.append_static_context orelse return error.TestExpectedEqual;
-        try append_static(deps.ctx, arena, &messages);
+        try append_static(deps.ctx, arena, null, &messages);
         try deps.append_runtime_context(deps.ctx, arena, &messages);
         try std.testing.expectEqual(
             ctx.permission_mode,
@@ -4965,7 +4965,7 @@ test "CLI prompt projection configures web search then blocks native execution" 
     defer messages.deinit(arena);
     const deps = agentRuntimeDeps(&ctx);
     const append_static = deps.append_static_context orelse return error.TestExpectedEqual;
-    try append_static(deps.ctx, arena, &messages);
+    try append_static(deps.ctx, arena, null, &messages);
     try deps.append_runtime_context(deps.ctx, arena, &messages);
 
     try std.testing.expectEqualStrings("stale-key", ctx.web_search_runtime.api_key);

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -2154,10 +2154,10 @@ fn appendRuntimeContext(raw_ctx: *anyopaque, arena: Allocator, messages: *std.Ar
     }, arena, messages);
 }
 
-fn appendStaticContext(raw_ctx: *anyopaque, arena: Allocator, messages: *std.ArrayList(ChatMessage)) !void {
+fn appendStaticContext(raw_ctx: *anyopaque, arena: Allocator, project_context: ?[]const u8, messages: *std.ArrayList(ChatMessage)) !void {
     const ctx: *AskContext = @ptrCast(@alignCast(raw_ctx));
     try ctx.deps.context_registry.appendDefaultStatic(.{
-        .project_context = ctx.modelVisibleProjectContext(),
+        .project_context = project_context orelse ctx.modelVisibleProjectContext(),
     }, arena, messages);
     var snapshot = if (ctx.mcp) |mcp|
         try mcp.snapshotModelCatalog(arena, ctx.permission_rules, true)

--- a/src/core/subagent/agent_adapter.zig
+++ b/src/core/subagent/agent_adapter.zig
@@ -497,10 +497,10 @@ fn appendRuntimeContext(raw: *anyopaque, arena: Allocator, messages: *std.ArrayL
     }, arena, messages);
 }
 
-fn appendStaticContext(raw: *anyopaque, arena: Allocator, messages: *std.ArrayList(types.ChatMessage)) !void {
+fn appendStaticContext(raw: *anyopaque, arena: Allocator, project_context: ?[]const u8, messages: *std.ArrayList(types.ChatMessage)) !void {
     const context: *Context = @ptrCast(@alignCast(raw));
     try context.config.context_registry.appendDefaultStatic(.{
-        .project_context = context.config.project_context,
+        .project_context = project_context orelse context.config.project_context,
     }, arena, messages);
     var snapshot = try snapshotModelCatalogForView(
         arena,

--- a/src/core/workspace/context_contract.zig
+++ b/src/core/workspace/context_contract.zig
@@ -130,6 +130,8 @@ pub const InitialContextInput = struct {
     targets: []const ApplicableTarget = &.{},
     omissions: []const ContextOmissionInput = &.{},
     omission_summary: ?ContextOmissionSummary = null,
+    /// Internal request reconstruction only; ordinary gathers retain their work limits.
+    bounded_reconstruction: bool = false,
     context_limits: context_limits.Values = .{},
 };
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -2265,8 +2265,8 @@ const App = struct {
         try AgentAppRuntime.appendTransientRuntimeContextMessage(self, arena, messages, &ignored_list_entries, max_list_entries, max_read_file_bytes, max_read_file_lines, max_read_file_line_len, max_command_output_bytes, builtin_gateway.retry_count, builtin_gateway.defaultChatUrl());
     }
 
-    pub fn appendStaticContextMessage(self: *App, arena: Allocator, messages: *std.ArrayList(ChatMessage)) !void {
-        try AgentAppRuntime.appendStaticContextMessage(self, arena, messages, &ignored_list_entries, max_list_entries, max_read_file_bytes, max_read_file_lines, max_read_file_line_len, max_command_output_bytes, builtin_gateway.retry_count, builtin_gateway.defaultChatUrl());
+    pub fn appendStaticContextMessage(self: *App, arena: Allocator, project_context: ?[]const u8, messages: *std.ArrayList(ChatMessage)) !void {
+        try AgentAppRuntime.appendStaticContextMessage(self, arena, project_context, messages, &ignored_list_entries, max_list_entries, max_read_file_bytes, max_read_file_lines, max_read_file_line_len, max_command_output_bytes, builtin_gateway.retry_count, builtin_gateway.defaultChatUrl());
         if (comptime host_target.is_wasm) {
             try messages.append(arena, .{
                 .role = .system,

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -4882,6 +4882,8 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       const instruction = "NESTED_INSTRUCTION_REFRESH_SENTINEL";
       const command = "cat AGENTS.md && printf 'executed\\n' >> executions.log";
       const finalText = "INSTRUCTION_REFRESH_FINAL";
+      const nextFinalText = "INSTRUCTION_REFRESH_NEXT_TURN_FINAL";
+      const currentInstruction = "NESTED_CURRENT_INSTRUCTION_SENTINEL";
       const refreshLabel = "Reading project instructions before continuing:";
       const header = "● 2 tool calls · 2 commands";
       mkdirSync(join(home, ".fx"), { recursive: true });
@@ -4903,6 +4905,8 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
             : undefined;
           return fakeGatewayFinalText(finalText);
         },
+        fakeShellRun("retained_scope_next_turn", command, { cwd: nested }),
+        fakeGatewayFinalText(nextFinalText),
       ]);
       gateway = refreshGateway;
       session = await TmuxSession.create({
@@ -4947,6 +4951,21 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       for (const output of [compact, escapes]) {
         expect(output).not.toMatch(/command not run|project instructions changed|\bfailed\b/i);
       }
+
+      writeFileSync(join(nested, "AGENTS.md"), `${currentInstruction}\n`);
+      await session.sendText("Run that same command once more.");
+      await session.waitForText(nextFinalText, TIMEOUT);
+      await session.waitForComposer(TIMEOUT);
+      expect(refreshGateway.requests).toHaveLength(5);
+      const nextInstructions = (parseGatewayRequest(refreshGateway.requests[3]!.body).prompt ?? [])
+        .filter((message) => message.role === "system")
+        .map((message) => contentText(message.content)).join("\n");
+      expect(nextInstructions).toContain(currentInstruction);
+      expect(nextInstructions).not.toContain(instruction);
+      expect(readFileSync(markerPath, "utf8")).toBe("executed\nexecuted\n");
+      expect(countOccurrences(await session.captureFullScrollback(), refreshLabel))
+        .toBe(countOccurrences(compact, refreshLabel));
+      expect(hasEmptyComposer(await session.capturePane())).toBe(true);
       expect(session.isAlive()).toBe(true);
       expect(session.isPaneAlive()).toBe(true);
       await session.sendText("/quit");


### PR DESCRIPTION
## Summary

- Load scoped project instructions from recent tool targets before planning continued turns, avoiding repeated instruction-only retries.
- Refresh queued instruction snapshots from current files when restoring prior scopes, including changed or deleted rules.
- Bound instruction reconstruction without suppressing live discovery of rules omitted by its work limits.