### PR TITLE
Preserve session ownership and report save failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,9 @@ Repeated continuation reuses validated summaries of unchanged older sessions ins
 
 Older sessions that saved Vercel connection settings can be opened through `-r`, `/resume`, `-c`, or an exact ID. Migration preserves their model settings and keeps unfinished responses as interrupted history, without replaying old requests or restoring saved credential references.
 
-If a saved conversation is damaged, run `fx session recover <id>` to copy its validated prefix into a new session. Recovery preserves checkpoint boundaries and referenced result files, leaves the original unchanged, and prints the new session ID. Records after the damaged boundary are not included, and recovery does not rerun commands. Healthy conversations can be resumed without recovery.
+If a saved conversation is damaged, run `fx session recover <id>` to copy its validated prefix into a new session. Recovery preserves checkpoint boundaries and referenced result files, leaves the original unchanged, and prints the new session ID. Records after the damaged boundary are not included, and recovery does not rerun commands. If only usage accounting is corrupt, recovery keeps the conversation and marks historical usage as incomplete in the copy; the original accounting file remains unchanged. Healthy conversations can be resumed without recovery.
+
+After an idle session is suspended with Ctrl+Z, foregrounding it reloads saved changes from other writers before accepting another turn. Quitting reports a failed history or usage save with a warning and a nonzero exit status instead of printing the normal resume hint.
 
 New sessions appear in resume selection only after their initial files are ready. Incomplete creation folders left by older builds do not block healthy conversations from resuming with `-c`; those folders remain available for diagnosis and are not deleted.
 
@@ -120,6 +122,8 @@ Run `/feedback` to open the feedback form at `fx.sh/feedback`. It does not creat
 Run `/trace` to create a private Markdown diagnostic with logs, session context, runtime state, permissions, and recent activity. On macOS, fx copies the `.md` file to the clipboard; on other platforms, it saves the file and prints its path. Review and redact the trace before sharing it.
 
 fx automatically summarizes a long session into a fresh context window when the active model request reaches 80% of its usable input capacity, then continues the same turn. Run `/compact` to create the same durable handoff immediately and wait for your next prompt. Manual compaction refreshes the selected login when needed; Ctrl+C cancels preparation. If authentication fails, the chat stays open and unchanged so you can reconnect and retry `/compact`.
+
+A failed checkpoint write is rolled back before fx reports it as rejected, so reopening does not apply that checkpoint. If rollback itself fails, fx reports `ConversationAppendIndeterminate` and refuses further writes through that session handle; the saved outcome must be checked on reopening.
 
 Compaction handoffs remain internal context for the model. Resuming a session and opening its full transcript show the conversation and tool activity, not internal summaries or operation ledgers.
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Older sessions that saved Vercel connection settings can be opened through `-r`,
 
 If a saved conversation is damaged, run `fx session recover <id>` to copy its validated prefix into a new session. Recovery preserves checkpoint boundaries and referenced result files, leaves the original unchanged, and prints the new session ID. Records after the damaged boundary are not included, and recovery does not rerun commands. If only usage accounting is corrupt, recovery keeps the conversation and marks historical usage as incomplete in the copy; the original accounting file remains unchanged. Healthy conversations can be resumed without recovery.
 
-After an idle session is suspended with Ctrl+Z, foregrounding it reloads saved changes from other writers before accepting another turn. Quitting reports a failed history or usage save with a warning and a nonzero exit status instead of printing the normal resume hint.
+A saved session has one writer until that session closes. Suspending it with Ctrl+Z keeps its lock, so another process trying to resume the same session gets `SessionBusy`. Foregrounding preserves the current conversation and draft without reloading them. Quitting reports a failed history or usage save with a warning and a nonzero exit status instead of printing the normal resume hint.
 
 New sessions appear in resume selection only after their initial files are ready. Incomplete creation folders left by older builds do not block healthy conversations from resuming with `-c`; those folders remain available for diagnosis and are not deleted.
 

--- a/src/core/app/app_entry_runtime.zig
+++ b/src/core/app/app_entry_runtime.zig
@@ -316,11 +316,15 @@ fn runInteractiveWithDeps(comptime App: type, comptime cooperative: bool, alloc:
         app.startModelCacheWarmup();
     }
 
+    var terminal_input_closed = false;
     app.run() catch |err| {
         app.releaseTerminal();
-        if (err == error.TerminalInputClosed) return .returned;
-        reportUnexpectedInteractiveError(deps, err);
-        return err;
+        if (err == error.TerminalInputClosed) {
+            terminal_input_closed = true;
+        } else {
+            reportUnexpectedInteractiveError(deps, err);
+            return err;
+        }
     };
     const relaunch_request: ?auto_upgrade.RelaunchRequest = if (comptime cooperative)
         null
@@ -342,7 +346,19 @@ fn runInteractiveWithDeps(comptime App: type, comptime cooperative: bool, alloc:
     const handoff_value = if (comptime cooperative) blk: {
         app.deinit();
         break :blk null;
-    } else app.deinitWithResumeHandoff();
+    } else app.deinitWithResumeHandoff() catch |err| {
+        var buffer: [256]u8 = undefined;
+        const message = std.fmt.bufPrint(&buffer, "fx: session save failed during shutdown: {s}. Unsaved work may be missing.\n", .{@errorName(err)}) catch "fx: session save failed during shutdown.\n";
+        writeStderr(deps, message);
+        return .{ .exit = 1 };
+    };
+    if (terminal_input_closed) {
+        if (handoff_value) |value| {
+            var handoff = value;
+            handoff.deinit(alloc);
+        }
+        return .returned;
+    }
     if (relaunch_request) |request| {
         if (handoff_value) |value| {
             var handoff = value;
@@ -623,6 +639,7 @@ const TestCapture = struct {
     record_stderr_event: bool = false,
     record_stdout_event: bool = false,
     resume_handoff_id: ?[]const u8 = null,
+    shutdown_error: ?anyerror = null,
     raise_sigint_during_deinit: bool = false,
     upgrade_relaunch_path: ?[]const u8 = null,
     upgrade_previous_revision: ?[]const u8 = null,
@@ -756,7 +773,11 @@ const TestApp = struct {
         self.* = undefined;
     }
 
-    fn deinitWithResumeHandoff(self: *TestApp) ?app_session_runtime.ResumeHandoff {
+    fn deinitWithResumeHandoff(self: *TestApp) !?app_session_runtime.ResumeHandoff {
+        if (active_capture.?.shutdown_error) |err| {
+            self.deinit();
+            return err;
+        }
         const handoff: ?app_session_runtime.ResumeHandoff = if (active_capture.?.resume_handoff_id) |id| blk: {
             const session_id = std.testing.allocator.dupe(u8, id) catch {
                 self.deinit();
@@ -1100,6 +1121,19 @@ test "app entry reports unexpected init errors once and preserves identity" {
     try expectEvents(&.{ "init:none", "stderr-attempt" });
 }
 
+test "app entry reports shutdown save failure after cleanup without a resume hint" {
+    const alloc = std.testing.allocator;
+    var capture = TestCapture.init(.{ .interactive = .{} });
+    defer capture.deinit();
+    capture.shutdown_error = error.InputOutput;
+    capture.resume_handoff_id = "session-123";
+    const outcome = try runWithDeps(TestApp, alloc, &.{}, testConfig(), capture.deps());
+    try std.testing.expectEqual(RunOutcome{ .exit = 1 }, outcome);
+    try std.testing.expect(std.mem.find(u8, capture.stderr.written(), "session save failed during shutdown: InputOutput") != null);
+    try std.testing.expectEqualStrings("", capture.stdout.written());
+    try expectEvents(&.{ "init:none", "mcp-discovery", "rebind-after-init", "auto-upgrade", "file-index", "worker-thread", "model-cache", "run", "terminal-release", "deinit" });
+}
+
 test "app entry releases terminal before reporting worker start errors" {
     const alloc = std.testing.allocator;
     var capture = TestCapture.init(.{ .interactive = .{} });
@@ -1201,6 +1235,19 @@ test "app entry treats terminal input closure as abnormal cleanup without stderr
         "terminal-release",
         "deinit",
     });
+}
+
+test "app entry reports shutdown save failure after terminal input closes" {
+    const alloc = std.testing.allocator;
+    var capture = TestCapture.init(.{ .interactive = .{} });
+    defer capture.deinit();
+    capture.run_error = error.TerminalInputClosed;
+    capture.shutdown_error = error.InputOutput;
+    capture.resume_handoff_id = "session-123";
+    const outcome = try runWithDeps(TestApp, alloc, &.{}, testConfig(), capture.deps());
+    try std.testing.expectEqual(RunOutcome{ .exit = 1 }, outcome);
+    try std.testing.expect(std.mem.find(u8, capture.stderr.written(), "session save failed during shutdown") != null);
+    try std.testing.expectEqualStrings("", capture.stdout.written());
 }
 
 test "app entry preserves run errors when fatal formatting fails" {

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -21,7 +21,6 @@ const provider_runtime = @import("provider_runtime.zig");
 const input_completion_runtime = @import("input_completion_runtime.zig");
 const image_attachments = @import("../images/image_attachments.zig");
 const core_input_runtime = @import("../input/runtime.zig");
-const composer_history = @import("../input/composer_history.zig");
 const io_mod = @import("../shared/io.zig");
 const list_window = @import("../shared/list_window.zig");
 const text_utils = @import("../shared/text_utils.zig");
@@ -2747,24 +2746,10 @@ pub fn Runtime(comptime App: type) type {
         }
 
         pub fn finalizePersistence(app: *App) void {
-            if (app.session_persistence.writable) |*loaded| {
-                if (loaded.log.isParked()) {
-                    app.session_persistence.resume_handoff_intent = .none;
-                    abandonParkedWritableSession(app);
-                    return;
-                }
-            }
             closeWritableSession(app);
         }
 
         pub fn finalizePersistenceWithResumeHandoff(app: *App) !?ResumeHandoff {
-            if (app.session_persistence.writable) |*loaded| {
-                if (loaded.log.isParked()) {
-                    app.session_persistence.resume_handoff_intent = .none;
-                    abandonParkedWritableSession(app);
-                    return null;
-                }
-            }
             return closeWritableSessionWithResumeHandoff(app);
         }
 
@@ -2787,124 +2772,12 @@ pub fn Runtime(comptime App: type) type {
         }
 
         pub fn suspendToJobControl(app: *App, footer_rows: u16) !void {
-            if (!shell_runtime.supports_resize_signal) return;
-            if (!tryBeginIdleSessionPark(app)) {
-                return app_lifecycle.suspendToJobControl(
-                    &app.terminal,
-                    &app.shell,
-                    &app.metrics,
-                    footer_rows,
-                );
-            }
-            defer app.worker.releaseTurnStartHold();
-
-            app.session.usage.cancelReconciliation();
-            app.session.usage.finishProfilePublicationsBeforeShutdown();
-            app.session.usage.checkpoint_mutex.lockUncancelable(io_mod.getIo());
-            const checkpoint_sink = app.session.usage.checkpoint_sink;
-            app.session.usage.checkpoint_sink = null;
-            app.session.usage.checkpoint_mutex.unlock(io_mod.getIo());
-            defer if (app.session_persistence.writable != null) app.session.usage.configureCheckpointSink(checkpoint_sink);
-            try prepareResumeHandoff(app);
-            const loaded = &app.session_persistence.writable.?;
-            loaded.log.park();
-            debug_trace.logf(
-                "session",
-                "parked writer lock for suspend session={s}",
-                .{loaded.active_id},
-            );
-
-            const lifecycle_result = app_lifecycle.suspendToJobControl(
+            return app_lifecycle.suspendToJobControl(
                 &app.terminal,
                 &app.shell,
                 &app.metrics,
                 footer_rows,
             );
-            refresh_parked_session(app) catch |err| {
-                debug_trace.logf("session", "unpark after suspend failed err={s}", .{@errorName(err)});
-                abandonParkedWritableSession(app);
-                app.worker.requestStop();
-                app.should_exit = true;
-                try lifecycle_result;
-                return err;
-            };
-
-            debug_trace.logf(
-                "session",
-                "unparked writer lock after suspend session={s}",
-                .{app.session_persistence.writable.?.active_id},
-            );
-            startResumedSessionReconciliation(app);
-            try lifecycle_result;
-        }
-
-        fn refresh_parked_session(app: *App) !void {
-            const parked = if (app.session_persistence.writable) |*value| value else return error.SessionPersistenceUnavailable;
-            if (!parked.log.isParked()) return error.SessionBusy;
-            const id = try app.alloc.dupe(u8, parked.active_id);
-            defer app.alloc.free(id);
-            var fresh = try loadResumeTargetForWrite(app, .{ .id = id }, .{});
-            var fresh_owned = true;
-            defer if (fresh_owned) fresh.deinit(app.alloc);
-            var display = try readNativeResumeDisplay(app, &fresh);
-            defer display.deinit(app.alloc);
-            const previous_next_image_id = app.next_image_id;
-            // The parked snapshot cannot settle state after another writer ran.
-            parked.deinit(app.alloc);
-            app.session_persistence.writable = fresh;
-            fresh_owned = false;
-            errdefer {
-                app.session_persistence.writable.?.deinit(app.alloc);
-                app.session_persistence.writable = null;
-            }
-            const active = &app.session_persistence.writable.?;
-            try hydrateResumedSession(app, active.state, display.title, .session);
-            var rebase_images = false;
-            for (app.pending_images.items) |image| {
-                if (image.id < app.next_image_id) rebase_images = true;
-            }
-            app.next_image_id = @max(app.next_image_id, previous_next_image_id);
-            if (rebase_images) {
-                app.next_image_id = try composer_history.rebase_active_images(
-                    app.alloc,
-                    &app.input_runtime.edit_state,
-                    &app.input_runtime.entities,
-                    &app.pending_images,
-                    app.next_image_id,
-                );
-            }
-            active.releaseHydrationHistory(app.alloc);
-            configureWebFetchArtifacts(app, active);
-        }
-
-        fn tryBeginIdleSessionPark(app: *App) bool {
-            if (app.session_persistence.writable == null or app.stream.active) {
-                return false;
-            }
-            return app.worker.tryHoldTurnStart();
-        }
-
-        /// Tear down a parked writable without converging or checkpointing.
-        fn abandonParkedWritableSession(app: *App) void {
-            discardAnyPendingCancelledCommand(app, "writable_session_abandon");
-            const loaded = if (app.session_persistence.writable) |*value|
-                value
-            else
-                return;
-            if (comptime @hasDecl(
-                @TypeOf(app.session),
-                "clearWebFetchArtifacts",
-            )) {
-                app.session.clearWebFetchArtifacts();
-            }
-            disableSubagentHost(app);
-            debug_trace.logf(
-                "session",
-                "abandon parked writable session={s}",
-                .{loaded.active_id},
-            );
-            loaded.deinit(app.alloc);
-            app.session_persistence.writable = null;
         }
 
         pub fn deinitPersistence(app: *App) void {
@@ -7291,7 +7164,7 @@ test "interactive session resume uses the live transition and shared restore pat
     );
 }
 
-test "parked session reload preserves other writer history and the local draft" {
+test "open session keeps exclusive writer ownership until close" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -7309,41 +7182,16 @@ test "parked session reload preserves other writer history and the local draft" 
         .user = .{ .text = @constCast("original") },
         .assistant = @constCast("original answer"),
     } });
-    Runtime(TestApp).enableSessionStores(&app);
-    const host = app.session_persistence.subagent_host;
-    try app.input_runtime.edit_state.input.appendSlice(alloc, "local unfinished draft");
-    app.next_image_id = 17;
     const id = try alloc.dupe(u8, app.session_persistence.writable.?.active_id);
     defer alloc.free(id);
-    app.session_persistence.writable.?.log.park();
-    {
-        var other = try Runtime(TestApp).loadResumeTargetForWrite(&app, .{ .id = id }, .{});
-        defer other.deinit(alloc);
-        _ = try other.appendEvent(alloc, .{ .history_turn_committed = .{
-            .conversation_language = session_runtime.ConversationLanguage.literal("en"),
-            .total_input_tokens = 0,
-            .total_output_tokens = 0,
-            .turn = .{ .assistant = .{
-                .user = .{ .text = @constCast("other writer") },
-                .assistant = @constCast("other committed answer"),
-            } },
-        } }, io_mod.milliTimestamp());
-    }
-    try Runtime(TestApp).refresh_parked_session(&app);
-    try std.testing.expectEqual(@as(usize, 2), app.session.historyLen());
-    try std.testing.expectEqualStrings("other committed answer", app.session.agent.history.items[1].assistant.assistant);
+    try app.input_runtime.edit_state.input.appendSlice(alloc, "local unfinished draft");
+    try std.testing.expectError(error.SessionBusy, Runtime(TestApp).loadResumeTargetForWrite(&app, .{ .id = id }, .{ .session_lock_deadline_ms = 1 }));
     try std.testing.expectEqualStrings("local unfinished draft", app.input_runtime.edit_state.input.items);
-    try std.testing.expectEqual(@as(usize, 17), app.next_image_id);
-    try std.testing.expect(app.session_persistence.subagent_host == host);
-    try Runtime(TestApp).appendHistoryTurn(&app, .{ .assistant = .{
-        .user = .{ .text = @constCast("continued") },
-        .assistant = @constCast("continued answer"),
-    } });
     Runtime(TestApp).finalizePersistence(&app);
-    var cold = try app.session_persistence.store.?.loadReadOnly(alloc, id);
-    defer cold.deinit(alloc);
-    try std.testing.expectEqual(@as(usize, 3), cold.history.len);
-    try std.testing.expectEqualStrings("other committed answer", cold.history[1].assistant.assistant);
+    var next = try Runtime(TestApp).loadResumeTargetForWrite(&app, .{ .id = id }, .{});
+    defer next.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 1), next.state.history.len);
+    try std.testing.expectEqualStrings("original answer", next.state.history[0].assistant.assistant);
 }
 
 test "interactive session resume preserves the current writer when the target is unavailable" {

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -21,6 +21,7 @@ const provider_runtime = @import("provider_runtime.zig");
 const input_completion_runtime = @import("input_completion_runtime.zig");
 const image_attachments = @import("../images/image_attachments.zig");
 const core_input_runtime = @import("../input/runtime.zig");
+const composer_history = @import("../input/composer_history.zig");
 const io_mod = @import("../shared/io.zig");
 const list_window = @import("../shared/list_window.zig");
 const text_utils = @import("../shared/text_utils.zig");
@@ -2168,6 +2169,7 @@ pub fn Runtime(comptime App: type) type {
                 value
             else
                 return error.SessionPersistenceUnavailable;
+            try loaded.ensure_writable();
             const recovery_checkpoint = try store.prepareUsageRecoveryCheckpoint(
                 app.alloc,
                 loaded,
@@ -2469,6 +2471,7 @@ pub fn Runtime(comptime App: type) type {
                 } },
                 io_mod.milliTimestamp(),
             ) catch |err| {
+                if (err == error.ConversationAppendIndeterminate or err == error.StaleConversationWriter) return err;
                 return switch (mode) {
                     .strict => err,
                     .visual_epoch => blk: {
@@ -2754,7 +2757,7 @@ pub fn Runtime(comptime App: type) type {
             closeWritableSession(app);
         }
 
-        pub fn finalizePersistenceWithResumeHandoff(app: *App) ?ResumeHandoff {
+        pub fn finalizePersistenceWithResumeHandoff(app: *App) !?ResumeHandoff {
             if (app.session_persistence.writable) |*loaded| {
                 if (loaded.log.isParked()) {
                     app.session_persistence.resume_handoff_intent = .none;
@@ -2795,6 +2798,14 @@ pub fn Runtime(comptime App: type) type {
             }
             defer app.worker.releaseTurnStartHold();
 
+            app.session.usage.cancelReconciliation();
+            app.session.usage.finishProfilePublicationsBeforeShutdown();
+            app.session.usage.checkpoint_mutex.lockUncancelable(io_mod.getIo());
+            const checkpoint_sink = app.session.usage.checkpoint_sink;
+            app.session.usage.checkpoint_sink = null;
+            app.session.usage.checkpoint_mutex.unlock(io_mod.getIo());
+            defer if (app.session_persistence.writable != null) app.session.usage.configureCheckpointSink(checkpoint_sink);
+            try prepareResumeHandoff(app);
             const loaded = &app.session_persistence.writable.?;
             loaded.log.park();
             debug_trace.logf(
@@ -2809,25 +2820,61 @@ pub fn Runtime(comptime App: type) type {
                 &app.metrics,
                 footer_rows,
             );
-            loaded.log.unpark() catch |err| {
-                debug_trace.logf(
-                    "session",
-                    "unpark after suspend failed session={s} err={s}",
-                    .{ loaded.active_id, @errorName(err) },
-                );
+            refresh_parked_session(app) catch |err| {
+                debug_trace.logf("session", "unpark after suspend failed err={s}", .{@errorName(err)});
                 abandonParkedWritableSession(app);
                 app.worker.requestStop();
                 app.should_exit = true;
                 try lifecycle_result;
-                return;
+                return err;
             };
 
             debug_trace.logf(
                 "session",
                 "unparked writer lock after suspend session={s}",
-                .{loaded.active_id},
+                .{app.session_persistence.writable.?.active_id},
             );
+            startResumedSessionReconciliation(app);
             try lifecycle_result;
+        }
+
+        fn refresh_parked_session(app: *App) !void {
+            const parked = if (app.session_persistence.writable) |*value| value else return error.SessionPersistenceUnavailable;
+            if (!parked.log.isParked()) return error.SessionBusy;
+            const id = try app.alloc.dupe(u8, parked.active_id);
+            defer app.alloc.free(id);
+            var fresh = try loadResumeTargetForWrite(app, .{ .id = id }, .{});
+            var fresh_owned = true;
+            defer if (fresh_owned) fresh.deinit(app.alloc);
+            var display = try readNativeResumeDisplay(app, &fresh);
+            defer display.deinit(app.alloc);
+            const previous_next_image_id = app.next_image_id;
+            // The parked snapshot cannot settle state after another writer ran.
+            parked.deinit(app.alloc);
+            app.session_persistence.writable = fresh;
+            fresh_owned = false;
+            errdefer {
+                app.session_persistence.writable.?.deinit(app.alloc);
+                app.session_persistence.writable = null;
+            }
+            const active = &app.session_persistence.writable.?;
+            try hydrateResumedSession(app, active.state, display.title, .session);
+            var rebase_images = false;
+            for (app.pending_images.items) |image| {
+                if (image.id < app.next_image_id) rebase_images = true;
+            }
+            app.next_image_id = @max(app.next_image_id, previous_next_image_id);
+            if (rebase_images) {
+                app.next_image_id = try composer_history.rebase_active_images(
+                    app.alloc,
+                    &app.input_runtime.edit_state,
+                    &app.input_runtime.entities,
+                    &app.pending_images,
+                    app.next_image_id,
+                );
+            }
+            active.releaseHydrationHistory(app.alloc);
+            configureWebFetchArtifacts(app, active);
         }
 
         fn tryBeginIdleSessionPark(app: *App) bool {
@@ -4155,10 +4202,12 @@ pub fn Runtime(comptime App: type) type {
 
         fn closeWritableSession(app: *App) void {
             app.session_persistence.resume_handoff_intent = .none;
-            _ = closeWritableSessionWithResumeHandoff(app);
+            _ = closeWritableSessionWithResumeHandoff(app) catch |err| {
+                debug_trace.logf("session", "final persistence settlement failed err={s}", .{@errorName(err)});
+            };
         }
 
-        fn closeWritableSessionWithResumeHandoff(app: *App) ?ResumeHandoff {
+        fn closeWritableSessionWithResumeHandoff(app: *App) !?ResumeHandoff {
             const handoff_intent = app.session_persistence.resume_handoff_intent;
             app.session_persistence.resume_handoff_intent = .none;
             if (comptime @hasField(@TypeOf(app.session), "usage")) {
@@ -4169,58 +4218,24 @@ pub fn Runtime(comptime App: type) type {
             app.session_persistence.write_mutex.lockUncancelable(io_mod.getIo());
             defer app.session_persistence.write_mutex.unlock(io_mod.getIo());
             discardAnyPendingCancelledCommand(app, "writable_session_close");
-            const loaded = if (app.session_persistence.writable) |*value|
-                value
-            else
+            const loaded = if (app.session_persistence.writable) |*value| value else return null;
+            defer {
+                if (comptime @hasDecl(@TypeOf(app.session), "clearWebFetchArtifacts")) app.session.clearWebFetchArtifacts();
+                disableSubagentHost(app);
+                loaded.deinit(app.alloc);
+                app.session_persistence.writable = null;
+            }
+            try settleDurableState(app, loaded);
+            if (!shouldCreateResumeHandoff(.{
+                .intent = handoff_intent,
+                .has_writable_session = true,
+                .is_pristine = session_store.isPristineStartedSession(loaded),
+            })) return null;
+            const session_id = app.alloc.dupe(u8, loaded.active_id) catch |err| {
+                debug_trace.logf("session", "resume handoff unavailable session={s} err={s}", .{ loaded.active_id, @errorName(err) });
                 return null;
-            var resume_boundary_valid = false;
-            if (handoff_intent != .none) {
-                var settlement_failed = false;
-                settleDurableState(app, loaded) catch |err| {
-                    settlement_failed = true;
-                    debug_trace.logf(
-                        "session",
-                        "resume handoff boundary invalid session={s} err={s}",
-                        .{ loaded.active_id, @errorName(err) },
-                    );
-                };
-                resume_boundary_valid = !settlement_failed;
-            } else {
-                settleDurableState(app, loaded) catch |err| {
-                    debug_trace.logf(
-                        "session",
-                        "final persistence settlement failed session={s} err={s}",
-                        .{ loaded.active_id, @errorName(err) },
-                    );
-                };
-            }
-            const should_create_handoff = resume_boundary_valid and
-                shouldCreateResumeHandoff(.{
-                    .intent = handoff_intent,
-                    .has_writable_session = true,
-                    .is_pristine = session_store.isPristineStartedSession(loaded),
-                });
-            const handoff: ?ResumeHandoff = if (should_create_handoff) blk: {
-                const session_id = app.alloc.dupe(u8, loaded.active_id) catch |err| {
-                    debug_trace.logf(
-                        "session",
-                        "resume handoff unavailable session={s} err={s}",
-                        .{ loaded.active_id, @errorName(err) },
-                    );
-                    break :blk null;
-                };
-                break :blk .{ .session_id = session_id };
-            } else null;
-            if (comptime @hasDecl(
-                @TypeOf(app.session),
-                "clearWebFetchArtifacts",
-            )) {
-                app.session.clearWebFetchArtifacts();
-            }
-            disableSubagentHost(app);
-            loaded.deinit(app.alloc);
-            app.session_persistence.writable = null;
-            return handoff;
+            };
+            return .{ .session_id = session_id };
         }
 
         fn configureWebFetchArtifacts(
@@ -4337,6 +4352,7 @@ pub fn Runtime(comptime App: type) type {
             app: *App,
             loaded: *session_store.LoadedWritableSession,
         ) !void {
+            try loaded.ensure_writable();
             const usage_dirty = if (comptime @hasField(@TypeOf(app.session), "usage"))
                 app.session.usage.isDirty()
             else
@@ -5753,7 +5769,7 @@ test "resume handoff suppresses missing and pristine writable sessions" {
     defer app.deinit();
 
     Runtime(TestApp).requestResumeHandoff(&app);
-    try std.testing.expect(Runtime(TestApp).finalizePersistenceWithResumeHandoff(&app) == null);
+    try std.testing.expect((try Runtime(TestApp).finalizePersistenceWithResumeHandoff(&app)) == null);
     try std.testing.expectEqual(
         ResumeHandoffIntent.none,
         app.session_persistence.resume_handoff_intent,
@@ -5764,7 +5780,7 @@ test "resume handoff suppresses missing and pristine writable sessions" {
     try Runtime(TestApp).beginFreshPersistedSession(&app);
     Runtime(TestApp).requestResumeHandoff(&app);
 
-    try std.testing.expect(Runtime(TestApp).finalizePersistenceWithResumeHandoff(&app) == null);
+    try std.testing.expect((try Runtime(TestApp).finalizePersistenceWithResumeHandoff(&app)) == null);
     try std.testing.expect(app.session_persistence.writable == null);
 }
 
@@ -5791,7 +5807,7 @@ test "upgrade resume handoff owns a validated pristine session" {
     defer alloc.free(expected_id);
     Runtime(TestApp).requestUpgradeResumeHandoff(&app);
 
-    var handoff = Runtime(TestApp).finalizePersistenceWithResumeHandoff(&app) orelse
+    var handoff = (try Runtime(TestApp).finalizePersistenceWithResumeHandoff(&app)) orelse
         return error.TestExpectedResumeHandoff;
     defer handoff.deinit(alloc);
 
@@ -5824,7 +5840,7 @@ test "resume handoff owns the exact non-pristine session id" {
     defer alloc.free(expected_id);
     Runtime(TestApp).requestResumeHandoff(&app);
 
-    var handoff = Runtime(TestApp).finalizePersistenceWithResumeHandoff(&app) orelse
+    var handoff = (try Runtime(TestApp).finalizePersistenceWithResumeHandoff(&app)) orelse
         return error.TestExpectedResumeHandoff;
     defer handoff.deinit(alloc);
 
@@ -5864,7 +5880,7 @@ test "resume handoff requires no derived cache write" {
     if (std.c.chmod(session_dir_z.ptr, 0o500) != 0) return error.TestChmodFailed;
     defer _ = std.c.chmod(session_dir_z.ptr, 0o700);
     Runtime(TestApp).requestResumeHandoff(&app);
-    var handoff = Runtime(TestApp).closeWritableSessionWithResumeHandoff(&app) orelse
+    var handoff = (try Runtime(TestApp).closeWritableSessionWithResumeHandoff(&app)) orelse
         return error.TestExpectedResumeHandoff;
     defer handoff.deinit(alloc);
 
@@ -5893,7 +5909,7 @@ test "resume handoff suppresses session id allocation failure" {
     Runtime(TestApp).requestResumeHandoff(&app);
     var failing = std.testing.FailingAllocator.init(alloc, .{ .fail_index = 0 });
     app.alloc = failing.allocator();
-    const handoff = Runtime(TestApp).finalizePersistenceWithResumeHandoff(&app);
+    const handoff = try Runtime(TestApp).finalizePersistenceWithResumeHandoff(&app);
     app.alloc = alloc;
 
     try std.testing.expect(failing.has_induced_failure);
@@ -7273,6 +7289,61 @@ test "interactive session resume uses the live transition and shared restore pat
         subagent_tool_host.RecoveryState.complete,
         host.recoveryState(),
     );
+}
+
+test "parked session reload preserves other writer history and the local draft" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const paths = try testPaths(alloc, &tmp);
+    defer alloc.free(paths.home);
+    defer alloc.free(paths.workspace);
+    const home = try TestHome.install(alloc, paths.home);
+    defer home.deinit();
+    var app = try TestApp.init(alloc, paths.workspace);
+    defer app.deinit();
+    try configureTestPreferences(&app);
+    try Runtime(TestApp).initializePersistence(&app, true);
+    try Runtime(TestApp).beginFreshPersistedSession(&app);
+    try Runtime(TestApp).appendHistoryTurn(&app, .{ .assistant = .{
+        .user = .{ .text = @constCast("original") },
+        .assistant = @constCast("original answer"),
+    } });
+    Runtime(TestApp).enableSessionStores(&app);
+    const host = app.session_persistence.subagent_host;
+    try app.input_runtime.edit_state.input.appendSlice(alloc, "local unfinished draft");
+    app.next_image_id = 17;
+    const id = try alloc.dupe(u8, app.session_persistence.writable.?.active_id);
+    defer alloc.free(id);
+    app.session_persistence.writable.?.log.park();
+    {
+        var other = try Runtime(TestApp).loadResumeTargetForWrite(&app, .{ .id = id }, .{});
+        defer other.deinit(alloc);
+        _ = try other.appendEvent(alloc, .{ .history_turn_committed = .{
+            .conversation_language = session_runtime.ConversationLanguage.literal("en"),
+            .total_input_tokens = 0,
+            .total_output_tokens = 0,
+            .turn = .{ .assistant = .{
+                .user = .{ .text = @constCast("other writer") },
+                .assistant = @constCast("other committed answer"),
+            } },
+        } }, io_mod.milliTimestamp());
+    }
+    try Runtime(TestApp).refresh_parked_session(&app);
+    try std.testing.expectEqual(@as(usize, 2), app.session.historyLen());
+    try std.testing.expectEqualStrings("other committed answer", app.session.agent.history.items[1].assistant.assistant);
+    try std.testing.expectEqualStrings("local unfinished draft", app.input_runtime.edit_state.input.items);
+    try std.testing.expectEqual(@as(usize, 17), app.next_image_id);
+    try std.testing.expect(app.session_persistence.subagent_host == host);
+    try Runtime(TestApp).appendHistoryTurn(&app, .{ .assistant = .{
+        .user = .{ .text = @constCast("continued") },
+        .assistant = @constCast("continued answer"),
+    } });
+    Runtime(TestApp).finalizePersistence(&app);
+    var cold = try app.session_persistence.store.?.loadReadOnly(alloc, id);
+    defer cold.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 3), cold.history.len);
+    try std.testing.expectEqualStrings("other committed answer", cold.history[1].assistant.assistant);
 }
 
 test "interactive session resume preserves the current writer when the target is unavailable" {

--- a/src/core/input/composer_history.zig
+++ b/src/core/input/composer_history.zig
@@ -330,6 +330,29 @@ const Snapshot = struct {
     }
 };
 
+/// Rebinds a live draft to a refreshed session. Snapshot filenames carry image
+/// identity, so verified replacements must exist before releasing old ownership.
+pub fn rebase_active_images(alloc: Allocator, edit: *editor_state.State, entities: *registered_entities.State, images: *ImageBlocks, first_image_id: usize) !usize {
+    if (images.items.len == 0) return first_image_id;
+    var original = try Snapshot.initCopy(alloc, edit.input.items, entities.pasted_blocks.items, images.items, entities.image_tokens.items, entities.skill_tokens.items);
+    defer original.deinit(alloc);
+    var prepared = try original.prepareRecall(alloc, first_image_id);
+    defer prepared.deinit(alloc);
+    const next_id = try std.math.add(usize, first_image_id, images.items.len);
+    const cursor = image_attachments.projectOffsetThroughPlaceholderRewrite(original.image_tokens.items, prepared.image_tokens.items, original.text.items.len, edit.cursor) orelse return error.InvalidPromptHistorySnapshot;
+    const anchor = if (edit.selection_anchor) |offset| image_attachments.projectOffsetThroughPlaceholderRewrite(original.image_tokens.items, prepared.image_tokens.items, original.text.items.len, offset) orelse return error.InvalidPromptHistorySnapshot else null;
+    edit.swapInput(&prepared.text);
+    edit.cursor = cursor;
+    edit.selection_anchor = anchor;
+    entities.replace(alloc, &prepared.pasted_blocks, &prepared.image_tokens, &prepared.skill_tokens);
+    for (images.items) |image| image_attachments.discardImageAttachment(alloc, image);
+    images.deinit(alloc);
+    images.* = prepared.images;
+    prepared.images = .empty;
+    prepared.owns_image_snapshots = false;
+    return next_id;
+}
+
 pub const State = struct {
     entries: std.ArrayList(Snapshot) = .empty,
     draft: ?Snapshot = null,
@@ -606,6 +629,48 @@ fn replaceActiveComposer(
     active.picker.model_completion_window_start = 0;
     active.picker.resetFilePickerIndex();
     active.input_limit_rejection.* = input_limit_rejection.clear();
+}
+
+test "rebasing draft image IDs preserves text selection and snapshot ownership" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const io_mod = @import("../shared/io.zig");
+    const file = try tmp.dir.createFile(std.testing.io, "pending.png", .{});
+    try file.writeStreamingAll(std.testing.io, "\x89PNG\r\n\x1a\nimage");
+    file.close(std.testing.io);
+    const path = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "pending.png");
+    defer alloc.free(path);
+    const directory = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(directory);
+    var edit: editor_state.State = .{};
+    defer edit.deinit(alloc);
+    var entities: registered_entities.State = .{};
+    defer entities.deinit(alloc);
+    var images: ImageBlocks = .empty;
+    defer {
+        for (images.items) |image| image_attachments.discardImageAttachment(alloc, image);
+        images.deinit(alloc);
+    }
+    try edit.setText(alloc, "look [Image #1] end");
+    edit.selection_anchor = 0;
+    try entities.image_tokens.append(alloc, .{ .id = 1, .span = .{ .raw_start = 5, .raw_end = 15 } });
+    try images.append(alloc, .{
+        .id = 1,
+        .path = try alloc.dupe(u8, path),
+        .media_type = try alloc.dupe(u8, "image/png"),
+    });
+    try image_attachments.captureImageSnapshot(alloc, &images.items[0], directory);
+    try std.testing.expectEqual(@as(usize, 13), try rebase_active_images(alloc, &edit, &entities, &images, 12));
+    try std.testing.expectEqualStrings("look [Image #12] end", edit.input.items);
+    try std.testing.expectEqual(edit.input.items.len, edit.cursor);
+    try std.testing.expectEqual(@as(?usize, 0), edit.selection_anchor);
+    try std.testing.expectEqual(@as(usize, 12), images.items[0].id);
+    try std.testing.expect(std.mem.startsWith(u8, std.fs.path.basename(images.items[0].snapshot_path.?), "image-12-"));
+    var verified = try image_attachments.loadVerifiedSnapshot(alloc, images.items[0], .{});
+    defer verified.deinit(alloc);
+    try std.testing.expectEqualStrings("\x89PNG\r\n\x1a\nimage", verified.bytes);
+    try std.testing.expectEqual(@as(usize, 12), entities.image_tokens.items[0].id);
 }
 
 test "navigation target follows bounded older and newer history laws" {

--- a/src/core/input/composer_history.zig
+++ b/src/core/input/composer_history.zig
@@ -330,29 +330,6 @@ const Snapshot = struct {
     }
 };
 
-/// Rebinds a live draft to a refreshed session. Snapshot filenames carry image
-/// identity, so verified replacements must exist before releasing old ownership.
-pub fn rebase_active_images(alloc: Allocator, edit: *editor_state.State, entities: *registered_entities.State, images: *ImageBlocks, first_image_id: usize) !usize {
-    if (images.items.len == 0) return first_image_id;
-    var original = try Snapshot.initCopy(alloc, edit.input.items, entities.pasted_blocks.items, images.items, entities.image_tokens.items, entities.skill_tokens.items);
-    defer original.deinit(alloc);
-    var prepared = try original.prepareRecall(alloc, first_image_id);
-    defer prepared.deinit(alloc);
-    const next_id = try std.math.add(usize, first_image_id, images.items.len);
-    const cursor = image_attachments.projectOffsetThroughPlaceholderRewrite(original.image_tokens.items, prepared.image_tokens.items, original.text.items.len, edit.cursor) orelse return error.InvalidPromptHistorySnapshot;
-    const anchor = if (edit.selection_anchor) |offset| image_attachments.projectOffsetThroughPlaceholderRewrite(original.image_tokens.items, prepared.image_tokens.items, original.text.items.len, offset) orelse return error.InvalidPromptHistorySnapshot else null;
-    edit.swapInput(&prepared.text);
-    edit.cursor = cursor;
-    edit.selection_anchor = anchor;
-    entities.replace(alloc, &prepared.pasted_blocks, &prepared.image_tokens, &prepared.skill_tokens);
-    for (images.items) |image| image_attachments.discardImageAttachment(alloc, image);
-    images.deinit(alloc);
-    images.* = prepared.images;
-    prepared.images = .empty;
-    prepared.owns_image_snapshots = false;
-    return next_id;
-}
-
 pub const State = struct {
     entries: std.ArrayList(Snapshot) = .empty,
     draft: ?Snapshot = null,
@@ -629,48 +606,6 @@ fn replaceActiveComposer(
     active.picker.model_completion_window_start = 0;
     active.picker.resetFilePickerIndex();
     active.input_limit_rejection.* = input_limit_rejection.clear();
-}
-
-test "rebasing draft image IDs preserves text selection and snapshot ownership" {
-    const alloc = std.testing.allocator;
-    var tmp = std.testing.tmpDir(.{});
-    defer tmp.cleanup();
-    const io_mod = @import("../shared/io.zig");
-    const file = try tmp.dir.createFile(std.testing.io, "pending.png", .{});
-    try file.writeStreamingAll(std.testing.io, "\x89PNG\r\n\x1a\nimage");
-    file.close(std.testing.io);
-    const path = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "pending.png");
-    defer alloc.free(path);
-    const directory = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
-    defer alloc.free(directory);
-    var edit: editor_state.State = .{};
-    defer edit.deinit(alloc);
-    var entities: registered_entities.State = .{};
-    defer entities.deinit(alloc);
-    var images: ImageBlocks = .empty;
-    defer {
-        for (images.items) |image| image_attachments.discardImageAttachment(alloc, image);
-        images.deinit(alloc);
-    }
-    try edit.setText(alloc, "look [Image #1] end");
-    edit.selection_anchor = 0;
-    try entities.image_tokens.append(alloc, .{ .id = 1, .span = .{ .raw_start = 5, .raw_end = 15 } });
-    try images.append(alloc, .{
-        .id = 1,
-        .path = try alloc.dupe(u8, path),
-        .media_type = try alloc.dupe(u8, "image/png"),
-    });
-    try image_attachments.captureImageSnapshot(alloc, &images.items[0], directory);
-    try std.testing.expectEqual(@as(usize, 13), try rebase_active_images(alloc, &edit, &entities, &images, 12));
-    try std.testing.expectEqualStrings("look [Image #12] end", edit.input.items);
-    try std.testing.expectEqual(edit.input.items.len, edit.cursor);
-    try std.testing.expectEqual(@as(?usize, 0), edit.selection_anchor);
-    try std.testing.expectEqual(@as(usize, 12), images.items[0].id);
-    try std.testing.expect(std.mem.startsWith(u8, std.fs.path.basename(images.items[0].snapshot_path.?), "image-12-"));
-    var verified = try image_attachments.loadVerifiedSnapshot(alloc, images.items[0], .{});
-    defer verified.deinit(alloc);
-    try std.testing.expectEqualStrings("\x89PNG\r\n\x1a\nimage", verified.bytes);
-    try std.testing.expectEqual(@as(usize, 12), entities.image_tokens.items[0].id);
 }
 
 test "navigation target follows bounded older and newer history laws" {

--- a/src/core/output/output_contracts.zig
+++ b/src/core/output/output_contracts.zig
@@ -1235,13 +1235,15 @@ pub const SessionRecoverySnapshot = struct {
         self: SessionRecoverySnapshot,
         alloc: Allocator,
     ) ![]u8 {
+        const usage_warning = if (self.result.usage_incomplete) "warning: historical usage is incomplete because the source accounting data is corrupt\n" else "";
         if (self.result.status == .indeterminate) {
             return std.fmt.allocPrint(
                 alloc,
-                "[session recovery] could not confirm target {s}\nsource: {s} (unchanged)\nresolve: fx --resume {s}\ninspect: fx doctor\n",
+                "[session recovery] could not confirm target {s}\nsource: {s} (unchanged)\n{s}resolve: fx --resume {s}\ninspect: fx doctor\n",
                 .{
                     self.result.recovered_session_id,
                     self.result.source_session_id,
+                    usage_warning,
                     self.result.recovered_session_id,
                 },
             );
@@ -1249,22 +1251,24 @@ pub const SessionRecoverySnapshot = struct {
         if (self.result.status == .recovered_with_unverified_artifacts) {
             return std.fmt.allocPrint(
                 alloc,
-                "[session recovery] copied {s} to {s}\nhistory_turns: {d}\nwarning: legacy command artifacts could not be authenticated\nresume: fx --resume {s}\n",
+                "[session recovery] copied {s} to {s}\nhistory_turns: {d}\nwarning: legacy command artifacts could not be authenticated\n{s}resume: fx --resume {s}\n",
                 .{
                     self.result.source_session_id,
                     self.result.recovered_session_id,
                     self.result.history_len,
+                    usage_warning,
                     self.result.recovered_session_id,
                 },
             );
         }
         return std.fmt.allocPrint(
             alloc,
-            "[session recovery] copied {s} to {s}\nhistory_turns: {d}\nresume: fx --resume {s}\n",
+            "[session recovery] copied {s} to {s}\nhistory_turns: {d}\n{s}resume: fx --resume {s}\n",
             .{
                 self.result.source_session_id,
                 self.result.recovered_session_id,
                 self.result.history_len,
+                usage_warning,
                 self.result.recovered_session_id,
             },
         );
@@ -1297,9 +1301,11 @@ pub const SessionRecoverySnapshot = struct {
             &out.writer,
         );
         try out.writer.print(
-            ",\"history_turns\":{d}}}",
+            ",\"history_turns\":{d}",
             .{self.result.history_len},
         );
+        if (self.result.usage_incomplete) try out.writer.writeAll(",\"usage_incomplete\":true");
+        try out.writer.writeByte('}');
         return try out.toOwnedSlice();
     }
 };
@@ -2649,6 +2655,21 @@ test "core session migration snapshot text and json stay stable" {
         "{\"kind\":\"session_migration\",\"id\":\"session.v3\",\"status\":\"migrated\",\"source_schema_version\":2,\"source_bytes\":4096}",
         json,
     );
+}
+
+test "core session recovery reports incomplete accounting in text and JSON" {
+    const snapshot: SessionRecoverySnapshot = .{ .result = .{
+        .source_session_id = @constCast("source"),
+        .recovered_session_id = @constCast("copy"),
+        .history_len = 1,
+        .usage_incomplete = true,
+    } };
+    const text = try snapshot.renderText(std.testing.allocator);
+    defer std.testing.allocator.free(text);
+    try std.testing.expect(std.mem.find(u8, text, "historical usage is incomplete") != null);
+    const json = try snapshot.renderJson(std.testing.allocator);
+    defer std.testing.allocator.free(json);
+    try std.testing.expect(std.mem.find(u8, json, "\"usage_incomplete\":true") != null);
 }
 
 test "core session recovery snapshot text and json stay stable" {

--- a/src/core/session/session_log.zig
+++ b/src/core/session/session_log.zig
@@ -2482,25 +2482,16 @@ pub const WritableSessionDir = struct {
         self.* = undefined;
     }
 
-    pub fn isParked(self: *const WritableSessionDir) bool {
+    fn isParked(self: *const WritableSessionDir) bool {
         return self.writer_lock == null;
     }
 
-    /// Release `session.lock` while keeping the session directory open for a
-    /// later `unpark` in the same process (idle job-control suspend).
+    /// Release ownership before handing the session to another runtime. The
+    /// existing writable must not mutate storage after releasing its lock.
     pub fn park(self: *WritableSessionDir) void {
         const lock = &(self.writer_lock orelse return);
         lock.release();
         self.writer_lock = null;
-    }
-
-    /// Reacquire `session.lock` after `park`. Fails with `SessionBusy` when
-    /// another process already owns the writer lock.
-    pub fn unpark(self: *WritableSessionDir) !void {
-        if (self.writer_lock != null) return;
-        self.writer_lock = acquireLock(&self.dir, session_lock_file, true) catch |err| {
-            return mapSessionLockError(err);
-        };
     }
 
     pub fn eventLogLengthForTest(self: *WritableSessionDir) !u64 {
@@ -3625,14 +3616,6 @@ fn entryExists(dir: *io_mod.VerifiedDir, name: []const u8) !bool {
     if (stat.kind != .file and stat.kind != .directory) return error.SessionPathUnsafe;
     if (stat.kind == .file and stat.nlink != 1) return error.SessionPathUnsafe;
     return true;
-}
-
-fn acquireLock(
-    dir: *io_mod.VerifiedDir,
-    name: []const u8,
-    create: bool,
-) !io_mod.TimedAdvisoryLock {
-    return acquireLockWithDeadline(dir, name, create, lock_deadline_ms);
 }
 
 fn acquireLockWithDeadline(

--- a/src/core/session/session_log.zig
+++ b/src/core/session/session_log.zig
@@ -118,6 +118,57 @@ pub const ConversationWriter = struct {
     latest_checkpoint_coverage: u64 = 0,
     turn_open: bool = false,
     pending_tool_calls: std.ArrayList(session_event.PendingToolCall) = .empty,
+    // Runtime-only: a fresh admission may still find the attempted suffix.
+    unusable: bool = false,
+    test_io: if (@import("builtin").is_test) ?std.Io else void = if (@import("builtin").is_test) null else {},
+
+    fn append_io(self: *const ConversationWriter) std.Io {
+        if (comptime @import("builtin").is_test) {
+            if (self.test_io) |io| return io;
+        }
+        return io_mod.getIo();
+    }
+
+    fn ensure_usable(self: *const ConversationWriter) !void {
+        if (self.unusable) return error.ConversationAppendIndeterminate;
+    }
+
+    fn ensure_current(self: *const ConversationWriter) !void {
+        try self.ensure_usable();
+        if (try self.file.length(self.append_io()) != self.committed_bytes) {
+            return error.StaleConversationWriter;
+        }
+    }
+
+    // Only this operation's attempted suffix may be rolled back. An ordinary
+    // error promises rollback; uncertainty must fence every later mutation.
+    fn append_and_rollback(self: *ConversationWriter, bytes: []const u8) !void {
+        try self.ensure_usable();
+        const next_bytes = std.math.add(u64, self.committed_bytes, bytes.len) catch
+            return error.ConversationSizeOverflow;
+        try self.ensure_current();
+        const io = self.append_io();
+        const append_error: ?(std.Io.File.WritePositionalError || std.Io.File.SyncError) = failed: {
+            self.file.writePositionalAll(io, bytes, self.committed_bytes) catch |err| break :failed err;
+            self.file.sync(io) catch |err| break :failed err;
+            break :failed null;
+        };
+        if (append_error) |original| {
+            const rollback_error: ?(std.Io.File.SetLengthError || std.Io.File.SyncError) = failed: {
+                self.file.setLength(io, self.committed_bytes) catch |err| break :failed err;
+                self.file.sync(io) catch |err| break :failed err;
+                break :failed null;
+            };
+            if (rollback_error) |err| {
+                self.unusable = true;
+                debug_trace.logf("session", "event=conversation_append_indeterminate offset={d} append_error={s} rollback_error={s}", .{ self.committed_bytes, @errorName(original), @errorName(err) });
+                return error.ConversationAppendIndeterminate;
+            }
+            debug_trace.logf("session", "event=conversation_append_rolled_back offset={d} bytes={d} err={s}", .{ self.committed_bytes, bytes.len, @errorName(original) });
+            return original;
+        }
+        self.committed_bytes = next_bytes;
+    }
 
     /// Takes ownership of `file` only on success.
     pub fn init(alloc: Allocator, file: std.Io.File) !ConversationWriter {
@@ -216,6 +267,7 @@ pub const ConversationWriter = struct {
         timestamp_ms: i64,
         event: session_event.ConversationEvent,
     ) !u64 {
+        try self.ensure_usable();
         const seq = std.math.add(u64, self.last_seq, 1) catch
             return error.ConversationSequenceOverflow;
         const envelope = session_event.ConversationEnvelope{
@@ -254,14 +306,7 @@ pub const ConversationWriter = struct {
 
         const frame = try session_event.encodeConversationFrame(alloc, envelope);
         defer alloc.free(frame);
-        if (try self.file.length(io_mod.getIo()) != self.committed_bytes) {
-            try self.file.setLength(io_mod.getIo(), self.committed_bytes);
-            try self.file.sync(io_mod.getIo());
-        }
-        try self.file.writePositionalAll(io_mod.getIo(), frame, self.committed_bytes);
-        try self.file.sync(io_mod.getIo());
-        self.committed_bytes = std.math.add(u64, self.committed_bytes, frame.len) catch
-            return error.ConversationSizeOverflow;
+        try self.append_and_rollback(frame);
         self.last_seq = seq;
         self.turn_open = turn_open;
 
@@ -291,6 +336,7 @@ pub const ConversationWriter = struct {
         timestamp_ms: i64,
         turn: types.HistoryTurn,
     ) !void {
+        try self.ensure_usable();
         if (turn == .compacted_summary) {
             _ = try self.append(alloc, timestamp_ms, .{
                 .context_checkpoint = .{
@@ -312,6 +358,7 @@ pub const ConversationWriter = struct {
         prefix: ?types.AssistantHistoryTurn,
         retained_from: ?types.ContextHistoryCut,
     ) !void {
+        try self.ensure_usable();
         if (prefix) |entry| {
             if (entry.assistant.len != 0) return error.InvalidConversationEvent;
             try self.appendTurnBatchWithCut(alloc, timestamp_ms, .{ .assistant = entry }, summary.summary, retained_from);
@@ -444,6 +491,7 @@ pub const ConversationWriter = struct {
         timestamp_ms: i64,
         events: []const session_event.ConversationEvent,
     ) !void {
+        try self.ensure_usable();
         if (events.len == 0) return;
         if (self.pending_tool_calls.items.len != 0) return error.UnresolvedToolCall;
 
@@ -492,21 +540,7 @@ pub const ConversationWriter = struct {
             try out.writer.writeAll(frame);
         }
         if (pending.items.len != 0) return error.UnresolvedToolCall;
-        if (try self.file.length(io_mod.getIo()) != self.committed_bytes) {
-            try self.file.setLength(io_mod.getIo(), self.committed_bytes);
-            try self.file.sync(io_mod.getIo());
-        }
-        try self.file.writePositionalAll(
-            io_mod.getIo(),
-            out.written(),
-            self.committed_bytes,
-        );
-        try self.file.sync(io_mod.getIo());
-        self.committed_bytes = std.math.add(
-            u64,
-            self.committed_bytes,
-            out.written().len,
-        ) catch return error.ConversationSizeOverflow;
+        try self.append_and_rollback(out.written());
         self.last_seq = seq;
         self.latest_checkpoint_coverage = checkpoint_coverage;
         self.turn_open = turn_open;
@@ -812,11 +846,10 @@ fn load_conversation_state_at_boundary(
     else
         null;
     errdefer if (last_work_id) |work_id| alloc.free(work_id);
-    var usage = try session_usage_sidecar.load(
-        alloc,
-        dir,
-        expected_session_id,
-    );
+    var usage = if (recovery != null)
+        (try session_usage_sidecar.load_for_recovery(alloc, dir, expected_session_id)).snapshot
+    else
+        try session_usage_sidecar.load(alloc, dir, expected_session_id);
     errdefer if (usage) |*snapshot| snapshot.deinit(alloc);
     var permission_state = try loadConversationPermissionState(alloc, dir);
     errdefer permission_state.deinit(alloc);
@@ -896,10 +929,33 @@ pub const ConversationRecoveryBoundary = struct {
 };
 
 /// Reads only. The existing transition validator remains the record authority.
-pub fn find_conversation_recovery_boundary(
+fn find_conversation_recovery_boundary(alloc: Allocator, dir: *io_mod.VerifiedDir) !ConversationRecoveryBoundary {
+    const scan = try scan_conversation_recovery(alloc, dir);
+    if (scan.complete) return error.SessionRecoveryNotNeeded;
+    return scan.boundary;
+}
+
+const ConversationRecovery = struct {
+    boundary: ConversationRecoveryBoundary,
+    usage_incomplete: bool,
+};
+
+pub fn classify_conversation_recovery(alloc: Allocator, dir: *io_mod.VerifiedDir, session_id: []const u8) !ConversationRecovery {
+    const scan = try scan_conversation_recovery(alloc, dir);
+    var usage = try session_usage_sidecar.load_for_recovery(alloc, dir, session_id);
+    defer if (usage.snapshot) |*snapshot| snapshot.deinit(alloc);
+    if (scan.complete and !usage.incomplete) {
+        var state = (try loadConversationStateIfPresent(alloc, dir, session_id)) orelse return error.InvalidSessionMetadata;
+        defer state.deinit(alloc);
+        return error.SessionRecoveryNotNeeded;
+    }
+    return .{ .boundary = scan.boundary, .usage_incomplete = usage.incomplete };
+}
+
+fn scan_conversation_recovery(
     alloc: Allocator,
     dir: *io_mod.VerifiedDir,
-) !ConversationRecoveryBoundary {
+) !struct { boundary: ConversationRecoveryBoundary, complete: bool } {
     var history_buffer: [8192]u8 = undefined;
     var reader = try ConversationHistoryReader.init(alloc, dir, &history_buffer);
     defer reader.deinit();
@@ -971,10 +1027,10 @@ pub fn find_conversation_recovery_boundary(
             };
         }
     }
-    if (offset == length and boundary.bytes == length) return error.SessionRecoveryNotNeeded;
-    if (boundary.bytes == 0) return error.SessionRecoveryBoundaryInvalid;
+    const complete = offset == length and boundary.bytes == length;
+    if (!complete and boundary.bytes == 0) return error.SessionRecoveryBoundaryInvalid;
     debug_trace.logf("session", "event=conversation_recovery_boundary source_bytes={d} retained_bytes={d} through_seq={d}", .{ length, boundary.bytes, boundary.seq });
-    return boundary;
+    return .{ .boundary = boundary, .complete = complete };
 }
 
 /// Caller owns the returned complete archive, with a checkpointed open turn
@@ -2495,10 +2551,16 @@ pub const LoadedWritableSession = struct {
         self.* = undefined;
     }
 
+    pub fn ensure_writable(self: *const LoadedWritableSession) !void {
+        if (self.log.isParked()) return error.SessionBusy;
+        try self.conversation_writer.ensure_usable();
+    }
+
     /// Returns a borrowed address that remains stable until deinit.
     pub fn childCapability(
         self: *LoadedWritableSession,
     ) !*session_child_store.SessionChildCapability {
+        try self.ensure_writable();
         return if (self.child_capability) |capability|
             capability
         else
@@ -2521,6 +2583,7 @@ pub const LoadedWritableSession = struct {
         alloc: Allocator,
         turn: *session.HistoryTurn,
     ) !void {
+        try self.ensure_writable();
         try externalizeConversationTurnResults(
             alloc,
             turn,
@@ -2533,6 +2596,7 @@ pub const LoadedWritableSession = struct {
         alloc: Allocator,
         title: []const u8,
     ) !bool {
+        try self.ensure_writable();
         const bytes = try readManagedFileAlloc(
             alloc,
             &self.log.dir,
@@ -2591,6 +2655,7 @@ pub const LoadedWritableSession = struct {
         event: SessionUpdate,
         timestamp_ms: i64,
     ) !CommitPosition {
+        try self.ensure_writable();
         return switch (event) {
             .history_turn_committed => self.appendConversationHistoryEvent(
                 alloc,
@@ -2623,6 +2688,7 @@ pub const LoadedWritableSession = struct {
         retained_from: ?types.ContextHistoryCut,
         timestamp_ms: i64,
     ) !CommitPosition {
+        try self.ensure_writable();
         var prepared: ?session.HistoryTurn = if (active_prefix) |prefix|
             try session.dupeHistoryTurn(alloc, .{ .assistant = prefix })
         else
@@ -2827,6 +2893,7 @@ pub const LoadedWritableSession = struct {
         permission_state: session_permission_state.State,
         timestamp_ms: i64,
     ) !void {
+        try self.ensure_writable();
         var next = try session_permission_state.dupe(alloc, permission_state);
         errdefer next.deinit(alloc);
         const bytes = try session_codec.encodePermissionState(alloc, next);
@@ -3810,6 +3877,136 @@ fn testState(alloc: Allocator, id: []const u8, updated_at_ms: i64) !session_code
         .total_input_tokens = 0,
         .total_output_tokens = 0,
     };
+}
+
+const ConversationAppendFault = struct {
+    mode: enum { partial_write, sync, rollback_truncate, rollback_sync },
+    writes: usize = 0,
+    syncs: usize = 0,
+    lengths: usize = 0,
+    vtable: std.Io.VTable = undefined,
+
+    fn io(self: *ConversationAppendFault) std.Io {
+        self.vtable = std.testing.io.vtable.*;
+        self.vtable.fileLength = length;
+        self.vtable.fileWritePositional = write;
+        self.vtable.fileSync = sync;
+        self.vtable.fileSetLength = truncate;
+        return .{ .userdata = self, .vtable = &self.vtable };
+    }
+
+    fn context(raw: ?*anyopaque) *ConversationAppendFault {
+        return @ptrCast(@alignCast(raw.?));
+    }
+
+    fn length(raw: ?*anyopaque, file: std.Io.File) std.Io.File.LengthError!u64 {
+        context(raw).lengths += 1;
+        return file.length(std.testing.io);
+    }
+
+    fn write(raw: ?*anyopaque, file: std.Io.File, header: []const u8, data: []const []const u8, splat: usize, offset: u64) std.Io.File.WritePositionalError!usize {
+        const self = context(raw);
+        self.writes += 1;
+        if (self.mode == .partial_write) {
+            if (self.writes > 1) return error.InputOutput;
+            const prefix = data[0][0..@min(data[0].len, 7)];
+            return std.testing.io.vtable.fileWritePositional(std.testing.io.userdata, file, &.{}, &.{prefix}, 1, offset);
+        }
+        return std.testing.io.vtable.fileWritePositional(std.testing.io.userdata, file, header, data, splat, offset);
+    }
+
+    fn sync(raw: ?*anyopaque, file: std.Io.File) std.Io.File.SyncError!void {
+        const self = context(raw);
+        self.syncs += 1;
+        if (self.mode != .partial_write and (self.syncs == 1 or self.mode == .rollback_sync)) return error.InputOutput;
+        return file.sync(std.testing.io);
+    }
+
+    fn truncate(raw: ?*anyopaque, file: std.Io.File, size: u64) std.Io.File.SetLengthError!void {
+        if (context(raw).mode == .rollback_truncate) return error.InputOutput;
+        return file.setLength(std.testing.io, size);
+    }
+};
+
+test "conversation append rolls back rejected checkpoints and fences uncertain writes" {
+    const alloc = std.testing.allocator;
+    inline for (.{ false, true }) |batched| {
+        inline for (std.meta.tags(@FieldType(ConversationAppendFault, "mode"))) |mode| {
+            var tmp = std.testing.tmpDir(.{});
+            defer tmp.cleanup();
+            const file = try tmp.dir.createFile(std.testing.io, "events.jsonl", .{ .read = true });
+            var writer = try ConversationWriter.init(alloc, file);
+            defer writer.deinit();
+            try writer.appendHistoryTurn(alloc, 10, .{ .assistant = .{
+                .user = .{ .text = @constCast("saved question") },
+                .assistant = @constCast("saved answer"),
+            } });
+            const before = try writer.readAllForTest(alloc);
+            defer alloc.free(before);
+            const prior_seq = writer.last_seq;
+            var fault: ConversationAppendFault = .{ .mode = mode };
+            writer.test_io = fault.io();
+            const expected = if (mode == .rollback_truncate or mode == .rollback_sync)
+                error.ConversationAppendIndeterminate
+            else
+                error.InputOutput;
+            try std.testing.expectError(expected, writer.appendContextCompaction(alloc, 11, .{
+                .summary = @constCast("rejected summary"),
+                .removed_turn_count = 1,
+                .compaction_count = 1,
+            }, if (batched) .{
+                .user = .{ .text = @constCast("active request") },
+                .assistant = @constCast(""),
+            } else null, null));
+            try std.testing.expect(fault.writes > 0);
+            try std.testing.expectEqual(prior_seq, writer.last_seq);
+            try std.testing.expectEqual(@as(u64, before.len), writer.committed_bytes);
+            try std.testing.expectEqual(@as(u64, 0), writer.latest_checkpoint_coverage);
+            try std.testing.expect(!writer.turn_open);
+            const prefix = try writer.readAllForTest(alloc);
+            defer alloc.free(prefix);
+            try std.testing.expectEqualStrings(before, prefix);
+            if (expected == error.ConversationAppendIndeterminate) {
+                const writes = fault.writes;
+                try std.testing.expectError(expected, writer.appendHistoryTurn(alloc, 12, .{ .assistant = .{
+                    .user = .{ .text = @constCast("must not write") },
+                    .assistant = @constCast("must not write"),
+                } }));
+                try std.testing.expectEqual(writes, fault.writes);
+            } else {
+                try std.testing.expectEqual(@as(u64, before.len), try file.length(std.testing.io));
+                const reopened_file = try tmp.dir.openFile(std.testing.io, "events.jsonl", .{ .mode = .read_write });
+                var reopened = try ConversationWriter.init(alloc, reopened_file);
+                defer reopened.deinit();
+                try std.testing.expectEqual(prior_seq, reopened.last_seq);
+                try std.testing.expectEqual(@as(u64, 0), reopened.latest_checkpoint_coverage);
+                writer.test_io = null;
+                try writer.appendHistoryTurn(alloc, 12, .{ .assistant = .{
+                    .user = .{ .text = @constCast("later question") },
+                    .assistant = @constCast("later answer"),
+                } });
+                try std.testing.expectEqual(prior_seq + 3, writer.last_seq);
+            }
+        }
+    }
+}
+
+test "conversation append refuses foreign suffix and checks size before I/O" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const file = try tmp.dir.createFile(std.testing.io, "events.jsonl", .{ .read = true });
+    var writer = try ConversationWriter.init(alloc, file);
+    defer writer.deinit();
+    try file.writePositionalAll(std.testing.io, "other writer", 0);
+    try std.testing.expectError(error.StaleConversationWriter, writer.append_and_rollback("overwrite"));
+    try std.testing.expectEqual(@as(u64, 12), try file.length(std.testing.io));
+    var fault: ConversationAppendFault = .{ .mode = .sync };
+    writer.test_io = fault.io();
+    writer.committed_bytes = std.math.maxInt(u64);
+    try std.testing.expectError(error.ConversationSizeOverflow, writer.append_and_rollback("x"));
+    try std.testing.expectEqual(@as(usize, 0), fault.lengths);
+    try std.testing.expectEqual(@as(usize, 0), fault.writes);
 }
 
 test "conversation writer appends one durable line per event" {

--- a/src/core/session/session_store.zig
+++ b/src/core/session/session_store.zig
@@ -3344,11 +3344,14 @@ pub const Store = struct {
         };
         defer if (metadata) |*current| current.deinit();
         var current_boundary: ?session_log.ConversationRecoveryBoundary = null;
+        var usage_incomplete = false;
         var recovered = recovery_state: {
             if (metadata) |current| {
                 if (!std.mem.eql(u8, current.value.id, session_id)) return error.SessionRecoveryBoundaryInvalid;
                 if (current.value.subagent_child) return error.SessionNotFound;
-                current_boundary = try session_log.find_conversation_recovery_boundary(alloc, &source.dir);
+                const recovery = try session_log.classify_conversation_recovery(alloc, &source.dir, session_id);
+                current_boundary = recovery.boundary;
+                usage_incomplete = recovery.usage_incomplete;
                 break :recovery_state try session_log.load_conversation_recovery_state(alloc, &source.dir, session_id, current_boundary.?);
             }
             const authority = try classifyAuthority(
@@ -3573,6 +3576,7 @@ pub const Store = struct {
                 .source_session_id = source_id,
                 .recovered_session_id = recovered_id,
                 .history_len = recovered.history.len,
+                .usage_incomplete = usage_incomplete,
                 .status = .indeterminate,
             };
         }
@@ -3589,6 +3593,7 @@ pub const Store = struct {
                 .source_session_id = source_id,
                 .recovered_session_id = recovered_id,
                 .history_len = recovered.history.len,
+                .usage_incomplete = usage_incomplete,
                 .status = .indeterminate,
             };
         };
@@ -3598,6 +3603,7 @@ pub const Store = struct {
                 .source_session_id = source_id,
                 .recovered_session_id = recovered_id,
                 .history_len = recovered.history.len,
+                .usage_incomplete = usage_incomplete,
                 .status = .indeterminate,
             };
         }
@@ -3606,6 +3612,7 @@ pub const Store = struct {
             .source_session_id = source_id,
             .recovered_session_id = recovered_id,
             .history_len = recovered.history.len,
+            .usage_incomplete = usage_incomplete,
             .status = if (contains_unverified_artifacts)
                 .recovered_with_unverified_artifacts
             else

--- a/src/core/session/session_store_types.zig
+++ b/src/core/session/session_store_types.zig
@@ -205,6 +205,7 @@ pub const SessionRecoveryResult = struct {
     recovered_session_id: []u8,
     history_len: usize,
     status: SessionRecoveryStatus = .recovered,
+    usage_incomplete: bool = false,
 
     pub fn deinit(self: *SessionRecoveryResult, alloc: Allocator) void {
         alloc.free(self.source_session_id);

--- a/src/core/session/session_usage_sidecar.zig
+++ b/src/core/session/session_usage_sidecar.zig
@@ -112,6 +112,97 @@ pub fn load(
     return snapshot;
 }
 
+const RecoveryLoad = struct {
+    snapshot: ?session_usage.Snapshot,
+    incomplete: bool = false,
+};
+
+/// Recovery owns the returned snapshot. Unsafe files and foreign identities are
+/// not corrupt accounting and must not authorize a lossy recovery copy.
+pub fn load_for_recovery(alloc: Allocator, session_dir: *io_mod.VerifiedDir, session_id: []const u8) !RecoveryLoad {
+    var captured = try capture(alloc, session_dir);
+    defer captured.deinit(alloc);
+    const bytes = switch (captured) {
+        .missing => return .{ .snapshot = null },
+        .invalid => |reason| {
+            if (std.mem.eql(u8, reason, "empty") or std.mem.eql(u8, reason, "oversized")) return incomplete_recovery_usage(alloc);
+            return error.InvalidUsageSidecar;
+        },
+        .encoded => |value| value,
+    };
+    var envelope = std.json.parseFromSlice(std.json.Value, alloc, bytes, .{}) catch |err| {
+        if (err == error.OutOfMemory) return err;
+        return incomplete_recovery_usage(alloc);
+    };
+    defer envelope.deinit();
+    if (envelope.value == .object) {
+        if (envelope.value.object.get("session_id")) |id| {
+            if (id == .string and id.string.len != 0 and !std.mem.eql(u8, id.string, session_id)) return error.UsageSidecarSessionMismatch;
+        }
+        if (envelope.value.object.get("schema_version")) |version| {
+            if (version == .integer and version.integer != 1) return error.UnsupportedUsageSidecar;
+        }
+    }
+    var decoded = decode(alloc, bytes) catch |err| {
+        if (err == error.OutOfMemory) return err;
+        return incomplete_recovery_usage(alloc);
+    };
+    if (!std.mem.eql(u8, decoded.session_id, session_id)) {
+        decoded.deinit(alloc);
+        return error.UsageSidecarSessionMismatch;
+    }
+    alloc.free(decoded.session_id);
+    return .{ .snapshot = decoded.snapshot };
+}
+
+fn incomplete_recovery_usage(alloc: Allocator) !RecoveryLoad {
+    var usage = session_usage.Usage.initLegacy();
+    defer usage.deinit(alloc);
+    usage.billing = .incomplete;
+    var snapshot = try usage.snapshot(alloc);
+    errdefer snapshot.deinit(alloc);
+    try session_usage.appendIncidentOwned(alloc, &snapshot, .{
+        .occurred_at_ms = @max(io_mod.milliTimestamp(), 0),
+        .completeness = .incomplete,
+    });
+    return .{ .snapshot = snapshot, .incomplete = true };
+}
+
+test "usage recovery preserves valid snapshots and marks corrupt accounting incomplete" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var dir: io_mod.VerifiedDir = .{ .dir = tmp.dir };
+    const missing = try load_for_recovery(alloc, &dir, "session");
+    try std.testing.expect(missing.snapshot == null and !missing.incomplete);
+    var usage = session_usage.Usage.initFresh();
+    defer usage.deinit(alloc);
+    var snapshot = try usage.snapshot(alloc);
+    defer snapshot.deinit(alloc);
+    try write(alloc, &dir, "session", snapshot);
+    var valid = try load_for_recovery(alloc, &dir, "session");
+    defer valid.snapshot.?.deinit(alloc);
+    try std.testing.expect(!valid.incomplete);
+    try std.testing.expectEqual(session_usage.Availability.complete, valid.snapshot.?.billing);
+    try io_mod.durableReplaceVerified(alloc, &dir, sidecar_file, "{broken");
+    try std.testing.expectError(error.InvalidUsageSidecar, load(alloc, &dir, "session"));
+    var recovered = try load_for_recovery(alloc, &dir, "session");
+    defer recovered.snapshot.?.deinit(alloc);
+    try std.testing.expect(recovered.incomplete);
+    try std.testing.expectEqual(session_usage.Availability.incomplete, recovered.snapshot.?.billing);
+    try std.testing.expect(!recovered.snapshot.?.api_duration_complete);
+    try session_usage.validateSnapshot(recovered.snapshot.?);
+    var retained = try capture(alloc, &dir);
+    defer retained.deinit(alloc);
+    try std.testing.expectEqualStrings("{broken", retained.encoded);
+    try write(alloc, &dir, "foreign", snapshot);
+    try std.testing.expectError(error.UsageSidecarSessionMismatch, load_for_recovery(alloc, &dir, "session"));
+    const file = try dir.dir.openFile(std.testing.io, sidecar_file, .{ .mode = .read_write });
+    defer file.close(std.testing.io);
+    try file.setPermissions(std.testing.io, .fromMode(0o644));
+    try std.testing.expectError(error.InvalidUsageSidecar, load_for_recovery(alloc, &dir, "session"));
+}
+
 pub fn capture(
     alloc: Allocator,
     session_dir: *io_mod.VerifiedDir,

--- a/src/core/session/session_usage_sidecar.zig
+++ b/src/core/session/session_usage_sidecar.zig
@@ -172,7 +172,8 @@ test "usage recovery preserves valid snapshots and marks corrupt accounting inco
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
-    var dir: io_mod.VerifiedDir = .{ .dir = tmp.dir };
+    var dir = try openTestVerifiedDir(tmp.dir);
+    defer dir.close();
     const missing = try load_for_recovery(alloc, &dir, "session");
     try std.testing.expect(missing.snapshot == null and !missing.incomplete);
     var usage = session_usage.Usage.initFresh();

--- a/src/main.zig
+++ b/src/main.zig
@@ -809,11 +809,11 @@ const App = struct {
     }
 
     pub fn deinit(self: *App) void {
-        _ = self.deinitImpl(false);
+        _ = self.deinitImpl(false) catch {};
     }
 
     /// Returns an owned handoff only after all interactive state is torn down.
-    pub fn deinitWithResumeHandoff(self: *App) ?app_session_runtime.ResumeHandoff {
+    pub fn deinitWithResumeHandoff(self: *App) !?app_session_runtime.ResumeHandoff {
         return self.deinitImpl(true);
     }
 
@@ -829,7 +829,7 @@ const App = struct {
         return ui_render.formatResumeHandoff(buffer, session_id, terminal_cols);
     }
 
-    fn deinitImpl(self: *App, capture_resume_handoff: bool) ?app_session_runtime.ResumeHandoff {
+    fn deinitImpl(self: *App, capture_resume_handoff: bool) !?app_session_runtime.ResumeHandoff {
         self.auth.stopProviderPreparation();
         // Client.deinit releases the herdr pane (clear agent + label) when enabled.
         self.herdr.deinit();
@@ -843,7 +843,9 @@ const App = struct {
 
         self.releaseTerminal();
         if (self.worker_thread) |thread| thread.join();
+        var persistence_error: ?anyerror = null;
         WorkerAppRuntime.settleFinishedPromptsForShutdown(self) catch |err| {
+            persistence_error = err;
             debug_trace.logf("session", "shutdown finished prompt persistence failed err={s}", .{@errorName(err)});
         };
         self.terminal_client.deinit();
@@ -851,8 +853,11 @@ const App = struct {
         self.model_cache.deinit();
         self.usage_dashboard.deinit();
         InputSubmitRuntime.clearPendingSubmission(self, "shutdown");
-        const resume_handoff = if (capture_resume_handoff)
-            SessionAppRuntime.finalizePersistenceWithResumeHandoff(self)
+        const resume_handoff = if (capture_resume_handoff and persistence_error == null)
+            SessionAppRuntime.finalizePersistenceWithResumeHandoff(self) catch |err| failed: {
+                persistence_error = err;
+                break :failed null;
+            }
         else blk: {
             SessionAppRuntime.finalizePersistence(self);
             break :blk null;
@@ -892,6 +897,7 @@ const App = struct {
         WorkspaceAppRuntime.deinit(self);
         self.workspace_identity.deinit(self.alloc);
         if (self.workspace_root.len > 0) self.alloc.free(self.workspace_root);
+        if (persistence_error) |err| return err;
         return resume_handoff;
     }
 

--- a/tests/e2e/session-recovery.test.ts
+++ b/tests/e2e/session-recovery.test.ts
@@ -279,6 +279,45 @@ function expectLegacyRequest(request: { body: string; headers: Headers }) {
 }
 
 describe("session recovery", () => {
+  for (const damagedTail of [false, true]) {
+    test(`corrupt usage recovers a usable copy with incomplete accounting, damaged tail=${damagedTail}`, async () => {
+      const fixture = createFixture("fx-session-usage-copy-");
+      const gateway = startFakeGateway([
+        fakeGatewayFinalText("ACCOUNTING_RECOVERY_SAVED"),
+        fakeGatewayFinalText("ACCOUNTING_RECOVERY_CONTINUED"),
+      ]);
+      try {
+        const id = await createSavedSession(fixture, gateway);
+        const source = join(fixture.home, ".fx", "sessions", id);
+        const committed = readFileSync(join(source, "events.jsonl"));
+        writeFileSync(join(source, "usage-v2.json"), "{broken usage", { mode: 0o600 });
+        if (damagedTail) appendFileSync(join(source, "events.jsonl"), "{broken tail");
+        const before = savedFileHashes(source);
+        const result = await runFx(["session", "recover", id, "--json"], {
+          cwd: fixture.workspace, env: gatewayEnv(fixture, gateway), timeoutMs: TIMEOUT,
+        });
+        expect(result.code).toBe(0);
+        expect(result.stderr).toBe("");
+        const recovered = JSON.parse(result.stdout);
+        expect(recovered).toMatchObject({ status: "recovered", usage_incomplete: true, source_id: id });
+        expect(recovered.recovered_id).not.toBe(id);
+        expect(savedFileHashes(source)).toEqual(before);
+        const copy = join(fixture.home, ".fx", "sessions", recovered.recovered_id);
+        expect(readFileSync(join(copy, "events.jsonl"))).toEqual(committed);
+        expect(JSON.parse(readFileSync(join(copy, "usage-v2.json"), "utf8")).snapshot.billing).toBe("incomplete");
+        const continued = await continueSession(fixture, gateway, recovered.recovered_id);
+        expect(continued.code).toBe(0);
+        expect(continued.stderr).toBe("");
+        expect(gateway.requests.at(-1)!.body).toContain("ACCOUNTING_RECOVERY_SAVED");
+        expect(JSON.parse(readFileSync(join(copy, "usage-v2.json"), "utf8")).snapshot.billing).toBe("incomplete");
+        expect(savedFileHashes(source)).toEqual(before);
+      } finally {
+        gateway.stop();
+        rmSync(fixture.root, { recursive: true, force: true });
+      }
+    }, TIMEOUT);
+  }
+
   test("healthy current conversation needs no recovery or migration", async () => {
     const fixture = createFixture("fx-session-current-healthy-");
     const gateway = startFakeGateway([fakeGatewayFinalText("SAVED_HEALTHY")]);

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -69,6 +69,60 @@ function shellQuote(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`;
 }
 
+test.skipIf(!tmuxAvailable())("foreground resume refreshes a suspended writer after another process commits", async () => {
+  const root = mkdtempSync(join(tmpdir(), "fx-parked-writer-"));
+  const home = join(root, "home"), workspace = join(root, "workspace");
+  mkdirSync(home); mkdirSync(workspace);
+  const trace = join(root, "trace.log"), exitPath = join(root, "exit");
+  const gateway = startFakeGateway([
+    fakeGatewayFinalText("ORIGINAL_HANDOFF_FACT"),
+    fakeGatewayFinalText("OTHER_WRITER_HANDOFF_FACT"),
+    fakeGatewayFinalText("FOREGROUND_WRITER_FINISHED"),
+    fakeGatewayFinalText("COLD_HANDOFF_FINISHED"),
+  ]);
+  const env = gatewayEnv(home, gateway);
+  let tui: TmuxSession | undefined;
+  try {
+    const seed = await runFx(["ask", "--json", "Save the original fact."], { cwd: workspace, env });
+    expect(seed.code).toBe(0);
+    const id = JSON.parse(seed.stdout).session_id;
+    const events = join(home, ".fx", "sessions", id, "events.jsonl");
+    tui = await TmuxSession.create({
+      cmd: "/bin/bash --noprofile --norc -i", cwd: workspace, isolated: true,
+      width: 110, height: 36,
+      env: { ...env, PS1: "HANDOFF_SHELL> ", FX_TRACE_LOG: trace, FX_TRACE_SCOPES: "session" },
+    });
+    await tui.waitForText("HANDOFF_SHELL>", TIMEOUT);
+    await tui.sendText(`${shellQuote(FX_BIN)} --resume ${shellQuote(id)}`);
+    await tui.waitForText("ORIGINAL_HANDOFF_FACT", TIMEOUT);
+    await tui.waitForStableComposer(TIMEOUT);
+    await tui.sendKeys("C-z");
+    await tui.waitForPane(() => existsSync(trace) && readFileSync(trace, "utf8").includes("parked writer lock for suspend"), TIMEOUT);
+    await tui.waitForText("Stopped", TIMEOUT);
+    const other = await runFx(["ask", "--json", "--resume-id", id, "Save another fact."], { cwd: workspace, env });
+    expect(other.code).toBe(0);
+    const accepted = readFileSync(events);
+    expect(accepted.toString()).toContain("OTHER_WRITER_HANDOFF_FACT");
+    await tui.sendText(`fg; printf '%s' "$?" > ${shellQuote(exitPath)}`);
+    await tui.waitForPane(() => readFileSync(trace, "utf8").includes("unparked writer lock after suspend"), TIMEOUT);
+    await tui.waitForStableComposer(TIMEOUT);
+    await tui.sendText("Continue after foregrounding.");
+    await tui.waitForText("FOREGROUND_WRITER_FINISHED", TIMEOUT);
+    await tui.waitForStableComposer(TIMEOUT);
+    expect(gateway.requests.at(-1)!.body).toContain("OTHER_WRITER_HANDOFF_FACT");
+    await tui.sendText("/quit");
+    await tui.waitForPane(() => existsSync(exitPath), TIMEOUT);
+    expect(readFileSync(exitPath, "utf8")).toBe("0");
+    expect(readFileSync(events).subarray(0, accepted.length)).toEqual(accepted);
+    const cold = await runFx(["ask", "--json", "--resume-id", id, "Check the complete saved history."], { cwd: workspace, env });
+    expect(cold.code).toBe(0);
+    expect(cold.stderr).toBe("");
+    expect(gateway.requests.at(-1)!.body).toContain("OTHER_WRITER_HANDOFF_FACT");
+  } finally {
+    await tui?.kill(); gateway.stop(); rmSync(root, { recursive: true, force: true });
+  }
+}, TIMEOUT * 3);
+
 function startUpgradeServer(
   root: string,
   argvLogPath: string,

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -69,16 +69,15 @@ function shellQuote(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`;
 }
 
-test.skipIf(!tmuxAvailable())("foreground resume refreshes a suspended writer after another process commits", async () => {
-  const root = mkdtempSync(join(tmpdir(), "fx-parked-writer-"));
+test.skipIf(!tmuxAvailable())("suspended sessions retain exclusive writer ownership until close", async () => {
+  const root = mkdtempSync(join(tmpdir(), "fx-single-writer-"));
   const home = join(root, "home"), workspace = join(root, "workspace");
   mkdirSync(home); mkdirSync(workspace);
-  const trace = join(root, "trace.log"), exitPath = join(root, "exit");
+  const exitPath = join(root, "exit");
   const gateway = startFakeGateway([
-    fakeGatewayFinalText("ORIGINAL_HANDOFF_FACT"),
-    fakeGatewayFinalText("OTHER_WRITER_HANDOFF_FACT"),
+    fakeGatewayFinalText("ORIGINAL_SAVED_FACT"),
     fakeGatewayFinalText("FOREGROUND_WRITER_FINISHED"),
-    fakeGatewayFinalText("COLD_HANDOFF_FINISHED"),
+    fakeGatewayFinalText("COLD_RESUME_FINISHED"),
   ]);
   const env = gatewayEnv(home, gateway);
   let tui: TmuxSession | undefined;
@@ -87,29 +86,30 @@ test.skipIf(!tmuxAvailable())("foreground resume refreshes a suspended writer af
     expect(seed.code).toBe(0);
     const id = JSON.parse(seed.stdout).session_id;
     const events = join(home, ".fx", "sessions", id, "events.jsonl");
+    const accepted = readFileSync(events);
     tui = await TmuxSession.create({
       cmd: "/bin/bash --noprofile --norc -i", cwd: workspace, isolated: true,
-      width: 110, height: 36,
-      env: { ...env, PS1: "HANDOFF_SHELL> ", FX_TRACE_LOG: trace, FX_TRACE_SCOPES: "session" },
+      width: 110, height: 36, env: { ...env, PS1: "SESSION_SHELL> " },
     });
-    await tui.waitForText("HANDOFF_SHELL>", TIMEOUT);
+    await tui.waitForText("SESSION_SHELL>", TIMEOUT);
     await tui.sendText(`${shellQuote(FX_BIN)} --resume ${shellQuote(id)}`);
-    await tui.waitForText("ORIGINAL_HANDOFF_FACT", TIMEOUT);
+    await tui.waitForText("ORIGINAL_SAVED_FACT", TIMEOUT);
     await tui.waitForStableComposer(TIMEOUT);
+    await tui.sendLiteral("DRAFT_SURVIVES_SUSPENSION");
+    await tui.waitForText("DRAFT_SURVIVES_SUSPENSION", TIMEOUT);
     await tui.sendKeys("C-z");
-    await tui.waitForPane(() => existsSync(trace) && readFileSync(trace, "utf8").includes("parked writer lock for suspend"), TIMEOUT);
     await tui.waitForText("Stopped", TIMEOUT);
-    const other = await runFx(["ask", "--json", "--resume-id", id, "Save another fact."], { cwd: workspace, env });
-    expect(other.code).toBe(0);
-    const accepted = readFileSync(events);
-    expect(accepted.toString()).toContain("OTHER_WRITER_HANDOFF_FACT");
+    const other = await runFx(["ask", "--json", "--resume-id", id, "Must not run while the writer is suspended."], { cwd: workspace, env });
+    expect(other.code).toBe(1);
+    expect(JSON.parse(other.stdout).error).toBe("SessionBusy");
+    expect(gateway.requests).toHaveLength(1);
+    expect(readFileSync(events)).toEqual(accepted);
     await tui.sendText(`fg; printf '%s' "$?" > ${shellQuote(exitPath)}`);
-    await tui.waitForPane(() => readFileSync(trace, "utf8").includes("unparked writer lock after suspend"), TIMEOUT);
-    await tui.waitForStableComposer(TIMEOUT);
-    await tui.sendText("Continue after foregrounding.");
+    await tui.waitForPane(pane => (pane.split("\n").filter(line => /^\s*┃/.test(line)).at(-1) ?? "").includes("DRAFT_SURVIVES_SUSPENSION"), TIMEOUT);
+    await tui.sendKeys("Enter");
     await tui.waitForText("FOREGROUND_WRITER_FINISHED", TIMEOUT);
     await tui.waitForStableComposer(TIMEOUT);
-    expect(gateway.requests.at(-1)!.body).toContain("OTHER_WRITER_HANDOFF_FACT");
+    expect(gateway.requests.at(-1)!.body).toContain("DRAFT_SURVIVES_SUSPENSION");
     await tui.sendText("/quit");
     await tui.waitForPane(() => existsSync(exitPath), TIMEOUT);
     expect(readFileSync(exitPath, "utf8")).toBe("0");
@@ -117,7 +117,8 @@ test.skipIf(!tmuxAvailable())("foreground resume refreshes a suspended writer af
     const cold = await runFx(["ask", "--json", "--resume-id", id, "Check the complete saved history."], { cwd: workspace, env });
     expect(cold.code).toBe(0);
     expect(cold.stderr).toBe("");
-    expect(gateway.requests.at(-1)!.body).toContain("OTHER_WRITER_HANDOFF_FACT");
+    expect(gateway.requests.at(-1)!.body).toContain("ORIGINAL_SAVED_FACT");
+    expect(gateway.requests.at(-1)!.body).toContain("FOREGROUND_WRITER_FINISHED");
   } finally {
     await tui?.kill(); gateway.stop(); rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- Keep saved sessions exclusively owned until close, including while suspended with Ctrl+Z.
- Roll back failed conversation writes and refuse further writes when rollback cannot be confirmed.
- Report shutdown save failures with a warning and nonzero exit, including when terminal input closes.
- Recover conversations with corrupt usage data into a new session with incomplete historical accounting, preserving the original.