### PR TITLE
Validate sessions before reporting no recovery needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ Older sessions that saved Vercel connection settings can be opened through `-r`,
 
 If a saved conversation is damaged, run `fx session recover <id>` to copy its validated prefix into a new session. Recovery preserves checkpoint boundaries and referenced result files, leaves the original unchanged, and prints the new session ID. Records after the damaged boundary are not included, and recovery does not rerun commands. Healthy conversations can be resumed without recovery. Paused requests retain their captured images across errors and restarts. Continuing uses those saved images even if the original files move or change; missing or corrupted saved images produce a recovery error.
 
+Recovery only reports that no repair is needed after confirming the saved session can be loaded. If a final session save fails during interactive shutdown, fx reports the failure and exits with a nonzero status after cleanup, without a successful resume hint or automatic upgrade relaunch.
+
 New sessions appear in resume selection only after their initial files are ready. Incomplete creation folders left by older builds do not block healthy conversations from resuming with `-c`; those folders remain available for diagnosis and are not deleted.
 
 Interactive terminal tabs show `fx v<version> | <folder>` using the running binary's version and current workspace folder name, for example `fx v0.0.7 | fx`. Renaming a session or switching models leaves the title unchanged. Resuming from another folder uses that folder's name. Exiting clears the fx-owned title. Noninteractive commands do not emit terminal-title controls.

--- a/src/core/cli/cli_surface.zig
+++ b/src/core/cli/cli_surface.zig
@@ -2857,7 +2857,12 @@ fn writeLookupFailure(
         error.SessionNotFound => {
             try writeStderr(deps, "fx session: record not found\n");
         },
-        error.InvalidSessionFormat => {
+        error.InvalidSessionFormat,
+        error.InvalidPermissionState,
+        error.PermissionStateTooLarge,
+        error.InvalidRecoveryCheckpoint,
+        error.InvalidUsageSidecar,
+        => {
             try writeStderr(
                 deps,
                 "fx session: record is corrupt; run `fx doctor` for recovery guidance\n",
@@ -3033,7 +3038,12 @@ fn lookupFailureMessage(err: anyerror) ?[]const u8 {
         error.NoSavedSessions => "no saved sessions for this workspace",
         error.NoReadableSessions => "saved sessions are unreadable; run `fx doctor` for recovery guidance",
         error.SessionNotFound => "record not found",
-        error.InvalidSessionFormat => "record is corrupt; run `fx doctor` for recovery guidance",
+        error.InvalidSessionFormat,
+        error.InvalidPermissionState,
+        error.PermissionStateTooLarge,
+        error.InvalidRecoveryCheckpoint,
+        error.InvalidUsageSidecar,
+        => "record is corrupt; run `fx doctor` for recovery guidance",
         error.UnsupportedSessionSchema => "record uses an unsupported session version",
         error.InvalidSessionId => "invalid session id",
         error.LegacySessionTooLarge => "legacy session is too large for automatic loading; run `fx session migrate <id> --allow-large`",
@@ -3116,6 +3126,32 @@ test "session detail failures separate corruption from unsupported schema" {
         "fx session: session future-session uses an unsupported session version\n",
         unsupported_text.stderr.written(),
     );
+}
+
+test "session lookup failures preserve supporting-state errors in the requested format" {
+    const cases = [_]struct { err: anyerror, code: []const u8 }{
+        .{ .err = error.InvalidPermissionState, .code = "InvalidPermissionState" },
+        .{ .err = error.PermissionStateTooLarge, .code = "PermissionStateTooLarge" },
+        .{ .err = error.InvalidRecoveryCheckpoint, .code = "InvalidRecoveryCheckpoint" },
+        .{ .err = error.InvalidUsageSidecar, .code = "InvalidUsageSidecar" },
+    };
+    for (cases) |case| {
+        for ([_]output_contracts.OutputFormat{ .text, .json }) |format| {
+            var output = CaptureOutput.init(std.testing.allocator);
+            defer output.deinit();
+            try writeLookupFailure(std.testing.allocator, output.deps(), "session", case.err, format);
+            const body = if (format == .json) output.stdout.written() else output.stderr.written();
+            const unused = if (format == .json) output.stderr.written() else output.stdout.written();
+            try std.testing.expectEqual(@as(usize, 0), unused.len);
+            try std.testing.expect(std.mem.find(u8, body, "fx doctor") != null);
+            try std.testing.expect(std.mem.find(u8, body, "resume it normally") == null);
+            if (format == .json) {
+                var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, body, .{});
+                defer parsed.deinit();
+                try std.testing.expectEqualStrings(case.code, parsed.value.object.get("code").?.string);
+            }
+        }
+    }
 }
 
 test "session recovery boundary failures keep stable text and json guidance" {

--- a/src/core/session/session_store.zig
+++ b/src/core/session/session_store.zig
@@ -3396,7 +3396,13 @@ pub const Store = struct {
             if (metadata) |current| {
                 if (!std.mem.eql(u8, current.value.id, session_id)) return error.SessionRecoveryBoundaryInvalid;
                 if (current.value.subagent_child) return error.SessionNotFound;
-                current_boundary = try session_log.find_conversation_recovery_boundary(alloc, &source.dir);
+                current_boundary = session_log.find_conversation_recovery_boundary(alloc, &source.dir) catch |err| {
+                    if (err == error.SessionRecoveryNotNeeded) {
+                        var healthy = try self.loadReadOnly(alloc, session_id);
+                        healthy.deinit(alloc);
+                    }
+                    return err;
+                };
                 break :recovery_state try session_log.load_conversation_recovery_state(alloc, &source.dir, session_id, current_boundary.?);
             }
             const authority = try classifyAuthority(
@@ -4527,6 +4533,29 @@ fn makeSessionDir(alloc: Allocator, store: Store, id: []const u8) !void {
     const dir = try sessionDirPath(alloc, store.sessions_dir, id);
     defer alloc.free(dir);
     try config_runtime.makeAbsolutePath(dir);
+}
+
+test "recovery no-op validates supporting state before advising normal resume" {
+    const alloc = std.testing.allocator;
+    for ([_][]const u8{ "permissions.json", "recovery.json" }) |name| {
+        var tmp = std.testing.tmpDir(.{});
+        defer tmp.cleanup();
+        var ctx = try initTempStore(alloc, &tmp);
+        defer ctx.deinit(alloc);
+        var initial = try testDurableState(alloc, "recovery-supporting-state", ctx.workspace);
+        defer initial.deinit(alloc);
+        {
+            var writer = try ctx.store.startWritableSession(alloc, initial);
+            defer writer.deinit(alloc);
+            try io_mod.durableReplaceVerified(alloc, &writer.log.dir, name, "{broken");
+        }
+        const expected_error = if (std.mem.eql(u8, name, "permissions.json"))
+            error.InvalidPermissionState
+        else
+            error.InvalidRecoveryCheckpoint;
+        try std.testing.expectError(expected_error, ctx.store.loadReadOnly(alloc, initial.id));
+        try std.testing.expectError(expected_error, ctx.store.recoverSessionCopy(alloc, initial.id, .{}));
+    }
 }
 
 fn makeRawSessionsEntry(store: Store, name: []const u8) !void {

--- a/tests/e2e/fixtures/session-sync-fault.c
+++ b/tests/e2e/fixtures/session-sync-fault.c
@@ -1,0 +1,71 @@
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdatomic.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#ifndef __APPLE__
+#include <dlfcn.h>
+#endif
+
+static _Atomic int fired;
+
+static int real_sync(int fd) {
+#ifdef __APPLE__
+    return fsync(fd);
+#else
+    int (*next)(int) = dlsym(RTLD_NEXT, "fsync");
+    if (next) return next(fd);
+    errno = EIO;
+    return -1;
+#endif
+}
+
+static int injected_sync(int fd) {
+    const char *target = getenv("FX_TEST_SYNC_TARGET");
+    const char *arm = getenv("FX_TEST_SYNC_ARM");
+    const char *record = getenv("FX_TEST_SYNC_RECORD");
+    const char *match = getenv("FX_TEST_SYNC_MATCH");
+    char actual[PATH_MAX], expected[PATH_MAX];
+    if (!target || !arm || !record || !match || access(arm, F_OK) || !realpath(target, expected)) return real_sync(fd);
+#ifdef __APPLE__
+    if (fcntl(fd, F_GETPATH, actual)) return real_sync(fd);
+#else
+    char link[64];
+    snprintf(link, sizeof(link), "/proc/self/fd/%d", fd);
+    ssize_t path_bytes = readlink(link, actual, sizeof(actual) - 1);
+    if (path_bytes < 0 || (size_t)path_bytes >= sizeof(actual) - 1) return real_sync(fd);
+    actual[path_bytes] = 0;
+#endif
+    if (strcmp(actual, expected)) return real_sync(fd);
+    struct stat state;
+    if (fstat(fd, &state) || !S_ISREG(state.st_mode)) return real_sync(fd);
+    if (!atomic_load(&fired)) {
+        char tail[16385];
+        size_t count = state.st_size < 16384 ? (size_t)state.st_size : 16384;
+        ssize_t got = pread(fd, tail, count, state.st_size - count);
+        if (got < 0) return real_sync(fd);
+        tail[got] = 0;
+        if (!strstr(tail, match)) return real_sync(fd);
+    }
+    int hit = atomic_fetch_add(&fired, 1) + 1;
+    int log = open(record, O_WRONLY | O_CREAT | O_APPEND, 0600);
+    if (log >= 0) {
+        dprintf(log, "hit=%d target=%s\n", hit, actual);
+        close(log);
+    }
+    errno = EIO;
+    return -1;
+}
+
+#ifdef __APPLE__
+__attribute__((used, section("__DATA,__interpose")))
+static const struct { const void *replacement; const void *original; }
+binding = { (const void *)injected_sync, (const void *)fsync };
+#else
+int fsync(int fd) { return injected_sync(fd); }
+#endif

--- a/tests/e2e/session-recovery.test.ts
+++ b/tests/e2e/session-recovery.test.ts
@@ -438,7 +438,7 @@ describe("session recovery", () => {
     }
   }, TIMEOUT * 3);
 
-  test("healthy current conversation needs no recovery or migration", async () => {
+  test("recovery no-op requires a loadable current conversation", async () => {
     const fixture = createFixture("fx-session-current-healthy-");
     const gateway = startFakeGateway([fakeGatewayFinalText("SAVED_HEALTHY")]);
     try {
@@ -454,19 +454,32 @@ describe("session recovery", () => {
       expect(savedFileHashes(source)).toEqual(before);
       expect(readdirSync(join(fixture.home, ".fx", "sessions"))).toEqual([id]);
       expect(gateway.requests).toHaveLength(1);
+      writeFileSync(join(source, "permissions.json"), "{broken", { mode: 0o600 });
+      const damaged = savedFileHashes(source);
+      const refused = await runFx(["session", "recover", id, "--json"], {
+        cwd: fixture.workspace, env: gatewayEnv(fixture, gateway), timeoutMs: TIMEOUT,
+      });
+      expect(refused.code).toBe(1);
+      expect(refused.stderr).toBe("");
+      expect(JSON.parse(refused.stdout).code).toBe("InvalidPermissionState");
+      expect(refused.stdout).not.toContain("resume it normally");
+      expect(savedFileHashes(source)).toEqual(damaged);
+      expect(readdirSync(join(fixture.home, ".fx", "sessions"))).toEqual([id]);
+      expect(gateway.requests).toHaveLength(1);
     } finally {
       gateway.stop();
       rmSync(fixture.root, { recursive: true, force: true });
     }
   }, TIMEOUT);
 
-  for (const { checkpointedTurn, missingUsage, fullCoverage } of [
-    { checkpointedTurn: false, missingUsage: false, fullCoverage: false },
-    { checkpointedTurn: true, missingUsage: false, fullCoverage: false },
-    { checkpointedTurn: false, missingUsage: true, fullCoverage: false },
-    { checkpointedTurn: false, missingUsage: false, fullCoverage: true },
+  for (const { checkpointedTurn, missingUsage, fullCoverage, damagedUsage } of [
+    { checkpointedTurn: false, missingUsage: false, fullCoverage: false, damagedUsage: false },
+    { checkpointedTurn: true, missingUsage: false, fullCoverage: false, damagedUsage: false },
+    { checkpointedTurn: false, missingUsage: true, fullCoverage: false, damagedUsage: false },
+    { checkpointedTurn: false, missingUsage: false, fullCoverage: true, damagedUsage: false },
+    { checkpointedTurn: false, missingUsage: false, fullCoverage: false, damagedUsage: true },
   ]) {
-    test(`current conversation recovery preserves exact checkpoints and artifacts with open=${checkpointedTurn} missing usage=${missingUsage} full coverage=${fullCoverage}`, async () => {
+    test(`current conversation recovery preserves exact checkpoints and artifacts with open=${checkpointedTurn} missing usage=${missingUsage} full coverage=${fullCoverage} damaged usage=${damagedUsage}`, async () => {
       const fixture = createFixture("fx-session-current-copy-");
       const responses = [
         fakeShellRun("saved-effect", "printf 'ONCE_RECOVERY_731\\n' >> effect.log; printf 'RESULT_RECOVERY_982\\n'"),
@@ -486,6 +499,7 @@ describe("session recovery", () => {
         metadata.title = "Recovered work keeps its chosen title";
         writeFileSync(metadataPath, JSON.stringify(metadata), { mode: 0o600 });
         if (missingUsage) rmSync(join(source, "usage-v2.json"));
+        if (damagedUsage) writeFileSync(join(source, "usage-v2.json"), "{damaged usage", { mode: 0o600 });
         const records = readFileSync(eventPath, "utf8").trimEnd().split("\n").map(JSON.parse);
         if (fullCoverage) records[0].event.user.work_id = "covered-recovery-work";
         const stored = records.find((record) => record.event.tool_result).event.tool_result;
@@ -515,6 +529,14 @@ describe("session recovery", () => {
         expect(gateway.requests).toHaveLength(2);
         expect(savedFileHashes(source)).toEqual(before);
         const target = join(fixture.home, ".fx", "sessions", result.recovered_id);
+        if (damagedUsage || missingUsage) {
+          const usage = JSON.parse(readFileSync(join(target, "usage-v2.json"), "utf8")).snapshot;
+          expect(usage.billing).toBe("incomplete");
+          expect(usage.api_duration_complete).toBe(false);
+          expect(usage.wall_duration_complete).toBe(false);
+          expect(usage.code_complete).toBe(false);
+          expect(usage.incidents.length).toBeGreaterThan(0);
+        }
         expect(JSON.parse(readFileSync(join(target, "session.json"), "utf8")).title).toBe(metadata.title);
         const targetEvents = readFileSync(join(target, "events.jsonl"), "utf8");
         expect(targetEvents.startsWith(prefix)).toBe(true);

--- a/tests/e2e/session-recovery.test.ts
+++ b/tests/e2e/session-recovery.test.ts
@@ -454,18 +454,31 @@ describe("session recovery", () => {
       expect(savedFileHashes(source)).toEqual(before);
       expect(readdirSync(join(fixture.home, ".fx", "sessions"))).toEqual([id]);
       expect(gateway.requests).toHaveLength(1);
-      writeFileSync(join(source, "permissions.json"), "{broken", { mode: 0o600 });
-      const damaged = savedFileHashes(source);
-      const refused = await runFx(["session", "recover", id, "--json"], {
-        cwd: fixture.workspace, env: gatewayEnv(fixture, gateway), timeoutMs: TIMEOUT,
-      });
-      expect(refused.code).toBe(1);
-      expect(refused.stderr).toBe("");
-      expect(JSON.parse(refused.stdout).code).toBe("InvalidPermissionState");
-      expect(refused.stdout).not.toContain("resume it normally");
-      expect(savedFileHashes(source)).toEqual(damaged);
-      expect(readdirSync(join(fixture.home, ".fx", "sessions"))).toEqual([id]);
-      expect(gateway.requests).toHaveLength(1);
+      async function expectRefused(code: string) {
+        const damaged = savedFileHashes(source);
+        const refused = await runFx(["session", "recover", id, "--json"], {
+          cwd: fixture.workspace, env: gatewayEnv(fixture, gateway), timeoutMs: TIMEOUT,
+        });
+        expect(refused.code).toBe(1);
+        expect(refused.stderr).toBe("");
+        expect(JSON.parse(refused.stdout).code).toBe(code);
+        expect(refused.stdout).not.toContain("resume it normally");
+        expect(savedFileHashes(source)).toEqual(damaged);
+        expect(readdirSync(join(fixture.home, ".fx", "sessions"))).toEqual([id]);
+        expect(gateway.requests).toHaveLength(1);
+      }
+      const permissionPath = join(source, "permissions.json");
+      const permissions = readFileSync(permissionPath);
+      writeFileSync(permissionPath, "{broken", { mode: 0o600 });
+      await expectRefused("InvalidPermissionState");
+      writeFileSync(permissionPath, "", { mode: 0o600 });
+      await expectRefused("PermissionStateTooLarge");
+      writeFileSync(permissionPath, permissions, { mode: 0o600 });
+      const usagePath = join(source, "usage-v2.json");
+      rmSync(usagePath);
+      mkdirSync(usagePath, { mode: 0o700 });
+      await expectRefused("InvalidUsageSidecar");
+      expect(readdirSync(usagePath)).toEqual([]);
     } finally {
       gateway.stop();
       rmSync(fixture.root, { recursive: true, force: true });

--- a/tests/e2e/tui-interrupt-recovery.test.ts
+++ b/tests/e2e/tui-interrupt-recovery.test.ts
@@ -12,12 +12,14 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { FX_BIN, runFx } from "../evals/eval-helpers";
 import { findFooterBlocks, readTrace } from "./tui-render-assertions";
 import {
   FAKE_GATEWAY_MODEL,
   fakeGatewayFinalText,
   fakeGatewayToolCall,
   fakeShellRun,
+  heldFakeGatewayFinalText,
   startFakeGateway,
   TmuxSession,
   tmuxAvailable,
@@ -62,6 +64,66 @@ afterEach(async () => {
 });
 
 describe.skipIf(SKIP)("tui: interrupt recovery", () => {
+  for (const inject of [false, true]) test(`quit reports final history persistence failure with fault=${inject}`, async () => {
+    root = realpathSync(mkdtempSync(join(tmpdir(), "fx-shutdown-save-")));
+    const home = join(root, "home"), workspace = join(root, "workspace");
+    mkdirSync(home); mkdirSync(workspace);
+    const library = join(root, process.platform === "darwin" ? "sync-fault.dylib" : "sync-fault.so");
+    const source = join(import.meta.dirname, "fixtures", "session-sync-fault.c");
+    const flags = process.platform === "darwin" ? ["-dynamiclib"] : ["-shared", "-fPIC"];
+    const compiled = Bun.spawnSync(["cc", ...flags, "-O2", "-Wall", "-Wextra", source, "-o", library,
+      ...(process.platform === "darwin" ? [] : ["-ldl"])]);
+    expect(compiled.exitCode).toBe(0);
+    const held = heldFakeGatewayFinalText();
+    let requestHeld = false;
+    gateway = startFakeGateway([
+      fakeGatewayFinalText("SHUTDOWN_SAVED_FACT_281"),
+      () => { requestHeld = true; return held.response; },
+      fakeGatewayFinalText("SHUTDOWN_RESUMED_281"),
+    ]);
+    const env = { HOME: home, AI_GATEWAY_API_KEY: "fake-shutdown-save", VERCEL_OIDC_TOKEN: undefined,
+      FX_DISABLE_KEYCHAIN: "1", FX_SKIP_ONBOARDING: "1", FX_SOUND: "0", FX_AUTO_UPGRADE: "0",
+      FX_MODEL: FAKE_GATEWAY_MODEL, FX_GATEWAY_BASE_URL: gateway.baseUrl, FX_GATEWAY_CHAT_URL: gateway.chatUrl,
+      FX_E2E_GATEWAY_CHAT_URL: gateway.chatUrl, FX_E2E_GATEWAY_MODELS_URL: `${gateway.baseUrl}/coding-agent/v1/models` };
+    try {
+      const seeded = await runFx(["ask", "--json", "Save the first fact."], { cwd: workspace, env, timeoutMs: TIMEOUT });
+      expect(seeded.code).toBe(0); expect(seeded.stderr).toBe("");
+      const id = JSON.parse(seeded.stdout).session_id;
+      const eventPath = join(home, ".fx", "sessions", id, "events.jsonl");
+      const saved = readFileSync(eventPath);
+      const stderrPath = join(root, "stderr.log"), tracePath = join(root, "trace.log");
+      const arm = join(root, "armed"), receipt = join(root, "injected.txt");
+      const quote = (text: string) => `'${text.replaceAll("'", "'\\''")}'`;
+      session = await TmuxSession.create({ cmd: `${quote(FX_BIN)} --resume ${quote(id)}`, cwd: workspace,
+        isolated: true, remainOnExit: true, width: 110, height: 36, stderrPath,
+        env: { ...env, [process.platform === "darwin" ? "DYLD_INSERT_LIBRARIES" : "LD_PRELOAD"]: library,
+          FX_TEST_SYNC_TARGET: eventPath, FX_TEST_SYNC_ARM: arm, FX_TEST_SYNC_RECORD: receipt,
+          FX_TEST_SYNC_MATCH: "SHUTDOWN_PENDING_REQUEST_392", FX_TRACE_LOG: tracePath,
+          FX_TRACE_SCOPES: "session,worker,input", FX_RECORD: join(root, "shutdown.fxtape") } });
+      await session.waitForStableComposer(TIMEOUT);
+      await session.sendText("SHUTDOWN_PENDING_REQUEST_392");
+      await waitForCondition(() => requestHeld, "held shutdown request");
+      if (inject) writeFileSync(arm, "armed");
+      await session.sendText("/quit");
+      await session.waitForPane(() => session!.paneStatus().dead, TIMEOUT);
+      const output = await session.captureFullScrollback();
+      const stderr = readFileSync(stderrPath, "utf8");
+      expect(existsSync(receipt)).toBe(inject);
+      if (inject) {
+        expect(readFileSync(receipt, "utf8")).toContain(`target=${eventPath}`);
+        expect(readFileSync(tracePath, "utf8")).toContain("shutdown finished prompt persistence failed");
+        expect(session.paneStatus().status).toBe(1);
+        expect(output + stderr).toMatch(/save.*fail|fail.*sav|could not.*sav|unable to.*sav/i);
+      } else { expect(session.paneStatus().status).toBe(0); expect(stderr).toBe(""); }
+      expect(readFileSync(eventPath).subarray(0, saved.length).equals(saved)).toBe(true);
+      const resumed = await runFx(["ask", "--json", "--resume-id", id, "Continue without repeating work."], {
+        cwd: workspace, env, timeoutMs: TIMEOUT });
+      expect(resumed.code).toBe(0); expect(resumed.stderr).toBe("");
+      expect(JSON.parse(resumed.stdout).session_id).toBe(id);
+      expect(gateway.requests.at(-1)!.body).toContain("SHUTDOWN_SAVED_FACT_281");
+    } finally { held.dispose(); }
+  }, TIMEOUT * 3);
+
   test(
     "Ctrl-C clears the composer before cancelling an active response",
     async () => {


### PR DESCRIPTION
## Summary

- Return the underlying session-load error instead of advising normal resume when an intact conversation has unreadable supporting state.
- Keep session-control load failures in the requested text or JSON format, with their existing error codes and doctor guidance.
