### PR TITLE
Keep subagent children and web search off freed host state

### DIFF
--- a/src/acp/prompt.zig
+++ b/src/acp/prompt.zig
@@ -154,8 +154,9 @@ const AcpContext = struct {
     /// session/set_mode changes never mutate a running turn.
     captured_mode: ?[]const u8 = null,
     captured_permission_mode: ?PermissionMode = null,
-    /// Set for subagent children: owned copies of the host credential so the
-    /// tool context never reads live session fields from the child thread.
+    /// Set for subagent children: owned copies of the host credential. The
+    /// child tool context takes its credential fields from here instead of the
+    /// live session, and leaves the parent-owned web search configuration alone.
     captured_host: ?*const ChildHostSnapshot = null,
     current_prompt_input: ?*ParsedPromptInput = null,
 
@@ -321,7 +322,10 @@ const AcpContext = struct {
         const credential_source = if (self.captured_host) |captured| captured.credential_source else session.credential_source;
         const gateway_team: ?[]const u8 = if (self.captured_host) |captured| captured.gateway_team else self.state.gateway_team;
         const account_id: ?[]const u8 = if (self.captured_host) |captured| captured.account_id else session.account_id;
-        if (provider_capabilities.fx_search) {
+        // The parent configures the shared web search runtime on its own
+        // thread from the live session; children search with that
+        // configuration rather than racing it with a stale copy.
+        if (provider_capabilities.fx_search and self.captured_host == null) {
             self.state.web_search_runtime.configure(self.alloc, .{
                 .api_key = api_key,
                 .credential_source = credential_source,
@@ -4115,9 +4119,12 @@ test "ACP subagent child owns its parent snapshot across later refreshes" {
         .session_id = active.session_id,
         .captured_host = &snapshot,
     };
+    try std.testing.expect(state.web_search_runtime.owned == null);
     const child_tool_context = child_ctx.toolContext();
     try std.testing.expect(child_tool_context.api_key.ptr == snapshot.api_key.ptr);
     try std.testing.expectEqual(snapshot.credential_source, child_tool_context.credential_source);
+    // The child must not reconfigure the parent-owned web search runtime.
+    try std.testing.expect(state.web_search_runtime.owned == null);
 
     // A later prompt replaces the parent snapshot while the child still runs.
     try refreshProjectContext(&state, alloc, &.{}, &.{}, null);

--- a/src/acp/prompt.zig
+++ b/src/acp/prompt.zig
@@ -4,6 +4,7 @@ const std_builtin = @import("builtin");
 const command_admission = @import("../core/permissions/command_admission.zig");
 const auth_runtime = @import("../core/auth/auth_runtime.zig");
 const credentials = @import("../core/auth/credentials.zig");
+const secret = @import("../core/auth/secret.zig");
 const model_provider = @import("../core/config/model_provider.zig");
 const host = @import("../core/hosts/host.zig");
 const host_target = @import("../core/hosts/target.zig");
@@ -314,7 +315,7 @@ const AcpContext = struct {
         const session = if (self.state.active_session) |*active| active else unreachable;
         const provider_capabilities = self.state.cfg.provider_set.select(session.provider).capabilities;
         if (provider_capabilities.fx_search) {
-            self.state.web_search_runtime.configure(.{
+            self.state.web_search_runtime.configure(self.alloc, .{
                 .api_key = session.api_key,
                 .credential_source = session.credential_source,
                 .gateway_team = self.state.gateway_team,
@@ -890,7 +891,12 @@ pub fn runSubagentChild(
     };
     const session_id = active.session_id;
     const captured_mode = active.mode;
+    var host_snapshot = ChildHostSnapshot.capture(alloc, state, active) catch {
+        state.subagent_authority_mutex.unlock(io_mod.getIo());
+        return error.OutOfMemory;
+    };
     state.subagent_authority_mutex.unlock(io_mod.getIo());
+    defer host_snapshot.deinit(alloc);
     var ctx = AcpContext{
         .alloc = alloc,
         .state = state,
@@ -912,9 +918,11 @@ pub fn runSubagentChild(
     defer child_projection.deinit(alloc);
     var skill_catalog = state.skills.acquireCatalog();
     defer skill_catalog.deinit();
+    var tool_context = ctx.toolContext();
+    host_snapshot.applyCredential(&tool_context);
     return subagent_agent_adapter.run(.{
         .host = subagent_host,
-        .tool_context = ctx.toolContext(),
+        .tool_context = tool_context,
         .provider_set = state.cfg.provider_set,
         .system_prompt = state.cfg.prompt_policy.system_prompt,
         .model_prompt_overlay = state.cfg.prompt_policy.modelPromptOverlay(admission.model),
@@ -924,10 +932,56 @@ pub fn runSubagentChild(
         .custom_tool_guidance = child_projection.custom_guidance,
         .context_registry = state.cfg.context_registry,
         .context_enabled = state.context_enabled,
-        .project_context = state.context_snapshot.modelVisibleBytes(),
+        .project_context = host_snapshot.project_context,
         .lifecycle_view = state.lifecycle_view,
     }, turn, message, admission, cancel);
 }
+
+/// Parent state a subagent child keeps reading after its own thread starts.
+/// The child can outlive the parent's cancelled turn, and the next prompt may
+/// replace the project context or rotate the credential, so the child owns
+/// copies taken under `subagent_authority_mutex`. The parent swaps those fields
+/// under the same lock before freeing the previous values.
+const ChildHostSnapshot = struct {
+    project_context: []u8,
+    api_key: []u8,
+    gateway_team: ?[]u8,
+    account_id: ?[]u8,
+
+    fn capture(
+        alloc: Allocator,
+        state: *const server.ServerState,
+        active: *const server.ActiveSessionState,
+    ) Allocator.Error!ChildHostSnapshot {
+        const project_context = try alloc.dupe(u8, state.context_snapshot.modelVisibleBytes());
+        errdefer alloc.free(project_context);
+        const api_key = try alloc.dupe(u8, active.api_key);
+        errdefer secret.zeroAndFree(alloc, api_key);
+        const gateway_team = if (state.gateway_team) |team| try alloc.dupe(u8, team) else null;
+        errdefer if (gateway_team) |team| alloc.free(team);
+        const account_id = if (active.account_id) |id| try alloc.dupe(u8, id) else null;
+        return .{
+            .project_context = project_context,
+            .api_key = api_key,
+            .gateway_team = gateway_team,
+            .account_id = account_id,
+        };
+    }
+
+    fn applyCredential(self: *const ChildHostSnapshot, tool_context: *tool_runtime.Context) void {
+        tool_context.api_key = self.api_key;
+        tool_context.gateway_team = self.gateway_team;
+        tool_context.account_id = self.account_id;
+    }
+
+    fn deinit(self: *ChildHostSnapshot, alloc: Allocator) void {
+        alloc.free(self.project_context);
+        secret.zeroAndFree(alloc, self.api_key);
+        if (self.gateway_team) |team| alloc.free(team);
+        if (self.account_id) |id| alloc.free(id);
+        self.* = undefined;
+    }
+};
 
 fn refreshProjectContext(
     state: *server.ServerState,
@@ -936,10 +990,12 @@ fn refreshProjectContext(
     omissions: []const context_contract.ContextOmissionInput,
     omission_summary: ?context_contract.ContextOmissionSummary,
 ) context_contract.ProviderError!void {
-    state.context_snapshot.deinit(alloc);
-    if (!state.context_enabled) return;
+    if (!state.context_enabled) {
+        replaceProjectContextSnapshot(state, alloc, .{});
+        return;
+    }
 
-    state.context_snapshot = state.cfg.context_registry.gatherDefaultSnapshot(alloc, .{
+    const next = state.cfg.context_registry.gatherDefaultSnapshot(alloc, .{
         .workspace_root = state.workspace_root,
         .access_scope = state.workspace_access.scope(state.workspace_root),
         .targets = targets,
@@ -948,8 +1004,25 @@ fn refreshProjectContext(
         .context_limits = state.context_limits,
     }) catch |err| {
         debug_trace.logf("context", "acp gather failed err={s}", .{@errorName(err)});
+        replaceProjectContextSnapshot(state, alloc, .{});
         return err;
     };
+    replaceProjectContextSnapshot(state, alloc, next);
+}
+
+/// Swaps the parent snapshot under the lock subagent children hold while they
+/// copy it (`ChildHostSnapshot.capture`), then frees the previous bytes once no
+/// child can still see them.
+fn replaceProjectContextSnapshot(
+    state: *server.ServerState,
+    alloc: Allocator,
+    next: context_contract.GatheredContextSnapshot,
+) void {
+    state.subagent_authority_mutex.lockUncancelable(io_mod.getIo());
+    var previous = state.context_snapshot;
+    state.context_snapshot = next;
+    state.subagent_authority_mutex.unlock(io_mod.getIo());
+    previous.deinit(alloc);
 }
 
 const AgentConfigSections = struct {
@@ -4013,6 +4086,35 @@ test "ACP refreshes typed registry context and propagates enabled gathering erro
     try std.testing.expect(state.context_snapshot.contribution == null);
 }
 
+test "ACP subagent child owns its parent snapshot across later refreshes" {
+    const alloc = std.testing.allocator;
+    AcpContextRegistryFixture.reset();
+
+    var state = try initTestAcpState(alloc, "/tmp/workspace", .ask);
+    defer state.deinit();
+    const active = &state.active_session.?;
+    try refreshProjectContext(&state, alloc, &.{}, &.{}, null);
+
+    var snapshot = try ChildHostSnapshot.capture(alloc, &state, active);
+    defer snapshot.deinit(alloc);
+    try std.testing.expectEqualStrings("ACP registry context 1", snapshot.project_context);
+    try std.testing.expect(snapshot.project_context.ptr != state.context_snapshot.modelVisibleBytes().ptr);
+    try std.testing.expectEqualStrings(active.api_key, snapshot.api_key);
+    try std.testing.expect(snapshot.api_key.ptr != active.api_key.ptr);
+    try std.testing.expect(snapshot.gateway_team == null);
+    try std.testing.expect(snapshot.account_id == null);
+
+    // A later prompt replaces the parent snapshot while the child still runs.
+    try refreshProjectContext(&state, alloc, &.{}, &.{}, null);
+    try std.testing.expectEqualStrings("ACP registry context 2", state.context_snapshot.modelVisibleBytes());
+    try std.testing.expectEqualStrings("ACP registry context 1", snapshot.project_context);
+
+    state.context_enabled = false;
+    try refreshProjectContext(&state, alloc, &.{}, &.{}, null);
+    try std.testing.expectEqualStrings("", state.context_snapshot.modelVisibleBytes());
+    try std.testing.expectEqualStrings("ACP registry context 1", snapshot.project_context);
+}
+
 test "ACP prompt propagates context provider errors before pending prompt state" {
     const alloc = std.testing.allocator;
     var state = try initTestAcpState(alloc, "/tmp/workspace", .ask);
@@ -4236,11 +4338,12 @@ test "ACP prompt projection configures web search then blocks native execution" 
     var provider = state.web_search_runtime.provider orelse return error.TestExpectedEqual;
     provider.context = @ptrCast(&provider_state);
     provider.execute_fn = FailingWebSearchProvider.execute;
+    state.web_search_runtime.deinit();
     state.web_search_runtime = web_search_runtime.Runtime.init(.{
         .provider = provider,
     });
 
-    state.web_search_runtime.configure(.{
+    state.web_search_runtime.configure(alloc, .{
         .api_key = "stale-key",
         .worker_model = "stale-model",
         .gateway_retry_count = 99,

--- a/src/acp/prompt.zig
+++ b/src/acp/prompt.zig
@@ -154,6 +154,9 @@ const AcpContext = struct {
     /// session/set_mode changes never mutate a running turn.
     captured_mode: ?[]const u8 = null,
     captured_permission_mode: ?PermissionMode = null,
+    /// Set for subagent children: owned copies of the host credential so the
+    /// tool context never reads live session fields from the child thread.
+    captured_host: ?*const ChildHostSnapshot = null,
     current_prompt_input: ?*ParsedPromptInput = null,
 
     fn deinitPublishedToolCalls(self: *AcpContext) void {
@@ -314,11 +317,15 @@ const AcpContext = struct {
     fn toolContext(self: *AcpContext) tool_runtime.Context {
         const session = if (self.state.active_session) |*active| active else unreachable;
         const provider_capabilities = self.state.cfg.provider_set.select(session.provider).capabilities;
+        const api_key: []const u8 = if (self.captured_host) |captured| captured.api_key else session.api_key;
+        const credential_source = if (self.captured_host) |captured| captured.credential_source else session.credential_source;
+        const gateway_team: ?[]const u8 = if (self.captured_host) |captured| captured.gateway_team else self.state.gateway_team;
+        const account_id: ?[]const u8 = if (self.captured_host) |captured| captured.account_id else session.account_id;
         if (provider_capabilities.fx_search) {
             self.state.web_search_runtime.configure(self.alloc, .{
-                .api_key = session.api_key,
-                .credential_source = session.credential_source,
-                .gateway_team = self.state.gateway_team,
+                .api_key = api_key,
+                .credential_source = credential_source,
+                .gateway_team = gateway_team,
                 .worker_model = session.model,
                 .gateway_retry_count = self.state.cfg.gateway_retry_count,
                 .gateway_chat_url = self.state.cfg.gateway_chat_url,
@@ -336,15 +343,15 @@ const AcpContext = struct {
             .max_read_file_line_len = self.state.cfg.max_read_file_line_len,
             .max_command_output_bytes = self.state.cfg.max_command_output_bytes,
             .max_tool_result_bytes = session.max_tool_result_bytes,
-            .api_key = session.api_key,
+            .api_key = api_key,
             .agent_stream_provider = server.streamProviderFor(self.state, session.provider),
-            .credential_source = session.credential_source,
-            .account_id = session.account_id,
+            .credential_source = credential_source,
+            .account_id = account_id,
             .provider = session.provider,
             .provider_capabilities = provider_capabilities,
             .oauth_transport = self.state.cfg.gateway_provider.oauth_transport,
             .secret_store = self.state.cfg.secret_store,
-            .gateway_team = self.state.gateway_team,
+            .gateway_team = gateway_team,
             .model = session.model,
             .gateway_retry_count = self.state.cfg.gateway_retry_count,
             .gateway_chat_url = self.state.cfg.gateway_chat_url,
@@ -903,6 +910,7 @@ pub fn runSubagentChild(
         .session_id = session_id,
         .captured_mode = captured_mode,
         .captured_permission_mode = admission.permission_mode,
+        .captured_host = &host_snapshot,
     };
     defer ctx.deinitPublishedToolCalls();
     var child_projection = state.cfg.mode_registry.buildModelToolProjection(
@@ -918,11 +926,9 @@ pub fn runSubagentChild(
     defer child_projection.deinit(alloc);
     var skill_catalog = state.skills.acquireCatalog();
     defer skill_catalog.deinit();
-    var tool_context = ctx.toolContext();
-    host_snapshot.applyCredential(&tool_context);
     return subagent_agent_adapter.run(.{
         .host = subagent_host,
-        .tool_context = tool_context,
+        .tool_context = ctx.toolContext(),
         .provider_set = state.cfg.provider_set,
         .system_prompt = state.cfg.prompt_policy.system_prompt,
         .model_prompt_overlay = state.cfg.prompt_policy.modelPromptOverlay(admission.model),
@@ -941,10 +947,13 @@ pub fn runSubagentChild(
 /// The child can outlive the parent's cancelled turn, and the next prompt may
 /// replace the project context or rotate the credential, so the child owns
 /// copies taken under `subagent_authority_mutex`. The parent swaps those fields
-/// under the same lock before freeing the previous values.
+/// under the same lock before freeing the previous values. `AcpContext`
+/// consumes the snapshot through `captured_host` when building the child tool
+/// context.
 const ChildHostSnapshot = struct {
     project_context: []u8,
     api_key: []u8,
+    credential_source: ?types.CredentialSource,
     gateway_team: ?[]u8,
     account_id: ?[]u8,
 
@@ -963,15 +972,10 @@ const ChildHostSnapshot = struct {
         return .{
             .project_context = project_context,
             .api_key = api_key,
+            .credential_source = active.credential_source,
             .gateway_team = gateway_team,
             .account_id = account_id,
         };
-    }
-
-    fn applyCredential(self: *const ChildHostSnapshot, tool_context: *tool_runtime.Context) void {
-        tool_context.api_key = self.api_key;
-        tool_context.gateway_team = self.gateway_team;
-        tool_context.account_id = self.account_id;
     }
 
     fn deinit(self: *ChildHostSnapshot, alloc: Allocator) void {
@@ -4101,8 +4105,19 @@ test "ACP subagent child owns its parent snapshot across later refreshes" {
     try std.testing.expect(snapshot.project_context.ptr != state.context_snapshot.modelVisibleBytes().ptr);
     try std.testing.expectEqualStrings(active.api_key, snapshot.api_key);
     try std.testing.expect(snapshot.api_key.ptr != active.api_key.ptr);
+    try std.testing.expectEqual(active.credential_source, snapshot.credential_source);
     try std.testing.expect(snapshot.gateway_team == null);
     try std.testing.expect(snapshot.account_id == null);
+
+    var child_ctx = AcpContext{
+        .alloc = alloc,
+        .state = &state,
+        .session_id = active.session_id,
+        .captured_host = &snapshot,
+    };
+    const child_tool_context = child_ctx.toolContext();
+    try std.testing.expect(child_tool_context.api_key.ptr == snapshot.api_key.ptr);
+    try std.testing.expectEqual(snapshot.credential_source, child_tool_context.credential_source);
 
     // A later prompt replaces the parent snapshot while the child still runs.
     try refreshProjectContext(&state, alloc, &.{}, &.{}, null);

--- a/src/acp/server.zig
+++ b/src/acp/server.zig
@@ -356,31 +356,39 @@ fn credentialReadyAt(
 }
 
 fn adoptServerCredential(state: *ServerState, credential: *credentials.Credential) void {
-    if (state.active_session) |*active| active.api_key = &.{};
-    if (state.api_key.len > 0) secret.zeroAndFree(state.alloc, state.api_key);
-    if (state.gateway_team) |team| state.alloc.free(team);
-    if (state.account_id) |account_id| state.alloc.free(account_id);
+    const previous_api_key = state.api_key;
+    const previous_gateway_team = state.gateway_team;
+    const previous_account_id = state.account_id;
 
+    // Subagent children copy these fields under the same lock; swap first and
+    // free the previous values only after no child can still observe them.
+    state.subagent_authority_mutex.lockUncancelable(io_mod.getIo());
     state.api_key = credential.token;
-    credential.token = &.{};
     state.credential_source = credential.source;
     state.credential_refresh_after_ms = credential.refresh_after_ms;
     state.account_id = credential.account_id;
-    credential.account_id = null;
     state.gateway_team = if (credential.team_id) |team| team else credential.team_slug;
-    if (credential.team_id != null) {
-        credential.team_id = null;
-        if (credential.team_slug) |slug| state.alloc.free(slug);
-        credential.team_slug = null;
-    } else {
-        credential.team_slug = null;
-    }
     if (state.active_session) |*active| {
         active.api_key = state.api_key;
         active.credential_source = state.credential_source;
         active.credential_refresh_after_ms = state.credential_refresh_after_ms;
         active.account_id = state.account_id;
-        if (comptime !host_target.is_wasm) {
+    }
+    state.subagent_authority_mutex.unlock(io_mod.getIo());
+
+    credential.token = &.{};
+    credential.account_id = null;
+    if (credential.team_id != null) {
+        credential.team_id = null;
+        if (credential.team_slug) |slug| state.alloc.free(slug);
+    }
+    credential.team_slug = null;
+    if (previous_api_key.len > 0) secret.zeroAndFree(state.alloc, previous_api_key);
+    if (previous_gateway_team) |team| state.alloc.free(team);
+    if (previous_account_id) |account_id| state.alloc.free(account_id);
+
+    if (comptime !host_target.is_wasm) {
+        if (state.active_session) |*active| {
             if (state.credential_source == .chatgpt_subscription or state.credential_source == .grok_subscription) {
                 active.session_rt.usage.clearReconciliationCredential();
             }
@@ -2862,6 +2870,7 @@ test "ACP publishes an account-bound refreshed Codex token for later prompts" {
     const alloc = std.testing.allocator;
     var state: ServerState = undefined;
     state.alloc = alloc;
+    state.subagent_authority_mutex = .init;
     state.api_key = try alloc.dupe(u8, "stale-token");
     state.account_id = try alloc.dupe(u8, "acct-1");
     state.credential_source = .chatgpt_subscription;
@@ -2909,6 +2918,7 @@ test "ACP rejects refreshed Codex tokens for another account" {
     const alloc = std.testing.allocator;
     var state: ServerState = undefined;
     state.alloc = alloc;
+    state.subagent_authority_mutex = .init;
     state.api_key = try alloc.dupe(u8, "stale-token");
     state.account_id = try alloc.dupe(u8, "acct-1");
     state.credential_source = .chatgpt_subscription;

--- a/src/acp/server.zig
+++ b/src/acp/server.zig
@@ -356,13 +356,12 @@ fn credentialReadyAt(
 }
 
 fn adoptServerCredential(state: *ServerState, credential: *credentials.Credential) void {
-    const previous_api_key = state.api_key;
-    const previous_gateway_team = state.gateway_team;
-    const previous_account_id = state.account_id;
-
     // Subagent children copy these fields under the same lock; swap first and
     // free the previous values only after no child can still observe them.
     state.subagent_authority_mutex.lockUncancelable(io_mod.getIo());
+    const previous_api_key = state.api_key;
+    const previous_gateway_team = state.gateway_team;
+    const previous_account_id = state.account_id;
     state.api_key = credential.token;
     state.credential_source = credential.source;
     state.credential_refresh_after_ms = credential.refresh_after_ms;

--- a/src/core/app/app_agent_runtime.zig
+++ b/src/core/app/app_agent_runtime.zig
@@ -302,7 +302,7 @@ pub fn Runtime(comptime App: type) type {
             }
             if (comptime @hasField(App, "web_search_runtime")) {
                 if (provider_capabilities.fx_search) {
-                    app.web_search_runtime.configure(.{
+                    app.web_search_runtime.configure(app.alloc, .{
                         .api_key = app.auth.apiKey() orelse "",
                         .credential_source = app.auth.credentialSource(),
                         .gateway_team = app.auth.gatewayTeam(),
@@ -777,7 +777,7 @@ pub fn Runtime(comptime App: type) type {
             ctx.gateway_team = credential.tenant();
             if (comptime @hasField(App, "web_search_runtime") and @hasField(App, "session")) {
                 if (ctx.provider_capabilities.fx_search) {
-                    app.web_search_runtime.configure(.{
+                    app.web_search_runtime.configure(app.alloc, .{
                         .api_key = credential_secret,
                         .credential_source = credential_source,
                         .gateway_team = credential.tenant(),
@@ -2061,11 +2061,12 @@ test "app prompt projection configures web search then blocks native execution" 
     var provider = app.web_search_runtime.provider orelse return error.TestExpectedEqual;
     provider.context = @ptrCast(&provider_state);
     provider.execute_fn = FailingWebSearchProvider.execute;
+    app.web_search_runtime.deinit();
     app.web_search_runtime = web_search_runtime.Runtime.init(.{
         .provider = provider,
     });
 
-    app.web_search_runtime.configure(.{
+    app.web_search_runtime.configure(alloc, .{
         .api_key = "stale-key",
         .worker_model = "stale-model",
         .gateway_retry_count = 99,

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -956,7 +956,7 @@ const AskContext = struct {
     fn toolContext(self: *AskContext) tool_runtime.Context {
         const provider_capabilities = self.cfg.provider_set.select(self.provider).capabilities;
         if (provider_capabilities.fx_search) {
-            self.web_search_runtime.configure(.{
+            self.web_search_runtime.configure(self.alloc, .{
                 .api_key = self.api_key,
                 .credential_source = self.credential_source,
                 .gateway_team = self.gateway_team,
@@ -4947,11 +4947,12 @@ test "CLI prompt projection configures web search then blocks native execution" 
     var provider = ctx.web_search_runtime.provider orelse return error.TestExpectedEqual;
     provider.context = @ptrCast(&provider_state);
     provider.execute_fn = FailingWebSearchProvider.execute;
+    ctx.web_search_runtime.deinit();
     ctx.web_search_runtime = web_search_runtime.Runtime.init(.{
         .provider = provider,
     });
 
-    ctx.web_search_runtime.configure(.{
+    ctx.web_search_runtime.configure(alloc, .{
         .api_key = "stale-key",
         .worker_model = "stale-model",
         .gateway_retry_count = 99,

--- a/src/core/tooling/web_search_runtime.zig
+++ b/src/core/tooling/web_search_runtime.zig
@@ -57,6 +57,26 @@ const OwnedInputs = struct {
     usage: ?*session_usage.Usage,
     usage_allocator: Allocator,
 
+    fn dupe(alloc: Allocator, inputs: Inputs) Allocator.Error!OwnedInputs {
+        const api_key = try alloc.dupe(u8, inputs.api_key);
+        errdefer alloc.free(api_key);
+        const gateway_team = if (inputs.gateway_team) |team| try alloc.dupe(u8, team) else null;
+        errdefer if (gateway_team) |team| alloc.free(team);
+        const worker_model = try alloc.dupe(u8, inputs.worker_model);
+        errdefer alloc.free(worker_model);
+        const gateway_chat_url = try alloc.dupe(u8, inputs.gateway_chat_url);
+        return .{
+            .api_key = api_key,
+            .credential_source = inputs.credential_source,
+            .gateway_team = gateway_team,
+            .worker_model = worker_model,
+            .gateway_retry_count = inputs.gateway_retry_count,
+            .gateway_chat_url = gateway_chat_url,
+            .usage = inputs.usage,
+            .usage_allocator = inputs.usage_allocator,
+        };
+    }
+
     fn deinit(self: *OwnedInputs, alloc: Allocator) void {
         alloc.free(self.api_key);
         if (self.gateway_team) |team| alloc.free(team);
@@ -85,6 +105,8 @@ pub const Runtime = struct {
     provider: ?web_search_provider.Provider,
     clock: Clock,
     policy: web_search_policy.WebSearchPolicy,
+    // Current worker inputs. `init` points these at caller-provided defaults
+    // that must outlive the runtime; `configure` points them at `owned`.
     api_key: []const u8,
     credential_source: ?types.CredentialSource = null,
     gateway_team: ?[]const u8 = null,
@@ -93,6 +115,9 @@ pub const Runtime = struct {
     gateway_chat_url: []const u8,
     usage: ?*session_usage.Usage,
     usage_allocator: Allocator,
+    owned: ?OwnedInputs = null,
+    owned_allocator: ?Allocator = null,
+    configure_failed: bool = false,
     config_mutex: std.Io.Mutex = .init,
     fallback_cancel_flag: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
 
@@ -112,19 +137,42 @@ pub const Runtime = struct {
         };
     }
 
-    pub fn deinit(_: *Runtime) void {}
+    pub fn deinit(self: *Runtime) void {
+        if (self.owned) |*owned| owned.deinit(self.owned_allocator.?);
+        self.owned = null;
+        self.owned_allocator = null;
+    }
 
-    pub fn configure(self: *Runtime, inputs: Inputs) void {
+    /// Retains an owned copy of `inputs`, so callers may free their strings
+    /// (for example on credential rotation) while searches are still running
+    /// on other threads. When the copy cannot be allocated the previous
+    /// inputs stay in place and the next search fails with `OutOfMemory`
+    /// instead of reading caller memory of unknown lifetime.
+    pub fn configure(self: *Runtime, alloc: Allocator, inputs: Inputs) void {
+        const next = OwnedInputs.dupe(alloc, inputs) catch {
+            debug_trace.logf("web_search", "configure failed err=OutOfMemory", .{});
+            self.config_mutex.lockUncancelable(io_mod.getIo());
+            defer self.config_mutex.unlock(io_mod.getIo());
+            self.configure_failed = true;
+            return;
+        };
         self.config_mutex.lockUncancelable(io_mod.getIo());
-        defer self.config_mutex.unlock(io_mod.getIo());
-        self.api_key = inputs.api_key;
-        self.credential_source = inputs.credential_source;
-        self.gateway_team = inputs.gateway_team;
-        self.worker_model = inputs.worker_model;
-        self.gateway_retry_count = inputs.gateway_retry_count;
-        self.gateway_chat_url = inputs.gateway_chat_url;
-        self.usage = inputs.usage;
-        self.usage_allocator = inputs.usage_allocator;
+        var previous = self.owned;
+        const previous_allocator = self.owned_allocator;
+        self.owned = next;
+        self.owned_allocator = alloc;
+        self.configure_failed = false;
+        const current = &self.owned.?;
+        self.api_key = current.api_key;
+        self.credential_source = current.credential_source;
+        self.gateway_team = current.gateway_team;
+        self.worker_model = current.worker_model;
+        self.gateway_retry_count = current.gateway_retry_count;
+        self.gateway_chat_url = current.gateway_chat_url;
+        self.usage = current.usage;
+        self.usage_allocator = current.usage_allocator;
+        self.config_mutex.unlock(io_mod.getIo());
+        if (previous) |*owned| owned.deinit(previous_allocator.?);
     }
 
     pub fn dispatchBackend(self: *Runtime) tool_dispatch.WebSearchBackend {
@@ -222,23 +270,17 @@ pub const Runtime = struct {
     fn inputsSnapshot(self: *Runtime, alloc: Allocator) !OwnedInputs {
         self.config_mutex.lockUncancelable(io_mod.getIo());
         defer self.config_mutex.unlock(io_mod.getIo());
-        const api_key = try alloc.dupe(u8, self.api_key);
-        errdefer alloc.free(api_key);
-        const gateway_team = if (self.gateway_team) |team| try alloc.dupe(u8, team) else null;
-        errdefer if (gateway_team) |team| alloc.free(team);
-        const worker_model = try alloc.dupe(u8, self.worker_model);
-        errdefer alloc.free(worker_model);
-        const gateway_chat_url = try alloc.dupe(u8, self.gateway_chat_url);
-        return .{
-            .api_key = api_key,
+        if (self.configure_failed) return error.OutOfMemory;
+        return OwnedInputs.dupe(alloc, .{
+            .api_key = self.api_key,
             .credential_source = self.credential_source,
-            .gateway_team = gateway_team,
-            .worker_model = worker_model,
+            .gateway_team = self.gateway_team,
+            .worker_model = self.worker_model,
             .gateway_retry_count = self.gateway_retry_count,
-            .gateway_chat_url = gateway_chat_url,
+            .gateway_chat_url = self.gateway_chat_url,
             .usage = self.usage,
             .usage_allocator = self.usage_allocator,
-        };
+        });
     }
 
     fn executeProvider(
@@ -827,13 +869,14 @@ const SearchConfigStress = struct {
     inputs: Inputs,
 
     fn run(self: SearchConfigStress) void {
-        for (0..2000) |_| self.runtime.configure(self.inputs);
+        for (0..2000) |_| self.runtime.configure(std.testing.allocator, self.inputs);
     }
 };
 
 test "web_search runtime updates its worker model during configuration" {
     var runtime = Runtime.init(.{});
-    runtime.configure(.{
+    defer runtime.deinit();
+    runtime.configure(std.testing.allocator, .{
         .api_key = "key",
         .worker_model = "provider/model",
         .gateway_retry_count = 2,
@@ -844,6 +887,74 @@ test "web_search runtime updates its worker model during configuration" {
     try std.testing.expectEqualStrings("key", runtime.api_key);
     try std.testing.expectEqual(@as(usize, 2), runtime.gateway_retry_count);
     try std.testing.expectEqualStrings("https://gateway.test/chat", runtime.gateway_chat_url);
+}
+
+test "web_search runtime owns configured inputs after the caller frees its strings" {
+    const alloc = std.testing.allocator;
+    var runtime = Runtime.init(.{});
+    defer runtime.deinit();
+
+    const caller_key = try alloc.dupe(u8, "rotating-key");
+    const caller_team = try alloc.dupe(u8, "team-a");
+    runtime.configure(alloc, .{
+        .api_key = caller_key,
+        .gateway_team = caller_team,
+        .worker_model = "provider/model",
+        .gateway_retry_count = 2,
+        .gateway_chat_url = "https://gateway.test/chat",
+    });
+    try std.testing.expect(runtime.api_key.ptr != caller_key.ptr);
+    try std.testing.expect(runtime.gateway_team.?.ptr != caller_team.ptr);
+    // Credential rotation frees the caller's strings while the runtime may
+    // still be executing searches on another thread.
+    alloc.free(caller_key);
+    alloc.free(caller_team);
+
+    var snapshot = try runtime.inputsSnapshot(alloc);
+    defer snapshot.deinit(alloc);
+    try std.testing.expectEqualStrings("rotating-key", snapshot.api_key);
+    try std.testing.expectEqualStrings("team-a", snapshot.gateway_team.?);
+
+    runtime.configure(alloc, .{
+        .api_key = "next-key",
+        .worker_model = "provider/model",
+        .gateway_retry_count = 2,
+        .gateway_chat_url = "https://gateway.test/chat",
+    });
+    try std.testing.expectEqualStrings("next-key", runtime.api_key);
+    try std.testing.expect(runtime.gateway_team == null);
+}
+
+test "web_search runtime fails searches when configured inputs cannot be retained" {
+    const alloc = std.testing.allocator;
+    var runtime = Runtime.init(.{});
+    defer runtime.deinit();
+    runtime.configure(alloc, .{
+        .api_key = "key",
+        .worker_model = "provider/model",
+        .gateway_retry_count = 2,
+        .gateway_chat_url = "https://gateway.test/chat",
+    });
+
+    var failing = std.testing.FailingAllocator.init(alloc, .{ .fail_index = 0 });
+    runtime.configure(failing.allocator(), .{
+        .api_key = "unretained-key",
+        .worker_model = "provider/model",
+        .gateway_retry_count = 2,
+        .gateway_chat_url = "https://gateway.test/chat",
+    });
+    try std.testing.expectEqualStrings("key", runtime.api_key);
+    try std.testing.expectError(error.OutOfMemory, runtime.inputsSnapshot(alloc));
+
+    runtime.configure(alloc, .{
+        .api_key = "recovered-key",
+        .worker_model = "provider/model",
+        .gateway_retry_count = 2,
+        .gateway_chat_url = "https://gateway.test/chat",
+    });
+    var snapshot = try runtime.inputsSnapshot(alloc);
+    defer snapshot.deinit(alloc);
+    try std.testing.expectEqualStrings("recovered-key", snapshot.api_key);
 }
 
 test "web_search runtime preserves session usage through worker input snapshots" {
@@ -864,6 +975,7 @@ test "web_search runtime preserves session usage through worker input snapshots"
 
 test "web_search input snapshots stay coherent during parallel reconfiguration" {
     var runtime = Runtime.init(.{});
+    defer runtime.deinit();
     const inputs_a = Inputs{
         .api_key = "key-a",
         .worker_model = "model-a",
@@ -876,7 +988,7 @@ test "web_search input snapshots stay coherent during parallel reconfiguration" 
         .gateway_retry_count = 2,
         .gateway_chat_url = "https://b.invalid/chat",
     };
-    runtime.configure(inputs_a);
+    runtime.configure(std.testing.allocator, inputs_a);
 
     const thread_a = try std.Thread.spawn(.{}, SearchConfigStress.run, .{SearchConfigStress{ .runtime = &runtime, .inputs = inputs_a }});
     defer thread_a.join();

--- a/src/core/tooling/web_search_runtime.zig
+++ b/src/core/tooling/web_search_runtime.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const debug_trace = @import("../shared/debug_trace.zig");
 const diagnostics = @import("../workspace/diagnostics.zig");
+const secret = @import("../auth/secret.zig");
 const io_mod = @import("../shared/io.zig");
 const types = @import("../shared/types.zig");
 const tool_dispatch = @import("tool_dispatch.zig");
@@ -59,7 +60,7 @@ const OwnedInputs = struct {
 
     fn dupe(alloc: Allocator, inputs: Inputs) Allocator.Error!OwnedInputs {
         const api_key = try alloc.dupe(u8, inputs.api_key);
-        errdefer alloc.free(api_key);
+        errdefer secret.zeroAndFree(alloc, api_key);
         const gateway_team = if (inputs.gateway_team) |team| try alloc.dupe(u8, team) else null;
         errdefer if (gateway_team) |team| alloc.free(team);
         const worker_model = try alloc.dupe(u8, inputs.worker_model);
@@ -78,7 +79,7 @@ const OwnedInputs = struct {
     }
 
     fn deinit(self: *OwnedInputs, alloc: Allocator) void {
-        alloc.free(self.api_key);
+        secret.zeroAndFree(alloc, self.api_key);
         if (self.gateway_team) |team| alloc.free(team);
         alloc.free(self.worker_model);
         alloc.free(self.gateway_chat_url);


### PR DESCRIPTION
## Summary

- A subagent child that is still running after its ACP prompt is cancelled keeps the project instructions it started with; the next prompt no longer frees them out from under it.
- A credential refresh or provider change at the next ACP prompt no longer leaves a running child using a freed API key, gateway team, or account id for security reviews, vision, or web search.
- Web search keeps the credential it was configured with when the host rotates credentials mid-session, in the interactive shell, fx ask, and ACP.
- When web search configuration cannot be retained, the next search fails with an out-of-memory error instead of using stale values.