### PR TITLE
Preserve recovery images across failure and restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Repeated continuation reuses validated summaries of unchanged older sessions ins
 
 Older sessions that saved Vercel connection settings can be opened through `-r`, `/resume`, `-c`, or an exact ID. Migration preserves their model settings and keeps unfinished responses as interrupted history, without replaying old requests or restoring saved credential references.
 
-If a saved conversation is damaged, run `fx session recover <id>` to copy its validated prefix into a new session. Recovery preserves checkpoint boundaries and referenced result files, leaves the original unchanged, and prints the new session ID. Records after the damaged boundary are not included, and recovery does not rerun commands. Healthy conversations can be resumed without recovery.
+If a saved conversation is damaged, run `fx session recover <id>` to copy its validated prefix into a new session. Recovery preserves checkpoint boundaries and referenced result files, leaves the original unchanged, and prints the new session ID. Records after the damaged boundary are not included, and recovery does not rerun commands. Healthy conversations can be resumed without recovery. Paused requests retain their captured images across errors and restarts. Continuing uses those saved images even if the original files move or change; missing or corrupted saved images produce a recovery error.
 
 New sessions appear in resume selection only after their initial files are ready. Incomplete creation folders left by older builds do not block healthy conversations from resuming with `-c`; those folders remain available for diagnosis and are not deleted.
 

--- a/src/acp/prompt.zig
+++ b/src/acp/prompt.zig
@@ -661,8 +661,15 @@ pub fn handlePrompt(
         },
     };
 
-    const prior_image_catalog = try session.session_rt.snapshotImageCatalog(alloc, &.{});
+    var prior_image_catalog = try session.session_rt.snapshotImageCatalog(alloc, &.{});
     defer types.freeImageAttachmentSlice(alloc, prior_image_catalog);
+    if (session.writable) |writable| {
+        if (writable.state.recovery_checkpoint) |checkpoint| {
+            const merged = try session_runtime.merge_image_catalog_history_turn(alloc, prior_image_catalog, checkpoint.interruptedTurn());
+            types.freeImageAttachmentSlice(alloc, prior_image_catalog);
+            prior_image_catalog = merged;
+        }
+    }
     const next_image_id = (try image_attachments.calculate_next_image_id(prior_image_catalog)).next_id;
     var prompt_input = parsePromptInputWithFirstImageId(alloc, params, next_image_id) catch |err|
         return promptInputFailure(err);
@@ -777,8 +784,11 @@ pub fn handlePrompt(
     defer alloc.free(root_user_intent_context);
 
     const current_images = if (recovery_checkpoint) |checkpoint| checkpoint.user.images else prompt_input.images;
-    const authorized_image_catalog = try session.session_rt.snapshotImageCatalog(alloc, current_images);
-    defer types.freeImageAttachmentSlice(alloc, authorized_image_catalog);
+    const authorized_image_catalog = if (recovery_checkpoint != null)
+        prior_image_catalog
+    else
+        try session.session_rt.snapshotImageCatalog(alloc, current_images);
+    defer if (recovery_checkpoint == null) types.freeImageAttachmentSlice(alloc, authorized_image_catalog);
 
     const job: worker_runtime.QueuedPrompt = .{
         .turn_id = if (recovery_checkpoint) |checkpoint| checkpoint.turn_id else 0,
@@ -2039,6 +2049,9 @@ fn setRecoveryCheckpoint(
     checkpoint: session_codec.RecoveryCheckpoint,
 ) !void {
     const ctx: *AcpContext = @ptrCast(@alignCast(raw_ctx));
+    errdefer |err| if (err == error.SessionPersistenceUncertain) {
+        if (ctx.current_prompt_input) |input| input.retainImageSnapshots();
+    };
     const session = if (ctx.state.active_session) |*value| value else return error.SessionPersistenceUnavailable;
     session.session_write_mutex.lockUncancelable(io_mod.getIo());
     defer session.session_write_mutex.unlock(io_mod.getIo());
@@ -2049,6 +2062,7 @@ fn setRecoveryCheckpoint(
         .{ .recovery_checkpoint_set = .{ .checkpoint = checkpoint } },
         now_ms,
     );
+    if (ctx.current_prompt_input) |input| input.retainImageSnapshots();
 }
 
 /// Stores grants on the active ACP session without persisting them.

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -4685,6 +4685,17 @@ fn processQueuedPromptInner(
     var within_turn_suffix: std.ArrayList(ChatMessage) = .empty;
     defer within_turn_suffix.deinit(arena);
     if (job.recovery_checkpoint) |checkpoint| {
+        for (checkpoint.user.images) |attachment| {
+            var verified = image_attachments.loadVerifiedSnapshot(
+                std.heap.c_allocator,
+                attachment,
+                .{ .cancel_flag = config.cancel_flag },
+            ) catch |err| {
+                debug_trace.logf("images", "recovery_snapshot_unavailable image_id={d} reason={s}", .{ attachment.id, @errorName(err) });
+                return if (err == error.FileNotFound) error.MissingImageSnapshot else err;
+            };
+            verified.deinit(std.heap.c_allocator);
+        }
         try session_runtime.appendExecutionMemoryChatMessages(
             arena,
             &within_turn_suffix,

--- a/src/core/agent/worker_runtime.zig
+++ b/src/core/agent/worker_runtime.zig
@@ -1946,6 +1946,12 @@ pub const WorkerRuntime = struct {
         ownership.deinit();
     }
 
+    pub fn preservePromptSnapshots(self: *WorkerRuntime, turn_id: u64, images: []const types.ImageAttachment) void {
+        self.worker_mutex.lockUncancelable(io_mod.getIo());
+        defer self.worker_mutex.unlock(io_mod.getIo());
+        _ = self.preservePromptSnapshotsLocked(turn_id, images);
+    }
+
     fn preservePromptSnapshotsLocked(
         self: *WorkerRuntime,
         turn_id: u64,
@@ -2617,7 +2623,9 @@ fn discardQueuedPrompt(
     prompt: QueuedPrompt,
     retained_images: []const types.ImageAttachment,
 ) void {
-    image_attachments.deleteUnreferencedImageSnapshots(prompt.images, retained_images);
+    if (prompt.recovery_checkpoint == null) {
+        image_attachments.deleteUnreferencedImageSnapshots(prompt.images, retained_images);
+    }
     freeQueuedPrompt(alloc, prompt);
 }
 
@@ -2659,62 +2667,68 @@ test "active prompt snapshot ownership discards every pre-transfer boundary" {
     }
 }
 
-test "session transfer preserves active and finished prompt snapshots" {
+test "session and checkpoint transfer preserve active and finished prompt snapshots" {
     const alloc = std.testing.allocator;
     const phases = [_]enum { take_before_begin, active, finished }{
         .take_before_begin,
         .active,
         .finished,
     };
-    for (phases) |phase| {
-        var tmp = std.testing.tmpDir(.{});
-        defer tmp.cleanup();
-        const name = switch (phase) {
-            .take_before_begin => "take-before-begin.bin",
-            .active => "active.bin",
-            .finished => "finished.bin",
-        };
-        {
-            var file = try tmp.dir.createFile(std.testing.io, name, .{});
-            defer file.close(std.testing.io);
-            try file.writeStreamingAll(std.testing.io, "snapshot");
-        }
-        const path = try io_mod.dirRealpathAlloc(alloc, tmp.dir, name);
-        defer alloc.free(path);
-        const images = [_]types.ImageAttachment{.{
-            .id = 1,
-            .path = @constCast("/tmp/source.png"),
-            .media_type = @constCast("image/png"),
-            .snapshot_path = path,
-            .snapshot_sha256 = @constCast("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-        }};
+    for ([_]bool{ false, true }) |checkpoint_accepted| {
+        for (phases) |phase| {
+            var tmp = std.testing.tmpDir(.{});
+            defer tmp.cleanup();
+            const name = switch (phase) {
+                .take_before_begin => "take-before-begin.bin",
+                .active => "active.bin",
+                .finished => "finished.bin",
+            };
+            {
+                var file = try tmp.dir.createFile(std.testing.io, name, .{});
+                defer file.close(std.testing.io);
+                try file.writeStreamingAll(std.testing.io, "snapshot");
+            }
+            const path = try io_mod.dirRealpathAlloc(alloc, tmp.dir, name);
+            defer alloc.free(path);
+            const images = [_]types.ImageAttachment{.{
+                .id = 1,
+                .path = @constCast("/tmp/source.png"),
+                .media_type = @constCast("image/png"),
+                .snapshot_path = path,
+                .snapshot_sha256 = @constCast("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+            }};
 
-        var runtime = WorkerRuntime{};
-        defer runtime.deinit(alloc);
-        runtime.active_turn_id = 41;
-        var active = ActivePromptSnapshotOwnership.init(&images);
-        if (phase != .take_before_begin) runtime.beginActivePromptSnapshots(&active);
-        if (phase == .finished) {
-            const ownership = (try runtime.handoffActivePromptSnapshots(alloc)) orelse
-                return error.TestExpectedSnapshotOwnership;
-            try runtime.pushEvent(alloc, .{ .finish_prompt = .{
-                .turn = .{ .assistant = .{
-                    .user = .{ .text = @constCast("prompt"), .images = @constCast(&images) },
-                    .assistant = @constCast("done"),
-                } },
-                .snapshot_file_ownership = ownership,
-            } });
-            ownership.release();
-            runtime.endActivePromptSnapshots(&active);
-            runtime.active_turn_id = 0;
-        }
+            var runtime = WorkerRuntime{};
+            defer runtime.deinit(alloc);
+            runtime.active_turn_id = 41;
+            var active = ActivePromptSnapshotOwnership.init(&images);
+            if (phase != .take_before_begin) runtime.beginActivePromptSnapshots(&active);
+            if (phase == .finished) {
+                const ownership = (try runtime.handoffActivePromptSnapshots(alloc)) orelse
+                    return error.TestExpectedSnapshotOwnership;
+                try runtime.pushEvent(alloc, .{ .finish_prompt = .{
+                    .turn = .{ .assistant = .{
+                        .user = .{ .text = @constCast("prompt"), .images = @constCast(&images) },
+                        .assistant = @constCast("done"),
+                    } },
+                    .snapshot_file_ownership = ownership,
+                } });
+                ownership.release();
+                runtime.endActivePromptSnapshots(&active);
+                runtime.active_turn_id = 0;
+            }
 
-        runtime.clearQueuedPromptsForSessionTransition(alloc, 41, &images);
-        if (phase == .take_before_begin) runtime.beginActivePromptSnapshots(&active);
-        if (phase != .finished) runtime.endActivePromptSnapshots(&active);
-        runtime.discardEvents(alloc);
-        try std.Io.Dir.accessAbsolute(std.testing.io, path, .{});
-        try std.Io.Dir.deleteFileAbsolute(std.testing.io, path);
+            if (checkpoint_accepted) {
+                runtime.preservePromptSnapshots(41, &images);
+            } else {
+                runtime.clearQueuedPromptsForSessionTransition(alloc, 41, &images);
+            }
+            if (phase == .take_before_begin) runtime.beginActivePromptSnapshots(&active);
+            if (phase != .finished) runtime.endActivePromptSnapshots(&active);
+            runtime.discardEvents(alloc);
+            try std.Io.Dir.accessAbsolute(std.testing.io, path, .{});
+            try std.Io.Dir.deleteFileAbsolute(std.testing.io, path);
+        }
     }
 }
 
@@ -6449,4 +6463,43 @@ test "question request rolls back pending state when its boundary event cannot b
     try std.testing.expect(runtime.pending_question_shared == null);
     try std.testing.expect(runtime.pending_question_response == .pending);
     try std.testing.expectEqual(@as(usize, 0), runtime.worker_events.items.len);
+}
+
+test "discarding queued recovery releases metadata without deleting saved images" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "saved.bin", .data = "snapshot" });
+    const path = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "saved.bin");
+    defer alloc.free(path);
+    const images = [_]types.ImageAttachment{.{
+        .id = 1,
+        .path = @constCast("/missing/source.png"),
+        .media_type = @constCast("image/png"),
+        .snapshot_path = path,
+        .snapshot_sha256 = @constCast("a" ** 64),
+    }};
+    var runtime = WorkerRuntime{};
+    defer runtime.deinit(alloc);
+    var prompt = try makePrompt(alloc, "recover", "test/model");
+    var owned = true;
+    defer if (owned) freeQueuedPrompt(alloc, prompt);
+    prompt.images = try types.dupeImageAttachmentSlice(alloc, &images);
+    prompt.recovery_checkpoint = try (session_codec.RecoveryCheckpoint{
+        .turn_id = 1,
+        .user = .{ .text = @constCast("recover"), .images = @constCast(&images) },
+        .assistant_source = @constCast(""),
+        .cause = .network_interrupted,
+        .action = .retrying_request,
+        .authority = .{ .provider = .gateway, .model = @constCast("test/model") },
+        .requested_fast_mode = false,
+        .fast_mode = false,
+        .max_provider_attempts = 10,
+        .consumed_provider_attempts = 1,
+    }).dupe(alloc);
+    try runtime.enqueuePrompt(alloc, prompt);
+    owned = false;
+    runtime.clearQueuedPrompts(alloc, &.{});
+    try std.testing.expectEqual(@as(usize, 0), runtime.queuedPromptCount());
+    try std.Io.Dir.accessAbsolute(std.testing.io, path, .{});
 }

--- a/src/core/app/app_agent_runtime.zig
+++ b/src/core/app/app_agent_runtime.zig
@@ -950,6 +950,9 @@ pub fn Runtime(comptime App: type) type {
             defer if (fresh_history) |*snapshot| snapshot.deinit(std.heap.c_allocator);
             var snapshot_ownership = worker_runtime.ActivePromptSnapshotOwnership.init(job.images);
             app.worker.beginActivePromptSnapshots(&snapshot_ownership);
+            if (job.recovery_checkpoint != null) {
+                app.worker.preservePromptSnapshots(job.turn_id, job.images);
+            }
             defer app.worker.endActivePromptSnapshots(&snapshot_ownership);
             if (job.recovery_checkpoint == null) {
                 if (try app_session_runtime.Runtime(App).snapshotFreshPromptBoundary(app, std.heap.c_allocator)) |value| {

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -220,9 +220,10 @@ test "live session transition decision defers only active cooperative requests" 
     }
 }
 
-fn nextImageIdForResumedHistory(
+fn nextImageIdForResume(
     alloc: Allocator,
     history: []const types.HistoryTurn,
+    checkpoint: ?session_codec.RecoveryCheckpoint,
 ) !usize {
     const restored_catalog = try session_runtime.collect_image_catalog(
         alloc,
@@ -230,8 +231,12 @@ fn nextImageIdForResumedHistory(
         &.{},
     );
     defer types.freeImageAttachmentSlice(alloc, restored_catalog);
-    const bounds = try image_attachments.calculate_next_image_id(restored_catalog);
-    return bounds.next_id;
+    if (checkpoint) |value| {
+        const merged = try session_runtime.merge_image_catalog_history_turn(alloc, restored_catalog, value.interruptedTurn());
+        defer types.freeImageAttachmentSlice(alloc, merged);
+        return (try image_attachments.calculate_next_image_id(merged)).next_id;
+    }
+    return (try image_attachments.calculate_next_image_id(restored_catalog)).next_id;
 }
 
 pub const SessionPickerScope = session_catalog.Scope;
@@ -1714,9 +1719,10 @@ pub fn Runtime(comptime App: type) type {
         ) !void {
             const previous_provider = provider_runtime.provider(app);
             if (comptime @hasField(App, "next_image_id")) {
-                app.next_image_id = try nextImageIdForResumedHistory(
+                app.next_image_id = try nextImageIdForResume(
                     app.alloc,
                     state.history,
+                    state.recovery_checkpoint,
                 );
             }
             try app.session.restoreWithPermissionState(
@@ -2188,21 +2194,31 @@ pub fn Runtime(comptime App: type) type {
             app: *App,
             checkpoint: session_codec.RecoveryCheckpoint,
         ) !void {
+            errdefer |err| if (err == error.SessionPersistenceUncertain) {
+                if (comptime @hasDecl(@TypeOf(app.worker), "preservePromptSnapshots")) {
+                    app.worker.preservePromptSnapshots(checkpoint.turn_id, checkpoint.user.images);
+                }
+            };
             if (comptime !@hasField(App, "session_persistence")) {
                 return error.SessionPersistenceUnavailable;
             }
-            app.session_persistence.write_mutex.lockUncancelable(io_mod.getIo());
-            defer app.session_persistence.write_mutex.unlock(io_mod.getIo());
-            const loaded = if (app.session_persistence.writable) |*value|
-                value
-            else
-                return error.SessionPersistenceUnavailable;
-            const now_ms = io_mod.milliTimestamp();
-            _ = try loaded.appendEvent(
-                app.alloc,
-                .{ .recovery_checkpoint_set = .{ .checkpoint = checkpoint } },
-                now_ms,
-            );
+            {
+                app.session_persistence.write_mutex.lockUncancelable(io_mod.getIo());
+                defer app.session_persistence.write_mutex.unlock(io_mod.getIo());
+                const loaded = if (app.session_persistence.writable) |*value|
+                    value
+                else
+                    return error.SessionPersistenceUnavailable;
+                const now_ms = io_mod.milliTimestamp();
+                _ = try loaded.appendEvent(
+                    app.alloc,
+                    .{ .recovery_checkpoint_set = .{ .checkpoint = checkpoint } },
+                    now_ms,
+                );
+            }
+            if (comptime @hasDecl(@TypeOf(app.worker), "preservePromptSnapshots")) {
+                app.worker.preservePromptSnapshots(checkpoint.turn_id, checkpoint.user.images);
+            }
         }
 
         pub fn snapshotRecoveryCheckpoint(
@@ -5570,7 +5586,7 @@ test "cold resume image id rebase rejects overflow before admission" {
 
     try std.testing.expectError(
         error.ImageIdOverflow,
-        nextImageIdForResumedHistory(std.testing.allocator, &history),
+        nextImageIdForResume(std.testing.allocator, &history, null),
     );
 }
 

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -1641,10 +1641,10 @@ fn runPromptInternal(alloc: Allocator, prompt: []const u8, permission_override: 
             options.images,
     );
     defer types.freeImageAttachmentSlice(alloc, current_images);
-    defer if (options.save_session and !ctx.prompt_snapshot_committed) {
+    defer if (recovery_checkpoint == null and options.save_session and !ctx.prompt_snapshot_committed) {
         image_attachments.deleteUnreferencedImageSnapshots(current_images, restored_image_catalog);
     };
-    if (current_images.len > 0) {
+    if (recovery_checkpoint == null and current_images.len > 0) {
         try ctx.checkCancellation();
         _ = std.math.add(
             usize,
@@ -1656,7 +1656,10 @@ fn runPromptInternal(alloc: Allocator, prompt: []const u8, permission_override: 
         try ctx.checkCancellation();
     }
 
-    const authorized_image_catalog = try ctx.session.snapshotImageCatalog(alloc, current_images);
+    const authorized_image_catalog = if (recovery_checkpoint) |checkpoint|
+        try session_runtime.merge_image_catalog_history_turn(alloc, restored_image_catalog, checkpoint.interruptedTurn())
+    else
+        try ctx.session.snapshotImageCatalog(alloc, current_images);
     defer types.freeImageAttachmentSlice(alloc, authorized_image_catalog);
 
     try ctx.checkCancellation();
@@ -2890,6 +2893,9 @@ fn setRecoveryCheckpoint(
     checkpoint: session_codec.RecoveryCheckpoint,
 ) !void {
     const ctx: *AskContext = @ptrCast(@alignCast(raw_ctx));
+    errdefer |err| if (err == error.SessionPersistenceUncertain) {
+        ctx.prompt_snapshot_committed = true;
+    };
     ctx.session_write_mutex.lockUncancelable(io_mod.getIo());
     defer ctx.session_write_mutex.unlock(io_mod.getIo());
     const writable = if (ctx.writable) |*value| value else return error.SessionPersistenceUnavailable;
@@ -2899,6 +2905,7 @@ fn setRecoveryCheckpoint(
         .{ .recovery_checkpoint_set = .{ .checkpoint = checkpoint } },
         now_ms,
     );
+    ctx.prompt_snapshot_committed = true;
 }
 
 fn flushAskSessionUsage(
@@ -8620,15 +8627,18 @@ test "json run with missing API key prints diagnostic then final object" {
     );
 }
 
-test "ordinary resumed ask preserves its user after a retained mid-turn checkpoint" {
+test "resumed ask preserves user and image identity after a retained mid-turn checkpoint" {
     const Process = struct {
         fn run(_: *agent_runtime.Agent, deps: *const agent_runtime.AgentRuntimeDeps, _: ?agent_runtime.SemanticPresentationSink, _: agent_runtime.LifecycleContext, _: agent_runtime.Config, job: worker_runtime.QueuedPrompt) !void {
             if (job.recovery_checkpoint) |checkpoint| {
                 try std.testing.expectEqual(@as(u64, 7), checkpoint.turn_id);
                 try std.testing.expectEqualStrings("original request", job.prompt);
+                try std.testing.expectEqual(@as(usize, 7), job.images[0].id);
+                try std.testing.expectEqual(@as(usize, 1), job.authorized_image_catalog.len);
+                try std.testing.expectEqualStrings(job.images[0].snapshot_sha256.?, job.authorized_image_catalog[0].snapshot_sha256.?);
             }
             try deps.propagate_history_turn(deps.ctx, .{ .assistant = .{
-                .user = .{ .text = job.prompt },
+                .user = .{ .text = job.prompt, .images = job.images },
                 .assistant = @constCast("new answer"),
             } });
             try testPushAssistantText(deps, "new answer");
@@ -8652,7 +8662,17 @@ test "ordinary resumed ask preserves its user after a retained mid-turn checkpoi
         defer store.deinit(alloc);
         var state = try testAskDurableState(alloc, "/tmp/fx-test", session_id);
         defer state.deinit(alloc);
-        const old_user = types.UserTurn{ .text = @constCast("original request") };
+        var images = [_]ImageAttachment{.{
+            .id = 7,
+            .path = @constCast("/missing/original.png"),
+            .media_type = @constCast("image/png"),
+            .snapshot_path = @constCast("images/image-7-aaaaaaaaaaaaaaaa.bin"),
+            .snapshot_sha256 = @constCast("a" ** 64),
+        }};
+        const old_user = types.UserTurn{
+            .text = @constCast("original request"),
+            .images = if (case.continue_recovery) &images else &.{},
+        };
         {
             var writable = try store.startWritableSession(alloc, state);
             defer writable.deinit(alloc);

--- a/src/core/session/session.zig
+++ b/src/core/session/session.zig
@@ -5922,3 +5922,23 @@ fn deinitMessages(alloc: Allocator, messages: *std.ArrayList(message.Message)) v
     for (messages.items) |*msg| msg.deinit(alloc);
     messages.deinit(alloc);
 }
+
+test "image catalog merges a retained recovery image and rejects changed identity" {
+    const alloc = std.testing.allocator;
+    var images = [_]ImageAttachment{.{
+        .id = 7,
+        .path = @constCast("/missing/original.png"),
+        .media_type = @constCast("image/png"),
+        .snapshot_path = @constCast("/session/images/saved.bin"),
+        .snapshot_sha256 = @constCast("a" ** 64),
+    }};
+    const turn: HistoryTurn = .{ .interrupted = .{ .user = .{ .text = @constCast("recover"), .images = &images } } };
+    const catalog = try collect_image_catalog(alloc, &.{turn}, &.{});
+    defer core_types.freeImageAttachmentSlice(alloc, catalog);
+    const merged = try merge_image_catalog_history_turn(alloc, catalog, turn);
+    defer core_types.freeImageAttachmentSlice(alloc, merged);
+    try std.testing.expectEqual(@as(usize, 1), merged.len);
+    try std.testing.expectEqual(@as(usize, 7), merged[0].id);
+    images[0].snapshot_sha256 = @constCast("b" ** 64);
+    try std.testing.expectError(error.StaleImageCatalog, merge_image_catalog_history_turn(alloc, catalog, turn));
+}

--- a/src/core/session/session_store.zig
+++ b/src/core/session/session_store.zig
@@ -1206,7 +1206,7 @@ pub const Store = struct {
         while (try reader.next()) |turn| {
             var turns = [_]session.HistoryTurn{turn};
             defer session.freeHistoryTurn(alloc, turns[0]);
-            try resolveSessionSnapshotLocators(alloc, &turns, self.sessions_dir, session_id);
+            try resolveSessionSnapshotLocators(alloc, &turns, null, self.sessions_dir, session_id);
             try visitor.append(turns[0]);
         }
     }
@@ -1281,6 +1281,7 @@ pub const Store = struct {
             resolveSessionSnapshotLocators(
                 alloc,
                 turns,
+                null,
                 self.sessions_dir,
                 session_id,
             ) catch |err| return mapHistoryPageLoadError(err);
@@ -1672,6 +1673,7 @@ pub const Store = struct {
             try resolveSessionSnapshotLocators(
                 alloc,
                 state.history,
+                if (state.recovery_checkpoint) |*checkpoint| checkpoint else null,
                 self.sessions_dir,
                 session_id,
             );
@@ -1697,6 +1699,7 @@ pub const Store = struct {
                 try resolveSessionSnapshotLocators(
                     alloc,
                     state.history,
+                    if (state.recovery_checkpoint) |*checkpoint| checkpoint else null,
                     self.sessions_dir,
                     session_id,
                 );
@@ -2547,6 +2550,7 @@ pub const Store = struct {
         try resolveSessionSnapshotLocators(
             alloc,
             state.history,
+            if (state.recovery_checkpoint) |*checkpoint| checkpoint else null,
             self.sessions_dir,
             session_id,
         );
@@ -2650,6 +2654,7 @@ pub const Store = struct {
         try resolveSessionSnapshotLocators(
             alloc,
             loaded.state.history,
+            if (loaded.state.recovery_checkpoint) |*checkpoint| checkpoint else null,
             self.sessions_dir,
             loaded.active_id,
         );
@@ -3422,6 +3427,7 @@ pub const Store = struct {
         try resolveSessionSnapshotLocators(
             alloc,
             recovered.history,
+            if (recovered.recovery_checkpoint) |*checkpoint| checkpoint else null,
             self.sessions_dir,
             session_id,
         );
@@ -4034,6 +4040,7 @@ fn canonicalSnapshotLeaf(image: session.ImageAttachment, stored: []const u8) ![]
 fn resolveSessionSnapshotLocators(
     alloc: Allocator,
     history: []session.HistoryTurn,
+    checkpoint: ?*session_codec.RecoveryCheckpoint,
     sessions_dir: []const u8,
     session_id: []const u8,
 ) !void {
@@ -4048,13 +4055,22 @@ fn resolveSessionSnapshotLocators(
             .assistant => |*entry| entry.user.images,
             .interrupted => |*entry| entry.user.images,
         };
-        for (images) |*image| {
-            const stored = image.snapshot_path orelse continue;
-            const leaf = try canonicalSnapshotLeaf(image.*, stored);
-            const resolved = try std.fs.path.join(alloc, &.{ image_dir, leaf });
-            alloc.free(stored);
-            image.snapshot_path = resolved;
-        }
+        try resolveImageSnapshotLocators(alloc, images, image_dir);
+    }
+    if (checkpoint) |value| try resolveImageSnapshotLocators(alloc, value.user.images, image_dir);
+}
+
+fn resolveImageSnapshotLocators(
+    alloc: Allocator,
+    images: []session.ImageAttachment,
+    image_dir: []const u8,
+) !void {
+    for (images) |*image| {
+        const stored = image.snapshot_path orelse continue;
+        const leaf = try canonicalSnapshotLeaf(image.*, stored);
+        const resolved = try std.fs.path.join(alloc, &.{ image_dir, leaf });
+        alloc.free(stored);
+        image.snapshot_path = resolved;
     }
 }
 
@@ -4111,6 +4127,7 @@ test "session snapshot locators resolve through their owning store" {
     try resolveSessionSnapshotLocators(
         alloc,
         history,
+        null,
         "/new/fx-home/sessions",
         "id",
     );
@@ -4144,6 +4161,7 @@ test "current session snapshot locators reject absolute paths" {
         resolveSessionSnapshotLocators(
             alloc,
             history,
+            null,
             "/new/fx-home/sessions",
             "id",
         ),
@@ -4183,6 +4201,7 @@ test "session snapshot locator resolver rejects noncanonical tampering" {
             resolveSessionSnapshotLocators(
                 alloc,
                 history,
+                null,
                 "/new/fx-home/sessions",
                 "id",
             ),
@@ -4306,6 +4325,7 @@ test "session snapshot locator resolver rejects symlink leaves and directories" 
         try resolveSessionSnapshotLocators(
             alloc,
             history,
+            null,
             sessions_path,
             "session",
         );
@@ -8444,4 +8464,50 @@ test "history page allocation failure sweep frees replay and page ownership" {
         try std.testing.expect(failing.has_induced_failure);
         try std.testing.expectEqual(failing.allocated_bytes, failing.freed_bytes);
     }
+}
+
+test "recovery checkpoint images resolve on read-only and writable resume" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var ctx = try initTempStore(alloc, &tmp);
+    defer ctx.deinit(alloc);
+    var state = try testDurableState(alloc, "checkpoint-images", ctx.workspace);
+    defer state.deinit(alloc);
+    var writable = try ctx.store.startWritableSession(alloc, state);
+    var writable_owned = true;
+    defer if (writable_owned) writable.deinit(alloc);
+    var temp_dir: ?[]u8 = null;
+    const image_dir = try imageSnapshotStorageDir(alloc, ctx.store.sessions_dir, state.id, &temp_dir);
+    defer alloc.free(image_dir);
+    const image = try image_attachments.captureInlineImageBytes(alloc, 7, "image/png", "\x89PNG\r\n\x1a\ncheckpoint", image_dir);
+    defer core_types.freeImageAttachment(alloc, image);
+    var images = [_]session.ImageAttachment{image};
+    const checkpoint = session_codec.RecoveryCheckpoint{
+        .turn_id = 1,
+        .user = .{ .text = @constCast("recover"), .images = &images },
+        .assistant_source = @constCast(""),
+        .cause = .network_interrupted,
+        .action = .retrying_request,
+        .authority = .{ .provider = .gateway, .model = @constCast("test/model") },
+        .requested_fast_mode = false,
+        .fast_mode = false,
+        .max_provider_attempts = 10,
+        .consumed_provider_attempts = 1,
+    };
+    _ = try writable.appendEvent(alloc, .{ .recovery_checkpoint_set = .{ .checkpoint = checkpoint } }, 20);
+    writable.deinit(alloc);
+    writable_owned = false;
+    var detail = try ctx.store.loadReadOnlyDetail(alloc, state.id, .{});
+    defer detail.deinit(alloc);
+    const restored = detail.state.recovery_checkpoint.?.user.images[0];
+    try std.testing.expectEqual(@as(usize, 7), restored.id);
+    try std.testing.expectEqualStrings(image.snapshot_path.?, restored.snapshot_path.?);
+    var verified = try image_attachments.loadVerifiedSnapshot(alloc, restored, .{});
+    defer verified.deinit(alloc);
+    var resumed = try ctx.store.resumeTargetForWrite(alloc, .{ .id = state.id }, ctx.workspace, .{});
+    defer resumed.deinit(alloc);
+    try std.testing.expectEqualStrings(image.snapshot_path.?, resumed.state.recovery_checkpoint.?.user.images[0].snapshot_path.?);
+    _ = try resumed.appendEvent(alloc, .{ .recovery_checkpoint_cleared = .{} }, 30);
+    try std.Io.Dir.accessAbsolute(std.testing.io, image.snapshot_path.?, .{});
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -1405,10 +1405,15 @@ const App = struct {
             null;
         errdefer if (account_id_copy) |account_id| std.heap.c_allocator.free(account_id);
 
-        const authorized_image_catalog = try self.session.snapshotImageCatalog(
-            std.heap.c_allocator,
-            source_images,
-        );
+        const authorized_image_catalog = if (recovery_checkpoint) |checkpoint| blk: {
+            const history_catalog = try self.session.snapshotImageCatalog(std.heap.c_allocator, &.{});
+            defer types.freeImageAttachmentSlice(std.heap.c_allocator, history_catalog);
+            break :blk try session_runtime.merge_image_catalog_history_turn(
+                std.heap.c_allocator,
+                history_catalog,
+                checkpoint.interruptedTurn(),
+            );
+        } else try self.session.snapshotImageCatalog(std.heap.c_allocator, source_images);
         errdefer types.freeImageAttachmentSlice(std.heap.c_allocator, authorized_image_catalog);
 
         const history_copy = try self.session.snapshotHistory(std.heap.c_allocator);

--- a/tests/e2e/acp.test.ts
+++ b/tests/e2e/acp.test.ts
@@ -5257,6 +5257,52 @@ describe("acp: model-independent", () => {
     TIMEOUT,
   );
 
+  for (const continueSaved of [true, false]) test(`ACP recovery retains image snapshots through provider failure and reload: ${continueSaved ? "continue" : "new image"}`, async () => {
+    const root = createIsolatedRoot("fx-acp-checkpoint-image-");
+    const imageData = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9WlXYX0AAAAASUVORK5CYII=";
+    const gateway = startFakeGateway([
+      finalText("INVALID_FINAL_WITHOUT_VISION"),
+      fakeGatewayToolCall("recover_vision", "vision", { image_ids: [continueSaved ? 1 : 2], focus: "describe" }),
+      finalText(JSON.stringify({ images: [{ image_id: continueSaved ? 1 : 2, status: "ok", summary: "small fixture", visible_text: [], details: [] }] })),
+      finalText("ACP_RECOVERY_IMAGE_COMPLETE"),
+    ]);
+    try {
+      client = await AcpClient.create({ cwd: root.workspace, env: fakeGatewayEnv(root, gateway) });
+      const sessionId = await startCodeSession(client);
+      const failed = await runPromptBlocks(client, [
+        { type: "text", text: "Describe the image." },
+        { type: "image", data: imageData, mimeType: "image/png" },
+      ], TIMEOUT);
+      expect(JSON.stringify(failed)).toContain("RequiredVisionToolCallMissing");
+      const source = join(root.home, ".fx", "sessions", sessionId);
+      const checkpoint = JSON.parse(readFileSync(join(source, "recovery.json"), "utf8")).checkpoint;
+      const snapshot = join(source, checkpoint.user.images[0].snapshot_path);
+      expect(readFileSync(snapshot).toString("base64")).toBe(imageData);
+      await client.close();
+      client = await AcpClient.create({ cwd: root.workspace, env: fakeGatewayEnv(root, gateway) });
+      await client.request("initialize", { protocolVersion: 1 }, 10);
+      client.send({ jsonrpc: "2.0", id: 11, method: "session/load", params: { sessionId, cwd: root.workspace, mcpServers: [] } });
+      expect((await readResponse(client, 11)).error).toBeUndefined();
+      const resumed = continueSaved
+        ? await continueRecovery(client, TIMEOUT, sessionId)
+        : await runPromptBlocks(client, [
+          { type: "text", text: "Describe this new image instead." },
+          { type: "image", data: imageData, mimeType: "image/png" },
+        ], TIMEOUT);
+      expect(resumed.promptResult.error).toBeUndefined();
+      expect(resumed.promptResult.result.stopReason).toBe("end_turn");
+      expect(gateway.requests).toHaveLength(4);
+      expect(gateway.requests[2]!.body).toContain(imageData);
+      expect(readFileSync(snapshot).toString("base64")).toBe(imageData);
+      expect(existsSync(join(source, "recovery.json"))).toBe(false);
+      expect(client.stderr).toBe("");
+    } finally {
+      await client?.close();
+      gateway.stop();
+      rmSync(root.root, { recursive: true, force: true });
+    }
+  }, TIMEOUT * 2);
+
   test(
     "image prompt reaches the Gateway and replays from saved history",
     async () => {

--- a/tests/e2e/vision-route-fake-gateway.test.ts
+++ b/tests/e2e/vision-route-fake-gateway.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import {
   copyFileSync,
@@ -3099,3 +3101,119 @@ describe("Vision route fake Gateway", () => {
     30_000,
   );
 });
+
+for (const sourceChange of ["removed", "changed", "saved snapshot missing", "saved snapshot corrupt"] as const) {
+  test(`recovery preserves captured image identity when ${sourceChange}`, async () => {
+    const root = createIsolatedRoot();
+    const input = join(root.workspace, "input.png");
+    const original = writeMarkedImage(input, "ORIGINAL_RECOVERY_INPUT");
+    const digest = createHash("sha256").update(Buffer.from(original, "base64")).digest("hex");
+    const gateway = startImageGateway([
+      sseText("INVALID_FINAL_WITHOUT_VISION"),
+      sseToolCall("vision", { image_ids: [1], focus: "describe" }, "recover_vision"),
+      sseText(VISION_RESULT),
+      sseText("RECOVERY_IMAGE_COMPLETE"),
+    ]);
+    const options = { cwd: root.workspace, env: fakeGatewayEnv(root, gateway, GLM_MODEL), timeoutMs: TIMEOUT };
+    try {
+      const failed = await runFx(["ask", "--json", "--auto", "--image", input, "Describe the saved image."], options);
+      expect(failed.code).toBe(1);
+      expect(failed.stdout).toContain("RequiredVisionToolCallMissing");
+      const sessions = join(root.home, ".fx", "sessions");
+      const id = readdirSync(sessions).find(name => existsSync(join(sessions, name, "recovery.json")))!;
+      expect(id).toBeDefined();
+      const checkpointPath = join(sessions, id, "recovery.json");
+      const checkpointBytes = readFileSync(checkpointPath);
+      const image = JSON.parse(checkpointBytes.toString()).checkpoint.user.images[0];
+      const snapshot = join(sessions, id, image.snapshot_path);
+      expect(image.id).toBe(1);
+      expect(image.snapshot_sha256).toBe(digest);
+      expect(readFileSync(snapshot).toString("base64")).toBe(original);
+      if (sourceChange === "removed") rmSync(input);
+      else if (sourceChange === "changed") writeMarkedImage(input, "REPLACEMENT_MUST_NOT_BE_USED");
+      else if (sourceChange === "saved snapshot missing") rmSync(snapshot);
+      else writeFileSync(snapshot, "corrupted saved bytes");
+      const resumed = await runFx(["ask", "--json", "--auto", "--resume-id", id, "--continue-recovery"], options);
+      if (sourceChange.startsWith("saved snapshot")) {
+        expect(resumed.code).toBe(1);
+        expect(resumed.stdout).toContain(sourceChange.endsWith("missing") ? "MissingImageSnapshot" : "ImageSnapshotCorrupt");
+        expect(gateway.chatRequests).toHaveLength(1);
+        expect(readFileSync(checkpointPath).equals(checkpointBytes)).toBe(true);
+        return;
+      }
+      expect(parseFxJson(resumed).output).toContain("RECOVERY_IMAGE_COMPLETE");
+      expect(gateway.chatRequests).toHaveLength(4);
+      const parts = nativeFileParts(gateway.chatRequests[2]!.body);
+      expect(parts).toHaveLength(1);
+      expect(createHash("sha256").update(Buffer.from(parts[0]!.data, "base64")).digest("hex")).toBe(digest);
+      const history = readFileSync(join(sessions, id, "events.jsonl"), "utf8");
+      expect(history).toContain(digest);
+      expect(readFileSync(snapshot).toString("base64")).toBe(original);
+      expect(existsSync(checkpointPath)).toBe(false);
+    } finally {
+      gateway.stop();
+      rmSync(root.root, { recursive: true, force: true });
+    }
+  }, TIMEOUT * 2);
+}
+
+test.skipIf(!tmuxAvailable())("TUI recovery retains images through failure and cold restart", async () => {
+  const root = createIsolatedRoot();
+  const input = join(root.workspace, "input.png");
+  const original = writeMarkedImage(input, "TUI_RECOVERY_INPUT");
+  const gateway = startImageGateway([
+    sseText("INVALID_FINAL_WITHOUT_VISION"),
+    sseToolCall("vision", { image_ids: [1], focus: "describe" }, "recover_vision"),
+    sseText(VISION_RESULT),
+    sseText("TUI_RECOVERY_IMAGE_COMPLETE"),
+    sseToolCall("vision", { image_ids: [2], focus: "describe new image" }, "new_vision"),
+    sseText(visionResult(2, "second image")),
+    sseText("TUI_NEW_IMAGE_COMPLETE"),
+  ]);
+  let session: TmuxSession | null = null;
+  const env = fakeGatewayEnv(root, gateway, GLM_MODEL);
+  try {
+    session = await TmuxSession.create({ cmd: FX_BIN, cwd: root.workspace, env, isolated: true, remainOnExit: true });
+    await session.waitForStableComposer(TIMEOUT);
+    await session.sendText(`/image ${input}`);
+    await session.waitForText("attached image:", TIMEOUT);
+    await session.sendText("Describe this image.");
+    await session.waitForText("RequiredVisionToolCallMissing", TIMEOUT);
+    await session.waitForStableComposer(TIMEOUT);
+    const sessions = join(root.home, ".fx", "sessions");
+    const id = readdirSync(sessions).find(name => existsSync(join(sessions, name, "recovery.json")))!;
+    const checkpoint = JSON.parse(readFileSync(join(sessions, id, "recovery.json"), "utf8")).checkpoint;
+    const snapshot = join(sessions, id, checkpoint.user.images[0].snapshot_path);
+    expect(readFileSync(snapshot).toString("base64")).toBe(original);
+    await session.sendText("/quit");
+    await session.waitForPane(() => session!.paneStatus().dead, TIMEOUT);
+    expect(session.paneStatus().status).toBe(0);
+    await session.kill();
+    session = null;
+    rmSync(input);
+    session = await TmuxSession.create({ cmd: `${FX_BIN} --resume ${id}`, cwd: root.workspace, env, isolated: true, remainOnExit: true });
+    await session.waitForStableComposer(TIMEOUT);
+    await session.sendText("/continue");
+    await session.waitForText("TUI_RECOVERY_IMAGE_COMPLETE", TIMEOUT);
+    await session.waitForStableComposer(TIMEOUT);
+    expect(nativeFileParts(gateway.chatRequests[2]!.body)[0]!.data).toBe(original);
+    writeMarkedImage(input, "NEW_IMAGE_AFTER_RECOVERY");
+    await session.sendText(`/image ${input}`);
+    await session.waitForText("attached image:", TIMEOUT);
+    await session.sendText("Describe the new image.");
+    await session.waitForText("TUI_NEW_IMAGE_COMPLETE", TIMEOUT);
+    await session.waitForStableComposer(TIMEOUT);
+    const scrollback = await session.captureFullScrollback();
+    expect(scrollback).not.toContain("ImageSnapshotPathUnsafe");
+    expect(scrollback).not.toContain("DuplicateImageId");
+    expect(gateway.chatRequests).toHaveLength(7);
+    await session.sendText("/quit");
+    await session.waitForPane(() => session!.paneStatus().dead, TIMEOUT);
+    expect(session.paneStatus().status).toBe(0);
+    expect(readFileSync(snapshot).toString("base64")).toBe(original);
+  } finally {
+    await session?.kill();
+    gateway.stop();
+    rmSync(root.root, { recursive: true, force: true });
+  }
+}, TIMEOUT * 3);


### PR DESCRIPTION
## Summary

- Retain images referenced by paused requests after provider failure or cancellation.
- Restore saved image requests after restarting the CLI, terminal, or ACP session.
- Continue from captured image bytes when the original files move or change.
- Report missing or corrupt saved images without clearing the recovery checkpoint.
- Preserve image IDs through compaction and avoid collisions with subsequent attachments.
