### PR TITLE
Restore provider replay in SDK conversations

### DIFF
--- a/sdk/tests/test-checkpoint.mjs
+++ b/sdk/tests/test-checkpoint.mjs
@@ -11,80 +11,105 @@ const targetBackend = process.argv[3] || "wasm";
 const scriptDir = fileURLToPath(new URL(".", import.meta.url));
 const addon = resolve(scriptDir, "../../zig-out/lib/libfx.node");
 const wasm = await readFile(resolve(scriptDir, "../../zig-out/bin/fx-core.wasm"));
-let modelRequests = 0;
-
-const server = createServer((request, response) => {
-  let body = "";
-  request.setEncoding("utf8");
-  request.on("data", (chunk) => { body += chunk; });
-  request.on("end", () => {
-    if (request.method === "GET") {
-      response.writeHead(200, { "content-type": "application/json" });
-      response.end(JSON.stringify({ object: "list", data: [{ id: "checkpoint/model", type: "language" }] }));
-      return;
-    }
-    modelRequests += 1;
-    response.writeHead(200, { "content-type": "text/event-stream" });
-    if (modelRequests === 1) {
+for (const shape of ["plain", "reasoning-text", "reasoning-only", "provider-terminal"]) {
+  let modelRequests = 0;
+  const remembered = shape === "reasoning-only" ? "Done." : "remembered value";
+  const server = createServer((request, response) => {
+    let body = "";
+    request.setEncoding("utf8");
+    request.on("data", (chunk) => { body += chunk; });
+    request.on("end", () => {
+      if (request.method === "GET") {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(JSON.stringify({ object: "list", data: [{ id: "checkpoint/model", type: "language" }] }));
+        return;
+      }
+      modelRequests += 1;
+      response.writeHead(200, { "content-type": "text/event-stream" });
+      if (modelRequests === 1) {
+        const frames = [];
+        if (shape !== "plain") frames.push(
+          { type: "reasoning-start", id: "reasoning" },
+          { type: "reasoning-delta", id: "reasoning", delta: "Retain this context." },
+          { type: "reasoning-end", id: "reasoning", providerMetadata: { vertex: { thoughtSignature: "checkpoint-reasoning" } } },
+        );
+        if (shape === "provider-terminal") frames.push(
+          { type: "tool-call", toolCallId: "lookup", toolName: "exa_search", input: { query: "fixture" }, providerExecuted: true, providerMetadata: { vertex: { thoughtSignature: "checkpoint-call" } } },
+          { type: "tool-result", toolCallId: "lookup", result: { content: "stored-provider-evidence" } },
+        );
+        if (shape !== "reasoning-only") frames.push({ type: "text-delta", id: "answer", delta: remembered });
+        frames.push({ type: "finish", finishReason: { unified: "stop", raw: "stop" }, usage: { inputTokens: { total: 2 }, outputTokens: { total: 2 } } });
+        response.end(frames.map((frame) => `data: ${JSON.stringify(frame)}\n\n`).join("") + "data: [DONE]\n\n");
+        return;
+      }
+      assert.equal(modelRequests, 2, "unexpected extra model request");
+      assert.ok(body.includes("store this context"), "restored request omitted the prior user turn");
+      const parts = JSON.parse(body).prompt.flatMap((message) => Array.isArray(message.content) ? message.content : []);
+      assert.equal(parts.filter((part) => part.type === "text" && part.text === remembered).length, 1, "restored answer must appear exactly once");
+      if (shape !== "plain") {
+        const reasoning = parts.filter((part) => part.type === "reasoning");
+        assert.equal(reasoning.length, 1, "restored reasoning must appear exactly once");
+        assert.equal(reasoning[0].providerOptions.vertex.thoughtSignature, "checkpoint-reasoning");
+      }
+      if (shape === "provider-terminal") {
+        const calls = parts.filter((part) => part.type === "tool-call");
+        const results = parts.filter((part) => part.type === "tool-result");
+        assert.equal(calls.length, 1);
+        assert.equal(results.length, 1);
+        assert.equal(calls[0].toolCallId, results[0].toolCallId);
+        assert.equal(calls[0].providerOptions.vertex.thoughtSignature, "checkpoint-call");
+        assert.ok(body.includes("stored-provider-evidence"));
+      }
       response.end([
-        'data: {"type":"text-delta","delta":"remembered value"}',
-        'data: {"type":"finish","finishReason":{"unified":"stop","raw":"stop"},"usage":{"inputTokens":{"total":2},"outputTokens":{"total":2}}}',
+        'data: {"type":"text-delta","delta":"restored"}',
+        'data: {"type":"finish","finishReason":{"unified":"stop","raw":"stop"},"usage":{"inputTokens":{"total":4},"outputTokens":{"total":1}}}',
         "data: [DONE]",
         "",
       ].join("\n\n"));
-      return;
-    }
-    assert.ok(body.includes("store this context"), "restored request omitted the prior user turn");
-    assert.ok(body.includes("remembered value"), "restored request omitted the prior assistant turn");
-    response.end([
-      'data: {"type":"text-delta","delta":"restored"}',
-      'data: {"type":"finish","finishReason":{"unified":"stop","raw":"stop"},"usage":{"inputTokens":{"total":4},"outputTokens":{"total":1}}}',
-      "data: [DONE]",
-      "",
-    ].join("\n\n"));
+    });
   });
-});
-await new Promise((resolveListen) => server.listen(0, "127.0.0.1", resolveListen));
-const { port } = server.address();
+  await new Promise((resolveListen) => server.listen(0, "127.0.0.1", resolveListen));
+  const { port } = server.address();
 
-const options = (backend, checkpoint) => ({
-  backend,
-  nativeAddon: addon,
-  ...(backend === "wasm" ? { wasm } : {}),
-  ...(checkpoint ? { checkpoint } : {}),
-  fetch,
-  apiKey: "checkpoint-key",
-  gatewayChatUrl: `http://127.0.0.1:${port}/chat`,
-  model: "checkpoint/model",
-});
+  const options = (backend, checkpoint) => ({
+    backend,
+    nativeAddon: addon,
+    ...(backend === "wasm" ? { wasm } : {}),
+    ...(checkpoint ? { checkpoint } : {}),
+    fetch,
+    apiKey: "checkpoint-key",
+    gatewayChatUrl: `http://127.0.0.1:${port}/chat`,
+    model: "checkpoint/model",
+  });
 
-let source;
-let target;
-try {
-  source = await createFxAgent(options(sourceBackend));
-  const first = source.prompt("store this context");
-  for await (const _ of first) {}
-  assert.equal((await first.result).stopReason, "end_turn");
-  const checkpoint = await source.checkpoint();
-  assert.ok(checkpoint instanceof Uint8Array && checkpoint.length > 48);
-  assert.equal(await source.close(), undefined);
-  source = null;
+  let source;
+  let target;
+  try {
+    source = await createFxAgent(options(sourceBackend));
+    const first = source.prompt("store this context");
+    for await (const _ of first) {}
+    assert.equal((await first.result).stopReason, "end_turn");
+    const checkpoint = await source.checkpoint();
+    assert.ok(checkpoint instanceof Uint8Array && checkpoint.length > 48);
+    assert.equal(await source.close(), undefined);
+    source = null;
 
-  target = await createFxAgent(options(targetBackend, checkpoint));
-  const second = target.prompt("continue");
-  let text = "";
-  for await (const update of second) {
-    if (update.type === "text_delta") text += update.delta;
+    target = await createFxAgent(options(targetBackend, checkpoint));
+    const second = target.prompt("continue");
+    let text = "";
+    for await (const update of second) {
+      if (update.type === "text_delta") text += update.delta;
+    }
+    assert.equal(text.trim(), "restored");
+    assert.equal((await second.result).stopReason, "end_turn");
+    assert.equal(await target.close(), undefined);
+    target = null;
+    assert.equal(modelRequests, 2);
+    console.log(`checkpoint integration passed: ${sourceBackend} -> ${targetBackend} (${shape})`);
+  } finally {
+    await source?.close().catch(() => {});
+    await target?.close().catch(() => {});
+    server.closeAllConnections();
+    await new Promise((resolveClose) => server.close(resolveClose));
   }
-  assert.equal(text.trim(), "restored");
-  assert.equal((await second.result).stopReason, "end_turn");
-  assert.equal(await target.close(), undefined);
-  target = null;
-  assert.equal(modelRequests, 2);
-  console.log(`checkpoint integration passed: ${sourceBackend} -> ${targetBackend}`);
-} finally {
-  await source?.close().catch(() => {});
-  await target?.close().catch(() => {});
-  server.closeAllConnections();
-  await new Promise((resolveClose) => server.close(resolveClose));
 }

--- a/src/gateway/host_stream_provider.zig
+++ b/src/gateway/host_stream_provider.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const stream_provider = @import("../core/agent/stream_provider.zig");
 const io_mod = @import("../core/shared/io.zig");
 const gateway_client = @import("client.zig");
+const vercel_protocol = @import("vercel_protocol.zig");
 const credential_authority = @import("../core/auth/credential_authority.zig");
 
 const Allocator = std.mem.Allocator;
@@ -55,6 +56,7 @@ pub fn provider(context: *ProviderContext) stream_provider.Provider {
         .context = context,
         .stream_fn = stream,
         .build_request_fn = buildRequest,
+        .project_replay_fn = vercel_protocol.selectReplayParts,
     };
 }
 
@@ -64,6 +66,54 @@ pub fn initContext(
     transport: Transport,
 ) ProviderContext {
     return .{ .build_fn = build_fn, .endpoint = endpoint, .transport = transport };
+}
+
+test "host provider selects replay without changing canonical input" {
+    const Unused = struct {
+        fn build(_: Allocator, _: stream_provider.RequestData) ![]u8 {
+            return error.UnexpectedRequest;
+        }
+        fn open(_: ?*anyopaque, _: []const u8, _: []const u8, _: []const u8, _: []const u8) !i32 {
+            return error.UnexpectedRequest;
+        }
+        fn status(_: ?*anyopaque, _: i32, _: *u16) i32 {
+            return -1;
+        }
+        fn next(_: ?*anyopaque, _: i32, _: []u8) i32 {
+            return -1;
+        }
+        fn close(_: ?*anyopaque, _: i32) void {}
+    };
+    const types = @import("../core/shared/types.zig");
+    const alloc = std.testing.allocator;
+    var context = initContext(Unused.build, .{ .fixed = "https://example.invalid" }, .{
+        .context = null,
+        .open_fn = Unused.open,
+        .status_fn = Unused.status,
+        .next_fn = Unused.next,
+        .close_fn = Unused.close,
+    });
+    const adapter = provider(&context);
+    const parts = "[{\"type\":\"reasoning\",\"text\":\"retained\"},{\"type\":\"tool-call\",\"toolCallId\":\"read\"},{\"type\":\"text\",\"offset\":0,\"length\":6}]";
+    const replay = types.ProviderReplay{
+        .source = .{ .provider = .gateway, .model = "fixture-model" },
+        .parts_json = parts,
+    };
+    const calls = [_]types.ToolCall{.{ .id = "read", .name = "read_file", .arguments_json = "{}" }};
+    const unchanged = (try adapter.projectReplay(alloc, replay, &calls, true, true)).?;
+    try std.testing.expect(unchanged.parts_json.ptr == parts.ptr);
+
+    const selected = (try adapter.projectReplay(alloc, replay, &calls, false, true)).?;
+    defer alloc.free(selected.parts_json);
+    try std.testing.expectEqualStrings("[{\"type\":\"reasoning\",\"text\":\"retained\"},{\"type\":\"tool-call\",\"toolCallId\":\"read\"}]", selected.parts_json);
+    try std.testing.expectEqualStrings(parts, replay.parts_json);
+    try std.testing.expect(selected.matches(replay.source));
+    try std.testing.expectEqual(@as(?types.ProviderReplay, null), try adapter.projectReplay(alloc, replay, &.{}, false, false));
+    try std.testing.expectEqual(@as(?types.ProviderReplay, null), try adapter.projectReplay(alloc, null, &.{}, true, true));
+    try std.testing.expectError(error.InvalidProviderState, adapter.projectReplay(alloc, .{
+        .source = replay.source,
+        .parts_json = "{}",
+    }, &.{}, false, true));
 }
 
 fn stream(raw: ?*anyopaque, alloc: Allocator, request: stream_provider.ModelRequest) anyerror!stream_provider.Result {


### PR DESCRIPTION
## Summary

- Complete SDK responses that contain reasoning without visible text.
- Complete provider-executed tool responses without failing after the answer streams.
- Preserve reasoning and tool metadata when SDK conversations are restored from checkpoints.
