### PR TITLE
Load libfx assets from webpack server bundles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,12 +189,27 @@ jobs:
               node sdk/tests/test-host-tool-cancel.mjs native
             '
 
+      - name: Build foreign addons for package qualification
+        run: |
+          mkdir -p native-addons
+          cp zig-out/lib/libfx.node native-addons/libfx.linux-x64.node
+          prefix="$(mktemp -d "$RUNNER_TEMP/libfx-linux-arm64.XXXXXX")"
+          zig build libfx-napi -Dnapi-surface=core -Doptimize=ReleaseSafe -Dtarget=aarch64-linux-gnu.2.34 -Dcpu=baseline --prefix "$prefix"
+          cp "$prefix/lib/libfx.node" native-addons/libfx.linux-arm64.node
+          prefix="$(mktemp -d "$RUNNER_TEMP/libfx-darwin-x64.XXXXXX")"
+          zig build libfx-napi -Dnapi-surface=core -Doptimize=ReleaseSafe -Dtarget=x86_64-macos -Dcpu=baseline --prefix "$prefix"
+          cp "$prefix/lib/libfx.node" native-addons/libfx.darwin-x64.node
+          prefix="$(mktemp -d "$RUNNER_TEMP/libfx-darwin-arm64.XXXXXX")"
+          zig build libfx-napi -Dnapi-surface=core -Doptimize=ReleaseSafe -Dtarget=aarch64-macos -Dcpu=baseline --prefix "$prefix"
+          cp "$prefix/lib/libfx.node" native-addons/libfx.darwin-arm64.node
+
       - name: Test Node package and backend diagnostics
         run: |
           node --experimental-wasm-jspi sdk/tests/test-backend-info.mjs
+          node --experimental-wasm-jspi sdk/tests/test-node-bundled-assets.mjs
           node sdk/tests/test-node-package.mjs
           node sdk/tests/test-term-demo-package.mjs
-          node sdk/scripts/package-libfx.mjs sdk/dist/libfx
+          node sdk/scripts/package-libfx.mjs sdk/dist/libfx native-addons/libfx.linux-x64.node native-addons/libfx.linux-arm64.node native-addons/libfx.darwin-x64.node native-addons/libfx.darwin-arm64.node
           node --experimental-wasm-jspi sdk/tests/test-node-async-assets.mjs sdk/dist/libfx
           npm pack ./sdk/dist/libfx --ignore-scripts --json > /tmp/libfx-pack.json
           mv "$(node -p 'require("/tmp/libfx-pack.json")[0].filename')" /tmp/libfx-package.tgz
@@ -215,7 +230,10 @@ jobs:
       - name: Test installed package through Next
         env:
           LIBFX_TEST_ARTIFACT_ROOT: ${{ runner.temp }}/libfx-package-evidence
-        run: node sdk/tests/test-next-package.mjs /tmp/libfx-package.tgz
+        run: |
+          node sdk/tests/test-next-package.mjs /tmp/libfx-package.tgz
+          node sdk/tests/test-next-package.mjs /tmp/libfx-package.tgz --webpack
+          node sdk/tests/test-next-package.mjs /tmp/libfx-package.tgz --next15
 
       - name: Retain package qualification evidence
         if: always()

--- a/.github/workflows/publish-libfx.yml
+++ b/.github/workflows/publish-libfx.yml
@@ -297,6 +297,7 @@ jobs:
 
       - name: Test installed package and diagnostics
         run: |
+          node --experimental-wasm-jspi sdk/tests/test-node-bundled-assets.mjs
           node --experimental-wasm-jspi sdk/tests/test-node-async-assets.mjs sdk/dist/libfx
           node sdk/tests/test-packed-example.mjs libfx-package.tgz native esm
           node --no-experimental-require-module sdk/tests/test-packed-example.mjs libfx-package.tgz native cjs
@@ -314,7 +315,10 @@ jobs:
       - name: Test Next development, production and isolated output
         env:
           LIBFX_TEST_ARTIFACT_ROOT: ${{ runner.temp }}/libfx-package-evidence
-        run: node sdk/tests/test-next-package.mjs libfx-package.tgz
+        run: |
+          node sdk/tests/test-next-package.mjs libfx-package.tgz
+          node sdk/tests/test-next-package.mjs libfx-package.tgz --webpack
+          node sdk/tests/test-next-package.mjs libfx-package.tgz --next15
 
       - name: Retain package qualification evidence
         if: always()
@@ -415,6 +419,8 @@ jobs:
           node --experimental-wasm-jspi sdk/tests/test-packed-example.mjs libfx-registry.tgz wasm esm
           node --experimental-wasm-jspi --no-experimental-require-module sdk/tests/test-packed-example.mjs libfx-registry.tgz wasm cjs
           node sdk/tests/test-next-package.mjs libfx-registry.tgz
+          node sdk/tests/test-next-package.mjs libfx-registry.tgz --webpack
+          node sdk/tests/test-next-package.mjs libfx-registry.tgz --next15
       - name: Retain registry qualification evidence
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/sdk/NAPI.md
+++ b/sdk/NAPI.md
@@ -281,7 +281,11 @@ when qualification fails, and report success only after cleanup succeeds.
 
 Live Vercel qualification is a separate release check. Run
 `node sdk/tests/test-vercel-package.mjs <tarball>` before publication, then run
-the same command with the immutable npm version afterward. Set
+the same command with the immutable npm version afterward. Repeat both checks
+with `--webpack` for Next.js 16 webpack and `--next15` for Next.js 15 webpack;
+the default is Next.js 16 Turbopack. The local `test-next-package.mjs` harness
+accepts the same selectors and verifies emitted native assets in the route
+trace before exercising production and relocated standalone output. Set
 `LIBFX_VERCEL_PROJECT_ID`, `LIBFX_VERCEL_ORG_ID`, and `AI_GATEWAY_API_KEY` in
 the environment. The harness uses the local Vercel CLI login, or
 `LIBFX_VERCEL_TOKEN` when supplied; npm publication does not require a Vercel

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -273,8 +273,14 @@ JIT tier-up.
 
 Create agents in a server route using the Node.js runtime. Import `libfx`
 normally; the package includes its native assets and exposes both ESM and
-CommonJS Node entrypoints. No `serverExternalPackages` setting or manual native
-file inclusion is required.
+CommonJS Node entrypoints. Native agents support Next.js 15 with webpack and
+Next.js 16 with webpack or Turbopack, without `serverExternalPackages` or manual
+native-file inclusion. Webpack's emitted assets are resolved relative to the
+server bundle, including standalone builds with a custom `distDir` or `assetPrefix`.
+
+This native setup does not require JSPI. Explicit WebAssembly use still needs
+JSPI and available Wasm assets; Next.js's standalone tracer excludes `.wasm`
+files, so a standalone Wasm host must supply those assets separately.
 
 ```js
 import { createFxAgent } from "libfx";

--- a/sdk/node.js
+++ b/sdk/node.js
@@ -42,6 +42,16 @@ const backendReasonCodes = {
   wasmLoad: "LIBFX_WASM_LOAD_FAILED",
 };
 
+function bundledAssetUrl(asset) {
+  if (asset.protocol !== "" || typeof asset.href !== "string" ||
+      typeof __webpack_base_uri__ === "undefined" || typeof __webpack_public_path__ !== "string" ||
+      !asset.href.startsWith(__webpack_public_path__)) {
+    throw new TypeError("Bundled asset URL has no filesystem mapping");
+  }
+  // Webpack's relative URL is a public asset address, not a Node URL instance.
+  return new URL(asset.href.slice(__webpack_public_path__.length), __webpack_base_uri__);
+}
+
 function jspiFallbackError(surface, nativeError) {
   const nativeDetail = nativeError ? ` Native loading failed: ${nativeError.message}.` : " No compatible native addon was found.";
   const error = new Error(
@@ -57,6 +67,7 @@ function jspiFallbackError(surface, nativeError) {
 async function loadNativeCandidate(candidate) {
   if (candidate == null) return null;
   if (candidate instanceof URL) {
+    if (candidate.protocol === "") candidate = bundledAssetUrl(candidate);
     if (candidate.protocol === "file:" && candidate.pathname.endsWith(".node")) {
       // Bundlers trace the asset URL; Node must load the native file at runtime.
       return Reflect.apply(nodeRequire, undefined, [fileURLToPath(candidate)]);
@@ -78,19 +89,27 @@ async function loadNativeCandidate(candidate) {
 function defaultNativeCandidate() {
   // Local path bindings let deployment tracers retain these assets in the generated CommonJS entry.
   if (process.platform === "linux" && process.arch === "x64") {
-    const path = fileURLToPath(new URL("./libfx.linux-x64.node", import.meta.url));
+    const asset = new URL("./libfx.linux-x64.node", import.meta.url);
+    if (asset.protocol === "") return fileURLToPath(bundledAssetUrl(asset));
+    const path = fileURLToPath(asset);
     return path;
   }
   if (process.platform === "linux" && process.arch === "arm64") {
-    const path = fileURLToPath(new URL("./libfx.linux-arm64.node", import.meta.url));
+    const asset = new URL("./libfx.linux-arm64.node", import.meta.url);
+    if (asset.protocol === "") return fileURLToPath(bundledAssetUrl(asset));
+    const path = fileURLToPath(asset);
     return path;
   }
   if (process.platform === "darwin" && process.arch === "x64") {
-    const path = fileURLToPath(new URL("./libfx.darwin-x64.node", import.meta.url));
+    const asset = new URL("./libfx.darwin-x64.node", import.meta.url);
+    if (asset.protocol === "") return fileURLToPath(bundledAssetUrl(asset));
+    const path = fileURLToPath(asset);
     return path;
   }
   if (process.platform === "darwin" && process.arch === "arm64") {
-    const path = fileURLToPath(new URL("./libfx.darwin-arm64.node", import.meta.url));
+    const asset = new URL("./libfx.darwin-arm64.node", import.meta.url);
+    if (asset.protocol === "") return fileURLToPath(bundledAssetUrl(asset));
+    const path = fileURLToPath(asset);
     return path;
   }
   return null;
@@ -115,7 +134,10 @@ function missingArtifact(error) {
 }
 
 function nativeCandidateFilePath(candidate) {
-  if (candidate instanceof URL) return candidate.protocol === "file:" ? fileURLToPath(candidate) : null;
+  if (candidate instanceof URL) {
+    if (candidate.protocol === "") candidate = bundledAssetUrl(candidate);
+    return candidate.protocol === "file:" ? fileURLToPath(candidate) : null;
+  }
   if (typeof candidate !== "string") return null;
   if (candidate.startsWith("file:")) return fileURLToPath(new URL(candidate));
   return URL.canParse(candidate) ? null : resolve(candidate);
@@ -196,7 +218,10 @@ function wasmInput(input) {
 }
 
 function wasmFilePath(input) {
-  if (input instanceof URL && input.protocol === "file:") return fileURLToPath(input);
+  if (input instanceof URL) {
+    if (input.protocol === "") input = bundledAssetUrl(input);
+    if (input.protocol === "file:") return fileURLToPath(input);
+  }
   if (typeof input === "string" && !URL.canParse(input)) return resolve(input);
   return null;
 }

--- a/sdk/tests/next/app/api/fx/route.js
+++ b/sdk/tests/next/app/api/fx/route.js
@@ -18,7 +18,7 @@ export async function GET(request) {
   const url = new URL(request.url);
   const backend = url.searchParams.get("backend") ?? "auto";
   const scenario = url.searchParams.get("scenario") ?? "host";
-  if (!["host", "mcp", "error", "cancel", "resume"].includes(scenario)) {
+  if (!["host", "mcp", "error", "cancel", "resume", "startup"].includes(scenario)) {
     return Response.json({ error: "Unknown scenario" }, { status: 400 });
   }
   let agent;
@@ -103,6 +103,9 @@ export async function GET(request) {
       } } : {}),
     };
     agent = await createFxAgent(options);
+    if (scenario === "startup") {
+      return Response.json({ ok: true, probe, checkpointBytes: (await agent.checkpoint()).length });
+    }
     const turn = agent.prompt("Look up key alpha and repeat its value.", { signal: controller.signal });
     let text = "";
     for await (const event of turn) {

--- a/sdk/tests/test-next-package.mjs
+++ b/sdk/tests/test-next-package.mjs
@@ -4,7 +4,7 @@ import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { once } from "node:events";
 import { createWriteStream } from "node:fs";
-import { cp, mkdir, mkdtemp, readFile, rename, writeFile } from "node:fs/promises";
+import { access, cp, mkdir, mkdtemp, readFile, rename, writeFile } from "node:fs/promises";
 import { createServer } from "node:net";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
@@ -13,6 +13,9 @@ import { fileURLToPath } from "node:url";
 import { serializeError } from "./package-report.mjs";
 
 const tarball = resolve(process.argv[2]);
+const next15 = process.argv.includes("--next15");
+const webpack = next15 || process.argv.includes("--webpack");
+const bundlerArgs = webpack && !next15 ? ["--webpack"] : [];
 const artifactRoot = process.env.LIBFX_TEST_ARTIFACT_ROOT || tmpdir();
 await mkdir(artifactRoot, { recursive: true });
 const root = await mkdtemp(resolve(artifactRoot, "libfx-next-"));
@@ -43,7 +46,9 @@ async function start(cwd, args, name) {
   const port = reservation.address().port;
   await new Promise((resolveClose) => reservation.close(resolveClose));
   const log = createWriteStream(resolve(root, `${name}.log`));
-  const child = spawn(process.execPath, ["--no-experimental-require-module", ...args, ...(name === "standalone" ? [] : ["--hostname", "127.0.0.1", "--port", String(port)])], {
+  // Next 16 dev forwards flags through NODE_OPTIONS, which rejects the JSPI flag.
+  const jspiArgs = name === "start" || (name === "dev" && next15) ? ["--experimental-wasm-jspi"] : [];
+  const child = spawn(process.execPath, [...jspiArgs, "--no-experimental-require-module", ...args, ...(name === "standalone" ? [] : ["--hostname", "127.0.0.1", "--port", String(port)])], {
     cwd, env: { ...env, HOSTNAME: "127.0.0.1", PORT: String(port) }, detached: true, stdio: ["ignore", "pipe", "pipe"],
   });
   child.stdout.pipe(log, { end: false });
@@ -89,6 +94,19 @@ async function exercise(server, stage) {
       console.log(`${stage}/${backend}/${scenario} passed`);
     }
   }
+  // Next's standalone tracer excludes .wasm assets; native selection above must not rely on that fallback.
+  if (stage === "start" || (stage === "dev" && next15)) {
+    const response = await fetch(`${server.url}/api/fx?backend=wasm&scenario=startup`, {
+      headers: { authorization: `Bearer ${token}` }, signal: AbortSignal.timeout(60_000),
+    });
+    const result = await response.json();
+    assert.equal(response.status, 200, JSON.stringify(result));
+    assert.equal(result.ok, true);
+    assert.equal(result.probe.backend, "wasm-jspi");
+    assert.ok(result.checkpointBytes > 48);
+    results.push({ stage, backend: "wasm", status: response.status, ...result });
+    console.log(`${stage}/wasm/default asset startup passed`);
+  }
   const concurrent = await Promise.all(Array.from({ length: 8 }, async () => {
     const response = await fetch(`${server.url}/api/fx?backend=native`, {
       headers: { authorization: `Bearer ${token}` }, signal: AbortSignal.timeout(60_000),
@@ -101,34 +119,53 @@ async function exercise(server, stage) {
   console.log(`${stage}/eight concurrent tool turns passed`);
 }
 
+async function assertBundledNativeAssets(buildDir) {
+  if (!webpack) return;
+  const routeDir = resolve(buildDir, "server/app/api/fx");
+  const trace = JSON.parse(await readFile(resolve(routeDir, "route.js.nft.json"), "utf8"));
+  for (const platform of ["linux-x64", "linux-arm64", "darwin-x64", "darwin-arm64"]) {
+    const file = trace.files.find((path) => path.includes(`/static/media/libfx.${platform}.`) && path.endsWith(".node"));
+    assert.ok(file, `webpack must trace the emitted ${platform} addon, not externalize libfx`);
+    await access(resolve(routeDir, file));
+  }
+}
+
 try {
   await cp(fixture, app, { recursive: true, filter: (path) => !["node_modules", ".next"].includes(path.split("/").at(-1)) });
   await cp(tarball, resolve(app, "libfx.tgz"));
   const manifest = JSON.parse(await readFile(resolve(app, "package.json"), "utf8"));
   manifest.dependencies.libfx = "file:./libfx.tgz";
+  if (next15) manifest.dependencies.next = "15.5.25";
   await writeFile(resolve(app, "package.json"), JSON.stringify(manifest, null, 2));
   await run(process.env.PNPM_BIN || "pnpm", ["install", "--no-frozen-lockfile", "--ignore-scripts"], app, "install");
   const require = createRequire(resolve(app, "package.json"));
-  await run(process.execPath, [
-    fileURLToPath(new URL("./test-node-tracing.mjs", import.meta.url)),
-    dirname(require.resolve("libfx")),
-    require.resolve("next/dist/compiled/@vercel/nft"),
-  ], app, "node-tracing");
+  if (!next15) {
+    await run(process.execPath, [
+      fileURLToPath(new URL("./test-node-tracing.mjs", import.meta.url)),
+      dirname(require.resolve("libfx")),
+      require.resolve("next/dist/compiled/@vercel/nft"),
+    ], app, "node-tracing");
+  }
   const next = resolve(app, "node_modules/next/dist/bin/next");
-  const dev = await start(app, [next, "dev"], "dev");
+  const dev = await start(app, [next, "dev", ...bundlerArgs], "dev");
   await exercise(dev, "dev");
   await stop(dev);
-  await run(process.execPath, ["--no-experimental-require-module", next, "build"], app, "build");
+  await run(process.execPath, ["--no-experimental-require-module", next, "build", ...bundlerArgs], app, "build");
+  await assertBundledNativeAssets(resolve(app, ".next"));
   const production = await start(app, [next, "start"], "start");
   await exercise(production, "start");
   await stop(production);
 
-  await writeFile(resolve(app, "next.config.mjs"), 'export default { output: "standalone" };\n');
-  await run(process.execPath, ["--no-experimental-require-module", next, "build"], app, "standalone-build");
+  const distDir = "build-output";
+  await writeFile(resolve(app, "next.config.mjs"), `export default ${JSON.stringify({
+    output: "standalone", distDir, assetPrefix: "https://cdn.example.test/assets",
+  })};\n`);
+  await run(process.execPath, ["--no-experimental-require-module", next, "build", ...bundlerArgs], app, "standalone-build");
+  await assertBundledNativeAssets(resolve(app, distDir));
   const isolated = resolve(root, "isolated");
-  await cp(resolve(app, ".next/standalone"), isolated, { recursive: true, verbatimSymlinks: true });
-  await mkdir(resolve(isolated, ".next"), { recursive: true });
-  await cp(resolve(app, ".next/static"), resolve(isolated, ".next/static"), { recursive: true });
+  await cp(resolve(app, distDir, "standalone"), isolated, { recursive: true, verbatimSymlinks: true });
+  await mkdir(resolve(isolated, distDir), { recursive: true });
+  await cp(resolve(app, distDir, "static"), resolve(isolated, distDir, "static"), { recursive: true });
   await rename(app, resolve(root, "source-unavailable"));
   const standalone = await start(isolated, [resolve(isolated, "server.js")], "standalone");
   await exercise(standalone, "standalone");
@@ -141,7 +178,7 @@ try {
     catch (error) { failure = failure ? new AggregateError([failure, error], "Verification and cleanup failed") : error; }
   }
   await writeFile(resolve(root, "results.json"), JSON.stringify({
-    node: process.version, tarball, results,
+    node: process.version, next15, bundler: webpack ? "webpack" : "turbopack", tarball, results,
     status: failure ? "failed" : "passed",
     error: serializeError(failure),
   }, null, 2));

--- a/sdk/tests/test-node-bundled-assets.mjs
+++ b/sdk/tests/test-node-bundled-assets.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+import { strict as assert } from "node:assert";
+import { cp, mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { createFxAgent, getBackendInfo } from "../node.js";
+
+const root = await mkdtemp(join(tmpdir(), "libfx bundled assets "));
+const media = join(root, "static", "media");
+const originalBase = Object.getOwnPropertyDescriptor(globalThis, "__webpack_base_uri__");
+const originalPublicPath = Object.getOwnPropertyDescriptor(globalThis, "__webpack_public_path__");
+
+// Match webpack's RelativeUrlRuntimeModule, including its misleading prototype.
+function relativeUrl(href) {
+  return Object.create(URL.prototype, {
+    href: { value: href },
+    pathname: { value: href.replace(/[?#].*/, "") },
+    protocol: { value: "" },
+    origin: { value: "" },
+  });
+}
+
+try {
+  await mkdir(media, { recursive: true });
+  const nativeName = `libfx.${process.platform}-${process.arch}.fixture.node`;
+  await cp(new URL("../../zig-out/lib/libfx.node", import.meta.url), join(media, nativeName));
+  for (const surface of ["core", "term"]) {
+    await cp(new URL(`../../zig-out/bin/fx-${surface}.wasm`, import.meta.url), join(media, `fx-${surface}.fixture.wasm`));
+  }
+  globalThis.__webpack_base_uri__ = pathToFileURL(`${root}/`).href;
+  for (const publicPath of ["/_next/", "https://cdn.example.test/assets/"]) {
+    globalThis.__webpack_public_path__ = publicPath;
+    const nativeAddon = relativeUrl(`${publicPath}static/media/${nativeName}`);
+    assert.ok(nativeAddon instanceof URL);
+    assert.throws(() => fileURLToPath(nativeAddon), { code: "ERR_INVALID_ARG_TYPE" });
+    assert.equal((await getBackendInfo({ backend: "native", nativeAddon })).backend, "native");
+    const agent = await createFxAgent({ backend: "native", nativeAddon, apiKey: "fixture-key" });
+    try { assert.ok((await agent.checkpoint()).length > 48); }
+    finally { await agent.close(); }
+    for (const [surface, artifact] of [["agent", "core"], ["terminal", "term"]]) {
+      const wasm = relativeUrl(`${publicPath}static/media/fx-${artifact}.fixture.wasm`);
+      const info = await getBackendInfo({ backend: "wasm", surface, wasm });
+      assert.equal(info.backend, "wasm-jspi", JSON.stringify(info));
+    }
+    const missing = await getBackendInfo({ backend: "native", nativeAddon: relativeUrl(`${publicPath}static/media/missing.node`) });
+    assert.equal(missing.attempts[0].reason.code, "LIBFX_NATIVE_ARTIFACT_MISSING");
+  }
+  const path = join(media, nativeName);
+  for (const nativeAddon of [path, pathToFileURL(path)]) {
+    assert.equal((await getBackendInfo({ backend: "native", nativeAddon })).backend, "native");
+  }
+  const unmapped = await getBackendInfo({ backend: "native", nativeAddon: relativeUrl("/different/asset.node") });
+  assert.equal(unmapped.backend, "unavailable");
+  assert.equal(unmapped.attempts[0].reason.code, "LIBFX_NATIVE_LOAD_FAILED");
+  delete globalThis.__webpack_base_uri__;
+  const unavailable = await getBackendInfo({ backend: "native", nativeAddon: relativeUrl("https://cdn.example.test/assets/static/media/asset.node") });
+  assert.equal(unavailable.backend, "unavailable");
+} finally {
+  for (const [name, descriptor] of [["__webpack_base_uri__", originalBase], ["__webpack_public_path__", originalPublicPath]]) {
+    if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+    else delete globalThis[name];
+  }
+  await rm(root, { recursive: true, force: true });
+}
+console.log("Bundled assets passed: webpack URLs, native startup, core and terminal Wasm, public prefixes, missing files, and ordinary Node paths");

--- a/sdk/tests/test-vercel-package.mjs
+++ b/sdk/tests/test-vercel-package.mjs
@@ -10,6 +10,8 @@ import { fileURLToPath } from "node:url";
 import { serializeError } from "./package-report.mjs";
 
 const input = process.argv[2];
+const next15 = process.argv.includes("--next15");
+const webpack = next15 || process.argv.includes("--webpack");
 assert.ok(input, "provide a published libfx version or local tarball");
 const projectId = process.env.LIBFX_VERCEL_PROJECT_ID;
 const orgId = process.env.LIBFX_VERCEL_ORG_ID;
@@ -59,6 +61,8 @@ try {
     assert.match(input, /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/, "pin an immutable version, not a tag");
     manifest.dependencies.libfx = input;
   }
+  if (next15) manifest.dependencies.next = "15.5.25";
+  if (webpack && !next15) manifest.scripts.build = "next build --webpack";
   await writeFile(resolve(app, "package.json"), JSON.stringify(manifest, null, 2));
   await run(process.env.PNPM_BIN || "pnpm", ["install", "--lockfile-only", "--no-frozen-lockfile", "--ignore-scripts"], "prepare");
   await mkdir(resolve(app, ".vercel"));
@@ -112,7 +116,7 @@ try {
     catch (error) { failure = failure ? new AggregateError([failure, error], "Verification and cleanup failed") : error; }
   }
   await writeFile(resolve(directory, "results.json"), redact(JSON.stringify({
-    input, deployment, results,
+    input, next15, bundler: webpack ? "webpack" : "turbopack", deployment, results,
     status: failure ? "failed" : "passed",
     error: serializeError(failure),
   }, null, 2)));


### PR DESCRIPTION
## Summary

- Load native agents from webpack-bundled Next.js 15 and 16 routes without `serverExternalPackages`, including relocated standalone builds and custom asset prefixes.
- Resolve webpack-emitted WebAssembly URLs to local files when the host provides JSPI and the required assets.