### PR TITLE
Indent wrapped lines of literal bullet lists

### DIFF
--- a/src/core/agent/assistant_presentation.zig
+++ b/src/core/agent/assistant_presentation.zig
@@ -2214,6 +2214,32 @@ test "unordered list asterisk gets bullet" {
     try std.testing.expectEqualStrings("\x1b[2m\xe2\x80\xa2 \x1b[22msecond item\n", out.items);
 }
 
+test "unordered list literal bullet gets dim marker" {
+    const alloc = std.testing.allocator;
+    var processor = MarkdownProcessor{};
+    defer processor.deinit(alloc);
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(alloc);
+
+    try processor.push(alloc, "\xe2\x80\xa2 third item\n  \xe2\x80\xa2 nested\n", &out);
+    try std.testing.expectEqualStrings(
+        "\x1b[2m\xe2\x80\xa2 \x1b[22mthird item\n" ++
+            "  \x1b[2m\xe2\x80\xa2 \x1b[22mnested\n",
+        out.items,
+    );
+}
+
+test "literal bullet without trailing space stays prose" {
+    const alloc = std.testing.allocator;
+    var processor = MarkdownProcessor{};
+    defer processor.deinit(alloc);
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(alloc);
+
+    try processor.push(alloc, "\xe2\x80\xa2item\n\xe2\x80\xa2\n", &out);
+    try std.testing.expectEqualStrings("\xe2\x80\xa2item\n\xe2\x80\xa2\n", out.items);
+}
+
 test "ordered list keeps number marker" {
     const alloc = std.testing.allocator;
     var processor = MarkdownProcessor{};

--- a/src/core/agent/presentation/block_parse.zig
+++ b/src/core/agent/presentation/block_parse.zig
@@ -151,13 +151,21 @@ const ParsedUnorderedList = struct {
     content: []const u8,
 };
 
+/// Accepts Markdown `-` and `*` markers plus a literal bullet so model output
+/// that already uses `•` gets the same styling and wrap continuation.
 pub fn parseUnorderedList(line: []const u8) ?ParsedUnorderedList {
+    const literal_bullet = "\xe2\x80\xa2";
     var i: usize = 0;
     while (i < line.len and (line[i] == ' ' or line[i] == '\t')) : (i += 1) {}
-    if (i + 1 >= line.len) return null;
-    if (line[i] != '-' and line[i] != '*') return null;
-    if (line[i + 1] != ' ') return null;
-    return .{ .indent = line[0..i], .content = line[i + 2 ..] };
+    const rest = line[i..];
+    const marker_len: usize = if (rest.len > 0 and (rest[0] == '-' or rest[0] == '*'))
+        1
+    else if (std.mem.startsWith(u8, rest, literal_bullet))
+        literal_bullet.len
+    else
+        return null;
+    if (marker_len >= rest.len or rest[marker_len] != ' ') return null;
+    return .{ .indent = line[0..i], .content = rest[marker_len + 1 ..] };
 }
 
 const ParsedOrderedList = struct {


### PR DESCRIPTION
## Summary

- Assistant lines that start with a literal bullet character are rendered as list items with the same dim marker as dash and asterisk lists.
- Wrapped continuation rows of those items keep the two-space hanging indent instead of starting at the left margin.
- A bullet character with no following space still renders as plain text.