### PR TITLE
Resume workspace sessions without repeated startup work

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,11 +105,11 @@ fx session resume last
 fx session resume --id <id>
 ```
 
-`fx -c` also resumes the latest session for the current workspace. It skips unrelated current-format conversation histories during selection and attempts safe recovery of the selected session after an interrupted migration. A busy or unrecoverable selected session produces an error rather than opening an older conversation.
+`fx -c` (or `fx --continue`) resumes the remembered session for the current workspace directly by ID. Selecting a saved session or saving the first work in a new interactive session remembers it; opening an empty window, later background activity, and quitting do not change that selection. If no session is remembered, choose one with `fx -r` or `fx --resume <id>`. `fx --resume last` still selects the latest workspace session by activity. A busy or unreadable target produces an error rather than opening another conversation. The session picker loads its catalog when opened.
 
-Repeated continuation reuses validated summaries of unchanged older sessions instead of replaying their histories during selection. The first scan, or a scan after those session files change, can take longer. Opening the resume picker preserves these cached summaries.
+Latest-session selection with `fx --resume last` reuses validated summaries of unchanged older sessions instead of replaying their histories. The first scan, or a scan after those session files change, can take longer. Opening the resume picker preserves these cached summaries.
 
-Older sessions that saved Vercel connection settings can be opened through `-r`, `/resume`, `-c`, or an exact ID. Migration preserves their model settings and keeps unfinished responses as interrupted history, without replaying old requests or restoring saved credential references.
+Older sessions that saved Vercel connection settings can be selected through `-r`, `/resume`, or an exact ID, then continued with `-c`. Migration preserves their model settings and keeps unfinished responses as interrupted history, without replaying old requests or restoring saved credential references.
 
 If a saved conversation is damaged, run `fx session recover <id>` to copy its validated prefix into a new session. Recovery preserves checkpoint boundaries and referenced result files, leaves the original unchanged, and prints the new session ID. Records after the damaged boundary are not included, and recovery does not rerun commands. If only accounting is corrupt, recovery keeps the conversation and marks historical usage as incomplete in the copy; the original accounting file remains unchanged. Healthy conversations can be resumed without recovery. Paused requests retain their captured images across errors and restarts. Continuing uses those saved images even if the original files move or change; missing or corrupted saved images produce a recovery error.
 
@@ -117,7 +117,7 @@ A saved session has one writer until it closes. Suspending it with Ctrl+Z keeps 
 
 Recovery only reports that no repair is needed after confirming the saved session can be loaded. If a final session save fails during interactive shutdown, fx reports the failure and exits with a nonzero status after cleanup, without a successful resume hint or automatic upgrade relaunch.
 
-New sessions appear in resume selection only after their initial files are ready. Incomplete creation folders left by older builds do not block healthy conversations from resuming with `-c`; those folders remain available for diagnosis and are not deleted.
+New sessions appear in discovery only after their initial files are ready. Incomplete creation folders left by older builds remain available for diagnosis and are not deleted. Remembered continuation does not scan these folders.
 
 Interactive terminal tabs show `fx v<version> | <folder>` using the running binary's version and current workspace folder name, for example `fx v0.0.7 | fx`. Renaming a session or switching models leaves the title unchanged. Resuming from another folder uses that folder's name. Exiting clears the fx-owned title. Noninteractive commands do not emit terminal-title controls.
 

--- a/README.md
+++ b/README.md
@@ -103,11 +103,11 @@ fx session resume last
 fx session resume --id <id>
 ```
 
-`fx -c` also resumes the latest session for the current workspace. It skips unrelated current-format conversation histories during selection and attempts safe recovery of the selected session after an interrupted migration. A busy or unrecoverable selected session produces an error rather than opening an older conversation.
+`fx -c` (or `fx --continue`) resumes the remembered session for the current workspace directly by ID. Selecting a saved session or saving the first work in a new interactive session remembers it; opening an empty window, later background activity, and quitting do not change that selection. If no session is remembered, choose one with `fx -r` or `fx --resume <id>`. `fx --resume last` still selects the latest workspace session by activity. A busy or unreadable target produces an error rather than opening another conversation. The session picker loads its catalog when opened.
 
 Repeated continuation reuses validated summaries of unchanged older sessions instead of replaying their histories during selection. The first scan, or a scan after those session files change, can take longer. Opening the resume picker preserves these cached summaries.
 
-Older sessions that saved Vercel connection settings can be opened through `-r`, `/resume`, `-c`, or an exact ID. Migration preserves their model settings and keeps unfinished responses as interrupted history, without replaying old requests or restoring saved credential references.
+Older sessions that saved Vercel connection settings can be selected through `-r`, `/resume`, or an exact ID, then continued with `-c`. Migration preserves their model settings and keeps unfinished responses as interrupted history, without replaying old requests or restoring saved credential references.
 
 If a saved conversation is damaged, run `fx session recover <id>` to copy its validated prefix into a new session. Recovery preserves checkpoint boundaries and referenced result files, leaves the original unchanged, and prints the new session ID. Records after the damaged boundary are not included, and recovery does not rerun commands. If only accounting is corrupt, recovery keeps the conversation and marks historical usage as incomplete in the copy; the original accounting file remains unchanged. Healthy conversations can be resumed without recovery. Paused requests retain their captured images across errors and restarts. Continuing uses those saved images even if the original files move or change; missing or corrupted saved images produce a recovery error.
 
@@ -115,7 +115,7 @@ A saved session has one writer until it closes. Suspending it with Ctrl+Z keeps 
 
 Recovery only reports that no repair is needed after confirming the saved session can be loaded. If a final session save fails during interactive shutdown, fx reports the failure and exits with a nonzero status after cleanup, without a successful resume hint or automatic upgrade relaunch.
 
-New sessions appear in resume selection only after their initial files are ready. Incomplete creation folders left by older builds do not block healthy conversations from resuming with `-c`; those folders remain available for diagnosis and are not deleted.
+New sessions appear in discovery only after their initial files are ready. Incomplete creation folders left by older builds remain available for diagnosis and are not deleted. Remembered continuation does not scan these folders.
 
 Interactive terminal tabs show `fx v<version> | <folder>` using the running binary's version and current workspace folder name, for example `fx v0.0.7 | fx`. Renaming a session or switching models leaves the title unchanged. Resuming from another folder uses that folder's name. Exiting clears the fx-owned title. Noninteractive commands do not emit terminal-title controls.
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ fx session resume --id <id>
 
 `fx -c` (or `fx --continue`) resumes the remembered session for the current workspace directly by ID. Selecting a saved session or saving the first work in a new interactive session remembers it; opening an empty window, later background activity, and quitting do not change that selection. If no session is remembered, choose one with `fx -r` or `fx --resume <id>`. `fx --resume last` still selects the latest workspace session by activity. A busy or unreadable target produces an error rather than opening another conversation. The session picker loads its catalog when opened.
 
-Repeated continuation reuses validated summaries of unchanged older sessions instead of replaying their histories during selection. The first scan, or a scan after those session files change, can take longer. Opening the resume picker preserves these cached summaries.
+Latest-session selection with `fx --resume last` reuses validated summaries of unchanged older sessions instead of replaying their histories. The first scan, or a scan after those session files change, can take longer. Opening the resume picker preserves these cached summaries.
 
 Older sessions that saved Vercel connection settings can be selected through `-r`, `/resume`, or an exact ID, then continued with `-c`. Migration preserves their model settings and keeps unfinished responses as interrupted history, without replaying old requests or restoring saved credential references.
 

--- a/src/acp/server.zig
+++ b/src/acp/server.zig
@@ -624,15 +624,6 @@ pub fn enableSubagentHost(state: *ServerState) void {
         state.subagent_store = null;
         return;
     };
-    state.subagent_host.?.requestBackgroundRecovery(
-        io_mod.milliTimestamp(),
-    ) catch |err| {
-        debug_trace.logf(
-            "subagent",
-            "acp background recovery unavailable root_id={s} outcome={s}",
-            .{ state.subagent_host.?.root_id, @errorName(err) },
-        );
-    };
 }
 
 fn resolveSubagentAuthority(

--- a/src/builtins/commands.zig
+++ b/src/builtins/commands.zig
@@ -341,7 +341,7 @@ pub const top_level_flags = [_]TopLevelFlag{
     },
     .{
         .usage = "-c, --continue",
-        .description = "Resume the latest workspace session",
+        .description = "Resume the remembered workspace session",
     },
     .{
         .usage = "-r",

--- a/src/core/app/app_entry_runtime.zig
+++ b/src/core/app/app_entry_runtime.zig
@@ -251,6 +251,14 @@ fn runInteractiveWithDeps(comptime App: type, comptime cooperative: bool, alloc:
                 writeStderr(deps, "fx: unable to start terminal recording.\n");
                 return .{ .exit = 1 };
             },
+            error.NoRememberedSession => {
+                writeStderr(deps, "fx: no remembered session for this workspace; choose one with fx -r or fx --resume <id>\n");
+                return .{ .exit = 1 };
+            },
+            error.RememberedSessionUnavailable => {
+                writeStderr(deps, "fx: the remembered session ID could not be read; choose one with fx -r or fx --resume <id>\n");
+                return .{ .exit = 1 };
+            },
             error.NoSavedSessions => {
                 writeStderr(deps, "fx: no saved sessions for this workspace.\n");
                 return .{ .exit = 1 };
@@ -629,6 +637,7 @@ fn appendInitEvent(launch: *const cli_surface.InteractiveLaunch) void {
         switch (target) {
             .pick => appendTestEvent("init:pick"),
             .last => appendTestEvent("init:last"),
+            .remembered => appendTestEvent("init:remembered"),
             .id => |id| appendTestEvent(std.fmt.bufPrint(&test_init_event_buf, "init:{s}", .{id}) catch "init:<invalid>"),
         }
     } else {

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -1037,6 +1037,7 @@ pub const Persistence = struct {
     write_mutex: std.Io.Mutex = .init,
     store: ?session_store.Store = null,
     writable: ?session_store.LoadedWritableSession = null,
+    remember_fresh_session: bool = false,
     subagent_host: ?*subagent_tool_host.Runtime = null,
     workspace_preferences: ?session_codec.DurableSessionPreferences = null,
     session_preferences: ?session_codec.DurableSessionPreferences = null,
@@ -1058,7 +1059,7 @@ pub const Persistence = struct {
     /// in a static release-binary template.
     pub fn initInto(storage: *Persistence) void {
         comptime {
-            if (std.meta.fields(Persistence).len != 19) {
+            if (std.meta.fields(Persistence).len != 20) {
                 @compileError("update Persistence.initInto for the changed field set");
             }
         }
@@ -1066,6 +1067,7 @@ pub const Persistence = struct {
         storage.write_mutex = .init;
         storage.store = null;
         storage.writable = null;
+        storage.remember_fresh_session = false;
         storage.subagent_host = null;
         storage.workspace_preferences = null;
         storage.session_preferences = null;
@@ -1308,6 +1310,7 @@ pub fn Runtime(comptime App: type) type {
                 try warnNonDurable(app, "session creation failed", err);
                 return;
             };
+            app.session_persistence.remember_fresh_session = true;
             app.session_persistence.degraded_warning_emitted = false;
             app.total_input_tokens = 0;
             app.total_output_tokens = 0;
@@ -1515,10 +1518,20 @@ pub fn Runtime(comptime App: type) type {
             app.requested_resume = null;
             defer target.deinit(app.alloc);
 
+            var remembered: ?[]u8 = null;
+            defer if (remembered) |id| app.alloc.free(id);
             const resume_target: session_store.ResumeTarget = switch (target) {
                 // Nothing to load yet: the picker asks which session to open.
                 .pick => return openSessionPicker(app),
                 .last => .last,
+                .remembered => blk: {
+                    const store = app.session_persistence.store orelse return error.SessionStoreUnavailable;
+                    remembered = store.readRememberedSessionId(app.alloc) catch |err| switch (err) {
+                        error.OutOfMemory => return err,
+                        else => return error.RememberedSessionUnavailable,
+                    };
+                    break :blk .{ .id = remembered orelse return error.NoRememberedSession };
+                },
                 .id => |session_id| .{ .id = session_id },
             };
             var loaded = try loadResumeTargetForWrite(app, resume_target, .{});
@@ -1529,6 +1542,7 @@ pub fn Runtime(comptime App: type) type {
             try installResumedSession(app, &loaded, notice);
             errdefer closeWritableSession(app);
             try app.commitStartupResumeReplayAnchor();
+            if (target != .remembered and notice == .session) rememberSelectedSession(app);
         }
 
         fn resumeRequestedJsHostSession(app: *App) !void {
@@ -1566,7 +1580,7 @@ pub fn Runtime(comptime App: type) type {
             const session_id = switch (target) {
                 .pick => unreachable,
                 .id => |id| id,
-                .last => latest: {
+                .remembered, .last => latest: {
                     const entries = app.session_persistence.js_host_store.list(app.alloc) catch |err| {
                         traceJsHostRestoreFailure("list", null, err);
                         try continueWithFreshJsHostSession(app);
@@ -1706,6 +1720,7 @@ pub fn Runtime(comptime App: type) type {
             requestSubagentBackgroundRecovery(app);
             startResumedSessionReconciliation(app);
             try app.finishLiveSessionResume();
+            rememberSelectedSession(app);
             return true;
         }
 
@@ -1919,28 +1934,6 @@ pub fn Runtime(comptime App: type) type {
                 if (!cache_visible) picker.load_state = .failed;
                 try writeSessionPickerError(app, err);
                 return;
-            };
-        }
-
-        pub fn primeSessionPicker(app: *App) void {
-            const store = if (app.session_persistence.store) |*value| value else return;
-            const active_id = if (app.session_persistence.writable) |*loaded|
-                loaded.active_id
-            else
-                null;
-            const loader = &app.session_persistence.session_picker_load;
-            const cache = &app.session_persistence.session_picker_cache;
-            if (cache.matches(active_id) and cache.isFresh()) return;
-            if (loader.matchingInitialGeneration(active_id) != null) return;
-            const request = SessionPickerLoad.PageRequest.init(
-                loader.allocateGeneration(),
-                active_id,
-            ) catch |err| {
-                debug_trace.logf("core", "session picker prewarm unavailable err={s}", .{@errorName(err)});
-                return;
-            };
-            loader.schedule(store, request) catch |err| {
-                debug_trace.logf("core", "session picker prewarm unavailable err={s}", .{@errorName(err)});
             };
         }
 
@@ -2244,6 +2237,7 @@ pub fn Runtime(comptime App: type) type {
             if (comptime !@hasField(App, "session_persistence")) {
                 return error.SessionPersistenceUnavailable;
             }
+            var remember_failure: ?RememberFailure = null;
             {
                 app.session_persistence.write_mutex.lockUncancelable(io_mod.getIo());
                 defer app.session_persistence.write_mutex.unlock(io_mod.getIo());
@@ -2251,13 +2245,19 @@ pub fn Runtime(comptime App: type) type {
                     value
                 else
                     return error.SessionPersistenceUnavailable;
+                const first_work = app.session_persistence.remember_fresh_session and !hasDurableUserWork(loaded);
                 const now_ms = io_mod.milliTimestamp();
                 _ = try loaded.appendEvent(
                     app.alloc,
                     .{ .recovery_checkpoint_set = .{ .checkpoint = checkpoint } },
                     now_ms,
                 );
+                if (first_work) {
+                    app.session_persistence.remember_fresh_session = false;
+                    remember_failure = rememberSession(app, loaded.active_id);
+                }
             }
+            if (remember_failure) |failure| reportRememberFailure(app, failure, true);
             if (comptime @hasDecl(@TypeOf(app.worker), "preservePromptSnapshots")) {
                 app.worker.preservePromptSnapshots(checkpoint.turn_id, checkpoint.user.images);
             }
@@ -2499,6 +2499,8 @@ pub fn Runtime(comptime App: type) type {
                 commitJsHostSnapshot(app, "history_turn");
                 return .committed;
             }
+            var remember_failure: ?RememberFailure = null;
+            defer if (remember_failure) |failure| reportRememberFailure(app, failure, false);
             app.session_persistence.write_mutex.lockUncancelable(io_mod.getIo());
             const loaded = if (app.session_persistence.writable) |*value|
                 value
@@ -2516,6 +2518,7 @@ pub fn Runtime(comptime App: type) type {
                 return .committed;
             };
             defer app.session_persistence.write_mutex.unlock(io_mod.getIo());
+            const first_work = app.session_persistence.remember_fresh_session and !hasDurableUserWork(loaded);
             try loaded.prepareHistoryTurnForCommit(app.alloc, &prepared);
             _ = loaded.appendEvent(
                 app.alloc,
@@ -2543,6 +2546,10 @@ pub fn Runtime(comptime App: type) type {
                     },
                 };
             };
+            if (first_work) {
+                app.session_persistence.remember_fresh_session = false;
+                remember_failure = rememberSession(app, loaded.active_id);
+            }
             if (comptime @hasDecl(@TypeOf(app.session), "commitPreparedHistoryEntry")) {
                 app.session.commitPreparedHistoryEntry(app.alloc, prepared);
                 prepared_owned = false;
@@ -4167,6 +4174,7 @@ pub fn Runtime(comptime App: type) type {
             }
             app.session_persistence.write_mutex.lockUncancelable(io_mod.getIo());
             defer app.session_persistence.write_mutex.unlock(io_mod.getIo());
+            app.session_persistence.remember_fresh_session = false;
             discardAnyPendingCancelledCommand(app, "writable_session_close");
             const loaded = if (app.session_persistence.writable) |*value|
                 value
@@ -4611,6 +4619,50 @@ pub fn Runtime(comptime App: type) type {
             try warnNonDurable(app, "session persistence degraded", err);
         }
 
+        const RememberFailure = struct {
+            id: [255]u8,
+            len: usize,
+            err: anyerror,
+        };
+
+        fn hasDurableUserWork(loaded: *const session_store.LoadedWritableSession) bool {
+            return loaded.conversation_writer.last_seq != 0 or loaded.state.recovery_checkpoint != null;
+        }
+
+        fn rememberSession(app: *App, id: []const u8) ?RememberFailure {
+            const store = app.session_persistence.store orelse return null;
+            store.rememberSessionId(app.alloc, id) catch |err| {
+                debug_trace.logf("session", "event=remember_session_failed id={s} err={s}", .{ id, @errorName(err) });
+                var failure = RememberFailure{ .id = undefined, .len = id.len, .err = err };
+                // Native loaded session IDs have already passed Store validation.
+                @memcpy(failure.id[0..id.len], id);
+                return failure;
+            };
+            return null;
+        }
+
+        fn rememberSelectedSession(app: *App) void {
+            if (app.session_persistence.writable) |*loaded| {
+                if (rememberSession(app, loaded.active_id)) |failure| reportRememberFailure(app, failure, false);
+            }
+        }
+
+        fn reportRememberFailure(app: *App, failure: RememberFailure, comptime from_worker: bool) void {
+            const alloc = std.heap.c_allocator;
+            const body = std.fmt.allocPrint(alloc, "Session saved, but could not remember it for -c ({s}). Resume with fx --resume {s}.", .{ @errorName(failure.err), failure.id[0..failure.len] }) catch return;
+            defer alloc.free(body);
+            const notice = types.SemanticNotice{ .topic = "session", .tone = .warning, .body = body };
+            if (comptime @hasDecl(@TypeOf(app.worker), "pushEvent") and (from_worker or !@hasDecl(App, "writeDomainNotice"))) {
+                app.worker.pushEvent(alloc, .{ .semantic_notice = notice }) catch |err| {
+                    debug_trace.logf("session", "event=remember_warning_dropped err={s}", .{@errorName(err)});
+                };
+            } else {
+                app.writeDomainNotice(notice, true) catch |err| {
+                    debug_trace.logf("session", "event=remember_warning_dropped err={s}", .{@errorName(err)});
+                };
+            }
+        }
+
         fn warnNonDurable(
             app: *App,
             label: []const u8,
@@ -4745,13 +4797,14 @@ const TestHome = struct {
 };
 
 const TestResumeTarget = union(enum) {
+    remembered,
     pick,
     last,
     id: []u8,
 
     fn deinit(self: *TestResumeTarget, alloc: Allocator) void {
         switch (self.*) {
-            .pick, .last => {},
+            .remembered, .pick, .last => {},
             .id => |id| alloc.free(id),
         }
         self.* = .last;
@@ -8694,7 +8747,7 @@ test "session picker refresh preserves selection and loaded pagination" {
     try std.testing.expectEqualStrings("two", picker.selectedId().?);
 }
 
-test "session picker prewarms one catalog for both workspace views" {
+test "session picker loads on demand and shares one catalog across workspace views" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -8725,12 +8778,10 @@ test "session picker prewarms one catalog for both workspace views" {
     );
     try Runtime(TestApp).beginFreshPersistedSession(&app);
 
-    Runtime(TestApp).primeSessionPicker(&app);
-    try waitForSessionPickerPrewarm(&app);
-    try std.testing.expect(!app.session_persistence.session_picker.active);
-    try std.testing.expect(app.session_persistence.session_picker_cache.ready);
-
+    try std.testing.expect(!app.session_persistence.session_picker_cache.ready);
+    try std.testing.expect(app.session_persistence.session_picker_load.task == null);
     try Runtime(TestApp).openSessionPicker(&app);
+    try waitForSessionPickerPrewarm(&app);
     try std.testing.expectEqual(.ready, app.session_persistence.session_picker.load_state);
     try std.testing.expectEqualStrings(
         "prewarmed-session",
@@ -8796,7 +8847,6 @@ test "session picker reuses a held catalog after resize and workspace switch" {
         try std.testing.expect(picker.isLoading());
         held.done.store(finished_before_switch, .release);
         app.shell.layout.rows = 80;
-        Runtime(TestApp).primeSessionPicker(&app);
         try std.testing.expect(try Runtime(TestApp).toggleSessionPickerScope(&app));
         try std.testing.expect(loader.task == held);
         try std.testing.expect(loader.pending == null);
@@ -9772,4 +9822,134 @@ test "uncertain finished history preserves snapshot files and rejects later writ
     try std.testing.expectEqual(@as(usize, 1), ownership.transfers);
     try std.testing.expectEqual(@as(usize, 0), app.session.historyLen());
     try std.testing.expectError(error.SessionPersistenceUncertain, Runtime(TestApp).appendHistoryTurn(&app, turn));
+}
+
+test "remembered session follows first durable work and ignores later activity" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const paths = try testPaths(alloc, &tmp);
+    defer {
+        alloc.free(paths.home);
+        alloc.free(paths.workspace);
+    }
+    const home = try TestHome.install(alloc, paths.home);
+    defer home.deinit();
+    var app = try TestApp.init(alloc, paths.workspace);
+    defer app.deinit();
+    try configureTestPreferences(&app);
+    try Runtime(TestApp).initializePersistence(&app, true);
+    try Runtime(TestApp).beginFreshPersistedSession(&app);
+    const store = app.session_persistence.store.?;
+    try std.testing.expect((try store.readRememberedSessionId(alloc)) == null);
+    const checkpoint: session_codec.RecoveryCheckpoint = .{
+        .turn_id = 1,
+        .user = .{ .text = @constCast("pending prompt") },
+        .assistant_source = @constCast(""),
+        .cause = .network_interrupted,
+        .action = .retrying_request,
+        .authority = .{ .provider = .gateway, .model = @constCast("test/model") },
+        .requested_fast_mode = false,
+        .fast_mode = false,
+        .max_provider_attempts = 3,
+        .consumed_provider_attempts = 1,
+    };
+    _ = try app.session_persistence.writable.?.appendEvent(alloc, .{ .preferences_changed = .{ .fast_mode = true } }, io_mod.milliTimestamp());
+    try std.testing.expect(!app.session_persistence.writable.?.freshly_started);
+    try Runtime(TestApp).setRecoveryCheckpoint(&app, checkpoint);
+    const first = (try store.readRememberedSessionId(alloc)).?;
+    defer alloc.free(first);
+    try std.testing.expectEqualStrings(app.session_persistence.writable.?.active_id, first);
+    try store.rememberSessionId(alloc, "other-selection");
+    try Runtime(TestApp).setRecoveryCheckpoint(&app, checkpoint);
+    const turn = try session_runtime.makeAssistantTurn(alloc, "pending prompt", "done");
+    defer session_runtime.freeHistoryTurn(alloc, turn);
+    try Runtime(TestApp).appendHistoryTurn(&app, turn);
+    const retained = (try store.readRememberedSessionId(alloc)).?;
+    defer alloc.free(retained);
+    try std.testing.expectEqualStrings("other-selection", retained);
+    try Runtime(TestApp).beginFreshPersistedSession(&app);
+    const empty = (try store.readRememberedSessionId(alloc)).?;
+    defer alloc.free(empty);
+    try std.testing.expectEqualStrings("other-selection", empty);
+    _ = try app.session_persistence.writable.?.appendEvent(alloc, .{ .preferences_changed = .{ .fast_mode = true } }, io_mod.milliTimestamp());
+    try Runtime(TestApp).appendHistoryTurn(&app, turn);
+    const next = (try store.readRememberedSessionId(alloc)).?;
+    defer alloc.free(next);
+    try std.testing.expectEqualStrings(app.session_persistence.writable.?.active_id, next);
+}
+
+test "remembered continuation consumes selection without republishing and preserves busy admission" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const paths = try testPaths(alloc, &tmp);
+    defer {
+        alloc.free(paths.home);
+        alloc.free(paths.workspace);
+    }
+    const home = try TestHome.install(alloc, paths.home);
+    defer home.deinit();
+    var app = try TestApp.init(alloc, paths.workspace);
+    defer app.deinit();
+    try configureTestPreferences(&app);
+    try Runtime(TestApp).initializePersistence(&app, true);
+    app.requested_resume = .remembered;
+    try std.testing.expectError(error.NoRememberedSession, Runtime(TestApp).resumeRequestedSession(&app));
+    const history = [_]types.HistoryTurn{.{ .assistant = .{
+        .user = .{ .text = @constCast("saved prompt") },
+        .assistant = @constCast("saved response"),
+    } }};
+    const store = app.session_persistence.store.?;
+    try writeSessionFixture(alloc, store, "remembered", &history, 0);
+    try store.rememberSessionId(alloc, "remembered");
+    app.requested_resume = .remembered;
+    try Runtime(TestApp).resumeRequestedSession(&app);
+    try std.testing.expectEqualStrings("remembered", app.session_persistence.writable.?.active_id);
+    try std.testing.expectError(error.SessionBusy, store.resumeTargetForWrite(alloc, .{ .id = "remembered" }, paths.workspace, .{ .log = .{ .session_lock_deadline_ms = 0 } }));
+    try store.rememberSessionId(alloc, "newer-selection");
+    // Reading a remembered target is not another publication; exact selection still is.
+    const retained = (try store.readRememberedSessionId(alloc)).?;
+    defer alloc.free(retained);
+    try std.testing.expectEqualStrings("newer-selection", retained);
+    try std.testing.expect(!app.session_persistence.session_picker_cache.ready);
+    try std.testing.expect(app.session_persistence.session_picker_load.task == null);
+}
+
+test "remembered selection write failure leaves pending user work durable and warns" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const paths = try testPaths(alloc, &tmp);
+    defer {
+        alloc.free(paths.home);
+        alloc.free(paths.workspace);
+    }
+    const home = try TestHome.install(alloc, paths.home);
+    defer home.deinit();
+    var app = try TestApp.init(alloc, paths.workspace);
+    defer app.deinit();
+    try configureTestPreferences(&app);
+    try Runtime(TestApp).initializePersistence(&app, true);
+    try Runtime(TestApp).beginFreshPersistedSession(&app);
+    var obstruction = try tmp.dir.createFile(io_mod.getIo(), "home/.fx/continue", .{});
+    obstruction.close(io_mod.getIo());
+    try Runtime(TestApp).setRecoveryCheckpoint(&app, .{
+        .turn_id = 1,
+        .user = .{ .text = @constCast("saved pending request") },
+        .assistant_source = @constCast(""),
+        .cause = .network_interrupted,
+        .action = .retrying_request,
+        .authority = .{ .provider = .gateway, .model = @constCast("test/model") },
+        .requested_fast_mode = false,
+        .fast_mode = false,
+        .max_provider_attempts = 3,
+        .consumed_provider_attempts = 1,
+    });
+    const loaded = &app.session_persistence.writable.?;
+    try std.testing.expect(loaded.state.recovery_checkpoint != null);
+    try std.testing.expect(loaded.conversation_writer.failure == null);
+    try std.testing.expectEqual(@as(usize, 1), app.notices.items.len);
+    try std.testing.expect(std.mem.find(u8, app.notices.items[0], "Session saved, but could not remember") != null);
+    try std.testing.expect(std.mem.find(u8, app.notices.items[0], loaded.active_id) != null);
 }

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -1037,6 +1037,7 @@ pub const Persistence = struct {
     write_mutex: std.Io.Mutex = .init,
     store: ?session_store.Store = null,
     writable: ?session_store.LoadedWritableSession = null,
+    remember_fresh_session: bool = false,
     subagent_host: ?*subagent_tool_host.Runtime = null,
     workspace_preferences: ?session_codec.DurableSessionPreferences = null,
     session_preferences: ?session_codec.DurableSessionPreferences = null,
@@ -1058,7 +1059,7 @@ pub const Persistence = struct {
     /// in a static release-binary template.
     pub fn initInto(storage: *Persistence) void {
         comptime {
-            if (std.meta.fields(Persistence).len != 19) {
+            if (std.meta.fields(Persistence).len != 20) {
                 @compileError("update Persistence.initInto for the changed field set");
             }
         }
@@ -1066,6 +1067,7 @@ pub const Persistence = struct {
         storage.write_mutex = .init;
         storage.store = null;
         storage.writable = null;
+        storage.remember_fresh_session = false;
         storage.subagent_host = null;
         storage.workspace_preferences = null;
         storage.session_preferences = null;
@@ -1308,6 +1310,7 @@ pub fn Runtime(comptime App: type) type {
                 try warnNonDurable(app, "session creation failed", err);
                 return;
             };
+            app.session_persistence.remember_fresh_session = true;
             app.session_persistence.degraded_warning_emitted = false;
             app.total_input_tokens = 0;
             app.total_output_tokens = 0;
@@ -1515,10 +1518,20 @@ pub fn Runtime(comptime App: type) type {
             app.requested_resume = null;
             defer target.deinit(app.alloc);
 
+            var remembered: ?[]u8 = null;
+            defer if (remembered) |id| app.alloc.free(id);
             const resume_target: session_store.ResumeTarget = switch (target) {
                 // Nothing to load yet: the picker asks which session to open.
                 .pick => return openSessionPicker(app),
                 .last => .last,
+                .remembered => blk: {
+                    const store = app.session_persistence.store orelse return error.SessionStoreUnavailable;
+                    remembered = store.readRememberedSessionId(app.alloc) catch |err| switch (err) {
+                        error.OutOfMemory => return err,
+                        else => return error.RememberedSessionUnavailable,
+                    };
+                    break :blk .{ .id = remembered orelse return error.NoRememberedSession };
+                },
                 .id => |session_id| .{ .id = session_id },
             };
             var loaded = try loadResumeTargetForWrite(app, resume_target, .{});
@@ -1529,6 +1542,7 @@ pub fn Runtime(comptime App: type) type {
             try installResumedSession(app, &loaded, notice);
             errdefer closeWritableSession(app);
             try app.commitStartupResumeReplayAnchor();
+            if (target != .remembered and notice == .session) rememberSelectedSession(app);
         }
 
         fn resumeRequestedJsHostSession(app: *App) !void {
@@ -1566,7 +1580,7 @@ pub fn Runtime(comptime App: type) type {
             const session_id = switch (target) {
                 .pick => unreachable,
                 .id => |id| id,
-                .last => latest: {
+                .remembered, .last => latest: {
                     const entries = app.session_persistence.js_host_store.list(app.alloc) catch |err| {
                         traceJsHostRestoreFailure("list", null, err);
                         try continueWithFreshJsHostSession(app);
@@ -1703,9 +1717,9 @@ pub fn Runtime(comptime App: type) type {
             try app.prepareLiveSessionResume();
             loaded_owned = false;
             try installResumedSession(app, &loaded, .session);
-            requestSubagentBackgroundRecovery(app);
             startResumedSessionReconciliation(app);
             try app.finishLiveSessionResume();
+            rememberSelectedSession(app);
             return true;
         }
 
@@ -1919,28 +1933,6 @@ pub fn Runtime(comptime App: type) type {
                 if (!cache_visible) picker.load_state = .failed;
                 try writeSessionPickerError(app, err);
                 return;
-            };
-        }
-
-        pub fn primeSessionPicker(app: *App) void {
-            const store = if (app.session_persistence.store) |*value| value else return;
-            const active_id = if (app.session_persistence.writable) |*loaded|
-                loaded.active_id
-            else
-                null;
-            const loader = &app.session_persistence.session_picker_load;
-            const cache = &app.session_persistence.session_picker_cache;
-            if (cache.matches(active_id) and cache.isFresh()) return;
-            if (loader.matchingInitialGeneration(active_id) != null) return;
-            const request = SessionPickerLoad.PageRequest.init(
-                loader.allocateGeneration(),
-                active_id,
-            ) catch |err| {
-                debug_trace.logf("core", "session picker prewarm unavailable err={s}", .{@errorName(err)});
-                return;
-            };
-            loader.schedule(store, request) catch |err| {
-                debug_trace.logf("core", "session picker prewarm unavailable err={s}", .{@errorName(err)});
             };
         }
 
@@ -2244,6 +2236,7 @@ pub fn Runtime(comptime App: type) type {
             if (comptime !@hasField(App, "session_persistence")) {
                 return error.SessionPersistenceUnavailable;
             }
+            var remember_failure: ?RememberFailure = null;
             {
                 app.session_persistence.write_mutex.lockUncancelable(io_mod.getIo());
                 defer app.session_persistence.write_mutex.unlock(io_mod.getIo());
@@ -2251,13 +2244,19 @@ pub fn Runtime(comptime App: type) type {
                     value
                 else
                     return error.SessionPersistenceUnavailable;
+                const first_work = app.session_persistence.remember_fresh_session and !hasDurableUserWork(loaded);
                 const now_ms = io_mod.milliTimestamp();
                 _ = try loaded.appendEvent(
                     app.alloc,
                     .{ .recovery_checkpoint_set = .{ .checkpoint = checkpoint } },
                     now_ms,
                 );
+                if (first_work) {
+                    app.session_persistence.remember_fresh_session = false;
+                    remember_failure = rememberSession(app, loaded.active_id);
+                }
             }
+            if (remember_failure) |failure| reportRememberFailure(app, failure, true);
             if (comptime @hasDecl(@TypeOf(app.worker), "preservePromptSnapshots")) {
                 app.worker.preservePromptSnapshots(checkpoint.turn_id, checkpoint.user.images);
             }
@@ -2499,6 +2498,8 @@ pub fn Runtime(comptime App: type) type {
                 commitJsHostSnapshot(app, "history_turn");
                 return .committed;
             }
+            var remember_failure: ?RememberFailure = null;
+            defer if (remember_failure) |failure| reportRememberFailure(app, failure, false);
             app.session_persistence.write_mutex.lockUncancelable(io_mod.getIo());
             const loaded = if (app.session_persistence.writable) |*value|
                 value
@@ -2516,6 +2517,7 @@ pub fn Runtime(comptime App: type) type {
                 return .committed;
             };
             defer app.session_persistence.write_mutex.unlock(io_mod.getIo());
+            const first_work = app.session_persistence.remember_fresh_session and !hasDurableUserWork(loaded);
             try loaded.prepareHistoryTurnForCommit(app.alloc, &prepared);
             _ = loaded.appendEvent(
                 app.alloc,
@@ -2543,6 +2545,10 @@ pub fn Runtime(comptime App: type) type {
                     },
                 };
             };
+            if (first_work) {
+                app.session_persistence.remember_fresh_session = false;
+                remember_failure = rememberSession(app, loaded.active_id);
+            }
             if (comptime @hasDecl(@TypeOf(app.session), "commitPreparedHistoryEntry")) {
                 app.session.commitPreparedHistoryEntry(app.alloc, prepared);
                 prepared_owned = false;
@@ -2784,18 +2790,6 @@ pub fn Runtime(comptime App: type) type {
             const host = app.session_persistence.subagent_host orelse return;
             const store = if (app.session_persistence.store) |*value| value else return;
             host.rebind(store, app, subagentAuthorityResolver(app));
-            requestSubagentBackgroundRecovery(app);
-        }
-
-        fn requestSubagentBackgroundRecovery(app: *App) void {
-            const host = app.session_persistence.subagent_host orelse return;
-            host.requestBackgroundRecovery(io_mod.milliTimestamp()) catch |err| {
-                debug_trace.logf(
-                    "subagent",
-                    "interactive background recovery unavailable root_id={s} outcome={s}",
-                    .{ host.root_id, @errorName(err) },
-                );
-            };
         }
 
         pub fn disableSubagentHost(app: *App) void {
@@ -4167,6 +4161,7 @@ pub fn Runtime(comptime App: type) type {
             }
             app.session_persistence.write_mutex.lockUncancelable(io_mod.getIo());
             defer app.session_persistence.write_mutex.unlock(io_mod.getIo());
+            app.session_persistence.remember_fresh_session = false;
             discardAnyPendingCancelledCommand(app, "writable_session_close");
             const loaded = if (app.session_persistence.writable) |*value|
                 value
@@ -4611,6 +4606,50 @@ pub fn Runtime(comptime App: type) type {
             try warnNonDurable(app, "session persistence degraded", err);
         }
 
+        const RememberFailure = struct {
+            id: [255]u8,
+            len: usize,
+            err: anyerror,
+        };
+
+        fn hasDurableUserWork(loaded: *const session_store.LoadedWritableSession) bool {
+            return loaded.conversation_writer.last_seq != 0 or loaded.state.recovery_checkpoint != null;
+        }
+
+        fn rememberSession(app: *App, id: []const u8) ?RememberFailure {
+            const store = app.session_persistence.store orelse return null;
+            store.rememberSessionId(app.alloc, id) catch |err| {
+                debug_trace.logf("session", "event=remember_session_failed id={s} err={s}", .{ id, @errorName(err) });
+                var failure = RememberFailure{ .id = undefined, .len = id.len, .err = err };
+                // Native loaded session IDs have already passed Store validation.
+                @memcpy(failure.id[0..id.len], id);
+                return failure;
+            };
+            return null;
+        }
+
+        fn rememberSelectedSession(app: *App) void {
+            if (app.session_persistence.writable) |*loaded| {
+                if (rememberSession(app, loaded.active_id)) |failure| reportRememberFailure(app, failure, false);
+            }
+        }
+
+        fn reportRememberFailure(app: *App, failure: RememberFailure, comptime from_worker: bool) void {
+            const alloc = std.heap.c_allocator;
+            const body = std.fmt.allocPrint(alloc, "Session saved, but could not remember it for -c ({s}). Resume with fx --resume {s}.", .{ @errorName(failure.err), failure.id[0..failure.len] }) catch return;
+            defer alloc.free(body);
+            const notice = types.SemanticNotice{ .topic = "session", .tone = .warning, .body = body };
+            if (comptime @hasDecl(@TypeOf(app.worker), "pushEvent") and (from_worker or !@hasDecl(App, "writeDomainNotice"))) {
+                app.worker.pushEvent(alloc, .{ .semantic_notice = notice }) catch |err| {
+                    debug_trace.logf("session", "event=remember_warning_dropped err={s}", .{@errorName(err)});
+                };
+            } else {
+                app.writeDomainNotice(notice, true) catch |err| {
+                    debug_trace.logf("session", "event=remember_warning_dropped err={s}", .{@errorName(err)});
+                };
+            }
+        }
+
         fn warnNonDurable(
             app: *App,
             label: []const u8,
@@ -4745,13 +4784,14 @@ const TestHome = struct {
 };
 
 const TestResumeTarget = union(enum) {
+    remembered,
     pick,
     last,
     id: []u8,
 
     fn deinit(self: *TestResumeTarget, alloc: Allocator) void {
         switch (self.*) {
-            .pick, .last => {},
+            .remembered, .pick, .last => {},
             .id => |id| alloc.free(id),
         }
         self.* = .last;
@@ -7224,6 +7264,92 @@ test "canceling a startup session picker starts a writable fresh session" {
     try std.testing.expect(app.session_persistence.writable != null);
 }
 
+test "subagent host publication requires successful registry recovery" {
+    const subagent_child_state = @import("../subagent/child_state.zig");
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const paths = try testPaths(alloc, &tmp);
+    defer {
+        alloc.free(paths.home);
+        alloc.free(paths.workspace);
+    }
+    const home = try TestHome.install(alloc, paths.home);
+    defer home.deinit();
+    var app = try TestApp.init(alloc, paths.workspace);
+    defer app.deinit();
+    try configureTestPreferences(&app);
+    try Runtime(TestApp).initializePersistence(&app, true);
+    try Runtime(TestApp).beginFreshPersistedSession(&app);
+    const parent_id = app.session_persistence.writable.?.active_id;
+    const state_store = subagent_child_state.Store{ .sessions = &app.session_persistence.store.?, .parent_id = parent_id };
+    var registry = try subagent_child_state.Registry.init(alloc, parent_id);
+    defer registry.deinit(alloc);
+    var active = subagent_child_state.ActiveWork{
+        .id = try alloc.dupe(u8, "abandoned-work"),
+        .message = try alloc.dupe(u8, "review this"),
+        .created_at_ms = 1,
+    };
+    defer active.deinit(alloc);
+    try registry.appendOneOff(alloc, "child", active);
+    try state_store.save(alloc, registry);
+    Runtime(TestApp).enableSessionStores(&app);
+    try std.testing.expect(app.session_persistence.subagent_host != null);
+    var recovered = try state_store.load(alloc);
+    defer recovered.deinit(alloc);
+    try std.testing.expectEqual(subagent_child_state.Phase.interrupted, recovered.children[0].phase);
+    try std.testing.expect(recovered.children[0].active == null);
+
+    registry.generation = recovered.generation + 1;
+    try state_store.save(alloc, registry);
+    Runtime(TestApp).rebindSubagentHost(&app);
+    var rebound = try state_store.load(alloc);
+    defer rebound.deinit(alloc);
+    try std.testing.expectEqual(registry.generation, rebound.generation);
+    try std.testing.expectEqual(subagent_child_state.Phase.running, rebound.children[0].phase);
+    const Faults = struct {
+        fn lock(_: ?*anyopaque, _: std.Io.File) anyerror!bool {
+            return error.InjectedLockFailure;
+        }
+        fn sync(_: ?*anyopaque, _: std.Io.File) anyerror!void {
+            return error.InjectedSyncFailure;
+        }
+    };
+    const host = app.session_persistence.subagent_host.?;
+    host.managed.state_store.options = .{ .lock_ops = .{ .try_lock = Faults.lock } };
+    try std.testing.expectError(error.SessionChildStoreFailed, host.managed.recoverInterrupted());
+    host.managed.state_store.options = .{ .replace_ops = .{ .sync_file = Faults.sync } };
+    try std.testing.expectError(error.SessionChildStoreFailed, host.managed.recoverInterrupted());
+    host.managed.state_store.options = .{};
+    var retained = try state_store.load(alloc);
+    defer retained.deinit(alloc);
+    try std.testing.expectEqual(registry.generation, retained.generation);
+    try std.testing.expectEqual(subagent_child_state.Phase.running, retained.children[0].phase);
+    Runtime(TestApp).disableSubagentHost(&app);
+    const capability = try app.session_persistence.writable.?.childCapability();
+    var entry = try capability.atomicReplace(alloc, .subagent_control, "children.json", "[]");
+    defer entry.deinit(alloc);
+    Runtime(TestApp).enableSessionStores(&app);
+    try std.testing.expect(app.session_persistence.subagent_host == null);
+    try std.testing.expect(app.session_persistence.writable != null);
+    const AllocationCheck = struct {
+        fn run(check_alloc: Allocator, store: *session_store.Store, id: []const u8) !void {
+            const created = subagent_tool_host.Runtime.create(check_alloc, store, id, .{ .resolve_fn = unavailable }, .{}) catch |err| {
+                if (err == error.OutOfMemory) return err;
+                try std.testing.expectEqual(error.InvalidState, err);
+                return;
+            };
+            created.deinit();
+            return error.TestExpectedError;
+        }
+
+        fn unavailable(_: ?*anyopaque, _: Allocator, _: []const u8) subagent_authority.HostResolveError!subagent_authority.HostAuthority {
+            return error.HostAuthorityUnavailable;
+        }
+    };
+    try std.testing.checkAllAllocationFailures(alloc, AllocationCheck.run, .{ &app.session_persistence.store.?, parent_id });
+}
+
 test "interactive session resume uses the live transition and shared restore path" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
@@ -7270,11 +7396,7 @@ test "interactive session resume uses the live transition and shared restore pat
     try std.testing.expectEqualStrings("● Session resumed: saved prompt", app.notices.items[0]);
     try std.testing.expect(!app.session_persistence.session_picker.active);
 
-    const host = app.session_persistence.subagent_host.?;
-    try std.testing.expectEqual(
-        subagent_tool_host.RecoveryState.complete,
-        host.recoveryState(),
-    );
+    try std.testing.expect(app.session_persistence.subagent_host != null);
 }
 
 test "interactive session resume preserves the current writer when the target is unavailable" {
@@ -8694,7 +8816,7 @@ test "session picker refresh preserves selection and loaded pagination" {
     try std.testing.expectEqualStrings("two", picker.selectedId().?);
 }
 
-test "session picker prewarms one catalog for both workspace views" {
+test "session picker loads on demand and shares one catalog across workspace views" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -8725,12 +8847,10 @@ test "session picker prewarms one catalog for both workspace views" {
     );
     try Runtime(TestApp).beginFreshPersistedSession(&app);
 
-    Runtime(TestApp).primeSessionPicker(&app);
-    try waitForSessionPickerPrewarm(&app);
-    try std.testing.expect(!app.session_persistence.session_picker.active);
-    try std.testing.expect(app.session_persistence.session_picker_cache.ready);
-
+    try std.testing.expect(!app.session_persistence.session_picker_cache.ready);
+    try std.testing.expect(app.session_persistence.session_picker_load.task == null);
     try Runtime(TestApp).openSessionPicker(&app);
+    try waitForSessionPickerPrewarm(&app);
     try std.testing.expectEqual(.ready, app.session_persistence.session_picker.load_state);
     try std.testing.expectEqualStrings(
         "prewarmed-session",
@@ -8796,7 +8916,6 @@ test "session picker reuses a held catalog after resize and workspace switch" {
         try std.testing.expect(picker.isLoading());
         held.done.store(finished_before_switch, .release);
         app.shell.layout.rows = 80;
-        Runtime(TestApp).primeSessionPicker(&app);
         try std.testing.expect(try Runtime(TestApp).toggleSessionPickerScope(&app));
         try std.testing.expect(loader.task == held);
         try std.testing.expect(loader.pending == null);
@@ -9772,4 +9891,134 @@ test "uncertain finished history preserves snapshot files and rejects later writ
     try std.testing.expectEqual(@as(usize, 1), ownership.transfers);
     try std.testing.expectEqual(@as(usize, 0), app.session.historyLen());
     try std.testing.expectError(error.SessionPersistenceUncertain, Runtime(TestApp).appendHistoryTurn(&app, turn));
+}
+
+test "remembered session follows first durable work and ignores later activity" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const paths = try testPaths(alloc, &tmp);
+    defer {
+        alloc.free(paths.home);
+        alloc.free(paths.workspace);
+    }
+    const home = try TestHome.install(alloc, paths.home);
+    defer home.deinit();
+    var app = try TestApp.init(alloc, paths.workspace);
+    defer app.deinit();
+    try configureTestPreferences(&app);
+    try Runtime(TestApp).initializePersistence(&app, true);
+    try Runtime(TestApp).beginFreshPersistedSession(&app);
+    const store = app.session_persistence.store.?;
+    try std.testing.expect((try store.readRememberedSessionId(alloc)) == null);
+    const checkpoint: session_codec.RecoveryCheckpoint = .{
+        .turn_id = 1,
+        .user = .{ .text = @constCast("pending prompt") },
+        .assistant_source = @constCast(""),
+        .cause = .network_interrupted,
+        .action = .retrying_request,
+        .authority = .{ .provider = .gateway, .model = @constCast("test/model") },
+        .requested_fast_mode = false,
+        .fast_mode = false,
+        .max_provider_attempts = 3,
+        .consumed_provider_attempts = 1,
+    };
+    _ = try app.session_persistence.writable.?.appendEvent(alloc, .{ .preferences_changed = .{ .fast_mode = true } }, io_mod.milliTimestamp());
+    try std.testing.expect(!app.session_persistence.writable.?.freshly_started);
+    try Runtime(TestApp).setRecoveryCheckpoint(&app, checkpoint);
+    const first = (try store.readRememberedSessionId(alloc)).?;
+    defer alloc.free(first);
+    try std.testing.expectEqualStrings(app.session_persistence.writable.?.active_id, first);
+    try store.rememberSessionId(alloc, "other-selection");
+    try Runtime(TestApp).setRecoveryCheckpoint(&app, checkpoint);
+    const turn = try session_runtime.makeAssistantTurn(alloc, "pending prompt", "done");
+    defer session_runtime.freeHistoryTurn(alloc, turn);
+    try Runtime(TestApp).appendHistoryTurn(&app, turn);
+    const retained = (try store.readRememberedSessionId(alloc)).?;
+    defer alloc.free(retained);
+    try std.testing.expectEqualStrings("other-selection", retained);
+    try Runtime(TestApp).beginFreshPersistedSession(&app);
+    const empty = (try store.readRememberedSessionId(alloc)).?;
+    defer alloc.free(empty);
+    try std.testing.expectEqualStrings("other-selection", empty);
+    _ = try app.session_persistence.writable.?.appendEvent(alloc, .{ .preferences_changed = .{ .fast_mode = true } }, io_mod.milliTimestamp());
+    try Runtime(TestApp).appendHistoryTurn(&app, turn);
+    const next = (try store.readRememberedSessionId(alloc)).?;
+    defer alloc.free(next);
+    try std.testing.expectEqualStrings(app.session_persistence.writable.?.active_id, next);
+}
+
+test "remembered continuation consumes selection without republishing and preserves busy admission" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const paths = try testPaths(alloc, &tmp);
+    defer {
+        alloc.free(paths.home);
+        alloc.free(paths.workspace);
+    }
+    const home = try TestHome.install(alloc, paths.home);
+    defer home.deinit();
+    var app = try TestApp.init(alloc, paths.workspace);
+    defer app.deinit();
+    try configureTestPreferences(&app);
+    try Runtime(TestApp).initializePersistence(&app, true);
+    app.requested_resume = .remembered;
+    try std.testing.expectError(error.NoRememberedSession, Runtime(TestApp).resumeRequestedSession(&app));
+    const history = [_]types.HistoryTurn{.{ .assistant = .{
+        .user = .{ .text = @constCast("saved prompt") },
+        .assistant = @constCast("saved response"),
+    } }};
+    const store = app.session_persistence.store.?;
+    try writeSessionFixture(alloc, store, "remembered", &history, 0);
+    try store.rememberSessionId(alloc, "remembered");
+    app.requested_resume = .remembered;
+    try Runtime(TestApp).resumeRequestedSession(&app);
+    try std.testing.expectEqualStrings("remembered", app.session_persistence.writable.?.active_id);
+    try std.testing.expectError(error.SessionBusy, store.resumeTargetForWrite(alloc, .{ .id = "remembered" }, paths.workspace, .{ .log = .{ .session_lock_deadline_ms = 0 } }));
+    try store.rememberSessionId(alloc, "newer-selection");
+    // Reading a remembered target is not another publication; exact selection still is.
+    const retained = (try store.readRememberedSessionId(alloc)).?;
+    defer alloc.free(retained);
+    try std.testing.expectEqualStrings("newer-selection", retained);
+    try std.testing.expect(!app.session_persistence.session_picker_cache.ready);
+    try std.testing.expect(app.session_persistence.session_picker_load.task == null);
+}
+
+test "remembered selection write failure leaves pending user work durable and warns" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const paths = try testPaths(alloc, &tmp);
+    defer {
+        alloc.free(paths.home);
+        alloc.free(paths.workspace);
+    }
+    const home = try TestHome.install(alloc, paths.home);
+    defer home.deinit();
+    var app = try TestApp.init(alloc, paths.workspace);
+    defer app.deinit();
+    try configureTestPreferences(&app);
+    try Runtime(TestApp).initializePersistence(&app, true);
+    try Runtime(TestApp).beginFreshPersistedSession(&app);
+    var obstruction = try tmp.dir.createFile(io_mod.getIo(), "home/.fx/continue", .{});
+    obstruction.close(io_mod.getIo());
+    try Runtime(TestApp).setRecoveryCheckpoint(&app, .{
+        .turn_id = 1,
+        .user = .{ .text = @constCast("saved pending request") },
+        .assistant_source = @constCast(""),
+        .cause = .network_interrupted,
+        .action = .retrying_request,
+        .authority = .{ .provider = .gateway, .model = @constCast("test/model") },
+        .requested_fast_mode = false,
+        .fast_mode = false,
+        .max_provider_attempts = 3,
+        .consumed_provider_attempts = 1,
+    });
+    const loaded = &app.session_persistence.writable.?;
+    try std.testing.expect(loaded.state.recovery_checkpoint != null);
+    try std.testing.expect(loaded.conversation_writer.failure == null);
+    try std.testing.expectEqual(@as(usize, 1), app.notices.items.len);
+    try std.testing.expect(std.mem.find(u8, app.notices.items[0], "Session saved, but could not remember") != null);
+    try std.testing.expect(std.mem.find(u8, app.notices.items[0], loaded.active_id) != null);
 }

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -906,13 +906,21 @@ const AskContext = struct {
             self.effort = preferences.effort;
             self.fast_mode = preferences.fast_mode;
         }
-        self.subagent_host = try subagent_tool_host.Runtime.create(
+        self.subagent_host = subagent_tool_host.Runtime.create(
             self.alloc,
             &self.store.?,
             self.writable.?.active_id,
             .{ .context = self, .resolve_fn = resolveAskSubagentAuthority },
             .{ .context = self, .run_fn = runAskChild },
-        );
+        ) catch |err| blk: {
+            if (err == error.OutOfMemory) return err;
+            debug_trace.logf(
+                "subagent",
+                "ask subagent host unavailable root_id={s} err={s}",
+                .{ self.writable.?.active_id, @errorName(err) },
+            );
+            break :blk null;
+        };
         const capability = try self.writable.?.childCapability();
         if (legacy_background_migration.migrate(
             self.alloc,

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -433,7 +433,6 @@ const RunDeps = struct {
     discard_pristine_session_ctx: ?*anyopaque = null,
     discard_pristine_session: DiscardPristineSessionFn = discardPristineSessionDefault,
     install_headless_interrupt: bool = false,
-    start_subagent_background_recovery: bool = true,
     stdin_source: StdinSource = .real,
 };
 
@@ -914,17 +913,6 @@ const AskContext = struct {
             .{ .context = self, .resolve_fn = resolveAskSubagentAuthority },
             .{ .context = self, .run_fn = runAskChild },
         );
-        if (self.deps.start_subagent_background_recovery) {
-            self.subagent_host.?.requestBackgroundRecovery(
-                io_mod.milliTimestamp(),
-            ) catch |err| {
-                debug_trace.logf(
-                    "subagent",
-                    "ask background recovery unavailable root_id={s} outcome={s}",
-                    .{ self.subagent_host.?.root_id, @errorName(err) },
-                );
-            };
-        }
         const capability = try self.writable.?.childCapability();
         if (legacy_background_migration.migrate(
             self.alloc,
@@ -7163,12 +7151,11 @@ fn exerciseSavedAskSessionStoreAllocation(
     defer stdout_capture.deinit(setup_alloc);
     var stderr_capture: TestCapture = .{};
     defer stderr_capture.deinit(setup_alloc);
-    var deps = testPromptRunDeps(
+    const deps = testPromptRunDeps(
         &stdout_capture,
         &stderr_capture,
         testPresentKeyStartup,
     );
-    deps.start_subagent_background_recovery = false;
     var ctx = AskContext.init(
         alloc,
         testConfig(),

--- a/src/core/cli/cli_surface.zig
+++ b/src/core/cli/cli_surface.zig
@@ -106,13 +106,14 @@ pub const UpgradeRelaunch = struct {
 const resume_picker_alias = "-r";
 
 pub const ResumeTarget = union(enum) {
+    remembered,
     pick,
     last,
     id: []u8,
 
     pub fn deinit(self: *ResumeTarget, alloc: Allocator) void {
         switch (self.*) {
-            .pick, .last => {},
+            .remembered, .pick, .last => {},
             .id => |value| alloc.free(value),
         }
         self.* = undefined;
@@ -3586,6 +3587,7 @@ fn parseResumeArgs(
         }
         if (args.len != 1) return error.InvalidResumeArgs;
         if (std.mem.eql(u8, args[0], resume_picker_alias)) return .pick;
+        if (std.mem.eql(u8, args[0], "-c") or std.mem.eql(u8, args[0], "--continue")) return .remembered;
         if (command_specs.matchesTopLevel(command_catalog, args[0], .@"resume")) return .last;
         if (!std.mem.startsWith(u8, args[0], resume_id_alias_prefix)) return error.InvalidResumeArgs;
         const id = args[0][resume_id_alias_prefix.len..];
@@ -4213,7 +4215,7 @@ test "parse resume args accepts explicit id flag" {
     defer target.deinit(std.testing.allocator);
 
     switch (target) {
-        .pick, .last => return error.TestExpectedExactResumeId,
+        .remembered, .pick, .last => return error.TestExpectedExactResumeId,
         .id => |id| try std.testing.expectEqualStrings("release.2026.06", id),
     }
 }
@@ -4227,7 +4229,7 @@ test "parse resume args accepts an operand on the top-level resume flag" {
     defer target.deinit(std.testing.allocator);
 
     switch (target) {
-        .pick, .last => return error.TestExpectedExactResumeId,
+        .remembered, .pick, .last => return error.TestExpectedExactResumeId,
         .id => |id| try std.testing.expectEqualStrings("session-123", id),
     }
 
@@ -4247,7 +4249,7 @@ test "parse resume args treats last after id flag as exact id" {
     defer target.deinit(std.testing.allocator);
 
     switch (target) {
-        .pick, .last => return error.TestExpectedExactResumeId,
+        .remembered, .pick, .last => return error.TestExpectedExactResumeId,
         .id => |id| try std.testing.expectEqualStrings("last", id),
     }
 }
@@ -4323,7 +4325,7 @@ test "parseInteractiveLaunch shares native resume grammar" {
                 const target = launch.requested_resume orelse return error.TestExpectedResumeTarget;
                 if (case.expected_id) |expected_id| switch (target) {
                     .id => |id| try std.testing.expectEqualStrings(expected_id, id),
-                    .pick, .last => return error.TestExpectedExactResumeId,
+                    .remembered, .pick, .last => return error.TestExpectedExactResumeId,
                 } else try std.testing.expectEqual(ResumeTarget.last, target);
             },
             .noninteractive => |value| {
@@ -4935,7 +4937,10 @@ test "runIfRequested top-level resume aliases return the existing target" {
             capture.deps(),
         );
         switch (result) {
-            .interactive => |launch| try std.testing.expectEqual(ResumeTarget.last, launch.requested_resume.?),
+            .interactive => |launch| {
+                const expected: ResumeTarget = if (std.mem.eql(u8, args[0], "-c") or std.mem.eql(u8, args[0], "--continue")) .remembered else .last;
+                try std.testing.expectEqual(expected, launch.requested_resume.?);
+            },
             else => return error.TestExpectedEqual,
         }
         try std.testing.expectEqualStrings("", capture.stdout.written());
@@ -4957,7 +4962,7 @@ test "runIfRequested top-level resume aliases return the existing target" {
             defer launch.deinit(std.testing.allocator);
             switch (launch.requested_resume.?) {
                 .id => |id| try std.testing.expectEqualStrings("session.123", id),
-                .pick, .last => return error.TestExpectedExactResumeId,
+                .remembered, .pick, .last => return error.TestExpectedExactResumeId,
             }
         },
         else => return error.TestExpectedEqual,
@@ -4978,7 +4983,7 @@ test "runIfRequested top-level resume aliases return the existing target" {
             defer launch.deinit(std.testing.allocator);
             switch (launch.requested_resume.?) {
                 .id => |id| try std.testing.expectEqualStrings("session.123", id),
-                .pick, .last => return error.TestExpectedExactResumeId,
+                .remembered, .pick, .last => return error.TestExpectedExactResumeId,
             }
         },
         else => return error.TestExpectedEqual,

--- a/src/core/session/session_log.zig
+++ b/src/core/session/session_log.zig
@@ -776,7 +776,22 @@ fn loadConversationStateIfPresent(
     dir: *io_mod.VerifiedDir,
     expected_session_id: []const u8,
 ) !?session_codec.DurableSessionState {
-    return load_conversation_state_at_boundary(alloc, dir, expected_session_id, null, null);
+    return load_conversation_state_at_boundary(alloc, dir, expected_session_id, null, null, null);
+}
+
+/// Loads owned detail state, distinguishing unreadable conversation history
+/// from supporting-file errors. Writable resume retains its original errors.
+pub fn loadConversationDetailState(
+    alloc: Allocator,
+    dir: *io_mod.VerifiedDir,
+    session_id: []const u8,
+) !session_codec.DurableSessionState {
+    var history_failed = false;
+    return (load_conversation_state_at_boundary(alloc, dir, session_id, null, null, &history_failed) catch |err| {
+        if (err == error.OutOfMemory or !history_failed) return err;
+        debug_trace.logf("session", "conversation detail history unavailable id={s} err={s}", .{ session_id, @errorName(err) });
+        return error.ConversationHistoryUnavailable;
+    }) orelse error.SessionMigrationRequired;
 }
 
 fn load_conversation_state_at_boundary(
@@ -785,6 +800,7 @@ fn load_conversation_state_at_boundary(
     expected_session_id: []const u8,
     recovery: ?ConversationRecoveryBoundary,
     replay_window: ?ConversationReplayWindow,
+    history_failed: ?*bool,
 ) !?session_codec.DurableSessionState {
     const metadata_bytes = readManagedFileAlloc(
         alloc,
@@ -816,13 +832,18 @@ fn load_conversation_state_at_boundary(
     if (!std.mem.eql(u8, metadata.value.id, expected_session_id)) {
         return error.InvalidSessionMetadata;
     }
-    var event_file = try openManagedFile(dir, events_file, .read_only);
-    defer event_file.close(io_mod.getIo());
     var conversation_seq: u64 = 0;
     var open_work_id: ?[]u8 = null;
     defer if (open_work_id) |work_id| alloc.free(work_id);
-    const length = if (recovery) |boundary| boundary.bytes else try event_file.length(io_mod.getIo());
-    const history = try replayConversationHistory(alloc, event_file, length, &conversation_seq, &open_work_id, replay_window);
+    const history = blk: {
+        errdefer if (history_failed) |failed| {
+            failed.* = true;
+        };
+        var event_file = try openManagedFile(dir, events_file, .read_only);
+        defer event_file.close(io_mod.getIo());
+        const length = if (recovery) |boundary| boundary.bytes else try event_file.length(io_mod.getIo());
+        break :blk try replayConversationHistory(alloc, event_file, length, &conversation_seq, &open_work_id, replay_window);
+    };
     errdefer session.freeHistoryTurnSlice(alloc, history);
     if (recovery == null) try restoreContextResultBodies(alloc, dir, history);
     const latest_work_id = if (recovery != null and recovery.?.turn_open and open_work_id != null)
@@ -1026,7 +1047,7 @@ pub fn load_conversation_recovery_state(
     session_id: []const u8,
     boundary: ConversationRecoveryBoundary,
 ) !session_codec.DurableSessionState {
-    const loaded = load_conversation_state_at_boundary(alloc, dir, session_id, boundary, null) catch |err| switch (err) {
+    const loaded = load_conversation_state_at_boundary(alloc, dir, session_id, boundary, null, null) catch |err| switch (err) {
         error.InvalidSessionMetadata, error.InvalidSessionFormat => return error.SessionRecoveryBoundaryInvalid,
         else => return err,
     };
@@ -1259,6 +1280,7 @@ fn openConversationWritableSession(
         writable.session_id,
         null,
         replay_window,
+        null,
     )) orelse return error.InvalidSessionMetadata;
     errdefer state.deinit(alloc);
     const active_id = try alloc.dupe(u8, writable.session_id);

--- a/src/core/session/session_store.zig
+++ b/src/core/session/session_store.zig
@@ -597,6 +597,11 @@ pub const Store = struct {
         var directory = (try self.openRememberedDirectory(false)) orelse return null;
         defer directory.close();
         const name = self.rememberedSessionFilename();
+        const path_stat = directory.dir.statFile(io_mod.getIo(), &name, .{ .follow_symlinks = false }) catch |err| switch (err) {
+            error.FileNotFound => return null,
+            else => return err,
+        };
+        if (path_stat.kind != .file) return error.InvalidRememberedSession;
         var file = directory.dir.openFile(io_mod.getIo(), &name, .{
             .mode = .read_only,
             .allow_directory = false,

--- a/src/core/session/session_store.zig
+++ b/src/core/session/session_store.zig
@@ -591,6 +591,83 @@ pub const Store = struct {
         self.* = undefined;
     }
 
+    /// Returns an owned ID, or null when this workspace has no remembered selection.
+    /// Reading never creates profile state or enumerates sessions.
+    pub fn readRememberedSessionId(self: Store, alloc: Allocator) !?[]u8 {
+        var directory = (try self.openRememberedDirectory(false)) orelse return null;
+        defer directory.close();
+        const name = self.rememberedSessionFilename();
+        var file = directory.dir.openFile(io_mod.getIo(), &name, .{
+            .mode = .read_only,
+            .allow_directory = false,
+            .follow_symlinks = false,
+            .resolve_beneath = true,
+        }) catch |err| switch (err) {
+            error.FileNotFound => return null,
+            else => return err,
+        };
+        defer file.close(io_mod.getIo());
+        return try readRememberedSessionFile(alloc, &file);
+    }
+
+    fn readRememberedSessionFile(alloc: Allocator, file: *std.Io.File) ![]u8 {
+        const stat = try file.stat(io_mod.getIo());
+        // An atomic replacement can unlink the valid version already opened here.
+        if (stat.kind != .file or stat.nlink > 1 or stat.permissions.toMode() & 0o777 != 0o600 or stat.size > 256) {
+            return error.InvalidRememberedSession;
+        }
+        const bytes = try io_mod.readFileToEnd(alloc, file, 256);
+        defer alloc.free(bytes);
+        return try alloc.dupe(u8, try parseRememberedSessionId(bytes));
+    }
+
+    /// Publishes one interactive selection. Conversation writes retain their own lock.
+    pub fn rememberSessionId(self: Store, alloc: Allocator, session_id: []const u8) !void {
+        if (self.canonical_root.mode != .writable) return error.SessionStoreReadOnly;
+        try validateSessionId(session_id);
+        var directory = (try self.openRememberedDirectory(true)) orelse return error.SessionStoreUnavailable;
+        defer directory.close();
+        const name = self.rememberedSessionFilename();
+        var buffer: [256]u8 = undefined;
+        const bytes = try std.fmt.bufPrint(&buffer, "{s}\n", .{session_id});
+        try io_mod.durableReplaceVerified(alloc, &directory, &name, bytes);
+    }
+
+    fn rememberedSessionFilename(self: Store) [64]u8 {
+        var digest: [32]u8 = undefined;
+        std.crypto.hash.sha2.Sha256.hash(normalizeWorkspaceRoot(self.workspace_root), &digest, .{});
+        return std.fmt.bytesToHex(digest, .lower);
+    }
+
+    fn openRememberedDirectory(self: Store, create: bool) !?io_mod.VerifiedDir {
+        const zio = io_mod.getIo();
+        var home = std.Io.Dir.openDirAbsolute(zio, self.home_dir, .{ .iterate = true }) catch |err| switch (err) {
+            error.FileNotFound => return null,
+            else => return err,
+        };
+        defer home.close(zio);
+        var profile = home.openDir(zio, profile_paths.root_dir_name, .{
+            .iterate = true,
+            .follow_symlinks = false,
+        }) catch |err| switch (err) {
+            error.FileNotFound => return null,
+            else => return err,
+        };
+        defer profile.close(zio);
+        if ((try profile.stat(zio)).permissions.toMode() & 0o777 != 0o700) return error.SessionPathUnsafe;
+        if (create) return try io_mod.openOrCreateVerifiedPrivateDirFromDir(profile, "continue");
+        var directory = profile.openDir(zio, "continue", .{
+            .iterate = true,
+            .follow_symlinks = false,
+        }) catch |err| switch (err) {
+            error.FileNotFound => return null,
+            else => return err,
+        };
+        errdefer directory.close(zio);
+        if ((try directory.stat(zio)).permissions.toMode() & 0o777 != 0o700) return error.SessionPathUnsafe;
+        return .{ .dir = directory };
+    }
+
     /// Starts a brand-new writable session from `state`, with default log options.
     pub fn startWritableSession(
         self: Store,
@@ -4489,6 +4566,13 @@ fn initWithHome(alloc: Allocator, home: []const u8, workspace_root: []const u8, 
         .canonical_root = canonical_root,
     };
 }
+fn parseRememberedSessionId(bytes: []const u8) ![]const u8 {
+    if (bytes.len < 2 or bytes.len > 256 or bytes[bytes.len - 1] != '\n') return error.InvalidRememberedSession;
+    const id = bytes[0 .. bytes.len - 1];
+    validateSessionId(id) catch return error.InvalidRememberedSession;
+    return id;
+}
+
 const TempStore = struct {
     home: []u8,
     workspace: []u8,
@@ -8644,4 +8728,76 @@ test "recovery checkpoint images resolve on read-only and writable resume" {
     try std.testing.expectEqualStrings(image.snapshot_path.?, resumed.state.recovery_checkpoint.?.user.images[0].snapshot_path.?);
     _ = try resumed.appendEvent(alloc, .{ .recovery_checkpoint_cleared = .{} }, 30);
     try std.Io.Dir.accessAbsolute(std.testing.io, image.snapshot_path.?, .{});
+}
+
+test "remembered session IDs are bounded and unambiguous" {
+    try std.testing.expectEqualStrings("session-1", try parseRememberedSessionId("session-1\n"));
+    for ([_][]const u8{ "", "\n", "../other\n", "session-1", "one\ntwo\n", "one\r\n", " one\n" }) |bytes| {
+        try std.testing.expectError(error.InvalidRememberedSession, parseRememberedSessionId(bytes));
+    }
+    var bytes: [257]u8 = @splat('a');
+    bytes[255] = '\n';
+    try std.testing.expectEqual(@as(usize, 255), (try parseRememberedSessionId(bytes[0..256])).len);
+    try std.testing.expectError(error.InvalidRememberedSession, parseRememberedSessionId(&bytes));
+}
+
+test "remembered session selection is private per workspace and read-only lookup creates nothing" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var ctx = try initTempStore(alloc, &tmp);
+    defer ctx.deinit(alloc);
+    try std.testing.expect((try ctx.store.readRememberedSessionId(alloc)) == null);
+    try std.testing.expectError(error.FileNotFound, tmp.dir.access(io_mod.getIo(), "home/.fx/continue", .{}));
+    try ctx.store.rememberSessionId(alloc, "first");
+    try ctx.store.rememberSessionId(alloc, "second");
+    var reader = try Store.initReadOnlyFromHome(alloc, ctx.home, ctx.workspace);
+    defer reader.deinit(alloc);
+    const selected = (try reader.readRememberedSessionId(alloc)).?;
+    defer alloc.free(selected);
+    try std.testing.expectEqualStrings("second", selected);
+    try std.testing.expectError(error.SessionStoreReadOnly, reader.rememberSessionId(alloc, "third"));
+    var other = try Store.initReadOnlyFromHome(alloc, ctx.home, "/other-workspace");
+    defer other.deinit(alloc);
+    try std.testing.expect((try other.readRememberedSessionId(alloc)) == null);
+    var directory = (try ctx.store.openRememberedDirectory(false)).?;
+    defer directory.close();
+    const name = ctx.store.rememberedSessionFilename();
+    const stat = try directory.dir.statFile(io_mod.getIo(), &name, .{});
+    try std.testing.expectEqual(@as(u32, 0o600), stat.permissions.toMode() & 0o777);
+    var file = try directory.dir.openFile(io_mod.getIo(), &name, .{ .mode = .read_write });
+    defer file.close(io_mod.getIo());
+    try file.setPermissions(io_mod.getIo(), .fromMode(0o400));
+    try std.testing.expectError(error.AccessDenied, ctx.store.rememberSessionId(alloc, "third"));
+    try file.setPermissions(io_mod.getIo(), .fromMode(0o600));
+    const preserved = (try reader.readRememberedSessionId(alloc)).?;
+    defer alloc.free(preserved);
+    try std.testing.expectEqualStrings("second", preserved);
+    try directory.dir.deleteFile(io_mod.getIo(), &name);
+    try directory.dir.symLink(io_mod.getIo(), "elsewhere", &name, .{});
+    if (ctx.store.readRememberedSessionId(alloc)) |value| {
+        if (value) |id| alloc.free(id);
+        return error.TestExpectedError;
+    } else |_| {}
+}
+
+test "remembered session reader retains an opened version across atomic replacement" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var ctx = try initTempStore(alloc, &tmp);
+    defer ctx.deinit(alloc);
+    try ctx.store.rememberSessionId(alloc, "before");
+    var directory = (try ctx.store.openRememberedDirectory(false)).?;
+    defer directory.close();
+    const name = ctx.store.rememberedSessionFilename();
+    var opened = try directory.dir.openFile(io_mod.getIo(), &name, .{ .follow_symlinks = false });
+    defer opened.close(io_mod.getIo());
+    try ctx.store.rememberSessionId(alloc, "after");
+    const prior = try Store.readRememberedSessionFile(alloc, &opened);
+    defer alloc.free(prior);
+    try std.testing.expectEqualStrings("before", prior);
+    const current = (try ctx.store.readRememberedSessionId(alloc)).?;
+    defer alloc.free(current);
+    try std.testing.expectEqualStrings("after", current);
 }

--- a/src/core/session/session_store.zig
+++ b/src/core/session/session_store.zig
@@ -591,6 +591,88 @@ pub const Store = struct {
         self.* = undefined;
     }
 
+    /// Returns an owned ID, or null when this workspace has no remembered selection.
+    /// Reading never creates profile state or enumerates sessions.
+    pub fn readRememberedSessionId(self: Store, alloc: Allocator) !?[]u8 {
+        var directory = (try self.openRememberedDirectory(false)) orelse return null;
+        defer directory.close();
+        const name = self.rememberedSessionFilename();
+        const path_stat = directory.dir.statFile(io_mod.getIo(), &name, .{ .follow_symlinks = false }) catch |err| switch (err) {
+            error.FileNotFound => return null,
+            else => return err,
+        };
+        if (path_stat.kind != .file) return error.InvalidRememberedSession;
+        var file = directory.dir.openFile(io_mod.getIo(), &name, .{
+            .mode = .read_only,
+            .allow_directory = false,
+            .follow_symlinks = false,
+            .resolve_beneath = true,
+        }) catch |err| switch (err) {
+            error.FileNotFound => return null,
+            else => return err,
+        };
+        defer file.close(io_mod.getIo());
+        return try readRememberedSessionFile(alloc, &file);
+    }
+
+    fn readRememberedSessionFile(alloc: Allocator, file: *std.Io.File) ![]u8 {
+        const stat = try file.stat(io_mod.getIo());
+        // An atomic replacement can unlink the valid version already opened here.
+        if (stat.kind != .file or stat.nlink > 1 or stat.permissions.toMode() & 0o777 != 0o600 or stat.size > 256) {
+            return error.InvalidRememberedSession;
+        }
+        const bytes = try io_mod.readFileToEnd(alloc, file, 256);
+        defer alloc.free(bytes);
+        return try alloc.dupe(u8, try parseRememberedSessionId(bytes));
+    }
+
+    /// Publishes one interactive selection. Conversation writes retain their own lock.
+    pub fn rememberSessionId(self: Store, alloc: Allocator, session_id: []const u8) !void {
+        if (self.canonical_root.mode != .writable) return error.SessionStoreReadOnly;
+        try validateSessionId(session_id);
+        var directory = (try self.openRememberedDirectory(true)) orelse return error.SessionStoreUnavailable;
+        defer directory.close();
+        const name = self.rememberedSessionFilename();
+        var buffer: [256]u8 = undefined;
+        const bytes = try std.fmt.bufPrint(&buffer, "{s}\n", .{session_id});
+        try io_mod.durableReplaceVerified(alloc, &directory, &name, bytes);
+    }
+
+    fn rememberedSessionFilename(self: Store) [64]u8 {
+        var digest: [32]u8 = undefined;
+        std.crypto.hash.sha2.Sha256.hash(normalizeWorkspaceRoot(self.workspace_root), &digest, .{});
+        return std.fmt.bytesToHex(digest, .lower);
+    }
+
+    fn openRememberedDirectory(self: Store, create: bool) !?io_mod.VerifiedDir {
+        const zio = io_mod.getIo();
+        var home = std.Io.Dir.openDirAbsolute(zio, self.home_dir, .{ .iterate = true }) catch |err| switch (err) {
+            error.FileNotFound => return null,
+            else => return err,
+        };
+        defer home.close(zio);
+        var profile = home.openDir(zio, profile_paths.root_dir_name, .{
+            .iterate = true,
+            .follow_symlinks = false,
+        }) catch |err| switch (err) {
+            error.FileNotFound => return null,
+            else => return err,
+        };
+        defer profile.close(zio);
+        if ((try profile.stat(zio)).permissions.toMode() & 0o777 != 0o700) return error.SessionPathUnsafe;
+        if (create) return try io_mod.openOrCreateVerifiedPrivateDirFromDir(profile, "continue");
+        var directory = profile.openDir(zio, "continue", .{
+            .iterate = true,
+            .follow_symlinks = false,
+        }) catch |err| switch (err) {
+            error.FileNotFound => return null,
+            else => return err,
+        };
+        errdefer directory.close(zio);
+        if ((try directory.stat(zio)).permissions.toMode() & 0o777 != 0o700) return error.SessionPathUnsafe;
+        return .{ .dir = directory };
+    }
+
     /// Starts a brand-new writable session from `state`, with default log options.
     pub fn startWritableSession(
         self: Store,
@@ -1460,17 +1542,12 @@ pub const Store = struct {
             else => error.SessionStoreUnavailable,
         };
         defer session_dir.close();
-        var candidate = classifyReadOnlyCandidate(
-            alloc,
-            &session_dir,
-            session_id,
-        ) catch |err| return switch (err) {
+        validateSubagentControlSession(alloc, &session_dir, session_id) catch |err| return switch (err) {
             error.OutOfMemory => error.OutOfMemory,
             error.SessionNotFound => error.SessionNotFound,
             error.SessionPathUnsafe => error.SessionPathUnsafe,
             else => error.SessionStoreUnavailable,
         };
-        candidate.deinit(alloc);
         const display_path = sessionDirPath(
             alloc,
             self.sessions_dir,
@@ -1492,6 +1569,24 @@ pub const Store = struct {
             error.PrivateStatePermissionsUnsupported => error.PrivateStatePermissionsUnsupported,
             error.SessionChildStoreFailed => error.SessionChildStoreFailed,
         };
+    }
+
+    fn validateSubagentControlSession(
+        alloc: Allocator,
+        session_dir: *io_mod.VerifiedDir,
+        session_id: []const u8,
+    ) !void {
+        if (try session_log.readConversationMetadata(alloc, session_dir)) |value| {
+            var metadata = value;
+            defer metadata.deinit();
+            if (!std.mem.eql(u8, metadata.value.id, session_id)) return error.InvalidSessionFormat;
+            _ = try session.ConversationLanguage.fromSlice(metadata.value.conversation_language);
+            const event_stat = try session_dir.dir.statFile(io_mod.getIo(), "events.jsonl", .{ .follow_symlinks = false });
+            if (event_stat.kind != .file or event_stat.nlink != 1) return error.SessionPathUnsafe;
+            return;
+        }
+        var candidate = try classifyReadOnlyCandidate(alloc, session_dir, session_id);
+        candidate.deinit(alloc);
     }
 
     /// Returns owned session metadata needed to initialize a control record.
@@ -1670,12 +1765,37 @@ pub const Store = struct {
         session_id: []const u8,
         options: ResumeOptions,
     ) !ReadOnlyDetail {
+        return self.loadReadOnlyDetailWithHistoryErrors(alloc, session_id, options, false);
+    }
+
+    /// Loads detail with a distinct history error for external admission.
+    /// Supporting-file failures and ordinary read-only loads retain their errors.
+    pub fn loadReadOnlyAdmissionDetail(
+        self: Store,
+        alloc: Allocator,
+        session_id: []const u8,
+        options: ResumeOptions,
+    ) !ReadOnlyDetail {
+        return self.loadReadOnlyDetailWithHistoryErrors(alloc, session_id, options, true);
+    }
+
+    fn loadReadOnlyDetailWithHistoryErrors(
+        self: Store,
+        alloc: Allocator,
+        session_id: []const u8,
+        options: ResumeOptions,
+        comptime classify_history_errors: bool,
+    ) !ReadOnlyDetail {
         try validateSessionId(session_id);
         var session_dir = try self.openSessionDir(session_id);
         defer session_dir.close();
         if (try session_log.hasConversationMetadata(alloc, &session_dir)) {
-            var root = self.canonical_root;
-            var state = try root.loadReadOnly(alloc, session_id, options.log);
+            var state = if (classify_history_errors)
+                try session_log.loadConversationDetailState(alloc, &session_dir, session_id)
+            else blk: {
+                var root = self.canonical_root;
+                break :blk try root.loadReadOnly(alloc, session_id, options.log);
+            };
             errdefer state.deinit(alloc);
             const archive = try session_log.loadConversationArchive(
                 alloc,
@@ -4489,6 +4609,13 @@ fn initWithHome(alloc: Allocator, home: []const u8, workspace_root: []const u8, 
         .canonical_root = canonical_root,
     };
 }
+fn parseRememberedSessionId(bytes: []const u8) ![]const u8 {
+    if (bytes.len < 2 or bytes.len > 256 or bytes[bytes.len - 1] != '\n') return error.InvalidRememberedSession;
+    const id = bytes[0 .. bytes.len - 1];
+    validateSessionId(id) catch return error.InvalidRememberedSession;
+    return id;
+}
+
 const TempStore = struct {
     home: []u8,
     workspace: []u8,
@@ -4540,6 +4667,59 @@ fn makeSessionDir(alloc: Allocator, store: Store, id: []const u8) !void {
     const dir = try sessionDirPath(alloc, store.sessions_dir, id);
     defer alloc.free(dir);
     try config_runtime.makeAbsolutePath(dir);
+}
+
+test "native subagent control opens do not decode conversation payloads" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var ctx = try initTempStore(alloc, &tmp);
+    defer ctx.deinit(alloc);
+    var initial = try testDurableState(alloc, "control-only", ctx.workspace);
+    defer initial.deinit(alloc);
+    {
+        var writer = try ctx.store.startWritableSession(alloc, initial);
+        defer writer.deinit(alloc);
+        try io_mod.durableReplaceVerified(alloc, &writer.log.dir, "events.jsonl", "invalid conversation\n");
+    }
+    var writable = try ctx.store.openSubagentControlCapabilityWritable(alloc, initial.id, .{});
+    defer writable.deinit();
+    var entry = try writable.atomicReplace(alloc, .subagent_control, "owner.json", "control sentinel");
+    defer entry.deinit(alloc);
+    var readonly = try ctx.store.openSubagentControlCapabilityReadOnly(alloc, initial.id, .{});
+    defer readonly.deinit();
+    var file = try readonly.openFileReadOnly(alloc, .subagent_control, "owner.json");
+    defer file.deinit();
+    const bytes = try file.readToEnd(alloc, 64);
+    defer alloc.free(bytes);
+    try std.testing.expectEqualStrings("control sentinel", bytes);
+    try std.testing.expectError(error.InvalidConversationFrame, ctx.store.resumeForWrite(alloc, initial.id));
+}
+
+test "native subagent control admission preserves identity and path checks" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var ctx = try initTempStore(alloc, &tmp);
+    defer ctx.deinit(alloc);
+    var initial = try testDurableState(alloc, "control-identity", ctx.workspace);
+    defer initial.deinit(alloc);
+    var writer = try ctx.store.startWritableSession(alloc, initial);
+    defer writer.deinit(alloc);
+    var metadata = (try session_log.readConversationMetadata(alloc, &writer.log.dir)).?;
+    defer metadata.deinit();
+    metadata.value.id = "different-id";
+    const mismatched = try session_codec.encodeSessionMetadata(alloc, metadata.value);
+    defer alloc.free(mismatched);
+    try io_mod.durableReplaceVerified(alloc, &writer.log.dir, "session.json", mismatched);
+    try std.testing.expectError(error.SessionStoreUnavailable, ctx.store.openSubagentControlCapabilityReadOnly(alloc, initial.id, .{}));
+    metadata.value.id = initial.id;
+    const valid = try session_codec.encodeSessionMetadata(alloc, metadata.value);
+    defer alloc.free(valid);
+    try io_mod.durableReplaceVerified(alloc, &writer.log.dir, "session.json", valid);
+    try writer.log.dir.dir.deleteFile(io_mod.getIo(), "events.jsonl");
+    try writer.log.dir.dir.symLink(io_mod.getIo(), "session.json", "events.jsonl", .{});
+    try std.testing.expectError(error.SessionPathUnsafe, ctx.store.openSubagentControlCapabilityWritable(alloc, initial.id, .{}));
 }
 
 test "recovery no-op validates supporting state before advising normal resume" {
@@ -8644,4 +8824,76 @@ test "recovery checkpoint images resolve on read-only and writable resume" {
     try std.testing.expectEqualStrings(image.snapshot_path.?, resumed.state.recovery_checkpoint.?.user.images[0].snapshot_path.?);
     _ = try resumed.appendEvent(alloc, .{ .recovery_checkpoint_cleared = .{} }, 30);
     try std.Io.Dir.accessAbsolute(std.testing.io, image.snapshot_path.?, .{});
+}
+
+test "remembered session IDs are bounded and unambiguous" {
+    try std.testing.expectEqualStrings("session-1", try parseRememberedSessionId("session-1\n"));
+    for ([_][]const u8{ "", "\n", "../other\n", "session-1", "one\ntwo\n", "one\r\n", " one\n" }) |bytes| {
+        try std.testing.expectError(error.InvalidRememberedSession, parseRememberedSessionId(bytes));
+    }
+    var bytes: [257]u8 = @splat('a');
+    bytes[255] = '\n';
+    try std.testing.expectEqual(@as(usize, 255), (try parseRememberedSessionId(bytes[0..256])).len);
+    try std.testing.expectError(error.InvalidRememberedSession, parseRememberedSessionId(&bytes));
+}
+
+test "remembered session selection is private per workspace and read-only lookup creates nothing" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var ctx = try initTempStore(alloc, &tmp);
+    defer ctx.deinit(alloc);
+    try std.testing.expect((try ctx.store.readRememberedSessionId(alloc)) == null);
+    try std.testing.expectError(error.FileNotFound, tmp.dir.access(io_mod.getIo(), "home/.fx/continue", .{}));
+    try ctx.store.rememberSessionId(alloc, "first");
+    try ctx.store.rememberSessionId(alloc, "second");
+    var reader = try Store.initReadOnlyFromHome(alloc, ctx.home, ctx.workspace);
+    defer reader.deinit(alloc);
+    const selected = (try reader.readRememberedSessionId(alloc)).?;
+    defer alloc.free(selected);
+    try std.testing.expectEqualStrings("second", selected);
+    try std.testing.expectError(error.SessionStoreReadOnly, reader.rememberSessionId(alloc, "third"));
+    var other = try Store.initReadOnlyFromHome(alloc, ctx.home, "/other-workspace");
+    defer other.deinit(alloc);
+    try std.testing.expect((try other.readRememberedSessionId(alloc)) == null);
+    var directory = (try ctx.store.openRememberedDirectory(false)).?;
+    defer directory.close();
+    const name = ctx.store.rememberedSessionFilename();
+    const stat = try directory.dir.statFile(io_mod.getIo(), &name, .{});
+    try std.testing.expectEqual(@as(u32, 0o600), stat.permissions.toMode() & 0o777);
+    var file = try directory.dir.openFile(io_mod.getIo(), &name, .{ .mode = .read_write });
+    defer file.close(io_mod.getIo());
+    try file.setPermissions(io_mod.getIo(), .fromMode(0o400));
+    try std.testing.expectError(error.AccessDenied, ctx.store.rememberSessionId(alloc, "third"));
+    try file.setPermissions(io_mod.getIo(), .fromMode(0o600));
+    const preserved = (try reader.readRememberedSessionId(alloc)).?;
+    defer alloc.free(preserved);
+    try std.testing.expectEqualStrings("second", preserved);
+    try directory.dir.deleteFile(io_mod.getIo(), &name);
+    try directory.dir.symLink(io_mod.getIo(), "elsewhere", &name, .{});
+    if (ctx.store.readRememberedSessionId(alloc)) |value| {
+        if (value) |id| alloc.free(id);
+        return error.TestExpectedError;
+    } else |_| {}
+}
+
+test "remembered session reader retains an opened version across atomic replacement" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var ctx = try initTempStore(alloc, &tmp);
+    defer ctx.deinit(alloc);
+    try ctx.store.rememberSessionId(alloc, "before");
+    var directory = (try ctx.store.openRememberedDirectory(false)).?;
+    defer directory.close();
+    const name = ctx.store.rememberedSessionFilename();
+    var opened = try directory.dir.openFile(io_mod.getIo(), &name, .{ .follow_symlinks = false });
+    defer opened.close(io_mod.getIo());
+    try ctx.store.rememberSessionId(alloc, "after");
+    const prior = try Store.readRememberedSessionFile(alloc, &opened);
+    defer alloc.free(prior);
+    try std.testing.expectEqualStrings("before", prior);
+    const current = (try ctx.store.readRememberedSessionId(alloc)).?;
+    defer alloc.free(current);
+    try std.testing.expectEqualStrings("after", current);
 }

--- a/src/core/slash_commands/command_specs.zig
+++ b/src/core/slash_commands/command_specs.zig
@@ -1663,7 +1663,7 @@ test "top-level help renders flags as compact aligned rows" {
 
     try std.testing.expect(lineContainsBoth(wide, "--context-limit <spec>", "Set name=bytes|off; repeatable"));
     try std.testing.expect(lineContainsBoth(wide, "--add-dir <path>", "Add a workspace directory; repeatable"));
-    try std.testing.expect(lineContainsBoth(wide, "-c, --continue", "Resume the latest workspace session"));
+    try std.testing.expect(lineContainsBoth(wide, "-c, --continue", "Resume the remembered workspace session"));
     try std.testing.expect(lineContainsBoth(wide, "-r", "Open the saved-session picker"));
     try std.testing.expect(lineContainsBoth(wide, "--resume [last|<id>]", "Resume the latest workspace session or an exact ID"));
     try std.testing.expect(lineContainsBoth(wide, "--resume-last", "Resume the latest workspace session"));

--- a/src/core/subagent/resume_admission.zig
+++ b/src/core/subagent/resume_admission.zig
@@ -301,7 +301,10 @@ pub fn loadVisibleReadOnlyDetail(
     };
     if (managed) return error.SessionNotFound;
 
-    var detail = try store.loadReadOnlyDetail(alloc, session_id, options);
+    var detail = store.loadReadOnlyAdmissionDetail(alloc, session_id, options) catch |err| switch (err) {
+        error.ConversationHistoryUnavailable => return error.SessionNotFound,
+        else => return err,
+    };
     errdefer detail.deinit(alloc);
     if (detail.state.subagent_child) return error.SessionNotFound;
     return detail;

--- a/src/core/subagent/tool_host.zig
+++ b/src/core/subagent/tool_host.zig
@@ -78,8 +78,6 @@ pub const ApprovalResolveOptions = struct {
     timestamp_ms: i64,
 };
 
-pub const RecoveryState = enum(u8) { pending, complete };
-
 pub const Runtime = struct {
     alloc: Allocator,
     sessions: *session_store.Store,
@@ -89,8 +87,9 @@ pub const Runtime = struct {
     approvals: approval_registry.Registry,
     authority_resolver: authority.Resolver,
     managed: managed_owner.Owner,
-    recovery_state: std.atomic.Value(RecoveryState) = .init(.pending),
 
+    /// Returns a host only after abandoned child work has been recovered.
+    /// Borrows the store and callback contexts until deinit.
     pub fn create(
         alloc: Allocator,
         sessions: *session_store.Store,
@@ -122,12 +121,9 @@ pub const Runtime = struct {
             .host = host_authority,
         };
         runtime.managed = runtime.managedOwnerValue();
-        runtime.requestBackgroundRecovery(io_mod.milliTimestamp()) catch |err|
-            debug_trace.logf(
-                "subagent",
-                "managed child recovery unavailable root_id={s} err={s}",
-                .{ root_id, @errorName(err) },
-            );
+        errdefer runtime.approvals.deinit();
+        errdefer runtime.managed.deinit();
+        try runtime.managed.recoverInterrupted();
         return runtime;
     }
 
@@ -157,15 +153,6 @@ pub const Runtime = struct {
         self.managed.services.context = self;
         self.managed.authority_resolver = &self.authority_resolver;
         self.managed.approvals = &self.approvals;
-    }
-
-    pub fn requestBackgroundRecovery(self: *Runtime, _: i64) !void {
-        try self.managed.recoverInterrupted();
-        self.recovery_state.store(.complete, .release);
-    }
-
-    pub fn recoveryState(self: *const Runtime) RecoveryState {
-        return self.recovery_state.load(.acquire);
     }
 
     pub fn pendingApprovalRequest(

--- a/src/main.zig
+++ b/src/main.zig
@@ -674,11 +674,6 @@ const App = struct {
                 SessionAppRuntime.syncTerminalTitle(&app);
             }
         }
-        if (comptime host_profile.durable_sessions) {
-            if (launch.upgrade_relaunch == null) {
-                SessionAppRuntime.primeSessionPicker(&app);
-            }
-        }
         const env_disabled = if (io_mod.getenv("FX_AUTO_UPGRADE")) |val|
             std.mem.eql(u8, val, "0") or std.ascii.eqlIgnoreCase(val, "false")
         else

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -6847,6 +6847,64 @@ printf '%s' ${JSON.stringify(trailingMarker)} > ${JSON.stringify(effectPath)}
     }
   }, 30_000);
 
+  test("ask continues and persists a healthy parent when child recovery is unavailable", async () => {
+    const root = createFixtureRoot("subagent-recovery-unavailable");
+    const tracePath = join(root.root, "trace.log");
+    const replies = ["PARENT_SEED_SENTINEL", "PARENT_CONTINUATION_SAVED", "PARENT_REOPENED"];
+    let requestIndex = 0;
+    const gateway = startDynamicFakeGateway((body) => {
+      if (requestIndex > 0) expect(body).toContain(replies[0]);
+      if (requestIndex === 2) expect(body).toContain(replies[1]);
+      return fakeGatewayFinalText(replies[requestIndex++] ?? "UNEXPECTED_REQUEST");
+    });
+    const env = { ...fixtureEnv(root, gateway, tracePath), FX_TRACE_SCOPES: "subagent,session" };
+    try {
+      const seeded = await runFx(["ask", "--json", "Start a saved conversation."], {
+        cwd: root.workspace, env, timeoutMs: 15_000,
+      });
+      expect(seeded.code).toBe(0);
+      const id = parseAskJson(seeded.stdout).session_id;
+      expect(id).not.toBe("");
+      const directory = join(root.home, ".fx", "sessions", id);
+      const eventsPath = join(directory, "events.jsonl");
+      const originalEvents = readFileSync(eventsPath, "utf8");
+      const childDirectory = join(directory, "subagent");
+      mkdirSync(childDirectory, { recursive: true, mode: 0o700 });
+      const registryPath = join(childDirectory, "children.json");
+      writeFileSync(registryPath, "[]", { mode: 0o600 });
+
+      const resumed = await runFx(["ask", "--json", "--resume-id", id, "Continue without delegation."], {
+        cwd: root.workspace, env, timeoutMs: 15_000,
+      });
+      expect(resumed.code).toBe(0);
+      expect(resumed.stderr).toBe("");
+      const result = parseAskJson(resumed.stdout);
+      expect(result.session_id).toBe(id);
+      expect(result.final_output).toBe(replies[1]);
+      expect(result.tool_calls).toEqual([]);
+      expect(gateway.requests).toHaveLength(2);
+      const continuedEvents = readFileSync(eventsPath, "utf8");
+      expect(continuedEvents.startsWith(originalEvents)).toBe(true);
+      expect(continuedEvents).toContain(replies[1]);
+      expect(continuedEvents.trim().split("\n").map(line => JSON.parse(line)).filter(frame => frame.event.turn_completed)).toHaveLength(2);
+      expect(readFileSync(registryPath, "utf8")).toBe("[]");
+      expect(readFileSync(tracePath, "utf8")).toContain("ask subagent host unavailable");
+
+      const reopened = await runFx(["ask", "--json", "--resume-id", id, "Continue again without delegation."], {
+        cwd: root.workspace, env, timeoutMs: 15_000,
+      });
+      expect(reopened.code).toBe(0);
+      expect(reopened.stderr).toBe("");
+      expect(parseAskJson(reopened.stdout).session_id).toBe(id);
+      expect(parseAskJson(reopened.stdout).final_output).toBe(replies[2]);
+      expect(gateway.requests).toHaveLength(3);
+      expect(readFileSync(registryPath, "utf8")).toBe("[]");
+    } finally {
+      gateway.stop();
+      rmSync(root.root, { recursive: true, force: true });
+    }
+  }, 45_000);
+
   test("ask fake Gateway exercises one-off and chat-created persistent subagents", async () => {
     const root = createFixtureRoot("subagent-managed-flow");
     const tracePath = join(root.root, "trace.log");

--- a/tests/e2e/session-recovery.test.ts
+++ b/tests/e2e/session-recovery.test.ts
@@ -3,6 +3,7 @@ import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
   appendFileSync,
+  chmodSync,
   existsSync,
   lstatSync,
   mkdtempSync,
@@ -476,7 +477,7 @@ describe("session recovery", () => {
         expect(readFileSync(stderrPath, "utf8")).toBe("");
         await tui.kill(); tui = undefined;
       }
-      await resume(["-c"], "HEALTHY_LATEST_USAGE", "latest");
+      await resume(["--resume-last"], "HEALTHY_LATEST_USAGE", "latest");
       expect(savedFileHashes(legacy.source)).toEqual(oldHashes);
       expect(gateway.requests).toHaveLength(1);
       expect(existsSync(join(fixture.home, ".fx", "sessions", healthyId))).toBe(true);
@@ -821,7 +822,7 @@ describe("session recovery", () => {
     }
   }, TIMEOUT);
 
-  test.skipIf(!tmuxAvailable())("continue ignores unrelated history and unfinished migration", async () => {
+  test.skipIf(!tmuxAvailable())("latest resume ignores unrelated history and unfinished migration", async () => {
     const fixture = createFixture("fx-continue-isolated-discovery-");
     const gateway = startFakeGateway([
       fakeGatewayFinalText("LOCAL_HISTORY_KEPT"),
@@ -853,7 +854,7 @@ describe("session recovery", () => {
       const fencedBefore = savedFileHashes(fenced);
       const stderrPath = join(fixture.root, "continue.stderr");
       tui = await TmuxSession.create({
-        cmd: `${JSON.stringify(FX_BIN)} -c`,
+        cmd: `${JSON.stringify(FX_BIN)} --resume-last`,
         cwd: fixture.workspace, env: gatewayEnv(fixture, gateway), stderrPath,
       });
       await tui.waitForComposer(TIMEOUT);
@@ -876,7 +877,7 @@ describe("session recovery", () => {
     }
   }, TIMEOUT);
 
-  test.skipIf(!tmuxAvailable())("continue reuses legacy ranking after opening the resume picker", async () => {
+  test.skipIf(!tmuxAvailable())("latest resume reuses legacy ranking after opening the resume picker", async () => {
     const fixture = createFixture("fx-continue-ranking-cache-");
     const legacy = createLegacySession(fixture, 3);
     const gateway = startFakeGateway([fakeGatewayFinalText("LATEST_CACHE_HISTORY")]);
@@ -888,7 +889,7 @@ describe("session recovery", () => {
         const trace = join(fixture.root, `ranking-${iteration}.trace`);
         const stderrPath = join(fixture.root, `ranking-${iteration}.stderr`);
         tui = await TmuxSession.create({
-          cmd: `${JSON.stringify(FX_BIN)} -c`, cwd: fixture.workspace, stderrPath,
+          cmd: `${JSON.stringify(FX_BIN)} --resume-last`, cwd: fixture.workspace, stderrPath,
           env: { ...gatewayEnv(fixture, gateway), FX_TRACE_LOG: trace, FX_TRACE_SCOPES: "session,core" },
         });
         await tui.waitForComposer(TIMEOUT);
@@ -1301,7 +1302,7 @@ describe("session recovery", () => {
     }, TIMEOUT);
   }
 
-  test("committed-history corruption fails closed without rewriting JSONL", async () => {
+  test.each(["malformed", "oversized", "unreadable"])("committed-history corruption (%s) fails closed without rewriting JSONL", async (fault) => {
     const fixture = createFixture("fx-session-middle-corruption-");
     const gateway = startFakeGateway([
       fakeGatewayFinalText("FIRST_TURN_SAVED"),
@@ -1316,8 +1317,11 @@ describe("session recovery", () => {
         "events.jsonl",
       );
       const committed = readFileSync(eventsPath, "utf8");
-      const corrupted = `[${committed.slice(1)}`;
+      const corrupted = fault === "malformed"
+        ? `[${committed.slice(1)}`
+        : fault === "oversized" ? "x".repeat(64 * 1024 * 1024 + 1) + "\n" : committed;
       writeFileSync(eventsPath, corrupted, { mode: 0o600 });
+      if (fault === "unreadable") chmodSync(eventsPath, 0);
 
       const detail = await runFx(
         ["session", "--id", sessionId, "--json"],
@@ -1332,6 +1336,7 @@ describe("session recovery", () => {
       expect(JSON.parse(detail.stdout)).toMatchObject({
         code: "SessionNotFound",
       });
+      if (fault === "unreadable") chmodSync(eventsPath, 0o600);
       expect(readFileSync(eventsPath, "utf8")).toBe(corrupted);
       expect(gateway.requests).toHaveLength(1);
     } finally {

--- a/tests/e2e/session-recovery.test.ts
+++ b/tests/e2e/session-recovery.test.ts
@@ -476,7 +476,7 @@ describe("session recovery", () => {
         expect(readFileSync(stderrPath, "utf8")).toBe("");
         await tui.kill(); tui = undefined;
       }
-      await resume(["-c"], "HEALTHY_LATEST_USAGE", "latest");
+      await resume(["--resume-last"], "HEALTHY_LATEST_USAGE", "latest");
       expect(savedFileHashes(legacy.source)).toEqual(oldHashes);
       expect(gateway.requests).toHaveLength(1);
       expect(existsSync(join(fixture.home, ".fx", "sessions", healthyId))).toBe(true);
@@ -821,7 +821,7 @@ describe("session recovery", () => {
     }
   }, TIMEOUT);
 
-  test.skipIf(!tmuxAvailable())("continue ignores unrelated history and unfinished migration", async () => {
+  test.skipIf(!tmuxAvailable())("latest resume ignores unrelated history and unfinished migration", async () => {
     const fixture = createFixture("fx-continue-isolated-discovery-");
     const gateway = startFakeGateway([
       fakeGatewayFinalText("LOCAL_HISTORY_KEPT"),
@@ -853,7 +853,7 @@ describe("session recovery", () => {
       const fencedBefore = savedFileHashes(fenced);
       const stderrPath = join(fixture.root, "continue.stderr");
       tui = await TmuxSession.create({
-        cmd: `${JSON.stringify(FX_BIN)} -c`,
+        cmd: `${JSON.stringify(FX_BIN)} --resume-last`,
         cwd: fixture.workspace, env: gatewayEnv(fixture, gateway), stderrPath,
       });
       await tui.waitForComposer(TIMEOUT);
@@ -876,7 +876,7 @@ describe("session recovery", () => {
     }
   }, TIMEOUT);
 
-  test.skipIf(!tmuxAvailable())("continue reuses legacy ranking after opening the resume picker", async () => {
+  test.skipIf(!tmuxAvailable())("latest resume reuses legacy ranking after opening the resume picker", async () => {
     const fixture = createFixture("fx-continue-ranking-cache-");
     const legacy = createLegacySession(fixture, 3);
     const gateway = startFakeGateway([fakeGatewayFinalText("LATEST_CACHE_HISTORY")]);
@@ -888,7 +888,7 @@ describe("session recovery", () => {
         const trace = join(fixture.root, `ranking-${iteration}.trace`);
         const stderrPath = join(fixture.root, `ranking-${iteration}.stderr`);
         tui = await TmuxSession.create({
-          cmd: `${JSON.stringify(FX_BIN)} -c`, cwd: fixture.workspace, stderrPath,
+          cmd: `${JSON.stringify(FX_BIN)} --resume-last`, cwd: fixture.workspace, stderrPath,
           env: { ...gatewayEnv(fixture, gateway), FX_TRACE_LOG: trace, FX_TRACE_SCOPES: "session,core" },
         });
         await tui.waitForComposer(TIMEOUT);

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -7252,6 +7252,14 @@ test.skipIf(!tmuxAvailable())("remembered continuation restores the selected con
     for (const label of ["select-a", "select-b", "reselect-a", "empty-window", "continue-a"]) {
       expect(readFileSync(join(root, label + ".stderr"), "utf8")).toBe("");
     }
+    rmSync(bookmark);
+    const fifo = Bun.spawnSync(["mkfifo", bookmark]);
+    expect(fifo.exitCode).toBe(0);
+    active = await open(["-c"], "invalid-bookmark");
+    await active.waitForPane(() => active!.paneStatus().dead, 3000);
+    expect(active.paneStatus().status).toBe(1);
+    expect(readFileSync(join(root, "invalid-bookmark.stderr"), "utf8")).toContain("remembered session ID could not be read");
+    await active.kill(); active = null;
     passed = true;
   } finally {
     await active?.kill(); await other?.kill(); gateway.stop();

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -6899,7 +6899,7 @@ test.skipIf(!tmuxAvailable())(
         writeFileSync(path, content, { mode: 0o600 });
         remnants.push([path, content]);
       }
-      for (const [flag, reply] of [["-c", "LATEST_CONTINUATION_SAVED"], ["-r", "PICKER_CONTINUATION_SAVED"]] as const) {
+      for (const [flag, reply] of [["--resume-last", "LATEST_CONTINUATION_SAVED"], ["-r", "PICKER_CONTINUATION_SAVED"]] as const) {
         const stderrPath = join(root, `${flag}.stderr`);
         active = await TmuxSession.create({ cmd: `${shellQuote(FX_BIN)} ${flag}`, cwd: workspace, env, stderrPath, remainOnExit: true });
         if (flag === "-r") {
@@ -7157,3 +7157,113 @@ for (const inspectDetails of [false, true]) {
     TIMEOUT * 2,
   );
 }
+
+
+test.skipIf(!tmuxAvailable())("remembered continuation restores the selected conversation without discovery", async () => {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), "fx-remembered-resume-")));
+  const home = join(root, "home"), workspace = join(root, "workspace");
+  mkdirSync(home); mkdirSync(workspace);
+  const gateway = startFakeGateway([
+    fakeGatewayFinalText("REMEMBERED_A_HISTORY"),
+    fakeGatewayFinalText("REMEMBERED_B_HISTORY"),
+    fakeGatewayFinalText("LATER_A_ACTIVITY"),
+    fakeGatewayFinalText("LATEST_B_ACTIVITY"),
+  ]);
+  const env = gatewayEnv(home, gateway);
+  const bookmark = join(home, ".fx", "continue", createHash("sha256").update(workspace).digest("hex"));
+  let active: TmuxSession | null = null, other: TmuxSession | null = null;
+  let passed = false;
+  async function open(args: string[], label: string) {
+    return TmuxSession.create({
+      cmd: [FX_BIN, ...args].map(shellQuote).join(" "), cwd: workspace,
+      env: { ...env, FX_TRACE_LOG: join(root, label + ".trace"), FX_TRACE_SCOPES: "core,session" },
+      stderrPath: join(root, label + ".stderr"), isolated: true, remainOnExit: true,
+      width: 110, height: 40,
+    });
+  }
+  async function close(tui: TmuxSession) {
+    await tui.sendText("/quit");
+    await tui.waitForPane(() => tui.paneStatus().dead, TIMEOUT);
+    expect(tui.paneStatus().status).toBe(0);
+    await tui.kill();
+  }
+  try {
+    const a = await runFx(["ask", "--json", "Remember conversation A."], { cwd: workspace, env, timeoutMs: TIMEOUT });
+    expect(a.code).toBe(0);
+    const aId = JSON.parse(a.stdout).session_id;
+    expect(existsSync(bookmark)).toBe(false);
+    active = await open(["-c"], "missing");
+    await active.waitForPane(() => active!.paneStatus().dead, TIMEOUT);
+    expect(active.paneStatus().status).toBe(1);
+    expect(readFileSync(join(root, "missing.stderr"), "utf8")).toContain("no remembered session");
+    await active.kill(); active = null;
+    active = await open(["--resume", aId], "select-a");
+    await active.waitForText("REMEMBERED_A_HISTORY", TIMEOUT);
+    await active.waitForStableComposer(TIMEOUT);
+    expect(readFileSync(bookmark, "utf8")).toBe(aId + "\n");
+    const b = await runFx(["ask", "--json", "Remember conversation B."], { cwd: workspace, env, timeoutMs: TIMEOUT });
+    expect(b.code).toBe(0);
+    const bId = JSON.parse(b.stdout).session_id;
+    other = await open(["--resume", bId], "select-b");
+    await other.waitForText("REMEMBERED_B_HISTORY", TIMEOUT);
+    await other.waitForStableComposer(TIMEOUT);
+    expect(readFileSync(bookmark, "utf8")).toBe(bId + "\n");
+    await active.sendText("Continue the older active conversation without tools.");
+    await active.waitForText("LATER_A_ACTIVITY", TIMEOUT);
+    await active.waitForStableComposer(TIMEOUT);
+    expect(readFileSync(bookmark, "utf8")).toBe(bId + "\n");
+    await close(active); active = null;
+    await close(other); other = null;
+    active = await open(["--resume", aId], "reselect-a");
+    await active.waitForStableComposer(TIMEOUT);
+    expect(readFileSync(bookmark, "utf8")).toBe(aId + "\n");
+    await close(active); active = null;
+    active = await open([], "empty-window");
+    await active.waitForStableComposer(TIMEOUT);
+    await close(active); active = null;
+    expect(readFileSync(bookmark, "utf8")).toBe(aId + "\n");
+    const latest = await runFx(["ask", "--json", "--resume-id", bId, "Update B without tools."], { cwd: workspace, env, timeoutMs: TIMEOUT });
+    expect(latest.code).toBe(0);
+    const last = await runFx(["session", "last", "--json"], { cwd: workspace, env });
+    expect(last.code).toBe(0); expect(JSON.parse(last.stdout).id).toBe(bId);
+    const before = statSync(bookmark);
+    active = await open(["-c"], "continue-a");
+    await active.waitForText("LATER_A_ACTIVITY", TIMEOUT);
+    await active.waitForStableComposer(TIMEOUT);
+    expect(readFileSync(bookmark, "utf8")).toBe(aId + "\n");
+    expect(statSync(bookmark).ino).toBe(before.ino);
+    const trace = readFileSync(join(root, "continue-a.trace"), "utf8");
+    expect(trace).not.toContain("mode=workspace_writable_last");
+    expect(trace).not.toContain("session picker catalog loaded");
+    other = await open(["--continue"], "busy");
+    await other.waitForPane(() => other!.paneStatus().dead, TIMEOUT);
+    expect(other.paneStatus().status).toBe(1);
+    expect(readFileSync(join(root, "busy.stderr"), "utf8")).toContain("another fx process");
+    await other.kill(); other = null;
+    await active.sendText("/resume");
+    await active.waitForText("Enter Resume", TIMEOUT);
+    await active.sendLiteralText("Remember conversation B.");
+    await active.waitForText("Sessions 1", TIMEOUT);
+    await active.sendKeys("Enter");
+    await active.waitForStableComposer(TIMEOUT);
+    expect(readFileSync(bookmark, "utf8")).toBe(bId + "\n");
+    await close(active); active = null;
+    expect(gateway.requests).toHaveLength(4);
+    for (const label of ["select-a", "select-b", "reselect-a", "empty-window", "continue-a"]) {
+      expect(readFileSync(join(root, label + ".stderr"), "utf8")).toBe("");
+    }
+    rmSync(bookmark);
+    const fifo = Bun.spawnSync(["mkfifo", bookmark]);
+    expect(fifo.exitCode).toBe(0);
+    active = await open(["-c"], "invalid-bookmark");
+    await active.waitForPane(() => active!.paneStatus().dead, 3000);
+    expect(active.paneStatus().status).toBe(1);
+    expect(readFileSync(join(root, "invalid-bookmark.stderr"), "utf8")).toContain("remembered session ID could not be read");
+    await active.kill(); active = null;
+    passed = true;
+  } finally {
+    await active?.kill(); await other?.kill(); gateway.stop();
+    if (passed) rmSync(root, { recursive: true, force: true });
+    else console.error(`retained remembered-continuation artifacts at ${root}`);
+  }
+}, 150_000);

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -6899,7 +6899,7 @@ test.skipIf(!tmuxAvailable())(
         writeFileSync(path, content, { mode: 0o600 });
         remnants.push([path, content]);
       }
-      for (const [flag, reply] of [["-c", "LATEST_CONTINUATION_SAVED"], ["-r", "PICKER_CONTINUATION_SAVED"]] as const) {
+      for (const [flag, reply] of [["--resume-last", "LATEST_CONTINUATION_SAVED"], ["-r", "PICKER_CONTINUATION_SAVED"]] as const) {
         const stderrPath = join(root, `${flag}.stderr`);
         active = await TmuxSession.create({ cmd: `${shellQuote(FX_BIN)} ${flag}`, cwd: workspace, env, stderrPath, remainOnExit: true });
         if (flag === "-r") {
@@ -7157,3 +7157,105 @@ for (const inspectDetails of [false, true]) {
     TIMEOUT * 2,
   );
 }
+
+
+test.skipIf(!tmuxAvailable())("remembered continuation restores the selected conversation without discovery", async () => {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), "fx-remembered-resume-")));
+  const home = join(root, "home"), workspace = join(root, "workspace");
+  mkdirSync(home); mkdirSync(workspace);
+  const gateway = startFakeGateway([
+    fakeGatewayFinalText("REMEMBERED_A_HISTORY"),
+    fakeGatewayFinalText("REMEMBERED_B_HISTORY"),
+    fakeGatewayFinalText("LATER_A_ACTIVITY"),
+    fakeGatewayFinalText("LATEST_B_ACTIVITY"),
+  ]);
+  const env = gatewayEnv(home, gateway);
+  const bookmark = join(home, ".fx", "continue", createHash("sha256").update(workspace).digest("hex"));
+  let active: TmuxSession | null = null, other: TmuxSession | null = null;
+  let passed = false;
+  async function open(args: string[], label: string) {
+    return TmuxSession.create({
+      cmd: [FX_BIN, ...args].map(shellQuote).join(" "), cwd: workspace,
+      env: { ...env, FX_TRACE_LOG: join(root, label + ".trace"), FX_TRACE_SCOPES: "core,session" },
+      stderrPath: join(root, label + ".stderr"), isolated: true, remainOnExit: true,
+      width: 110, height: 40,
+    });
+  }
+  async function close(tui: TmuxSession) {
+    await tui.sendText("/quit");
+    await tui.waitForPane(() => tui.paneStatus().dead, TIMEOUT);
+    expect(tui.paneStatus().status).toBe(0);
+    await tui.kill();
+  }
+  try {
+    const a = await runFx(["ask", "--json", "Remember conversation A."], { cwd: workspace, env, timeoutMs: TIMEOUT });
+    expect(a.code).toBe(0);
+    const aId = JSON.parse(a.stdout).session_id;
+    expect(existsSync(bookmark)).toBe(false);
+    active = await open(["-c"], "missing");
+    await active.waitForPane(() => active!.paneStatus().dead, TIMEOUT);
+    expect(active.paneStatus().status).toBe(1);
+    expect(readFileSync(join(root, "missing.stderr"), "utf8")).toContain("no remembered session");
+    await active.kill(); active = null;
+    active = await open(["--resume", aId], "select-a");
+    await active.waitForText("REMEMBERED_A_HISTORY", TIMEOUT);
+    await active.waitForStableComposer(TIMEOUT);
+    expect(readFileSync(bookmark, "utf8")).toBe(aId + "\n");
+    const b = await runFx(["ask", "--json", "Remember conversation B."], { cwd: workspace, env, timeoutMs: TIMEOUT });
+    expect(b.code).toBe(0);
+    const bId = JSON.parse(b.stdout).session_id;
+    other = await open(["--resume", bId], "select-b");
+    await other.waitForText("REMEMBERED_B_HISTORY", TIMEOUT);
+    await other.waitForStableComposer(TIMEOUT);
+    expect(readFileSync(bookmark, "utf8")).toBe(bId + "\n");
+    await active.sendText("Continue the older active conversation without tools.");
+    await active.waitForText("LATER_A_ACTIVITY", TIMEOUT);
+    await active.waitForStableComposer(TIMEOUT);
+    expect(readFileSync(bookmark, "utf8")).toBe(bId + "\n");
+    await close(active); active = null;
+    await close(other); other = null;
+    active = await open(["--resume", aId], "reselect-a");
+    await active.waitForStableComposer(TIMEOUT);
+    expect(readFileSync(bookmark, "utf8")).toBe(aId + "\n");
+    await close(active); active = null;
+    active = await open([], "empty-window");
+    await active.waitForStableComposer(TIMEOUT);
+    await close(active); active = null;
+    expect(readFileSync(bookmark, "utf8")).toBe(aId + "\n");
+    const latest = await runFx(["ask", "--json", "--resume-id", bId, "Update B without tools."], { cwd: workspace, env, timeoutMs: TIMEOUT });
+    expect(latest.code).toBe(0);
+    const last = await runFx(["session", "last", "--json"], { cwd: workspace, env });
+    expect(last.code).toBe(0); expect(JSON.parse(last.stdout).id).toBe(bId);
+    const before = statSync(bookmark);
+    active = await open(["-c"], "continue-a");
+    await active.waitForText("LATER_A_ACTIVITY", TIMEOUT);
+    await active.waitForStableComposer(TIMEOUT);
+    expect(readFileSync(bookmark, "utf8")).toBe(aId + "\n");
+    expect(statSync(bookmark).ino).toBe(before.ino);
+    const trace = readFileSync(join(root, "continue-a.trace"), "utf8");
+    expect(trace).not.toContain("mode=workspace_writable_last");
+    expect(trace).not.toContain("session picker catalog loaded");
+    other = await open(["--continue"], "busy");
+    await other.waitForPane(() => other!.paneStatus().dead, TIMEOUT);
+    expect(other.paneStatus().status).toBe(1);
+    expect(readFileSync(join(root, "busy.stderr"), "utf8")).toContain("another fx process");
+    await other.kill(); other = null;
+    await active.sendText("/resume");
+    await active.waitForText("Enter Resume", TIMEOUT);
+    await active.sendLiteralText("Remember conversation B.");
+    await active.waitForText("Sessions 1", TIMEOUT);
+    await active.sendKeys("Enter");
+    await active.waitForStableComposer(TIMEOUT);
+    expect(readFileSync(bookmark, "utf8")).toBe(bId + "\n");
+    await close(active); active = null;
+    expect(gateway.requests).toHaveLength(4);
+    for (const label of ["select-a", "select-b", "reselect-a", "empty-window", "continue-a"]) {
+      expect(readFileSync(join(root, label + ".stderr"), "utf8")).toBe("");
+    }
+    passed = true;
+  } finally {
+    await active?.kill(); await other?.kill(); gateway.stop();
+    if (passed) rmSync(root, { recursive: true, force: true });
+    else console.error(`retained remembered-continuation artifacts at ${root}`);
+  }
+}, 150_000);


### PR DESCRIPTION
## Summary

- Continue the remembered conversation for the current workspace with `-c` and `--continue`, without scanning every saved session.
- Remember interactive selections and the first saved work in a new session. Empty windows, later writes and exit preserve the selection.
- Report missing or unreadable continuation references instead of opening a different conversation.
- Warn when remembering fails while preserving the saved conversation and writer protection.
- Load the session picker catalog when the picker opens, removing its startup scan.
- Restore large sessions without replaying conversation history for subagent control-file access or repeating recovery after the composer appears.
- Leave delegation unavailable when its recovery fails, while preserving healthy parent `fx ask` continuations.
