### PR TITLE
Match GFM block syntax for fences, lists, headings, and quotes

### DIFF
--- a/src/core/agent/assistant_presentation.zig
+++ b/src/core/agent/assistant_presentation.zig
@@ -145,7 +145,8 @@ pub const MarkdownProcessor = struct {
     code_buf: std.ArrayList(u8) = .empty,
     code_language: std.ArrayList(u8) = .empty,
     in_code_block: bool = false,
-    code_fence_marker: ?u8 = null,
+    /// Set for fenced blocks; null while inside an indented code block.
+    code_fence: ?bp.CodeFence = null,
     in_pipe_block: bool = false,
     pipe_last_line_has_lf: bool = false,
     active_blockquote: ?bp.BlockquotePrefix = null,
@@ -172,7 +173,7 @@ pub const MarkdownProcessor = struct {
         self.code_language.clearAndFree(alloc);
         self.deinitFootnotes(alloc);
         self.in_code_block = false;
-        self.code_fence_marker = null;
+        self.code_fence = null;
         self.in_pipe_block = false;
         self.pipe_last_line_has_lf = false;
         self.active_blockquote = null;
@@ -252,7 +253,7 @@ pub const MarkdownProcessor = struct {
         if (self.in_code_block) {
             try self.finalizeCodeBlock(alloc, out, completions.code);
             self.in_code_block = false;
-            self.code_fence_marker = null;
+            self.code_fence = null;
         }
         try self.flushFootnotes(alloc, out);
     }
@@ -270,11 +271,11 @@ pub const MarkdownProcessor = struct {
 
         if (self.in_code_block) {
             self.active_definition = false;
-            if (self.code_fence_marker) |marker| {
-                if (bp.codeFenceMarker(tu.leftTrim(line)) == marker) {
+            if (self.code_fence) |fence| {
+                if (bp.closesCodeFence(line, fence)) {
                     try self.finalizeCodeBlock(alloc, out, completions.code);
                     self.in_code_block = false;
-                    self.code_fence_marker = null;
+                    self.code_fence = null;
                     return;
                 }
             } else if (!tu.isBlankMarkdownLine(line) and !bp.hasIndentedCodePrefix(line)) {
@@ -283,7 +284,9 @@ pub const MarkdownProcessor = struct {
                 try self.handleLine(alloc, line, line_has_lf, out, completions);
                 return;
             }
-            const code_line = if (self.code_fence_marker == null and !tu.isBlankMarkdownLine(line))
+            const code_line = if (self.code_fence) |fence|
+                bp.stripFenceIndent(line, fence.indent)
+            else if (!tu.isBlankMarkdownLine(line))
                 bp.deindentCodeLine(line)
             else
                 line;
@@ -359,7 +362,7 @@ pub const MarkdownProcessor = struct {
         if (self.previous_line_was_blank and bp.hasIndentedCodePrefix(line)) {
             self.active_definition = false;
             self.in_code_block = true;
-            self.code_fence_marker = null;
+            self.code_fence = null;
             self.code_language.clearRetainingCapacity();
             try self.appendCodeLine(alloc, bp.deindentCodeLine(line), line_has_lf, out, completions.code);
             return;
@@ -374,10 +377,14 @@ pub const MarkdownProcessor = struct {
             return;
         }
 
-        if (bp.codeFenceMarker(tu.leftTrim(line))) |marker| {
+        if (bp.parseCodeFence(tu.leftTrim(line))) |fence| {
             self.active_definition = false;
             self.in_code_block = true;
-            self.code_fence_marker = marker;
+            self.code_fence = .{
+                .marker = fence.marker,
+                .run = fence.run,
+                .indent = line.len - tu.leftTrim(line).len,
+            };
             self.code_language.clearRetainingCapacity();
             try self.code_language.appendSlice(alloc, bp.codeFenceLanguage(tu.leftTrim(line)));
             return;
@@ -465,30 +472,7 @@ pub const MarkdownProcessor = struct {
             return;
         }
 
-        if (bp.parseUnorderedList(line)) |parsed| {
-            try out.appendSlice(alloc, parsed.indent);
-            if (bp.parseTaskListItem(parsed.content)) |task| {
-                try block_render.writeTaskListMarker(alloc, out, task);
-                try inline_render.writeInline(alloc, tu.withoutTerminalHardBreakMarker(task.content, line_has_lf), out, false, &fs, &link_id_counter);
-                return;
-            }
-            try ansi.writeDim(alloc, out, ansi.bullet_marker);
-            try inline_render.writeInline(alloc, tu.withoutTerminalHardBreakMarker(parsed.content, line_has_lf), out, false, &fs, &link_id_counter);
-            return;
-        }
-
-        if (bp.parseOrderedList(line)) |parsed| {
-            try out.appendSlice(alloc, parsed.indent);
-            try ansi.writeDim(alloc, out, parsed.marker);
-            try out.append(alloc, ' ');
-            if (bp.parseTaskListItem(parsed.content)) |task| {
-                try block_render.writeTaskListMarker(alloc, out, task);
-                try inline_render.writeInline(alloc, tu.withoutTerminalHardBreakMarker(task.content, line_has_lf), out, false, &fs, &link_id_counter);
-                return;
-            }
-            try inline_render.writeInline(alloc, tu.withoutTerminalHardBreakMarker(parsed.content, line_has_lf), out, false, &fs, &link_id_counter);
-            return;
-        }
+        if (try block_render.writeListLine(alloc, line, line_has_lf, out, &fs, &link_id_counter)) return;
 
         try inline_render.writeInline(alloc, tu.withoutTerminalHardBreakMarker(line, line_has_lf), out, false, &fs, &link_id_counter);
     }
@@ -2225,6 +2209,124 @@ test "unordered list literal bullet gets dim marker" {
     try std.testing.expectEqualStrings(
         "\x1b[2m\xe2\x80\xa2 \x1b[22mthird item\n" ++
             "  \x1b[2m\xe2\x80\xa2 \x1b[22mnested\n",
+        out.items,
+    );
+}
+
+test "unordered list plus marker and tab separator get bullet" {
+    const alloc = std.testing.allocator;
+    var processor = MarkdownProcessor{};
+    defer processor.deinit(alloc);
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(alloc);
+
+    try processor.push(alloc, "+ plus item\n-\ttabbed item\n+not a list\n", &out);
+    try std.testing.expectEqualStrings(
+        "\x1b[2m\xe2\x80\xa2 \x1b[22mplus item\n" ++
+            "\x1b[2m\xe2\x80\xa2 \x1b[22mtabbed item\n" ++
+            "+not a list\n",
+        out.items,
+    );
+}
+
+test "ordered list accepts paren markers and rejects long numbers" {
+    const alloc = std.testing.allocator;
+    var processor = MarkdownProcessor{};
+    defer processor.deinit(alloc);
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(alloc);
+
+    try processor.push(alloc, "1) first\n12) twelfth\n1234567890. too long\n", &out);
+    try std.testing.expectEqualStrings(
+        "\x1b[2m1)\x1b[22m first\n" ++
+            "\x1b[2m12)\x1b[22m twelfth\n" ++
+            "1234567890. too long\n",
+        out.items,
+    );
+}
+
+test "atx heading strips closing hashes and allows small indent" {
+    const alloc = std.testing.allocator;
+    var processor = MarkdownProcessor{};
+    defer processor.deinit(alloc);
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(alloc);
+
+    try processor.push(alloc, "## Title ##\n   ## Indented\n## Keep#\n## Trail ##   \n    ## code\n", &out);
+    try std.testing.expectEqualStrings(
+        "\x1b[1mTitle\x1b[22m\n" ++
+            "\x1b[1mIndented\x1b[22m\n" ++
+            "\x1b[1mKeep#\x1b[22m\n" ++
+            "\x1b[1mTrail\x1b[22m\n" ++
+            "    ## code\n",
+        out.items,
+    );
+}
+
+test "longer code fence contains shorter fences" {
+    const alloc = std.testing.allocator;
+    var processor = MarkdownProcessor{};
+    defer processor.deinit(alloc);
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(alloc);
+
+    try processor.push(alloc, "````md\n```zig\ninner\n```\n````\nafter\n", &out);
+    try std.testing.expectEqualStrings(
+        "\x1b[2m\xe2\x94\x82 \x1b[22m```zig\n" ++
+            "\x1b[2m\xe2\x94\x82 \x1b[22minner\n" ++
+            "\x1b[2m\xe2\x94\x82 \x1b[22m```\n" ++
+            "after\n",
+        out.items,
+    );
+    try std.testing.expectEqual(@as(?bp.CodeFence, null), processor.code_fence);
+}
+
+test "code fence language skips the whole marker run" {
+    try std.testing.expectEqualStrings("md", bp.codeFenceLanguage("````md"));
+    try std.testing.expectEqualStrings("zig", bp.codeFenceLanguage("```   zig extra"));
+    try std.testing.expectEqualStrings("", bp.codeFenceLanguage("~~~"));
+}
+
+test "closing fence needs matching marker length and nothing after it" {
+    const open = bp.CodeFence{ .marker = '`', .run = 4, .indent = 0 };
+    try std.testing.expect(bp.closesCodeFence("````", open));
+    try std.testing.expect(bp.closesCodeFence("`````  ", open));
+    try std.testing.expect(!bp.closesCodeFence("```", open));
+    try std.testing.expect(!bp.closesCodeFence("~~~~", open));
+    try std.testing.expect(!bp.closesCodeFence("```` trailing", open));
+}
+
+test "fenced code inside a list item drops the item indentation" {
+    const alloc = std.testing.allocator;
+    var processor = MarkdownProcessor{};
+    defer processor.deinit(alloc);
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(alloc);
+
+    try processor.push(alloc, "1. step\n   ```sh\n   ls -la\n     nested\n   ```\n- next\n", &out);
+    try std.testing.expectEqualStrings(
+        "\x1b[2m1.\x1b[22m step\n" ++
+            "\x1b[2m\xe2\x94\x82 \x1b[22mls -la\n" ++
+            "\x1b[2m\xe2\x94\x82 \x1b[22m  nested\n" ++
+            "\x1b[2m\xe2\x80\xa2 \x1b[22mnext\n",
+        out.items,
+    );
+}
+
+test "blockquote renders headings and list items inside the quote" {
+    const alloc = std.testing.allocator;
+    var processor = MarkdownProcessor{};
+    defer processor.deinit(alloc);
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(alloc);
+
+    try processor.push(alloc, "> ## Note\n> - one\n> 2. two\n> - [x] done\n> plain\n", &out);
+    try std.testing.expectEqualStrings(
+        "\x1b[2m\xe2\x94\x82 \x1b[22m\x1b[1mNote\x1b[22m\n" ++
+            "\x1b[2m\xe2\x94\x82 \x1b[22m\x1b[2m\xe2\x80\xa2 \x1b[22mone\n" ++
+            "\x1b[2m\xe2\x94\x82 \x1b[22m\x1b[2m2.\x1b[22m two\n" ++
+            "\x1b[2m\xe2\x94\x82 \x1b[22m\x1b[38;5;252m\xe2\x9c\x93\x1b[39m done\n" ++
+            "\x1b[2m\xe2\x94\x82 \x1b[22mplain\n",
         out.items,
     );
 }

--- a/src/core/agent/assistant_presentation.zig
+++ b/src/core/agent/assistant_presentation.zig
@@ -382,16 +382,12 @@ pub const MarkdownProcessor = struct {
             return;
         }
 
-        if (bp.parseCodeFence(tu.leftTrim(line))) |fence| {
+        if (bp.parseCodeFence(line)) |fence| {
             self.active_definition = false;
             self.in_code_block = true;
-            self.code_fence = .{
-                .marker = fence.marker,
-                .run = fence.run,
-                .indent = line.len - tu.leftTrim(line).len,
-            };
+            self.code_fence = fence;
             self.code_language.clearRetainingCapacity();
-            try self.code_language.appendSlice(alloc, bp.codeFenceLanguage(tu.leftTrim(line)));
+            try self.code_language.appendSlice(alloc, bp.codeFenceLanguage(line));
             return;
         }
 
@@ -2334,6 +2330,9 @@ test "tab indented fence inside a list item closes on a tab indented fence" {
     );
 }
 
+// Known cost of the plus rule: a loose nested list written as "- a", a blank
+// line, then "    + nested" renders the nested line as indented code, while
+// "-" or "*" at the same indent still become list items.
 test "indented plus line after a blank stays indented code" {
     const alloc = std.testing.allocator;
     var processor = MarkdownProcessor{};

--- a/src/core/agent/assistant_presentation.zig
+++ b/src/core/agent/assistant_presentation.zig
@@ -2360,10 +2360,12 @@ test "heading keeps a backslash exposed by removing closing hashes" {
     var out: std.ArrayList(u8) = .empty;
     defer out.deinit(alloc);
 
-    try processor.push(alloc, "## C:\\ ###\n## trailing\\\n", &out);
+    try processor.push(alloc, "## C:\\ ###\n## trailing\\\n> ## C:\\ ###\n> ## quoted\\\n", &out);
     try std.testing.expectEqualStrings(
         "\x1b[1mC:\\\x1b[22m\n" ++
-            "\x1b[1mtrailing\x1b[22m\n",
+            "\x1b[1mtrailing\x1b[22m\n" ++
+            "\x1b[2m\xe2\x94\x82 \x1b[22m\x1b[1mC:\\\x1b[22m\n" ++
+            "\x1b[2m\xe2\x94\x82 \x1b[22m\x1b[1mquoted\x1b[22m\n",
         out.items,
     );
 }

--- a/src/core/agent/assistant_presentation.zig
+++ b/src/core/agent/assistant_presentation.zig
@@ -352,7 +352,12 @@ pub const MarkdownProcessor = struct {
             self.active_blockquote = null;
         }
 
-        if (bp.hasIndentedCodePrefix(line) and (bp.parseUnorderedList(line) != null or bp.parseOrderedList(line) != null)) {
+        // An indented list marker continues a list, except that a plus sign in
+        // indented-code position stays code so diff-style lines are preserved.
+        const indented_list_item = bp.hasIndentedCodePrefix(line) and
+            (bp.parseUnorderedList(line) != null or bp.parseOrderedList(line) != null);
+        const plus_in_code_position = indented_list_item and self.previous_line_was_blank and tu.leftTrim(line)[0] == '+';
+        if (indented_list_item and !plus_in_code_position) {
             self.active_definition = false;
             try self.processLine(alloc, line, line_has_lf, out);
             try out.append(alloc, '\n');
@@ -457,8 +462,8 @@ pub const MarkdownProcessor = struct {
             return;
         }
 
-        if (bp.parseHeader(line)) |header| {
-            try block_render.writeHeading(alloc, header.level, tu.withoutTerminalHardBreakMarker(header.content, line_has_lf), out, &fs, &link_id_counter);
+        if (bp.parseHeader(tu.withoutTerminalHardBreakMarker(line, line_has_lf))) |header| {
+            try block_render.writeHeading(alloc, header.level, header.content, out, &fs, &link_id_counter);
             return;
         }
 
@@ -2309,6 +2314,56 @@ test "fenced code inside a list item drops the item indentation" {
             "\x1b[2m\xe2\x94\x82 \x1b[22mls -la\n" ++
             "\x1b[2m\xe2\x94\x82 \x1b[22m  nested\n" ++
             "\x1b[2m\xe2\x80\xa2 \x1b[22mnext\n",
+        out.items,
+    );
+}
+
+test "tab indented fence inside a list item closes on a tab indented fence" {
+    const alloc = std.testing.allocator;
+    var processor = MarkdownProcessor{};
+    defer processor.deinit(alloc);
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(alloc);
+
+    try processor.push(alloc, "1. item\n\t```\n\tcode\n\t```\n\tprose after\n", &out);
+    try std.testing.expectEqualStrings(
+        "\x1b[2m1.\x1b[22m item\n" ++
+            "\x1b[2m\xe2\x94\x82 \x1b[22mcode\n" ++
+            "\tprose after\n",
+        out.items,
+    );
+}
+
+test "indented plus line after a blank stays indented code" {
+    const alloc = std.testing.allocator;
+    var processor = MarkdownProcessor{};
+    defer processor.deinit(alloc);
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(alloc);
+
+    try processor.push(alloc, "    + value\n    second\ntext\n- a\n    + nested\n", &out);
+    try processor.flush(alloc, &out);
+    try std.testing.expectEqualStrings(
+        "\x1b[2m\xe2\x94\x82 \x1b[22m+ value\n" ++
+            "\x1b[2m\xe2\x94\x82 \x1b[22msecond\n" ++
+            "text\n" ++
+            "\x1b[2m\xe2\x80\xa2 \x1b[22ma\n" ++
+            "    \x1b[2m\xe2\x80\xa2 \x1b[22mnested\n",
+        out.items,
+    );
+}
+
+test "heading keeps a backslash exposed by removing closing hashes" {
+    const alloc = std.testing.allocator;
+    var processor = MarkdownProcessor{};
+    defer processor.deinit(alloc);
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(alloc);
+
+    try processor.push(alloc, "## C:\\ ###\n## trailing\\\n", &out);
+    try std.testing.expectEqualStrings(
+        "\x1b[1mC:\\\x1b[22m\n" ++
+            "\x1b[1mtrailing\x1b[22m\n",
         out.items,
     );
 }

--- a/src/core/agent/presentation/block_parse.zig
+++ b/src/core/agent/presentation/block_parse.zig
@@ -1,12 +1,40 @@
 const std = @import("std");
 const tu = @import("text_util.zig");
 
-pub fn codeFenceMarker(line: []const u8) ?u8 {
-    if (line.len < 3) return null;
-    const marker = line[0];
+pub const CodeFence = struct {
+    marker: u8,
+    /// Number of marker characters in the run; a closing fence needs at least this many.
+    run: usize,
+    /// Leading spaces before the fence, stripped from the block's code lines.
+    indent: usize,
+};
+
+/// Parses an opening or closing fence of three or more backticks or tildes,
+/// allowing any leading spaces so fences inside list items are recognized.
+pub fn parseCodeFence(line: []const u8) ?CodeFence {
+    var i: usize = 0;
+    while (i < line.len and line[i] == ' ') : (i += 1) {}
+    const indent = i;
+    if (i >= line.len) return null;
+    const marker = line[i];
     if (marker != '`' and marker != '~') return null;
-    if (line[1] != marker or line[2] != marker) return null;
-    return marker;
+    var run: usize = 0;
+    while (i < line.len and line[i] == marker) : (i += 1) run += 1;
+    if (run < 3) return null;
+    return .{ .marker = marker, .run = run, .indent = indent };
+}
+
+pub fn codeFenceMarker(line: []const u8) ?u8 {
+    const fence = parseCodeFence(line) orelse return null;
+    return fence.marker;
+}
+
+/// True when `line` closes a block opened by `open`: same marker, a run at
+/// least as long, and nothing but whitespace after it.
+pub fn closesCodeFence(line: []const u8, open: CodeFence) bool {
+    const fence = parseCodeFence(line) orelse return false;
+    if (fence.marker != open.marker or fence.run < open.run) return false;
+    return tu.isBlankMarkdownLine(line[fence.indent + fence.run ..]);
 }
 
 fn isCodeFence(line: []const u8) bool {
@@ -14,9 +42,18 @@ fn isCodeFence(line: []const u8) bool {
 }
 
 pub fn codeFenceLanguage(line: []const u8) []const u8 {
-    const info = std.mem.trim(u8, line[3..], " \t");
+    const fence = parseCodeFence(line) orelse return "";
+    const info = std.mem.trim(u8, line[fence.indent + fence.run ..], " \t");
     const end = std.mem.indexOfAny(u8, info, " \t") orelse info.len;
     return info[0..end];
+}
+
+/// Strips up to `indent` leading spaces so code inside an indented list item
+/// renders flush with the fence.
+pub fn stripFenceIndent(line: []const u8, indent: usize) []const u8 {
+    var i: usize = 0;
+    while (i < line.len and i < indent and line[i] == ' ') : (i += 1) {}
+    return line[i..];
 }
 
 pub fn hasIndentedCodePrefix(line: []const u8) bool {
@@ -33,13 +70,27 @@ const ParsedHeader = struct {
     content: []const u8,
 };
 
+/// ATX heading: up to three leading spaces, one to six `#`, a space, then
+/// content with any closing `#` run removed.
 pub fn parseHeader(line: []const u8) ?ParsedHeader {
-    if (line.len == 0 or line[0] != '#') return null;
+    var start: usize = 0;
+    while (start < 3 and start < line.len and line[start] == ' ') : (start += 1) {}
     var level: usize = 0;
-    while (level < 6 and level < line.len and line[level] == '#') : (level += 1) {}
-    if (level == 0 or level >= line.len) return null;
-    if (line[level] != ' ') return null;
-    return .{ .level = level, .content = line[level + 1 ..] };
+    while (level < 6 and start + level < line.len and line[start + level] == '#') : (level += 1) {}
+    if (level == 0) return null;
+    const marker_end = start + level;
+    if (marker_end >= line.len or line[marker_end] != ' ') return null;
+    return .{ .level = level, .content = withoutClosingHashes(line[marker_end + 1 ..]) };
+}
+
+fn withoutClosingHashes(content: []const u8) []const u8 {
+    const trimmed = std.mem.trimEnd(u8, content, " \t");
+    var end = trimmed.len;
+    while (end > 0 and trimmed[end - 1] == '#') : (end -= 1) {}
+    if (end == trimmed.len) return content;
+    if (end == 0) return trimmed[0..0];
+    if (trimmed[end - 1] != ' ' and trimmed[end - 1] != '\t') return content;
+    return std.mem.trimEnd(u8, trimmed[0..end], " \t");
 }
 
 pub fn parseSetextUnderline(line: []const u8) ?usize {
@@ -151,20 +202,20 @@ const ParsedUnorderedList = struct {
     content: []const u8,
 };
 
-/// Accepts Markdown `-` and `*` markers plus a literal bullet so model output
-/// that already uses `•` gets the same styling and wrap continuation.
+/// Accepts Markdown `-`, `*`, and `+` markers plus a literal bullet so model
+/// output that already uses `•` gets the same styling and wrap continuation.
 pub fn parseUnorderedList(line: []const u8) ?ParsedUnorderedList {
     const literal_bullet = "\xe2\x80\xa2";
     var i: usize = 0;
     while (i < line.len and (line[i] == ' ' or line[i] == '\t')) : (i += 1) {}
     const rest = line[i..];
-    const marker_len: usize = if (rest.len > 0 and (rest[0] == '-' or rest[0] == '*'))
+    const marker_len: usize = if (rest.len > 0 and (rest[0] == '-' or rest[0] == '*' or rest[0] == '+'))
         1
     else if (std.mem.startsWith(u8, rest, literal_bullet))
         literal_bullet.len
     else
         return null;
-    if (marker_len >= rest.len or rest[marker_len] != ' ') return null;
+    if (marker_len >= rest.len or !tu.isSpace(rest[marker_len])) return null;
     return .{ .indent = line[0..i], .content = rest[marker_len + 1 ..] };
 }
 
@@ -179,10 +230,10 @@ pub fn parseOrderedList(line: []const u8) ?ParsedOrderedList {
     while (i < line.len and (line[i] == ' ' or line[i] == '\t')) : (i += 1) {}
     const indent_end = i;
     while (i < line.len and line[i] >= '0' and line[i] <= '9') : (i += 1) {}
-    if (i == indent_end) return null;
+    if (i == indent_end or i - indent_end > 9) return null;
     if (i + 1 >= line.len) return null;
-    if (line[i] != '.') return null;
-    if (line[i + 1] != ' ') return null;
+    if (line[i] != '.' and line[i] != ')') return null;
+    if (!tu.isSpace(line[i + 1])) return null;
     return .{
         .indent = line[0..indent_end],
         .marker = line[indent_end .. i + 1],

--- a/src/core/agent/presentation/block_parse.zig
+++ b/src/core/agent/presentation/block_parse.zig
@@ -13,7 +13,7 @@ pub const CodeFence = struct {
 /// allowing any leading spaces so fences inside list items are recognized.
 pub fn parseCodeFence(line: []const u8) ?CodeFence {
     var i: usize = 0;
-    while (i < line.len and line[i] == ' ') : (i += 1) {}
+    while (i < line.len and (line[i] == ' ' or line[i] == '\t')) : (i += 1) {}
     const indent = i;
     if (i >= line.len) return null;
     const marker = line[i];
@@ -48,11 +48,11 @@ pub fn codeFenceLanguage(line: []const u8) []const u8 {
     return info[0..end];
 }
 
-/// Strips up to `indent` leading spaces so code inside an indented list item
-/// renders flush with the fence.
+/// Strips up to `indent` leading spaces or tabs so code inside an indented
+/// list item renders flush with the fence.
 pub fn stripFenceIndent(line: []const u8, indent: usize) []const u8 {
     var i: usize = 0;
-    while (i < line.len and i < indent and line[i] == ' ') : (i += 1) {}
+    while (i < line.len and i < indent and (line[i] == ' ' or line[i] == '\t')) : (i += 1) {}
     return line[i..];
 }
 

--- a/src/core/agent/presentation/block_render.zig
+++ b/src/core/agent/presentation/block_render.zig
@@ -80,8 +80,8 @@ fn writeQuotedBlockContent(
     footnotes: ?*const payload.FootnoteSink,
     link_id: *u32,
 ) !void {
-    if (bp.parseHeader(content)) |header| {
-        try writeHeading(alloc, header.level, tu.withoutTerminalHardBreakMarker(header.content, line_has_lf), out, footnotes, link_id);
+    if (bp.parseHeader(tu.withoutTerminalHardBreakMarker(content, line_has_lf))) |header| {
+        try writeHeading(alloc, header.level, header.content, out, footnotes, link_id);
         return;
     }
     if (try writeListLine(alloc, content, line_has_lf, out, footnotes, link_id)) return;

--- a/src/core/agent/presentation/block_render.zig
+++ b/src/core/agent/presentation/block_render.zig
@@ -67,7 +67,61 @@ pub fn writeBlockquoteLine(
 ) !void {
     try out.appendNTimes(alloc, ' ', blockquote.indent);
     for (0..blockquote.depth) |_| try ansi.writeDim(alloc, out, ansi.vertical_rule_prefix);
+    try writeQuotedBlockContent(alloc, content, line_has_lf, out, footnotes, link_id);
+}
+
+/// Renders headings and list items inside a blockquote with their usual
+/// styling; everything else is inline prose.
+fn writeQuotedBlockContent(
+    alloc: Allocator,
+    content: []const u8,
+    line_has_lf: bool,
+    out: *std.ArrayList(u8),
+    footnotes: ?*const payload.FootnoteSink,
+    link_id: *u32,
+) !void {
+    if (bp.parseHeader(content)) |header| {
+        try writeHeading(alloc, header.level, tu.withoutTerminalHardBreakMarker(header.content, line_has_lf), out, footnotes, link_id);
+        return;
+    }
+    if (try writeListLine(alloc, content, line_has_lf, out, footnotes, link_id)) return;
     try inline_render.writeInline(alloc, tu.withoutTerminalHardBreakMarker(content, line_has_lf), out, false, footnotes, link_id);
+}
+
+/// Renders an unordered, ordered, or task list line without a trailing
+/// newline. Returns false when `line` is not a list item.
+pub fn writeListLine(
+    alloc: Allocator,
+    line: []const u8,
+    line_has_lf: bool,
+    out: *std.ArrayList(u8),
+    footnotes: ?*const payload.FootnoteSink,
+    link_id: *u32,
+) !bool {
+    if (bp.parseUnorderedList(line)) |parsed| {
+        try out.appendSlice(alloc, parsed.indent);
+        if (bp.parseTaskListItem(parsed.content)) |task| {
+            try writeTaskListMarker(alloc, out, task);
+            try inline_render.writeInline(alloc, tu.withoutTerminalHardBreakMarker(task.content, line_has_lf), out, false, footnotes, link_id);
+            return true;
+        }
+        try ansi.writeDim(alloc, out, ansi.bullet_marker);
+        try inline_render.writeInline(alloc, tu.withoutTerminalHardBreakMarker(parsed.content, line_has_lf), out, false, footnotes, link_id);
+        return true;
+    }
+    if (bp.parseOrderedList(line)) |parsed| {
+        try out.appendSlice(alloc, parsed.indent);
+        try ansi.writeDim(alloc, out, parsed.marker);
+        try out.append(alloc, ' ');
+        if (bp.parseTaskListItem(parsed.content)) |task| {
+            try writeTaskListMarker(alloc, out, task);
+            try inline_render.writeInline(alloc, tu.withoutTerminalHardBreakMarker(task.content, line_has_lf), out, false, footnotes, link_id);
+            return true;
+        }
+        try inline_render.writeInline(alloc, tu.withoutTerminalHardBreakMarker(parsed.content, line_has_lf), out, false, footnotes, link_id);
+        return true;
+    }
+    return false;
 }
 
 pub fn writeDefinitionLine(

--- a/src/ui/render_engine/assistant_wrap.zig
+++ b/src/ui/render_engine/assistant_wrap.zig
@@ -982,7 +982,7 @@ fn listContinuationIndentWidth(text: []const u8, line_start: usize) ?usize {
         marker_width += 1;
         i = skipPacerDimReassertions(text, i);
     }
-    if (marker_width == 0 or i >= text.len or text[i] != '.') return null;
+    if (marker_width == 0 or i >= text.len or (text[i] != '.' and text[i] != ')')) return null;
     i += 1;
     marker_width += 1;
     i = skipPacerDimReassertions(text, i);
@@ -1286,6 +1286,13 @@ test "wrapAssistantText recognizes paced list markers" {
     );
     defer alloc.free(blockquote);
     try std.testing.expectEqualStrings("\x1b[2m\xe2\x94\x82\x1b[0m\x1b[2m \x1b[0m\x1b[2m\x1b[22mabcde\n\x1b[2m\xe2\x94\x82 \x1b[22mfghij", blockquote);
+}
+
+test "wrapAssistantText indents paren-style ordered list continuations" {
+    const alloc = std.testing.allocator;
+    const out = try wrapAssistantText(alloc, "\x1b[2m12)\x1b[22m abcdefghij", 10);
+    defer alloc.free(out);
+    try std.testing.expectEqualStrings("\x1b[2m12)\x1b[22m abcdef\n    ghij", out);
 }
 
 test "wrapAssistantText indents ordered and nested list continuations" {

--- a/src/ui/resize_tests.zig
+++ b/src/ui/resize_tests.zig
@@ -1750,6 +1750,104 @@ test "streamed markdown lists reflow through shrink and grow" {
     try expectRowPrefix(&h, nested_wide + 1, "      ");
 }
 
+test "streamed longer code fence keeps inner fences inside the block" {
+    var h = try Harness.init(std.testing.allocator, 40, 40, 4);
+    defer h.deinit();
+    try h.shell.initViewport(&h.metrics, 1);
+
+    var processor = assistant_presentation.MarkdownProcessor{};
+    defer processor.deinit(h.alloc);
+    var formatted: std.ArrayList(u8) = .empty;
+    defer formatted.deinit(h.alloc);
+    try processor.push(
+        h.alloc,
+        "````md\n```zig\nconst inner = 1;\n```\n````\nafter the block\n",
+        &formatted,
+    );
+    try processor.flush(h.alloc, &formatted);
+
+    _ = try h.shell.streamAssistantChunk(h.alloc, &h.metrics, formatted.items);
+    try h.renderTranscriptFrame();
+    try h.flush();
+
+    const open_row = try findRowContaining(&h, "```zig");
+    try expectRowPrefix(&h, open_row, "  │ ```zig");
+    try expectRowPrefix(&h, open_row + 1, "  │ const inner = 1;");
+    try expectRowPrefix(&h, open_row + 2, "  │ ```");
+    try expectRowPrefix(&h, open_row + 3, "  after the block");
+    try expectGridNotContains(&h, "````");
+
+    try h.driveResize(24, 40, 4, true);
+    const narrow_row = try findRowContaining(&h, "```zig");
+    try expectRowPrefix(&h, narrow_row, "  │ ```zig");
+    try expectRowPrefix(&h, narrow_row + 2, "  │ ```");
+    try expectGridNotContains(&h, "````");
+}
+
+test "streamed plus and paren list markers wrap under their text" {
+    var h = try Harness.init(std.testing.allocator, 20, 40, 4);
+    defer h.deinit();
+    try h.shell.initViewport(&h.metrics, 1);
+
+    var processor = assistant_presentation.MarkdownProcessor{};
+    defer processor.deinit(h.alloc);
+    var formatted: std.ArrayList(u8) = .empty;
+    defer formatted.deinit(h.alloc);
+    try processor.push(
+        h.alloc,
+        "+ plus-abcdefghijklmnopqrstuvwxyzabcdefghijklmnop\n" ++
+            "1) paren-abcdefghijklmnopqrstuvwxyzabcdefghijklmnop\n",
+        &formatted,
+    );
+    try processor.flush(h.alloc, &formatted);
+
+    _ = try h.shell.streamAssistantChunk(h.alloc, &h.metrics, formatted.items);
+    try h.renderTranscriptFrame();
+    try h.flush();
+
+    const plus_row = try findRowContaining(&h, "plus-");
+    try expectRowPrefix(&h, plus_row, "  • plus-");
+    try expectRowPrefix(&h, plus_row + 1, "    ");
+    try expectGridNotContains(&h, "+ plus");
+
+    const paren_row = try findRowContaining(&h, "paren-");
+    try expectRowPrefix(&h, paren_row, "  1) paren-");
+    try expectRowPrefix(&h, paren_row + 1, "     ");
+
+    try h.driveResize(14, 40, 4, true);
+    const plus_narrow = try findRowContaining(&h, "plus-");
+    const paren_narrow = try findRowContaining(&h, "paren-");
+    try expectRowPrefix(&h, plus_narrow + 1, "    ");
+    try expectRowPrefix(&h, paren_narrow + 1, "     ");
+}
+
+test "streamed blockquote keeps heading and bullet styling inside the quote" {
+    var h = try Harness.init(std.testing.allocator, 40, 40, 4);
+    defer h.deinit();
+    try h.shell.initViewport(&h.metrics, 1);
+
+    var processor = assistant_presentation.MarkdownProcessor{};
+    defer processor.deinit(h.alloc);
+    var formatted: std.ArrayList(u8) = .empty;
+    defer formatted.deinit(h.alloc);
+    try processor.push(h.alloc, "> ## Quoted note\n> - quoted item\n", &formatted);
+    try processor.flush(h.alloc, &formatted);
+
+    _ = try h.shell.streamAssistantChunk(h.alloc, &h.metrics, formatted.items);
+    try h.renderTranscriptFrame();
+    try h.flush();
+
+    const heading_row = try findRowContaining(&h, "Quoted note");
+    try expectRowPrefix(&h, heading_row, "  │ Quoted note");
+    const heading_cell = h.vt.cellAt(heading_row, 5) orelse return error.TestMissingHeadingCell;
+    try std.testing.expect(heading_cell.style.flags.bold);
+    try expectGridNotContains(&h, "## Quoted");
+
+    const item_row = try findRowContaining(&h, "quoted item");
+    try expectRowPrefix(&h, item_row, "  │ • quoted item");
+    try expectGridNotContains(&h, "- quoted");
+}
+
 test "streamed markdown definitions reflow through shrink and grow" {
     const Capture = struct {
         fn deliver(_: *anyopaque, _: *std.ArrayList(u8)) !void {}

--- a/src/ui/resize_tests.zig
+++ b/src/ui/resize_tests.zig
@@ -1784,6 +1784,32 @@ test "streamed longer code fence keeps inner fences inside the block" {
     try expectGridNotContains(&h, "````");
 }
 
+test "streamed tab indented fence closes and releases the following prose" {
+    var h = try Harness.init(std.testing.allocator, 40, 40, 4);
+    defer h.deinit();
+    try h.shell.initViewport(&h.metrics, 1);
+
+    var processor = assistant_presentation.MarkdownProcessor{};
+    defer processor.deinit(h.alloc);
+    var formatted: std.ArrayList(u8) = .empty;
+    defer formatted.deinit(h.alloc);
+    try processor.push(h.alloc, "1. item\n\t```sh\n\tls\n\t```\n\tprose after\n", &formatted);
+    try processor.flush(h.alloc, &formatted);
+
+    _ = try h.shell.streamAssistantChunk(h.alloc, &h.metrics, formatted.items);
+    try h.renderTranscriptFrame();
+    try h.flush();
+
+    const code_row = try findRowContaining(&h, "ls");
+    try expectRowPrefix(&h, code_row, "  │ ls");
+    const prose_row = try findRowContaining(&h, "prose after");
+    try std.testing.expect(prose_row > code_row);
+    const prose_cell = h.vt.cellAt(prose_row, 2) orelse return error.TestMissingCell;
+    try std.testing.expect(prose_cell.style.fg.eql(.default));
+    try expectGridNotContains(&h, "│ ```");
+    try expectGridNotContains(&h, "│ prose");
+}
+
 test "streamed plus and paren list markers wrap under their text" {
     var h = try Harness.init(std.testing.allocator, 20, 40, 4);
     defer h.deinit();


### PR DESCRIPTION
## Summary

- A code block opened with four or more backticks or tildes stays open across shorter fences inside it and closes only on a run at least as long, so Markdown examples that contain code fences render as one block.
- The language label of a fence with more than three markers no longer includes stray marker characters.
- Fenced code inside an indented list item renders flush with the fence instead of carrying the item indentation.
- Lines starting with `+ ` render as bullet items, and a tab after any list marker is accepted as the separator.
- Ordered items written as `1)` render with a dim marker and keep their hanging indent when wrapped.
- ATX headings accept up to three leading spaces and drop a closing run of `#` characters.
- Headings and list items inside a blockquote render with heading and bullet styling instead of literal `#` and `-` characters.

Stacked on #747.