### PR TITLE
Parse GFM link destinations, code span runs, and entities

### DIFF
--- a/src/core/agent/assistant_presentation.zig
+++ b/src/core/agent/assistant_presentation.zig
@@ -1571,6 +1571,38 @@ test "code span closes only on a backtick run of the same length" {
     );
 }
 
+test "numeric entities for control characters stay literal" {
+    const alloc = std.testing.allocator;
+    var processor = MarkdownProcessor{};
+    defer processor.deinit(alloc);
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(alloc);
+
+    try processor.push(alloc, "x&#27;[2Ky &#x1b;[31m &#7; &#127;&#x9b; &#0; &#x41;\n", &out);
+    try std.testing.expectEqualStrings("x&#27;[2Ky &#x1b;[31m &#7; &#127;&#x9b; \xef\xbf\xbd A\n", out.items);
+    try std.testing.expect(std.mem.indexOfScalar(u8, out.items, 0x1b) == null);
+}
+
+test "entity lookup is bounded and a long ampersand line stays linear" {
+    const alloc = std.testing.allocator;
+    var processor = MarkdownProcessor{};
+    defer processor.deinit(alloc);
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(alloc);
+
+    // A semicolon farther than the longest accepted name never forms an entity.
+    try processor.push(alloc, "&ampersand; &amp;\n", &out);
+    try std.testing.expectEqualStrings("&ampersand; &\n", out.items);
+
+    out.clearRetainingCapacity();
+    var line: std.ArrayList(u8) = .empty;
+    defer line.deinit(alloc);
+    try line.appendNTimes(alloc, '&', 64 * 1024);
+    try line.append(alloc, '\n');
+    try processor.push(alloc, line.items, &out);
+    try std.testing.expectEqualStrings(line.items, out.items);
+}
+
 test "code span content is not entity decoded but prose is" {
     const alloc = std.testing.allocator;
     var processor = MarkdownProcessor{};

--- a/src/core/agent/assistant_presentation.zig
+++ b/src/core/agent/assistant_presentation.zig
@@ -644,6 +644,61 @@ test "markdown link is blue and underlined inside its OSC 8 scope" {
     try std.testing.expectEqualStrings(expected, out.items);
 }
 
+test "markdown link destination keeps balanced parentheses" {
+    const alloc = std.testing.allocator;
+    var processor = MarkdownProcessor{};
+    defer processor.deinit(alloc);
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(alloc);
+
+    const id_before = link_id_counter;
+    try processor.push(alloc, "[w](https://en.wikipedia.org/wiki/Foo_(bar)) tail\n", &out);
+
+    var expected_buf: [256]u8 = undefined;
+    const expected = try std.fmt.bufPrint(
+        &expected_buf,
+        "\x1b]8;id=fx-{d};https://en.wikipedia.org/wiki/Foo_(bar)\x1b\\\x1b[4mw\x1b[24m\x1b]8;;\x1b\\ tail\n",
+        .{id_before},
+    );
+    try std.testing.expectEqualStrings(expected, out.items);
+}
+
+test "markdown link drops its title and unwraps angle destinations" {
+    const alloc = std.testing.allocator;
+    var processor = MarkdownProcessor{};
+    defer processor.deinit(alloc);
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(alloc);
+
+    const id_before = link_id_counter;
+    try processor.push(
+        alloc,
+        "[t](https://example.com \"Title text\") [s](https://example.com/s 'single') [a](<https://example.com/a b>)\n",
+        &out,
+    );
+
+    var expected_buf: [512]u8 = undefined;
+    const expected = try std.fmt.bufPrint(
+        &expected_buf,
+        "\x1b]8;id=fx-{d};https://example.com\x1b\\\x1b[4mt\x1b[24m\x1b]8;;\x1b\\ " ++
+            "\x1b]8;id=fx-{d};https://example.com/s\x1b\\\x1b[4ms\x1b[24m\x1b]8;;\x1b\\ " ++
+            "\x1b]8;id=fx-{d};https://example.com/a b\x1b\\\x1b[4ma\x1b[24m\x1b]8;;\x1b\\\n",
+        .{ id_before, id_before + 1, id_before + 2 },
+    );
+    try std.testing.expectEqualStrings(expected, out.items);
+}
+
+test "markdown link with unbalanced or spaced destination stays literal" {
+    const alloc = std.testing.allocator;
+    var processor = MarkdownProcessor{};
+    defer processor.deinit(alloc);
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(alloc);
+
+    try processor.push(alloc, "[u](https://e.com/(x) [v](https://e.com/a b) [w](https://e.com \"open)\n", &out);
+    try std.testing.expectEqualStrings("[u](https://e.com/(x) [v](https://e.com/a b) [w](https://e.com \"open)\n", out.items);
+}
+
 test "markdown image renders its alt text with an image marker inside one OSC 8 scope" {
     const alloc = std.testing.allocator;
     var processor = MarkdownProcessor{};
@@ -1486,6 +1541,62 @@ test "table payload headers reassert outer bold after inline strong closes" {
         out.items,
         "\x1b[1mprefix \x1b[1mstrong\x1b[22m\x1b[1m suffix\x1b[22m",
     ) != null);
+}
+
+test "double backtick code span keeps inner backticks and trims one padding space" {
+    const alloc = std.testing.allocator;
+    var processor = MarkdownProcessor{};
+    defer processor.deinit(alloc);
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(alloc);
+
+    try processor.push(alloc, "use `` a ` b `` and ``x`` here\n", &out);
+    try std.testing.expectEqualStrings(
+        "use \x1b[38;5;245ma ` b\x1b[39m and \x1b[38;5;245mx\x1b[39m here\n",
+        out.items,
+    );
+}
+
+test "code span closes only on a backtick run of the same length" {
+    const alloc = std.testing.allocator;
+    var processor = MarkdownProcessor{};
+    defer processor.deinit(alloc);
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(alloc);
+
+    try processor.push(alloc, "`a``b` and ``` lonely **bold**\n", &out);
+    try std.testing.expectEqualStrings(
+        "\x1b[38;5;245ma``b\x1b[39m and ``` lonely \x1b[1mbold\x1b[22m\n",
+        out.items,
+    );
+}
+
+test "code span content is not entity decoded but prose is" {
+    const alloc = std.testing.allocator;
+    var processor = MarkdownProcessor{};
+    defer processor.deinit(alloc);
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(alloc);
+
+    try processor.push(alloc, "a &amp; b &lt;c&gt; &quot;d&quot; &#39;e&#39; &#x2192; `&amp;` &unknown; &amp\n", &out);
+    try std.testing.expectEqualStrings(
+        "a & b <c> \"d\" 'e' \xe2\x86\x92 \x1b[38;5;245m&amp;\x1b[39m &unknown; &amp\n",
+        out.items,
+    );
+}
+
+test "heading strips emphasis markers around a multi backtick code span" {
+    const alloc = std.testing.allocator;
+    var processor = MarkdownProcessor{};
+    defer processor.deinit(alloc);
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(alloc);
+
+    try processor.push(alloc, "## Run ``**raw**`` now\n", &out);
+    try std.testing.expectEqualStrings(
+        "\x1b[1mRun \x1b[38;5;245m**raw**\x1b[39m now\x1b[22m\n",
+        out.items,
+    );
 }
 
 test "inline code backticks wrap with ANSI" {

--- a/src/core/agent/presentation/inline_render.zig
+++ b/src/core/agent/presentation/inline_render.zig
@@ -20,9 +20,17 @@ pub fn writeInlineNoBold(
     while (i < text.len) {
         const c = text[i];
         if (c == '`') {
-            in_code = !in_code;
-            try stripped.append(alloc, c);
-            i += 1;
+            if (!in_code) {
+                if (codeSpanAt(text, i)) |span| {
+                    try stripped.appendSlice(alloc, text[i..span.end]);
+                    i = span.end;
+                    continue;
+                }
+            }
+            const run = backtickRunLength(text, i);
+            if (run == 1) in_code = !in_code;
+            try stripped.appendSlice(alloc, text[i .. i + run]);
+            i += run;
             continue;
         }
         if (!in_code and c == '\\' and i + 1 < text.len and tu.isEscapedPunctuationAt(text, i + 1)) {
@@ -69,6 +77,22 @@ pub fn writeInline(
         const c = text[i];
 
         if (c == '`') {
+            if (!in_code) {
+                if (codeSpanAt(text, i)) |span| {
+                    try out.appendSlice(alloc, ansi.inline_code_open);
+                    try out.appendSlice(alloc, text[span.content_start..span.content_end]);
+                    try out.appendSlice(alloc, ansi.inline_code_close);
+                    i = span.end;
+                    continue;
+                }
+            }
+            const run = backtickRunLength(text, i);
+            if (run > 1) {
+                // A longer run without a partner is literal text.
+                try out.appendSlice(alloc, text[i .. i + run]);
+                i += run;
+                continue;
+            }
             if (in_code) {
                 try out.appendSlice(alloc, ansi.inline_code_close);
                 in_code = false;
@@ -84,6 +108,14 @@ pub fn writeInline(
             try out.append(alloc, c);
             i += 1;
             continue;
+        }
+
+        if (c == '&') {
+            if (decodeEntity(text, i)) |entity| {
+                try out.appendSlice(alloc, entity.utf8[0..entity.len]);
+                i = entity.end;
+                continue;
+            }
         }
 
         if (c == '\\' and i + 1 < text.len and tu.isEscapedPunctuationAt(text, i + 1)) {
@@ -363,16 +395,181 @@ fn parseInlineBracketDestination(text: []const u8, start: usize, allow_empty_tex
     const text_end = j;
     if (!allow_empty_text and text_end == start + 1) return null;
     if (text_end + 1 >= text.len or text[text_end + 1] != '(') return null;
-    var k = text_end + 2;
-    while (k < text.len and text[k] != ')' and text[k] != '\n') : (k += 1) {}
-    if (k >= text.len or text[k] != ')') return null;
-    const url = text[text_end + 2 .. k];
-    if (!isValidLinkUrl(url)) return null;
+    const destination = parseLinkDestination(text, text_end + 2) orelse return null;
+    if (!isValidLinkUrl(destination.url)) return null;
     return .{
         .text = text[start + 1 .. text_end],
-        .url = url,
-        .end = k + 1,
+        .url = destination.url,
+        .end = destination.end,
     };
+}
+
+const LinkDestination = struct {
+    url: []const u8,
+    /// Index just past the closing `)`.
+    end: usize,
+};
+
+/// Parses `(destination "optional title")` starting just after the `(`.
+/// The destination is either `<...>` or a run without spaces whose
+/// parentheses balance; the title is validated and dropped.
+fn parseLinkDestination(text: []const u8, start: usize) ?LinkDestination {
+    var k = skipInlineSpaces(text, start);
+    if (k >= text.len) return null;
+
+    var url: []const u8 = undefined;
+    if (text[k] == '<') {
+        const close = std.mem.indexOfScalarPos(u8, text, k + 1, '>') orelse return null;
+        url = text[k + 1 .. close];
+        for (url) |byte| if (byte == '<' or byte == '\n') return null;
+        k = close + 1;
+    } else {
+        const url_start = k;
+        var depth: usize = 0;
+        while (k < text.len) : (k += 1) {
+            const byte = text[k];
+            if (byte == '\\' and k + 1 < text.len) {
+                k += 1;
+                continue;
+            }
+            if (byte <= ' ' or byte == 0x7f) break;
+            if (byte == '(') {
+                depth += 1;
+            } else if (byte == ')') {
+                if (depth == 0) break;
+                depth -= 1;
+            }
+        }
+        if (depth != 0 or k == url_start) return null;
+        url = text[url_start..k];
+    }
+
+    const after_url = k;
+    k = skipInlineSpaces(text, k);
+    if (k > after_url and k < text.len and text[k] != ')') {
+        k = linkTitleEnd(text, k) orelse return null;
+        k = skipInlineSpaces(text, k);
+    }
+    if (k >= text.len or text[k] != ')') return null;
+    return .{ .url = url, .end = k + 1 };
+}
+
+fn skipInlineSpaces(text: []const u8, start: usize) usize {
+    var k = start;
+    while (k < text.len and (text[k] == ' ' or text[k] == '\t')) : (k += 1) {}
+    return k;
+}
+
+/// Returns the index just past a `"..."`, `'...'`, or `(...)` link title.
+fn linkTitleEnd(text: []const u8, start: usize) ?usize {
+    if (start >= text.len) return null;
+    const closer: u8 = switch (text[start]) {
+        '"' => '"',
+        '\'' => '\'',
+        '(' => ')',
+        else => return null,
+    };
+    var k = start + 1;
+    while (k < text.len) : (k += 1) {
+        if (text[k] == '\\' and k + 1 < text.len) {
+            k += 1;
+            continue;
+        }
+        if (text[k] == '\n') return null;
+        if (text[k] == closer) return k + 1;
+    }
+    return null;
+}
+
+const CodeSpan = struct {
+    content_start: usize,
+    content_end: usize,
+    /// Index just past the closing backtick run.
+    end: usize,
+};
+
+fn backtickRunLength(text: []const u8, start: usize) usize {
+    var end = start;
+    while (end < text.len and text[end] == '`') : (end += 1) {}
+    return end - start;
+}
+
+/// Finds the code span opened by the backtick run at `start`: the content
+/// ends at the next run of exactly the same length. One leading and one
+/// trailing space are stripped when both are present and the content is
+/// not all spaces.
+fn codeSpanAt(text: []const u8, start: usize) ?CodeSpan {
+    const run = backtickRunLength(text, start);
+    if (run == 0) return null;
+    var k = start + run;
+    while (k < text.len) {
+        if (text[k] != '`') {
+            k += 1;
+            continue;
+        }
+        const candidate = backtickRunLength(text, k);
+        if (candidate == run) {
+            var content_start = start + run;
+            var content_end = k;
+            const content = text[content_start..content_end];
+            if (content.len >= 2 and content[0] == ' ' and content[content.len - 1] == ' ' and
+                std.mem.trim(u8, content, " ").len > 0)
+            {
+                content_start += 1;
+                content_end -= 1;
+            }
+            return .{ .content_start = content_start, .content_end = content_end, .end = k + run };
+        }
+        k += candidate;
+    }
+    return null;
+}
+
+const DecodedEntity = struct {
+    utf8: [4]u8,
+    len: usize,
+    /// Index just past the terminating `;`.
+    end: usize,
+};
+
+/// Decodes the HTML entities models commonly emit plus numeric references.
+fn decodeEntity(text: []const u8, start: usize) ?DecodedEntity {
+    if (start >= text.len or text[start] != '&') return null;
+    const semicolon = std.mem.indexOfScalarPos(u8, text, start + 1, ';') orelse return null;
+    const name = text[start + 1 .. semicolon];
+    if (name.len == 0 or name.len > 8) return null;
+
+    var codepoint: u21 = undefined;
+    if (name[0] == '#') {
+        const hex = name.len > 1 and (name[1] == 'x' or name[1] == 'X');
+        const digits = if (hex) name[2..] else name[1..];
+        if (digits.len == 0) return null;
+        const value = std.fmt.parseInt(u21, digits, if (hex) 16 else 10) catch return null;
+        codepoint = if (value == 0 or (value >= 0xD800 and value <= 0xDFFF)) 0xFFFD else value;
+    } else {
+        const named = [_]struct { name: []const u8, codepoint: u21 }{
+            .{ .name = "amp", .codepoint = '&' },
+            .{ .name = "lt", .codepoint = '<' },
+            .{ .name = "gt", .codepoint = '>' },
+            .{ .name = "quot", .codepoint = '"' },
+            .{ .name = "apos", .codepoint = '\'' },
+            .{ .name = "nbsp", .codepoint = 0xA0 },
+            .{ .name = "copy", .codepoint = 0xA9 },
+            .{ .name = "reg", .codepoint = 0xAE },
+            .{ .name = "hellip", .codepoint = 0x2026 },
+            .{ .name = "mdash", .codepoint = 0x2014 },
+            .{ .name = "ndash", .codepoint = 0x2013 },
+            .{ .name = "larr", .codepoint = 0x2190 },
+            .{ .name = "rarr", .codepoint = 0x2192 },
+        };
+        codepoint = for (named) |entry| {
+            if (std.mem.eql(u8, entry.name, name)) break entry.codepoint;
+        } else return null;
+    }
+
+    var decoded: DecodedEntity = .{ .utf8 = undefined, .len = 0, .end = semicolon + 1 };
+    decoded.len = std.unicode.utf8Encode(codepoint, &decoded.utf8) catch return null;
+    return decoded;
 }
 
 fn parseAngleAutolink(text: []const u8, start: usize) ?InlineLink {

--- a/src/core/agent/presentation/inline_render.zig
+++ b/src/core/agent/presentation/inline_render.zig
@@ -533,11 +533,15 @@ const DecodedEntity = struct {
 };
 
 /// Decodes the HTML entities models commonly emit plus numeric references.
+const max_entity_name_len = 8;
+
 fn decodeEntity(text: []const u8, start: usize) ?DecodedEntity {
     if (start >= text.len or text[start] != '&') return null;
-    const semicolon = std.mem.indexOfScalarPos(u8, text, start + 1, ';') orelse return null;
+    // Bound the terminator search so a line full of ampersands stays linear.
+    const window_end = @min(text.len, start + 1 + max_entity_name_len + 1);
+    const semicolon = std.mem.indexOfScalarPos(u8, text[0..window_end], start + 1, ';') orelse return null;
     const name = text[start + 1 .. semicolon];
-    if (name.len == 0 or name.len > 8) return null;
+    if (name.len == 0) return null;
 
     var codepoint: u21 = undefined;
     if (name[0] == '#') {
@@ -545,6 +549,9 @@ fn decodeEntity(text: []const u8, start: usize) ?DecodedEntity {
         const digits = if (hex) name[2..] else name[1..];
         if (digits.len == 0) return null;
         const value = std.fmt.parseInt(u21, digits, if (hex) 16 else 10) catch return null;
+        // Control characters would reach the terminal as real control bytes,
+        // so the reference stays literal instead of decoding.
+        if (value != 0 and (value < 0x20 or (value >= 0x7F and value <= 0x9F))) return null;
         codepoint = if (value == 0 or (value >= 0xD800 and value <= 0xDFFF)) 0xFFFD else value;
     } else {
         const named = [_]struct { name: []const u8, codepoint: u21 }{

--- a/src/ui/resize_tests.zig
+++ b/src/ui/resize_tests.zig
@@ -2161,6 +2161,67 @@ test "streamed H1 keeps bold underline through shrink and grow" {
     try std.testing.expect(wide_cell.style.flags.underline);
 }
 
+test "streamed link with parenthesized destination keeps the full URL" {
+    var h = try Harness.init(std.testing.allocator, 40, 40, 4);
+    defer h.deinit();
+    try h.shell.initViewport(&h.metrics, 1);
+
+    var processor = assistant_presentation.MarkdownProcessor{};
+    defer processor.deinit(h.alloc);
+    var formatted: std.ArrayList(u8) = .empty;
+    defer formatted.deinit(h.alloc);
+    try processor.push(
+        h.alloc,
+        "See [wiki](https://en.wikipedia.org/wiki/Foo_(bar) \"Foo\") tail\n",
+        &formatted,
+    );
+    try processor.flush(h.alloc, &formatted);
+
+    _ = try h.shell.streamAssistantChunk(h.alloc, &h.metrics, formatted.items);
+    try h.renderTranscriptFrame();
+    try h.flush();
+
+    const row = try findRowContaining(&h, "wiki");
+    try expectRowTrimmedEquals(&h, row, "  See wiki tail");
+    const link_cell = h.vt.cellAt(row, 7) orelse return error.TestMissingLinkCell;
+    try std.testing.expect(link_cell.style.flags.underline);
+    try std.testing.expectEqualStrings(
+        "https://en.wikipedia.org/wiki/Foo_(bar)",
+        h.vt.hyperlinkUrl(link_cell.style.hyperlink_id) orelse return error.TestMissingHyperlink,
+    );
+    const tail_cell = h.vt.cellAt(row, 13) orelse return error.TestMissingTailCell;
+    try std.testing.expectEqual(@as(u32, 0), tail_cell.style.hyperlink_id);
+    try std.testing.expect(!tail_cell.style.flags.underline);
+}
+
+test "streamed double backtick span and entities render as plain characters" {
+    var h = try Harness.init(std.testing.allocator, 40, 40, 4);
+    defer h.deinit();
+    try h.shell.initViewport(&h.metrics, 1);
+
+    var processor = assistant_presentation.MarkdownProcessor{};
+    defer processor.deinit(h.alloc);
+    var formatted: std.ArrayList(u8) = .empty;
+    defer formatted.deinit(h.alloc);
+    try processor.push(h.alloc, "Use ``a ` b`` for &lt;x&gt; &amp; y\n", &formatted);
+    try processor.flush(h.alloc, &formatted);
+
+    _ = try h.shell.streamAssistantChunk(h.alloc, &h.metrics, formatted.items);
+    try h.renderTranscriptFrame();
+    try h.flush();
+
+    const row = try findRowContaining(&h, "Use ");
+    try expectRowTrimmedEquals(&h, row, "  Use a ` b for <x> & y");
+    const code_cell = h.vt.cellAt(row, 7) orelse return error.TestMissingInlineCodeCell;
+    try std.testing.expect(code_cell.style.fg.eql(.{ .indexed = 245 }));
+    const inner_tick = h.vt.cellAt(row, 9) orelse return error.TestMissingInlineCodeCell;
+    try std.testing.expect(inner_tick.style.fg.eql(.{ .indexed = 245 }));
+    const prose_cell = h.vt.cellAt(row, 17) orelse return error.TestMissingProseCell;
+    try std.testing.expect(prose_cell.style.fg.eql(.default));
+    try expectGridNotContains(&h, "``");
+    try expectGridNotContains(&h, "&amp;");
+}
+
 test "streamed inline code color survives shrink and grow" {
     const cases = [_]struct { light: bool, fg: u8 }{
         .{ .light = false, .fg = 245 },

--- a/src/ui/resize_tests.zig
+++ b/src/ui/resize_tests.zig
@@ -2222,6 +2222,26 @@ test "streamed double backtick span and entities render as plain characters" {
     try expectGridNotContains(&h, "&amp;");
 }
 
+test "streamed control character entity cannot erase transcript cells" {
+    var h = try Harness.init(std.testing.allocator, 40, 40, 4);
+    defer h.deinit();
+    try h.shell.initViewport(&h.metrics, 1);
+
+    var processor = assistant_presentation.MarkdownProcessor{};
+    defer processor.deinit(h.alloc);
+    var formatted: std.ArrayList(u8) = .empty;
+    defer formatted.deinit(h.alloc);
+    try processor.push(h.alloc, "keep x&#27;[2Ky and &#x9b;2J end\n", &formatted);
+    try processor.flush(h.alloc, &formatted);
+
+    _ = try h.shell.streamAssistantChunk(h.alloc, &h.metrics, formatted.items);
+    try h.renderTranscriptFrame();
+    try h.flush();
+
+    const row = try findRowContaining(&h, "keep x");
+    try expectRowTrimmedEquals(&h, row, "  keep x&#27;[2Ky and &#x9b;2J end");
+}
+
 test "streamed inline code color survives shrink and grow" {
     const cases = [_]struct { light: bool, fg: u8 }{
         .{ .light = false, .fg = 245 },


### PR DESCRIPTION
## Summary

- Link destinations with balanced parentheses, such as Wikipedia page URLs, keep the full URL in the hyperlink and no longer leave a stray `)` after the link text.
- A link title in double quotes, single quotes, or parentheses is accepted and dropped instead of being appended to the hyperlink target.
- Angle-bracketed link destinations are unwrapped, so the hyperlink target no longer contains the brackets.
- Code spans delimited by two or more backticks close only on a run of the same length, so a span can contain a single backtick without splitting into separate code and prose fragments.
- A run of two or more backticks with no matching closer renders as literal text.
- Named entities such as `&amp;`, `&lt;`, `&gt;`, `&quot;`, and `&nbsp;` and numeric references such as `&#39;` or `&#x2192;` decode to their characters in prose; text inside code spans is left as written.

Stacked on #751.