### PR TITLE
Keep unmatched emphasis and backtick markers literal

### DIFF
--- a/src/core/agent/assistant_presentation.zig
+++ b/src/core/agent/assistant_presentation.zig
@@ -1043,6 +1043,14 @@ test "bare URL punctuation never hides emphasis that follows the URL" {
     try std.testing.expect(std.mem.indexOf(u8, second, ";https://example.com/a\x1b\\") != null);
     try std.testing.expect(std.mem.endsWith(u8, second, "\x1b[23mb* tail"));
 
+    // A delimiter run never closes itself, with or without a URL on the line.
+    out.clearRetainingCapacity();
+    try processor.push(alloc, "text **** https://example.com\ntext ~~~~ https://example.com\ntext **** here\n***both*** https://example.com\n", &out);
+    try std.testing.expect(std.mem.startsWith(u8, out.items, "text **** \x1b]8;"));
+    try std.testing.expect(std.mem.startsWith(u8, tu.nthLine(out.items, 1).?, "text ~~~~ \x1b]8;"));
+    try std.testing.expectEqualStrings("text **** here", tu.nthLine(out.items, 2).?);
+    try std.testing.expect(std.mem.startsWith(u8, tu.nthLine(out.items, 3).?, "\x1b[1m\x1b[3mboth\x1b[22m\x1b[23m \x1b]8;"));
+
     // After an active style ends the URL early, the rest of the line is
     // ordinary markup again: a code span, a bold pair, and another code span.
     out.clearRetainingCapacity();

--- a/src/core/agent/assistant_presentation.zig
+++ b/src/core/agent/assistant_presentation.zig
@@ -1454,8 +1454,8 @@ test "underscore formatted URLs require exact active markers" {
         url: []const u8,
         tail: []const u8,
     }{
-        .{ .input = "_https://example.com/path__ tail\n", .url = "https://example.com/path__", .tail = " tail\x1b[23m\n" },
-        .{ .input = "__https://example.com/path_ tail\n", .url = "https://example.com/path_", .tail = " tail\x1b[22m\n" },
+        .{ .input = "_https://example.com/path__ tail\n", .url = "https://example.com/path__", .tail = " tail\n" },
+        .{ .input = "__https://example.com/path_ tail\n", .url = "https://example.com/path_", .tail = " tail\n" },
     };
 
     for (wrong_closer_cases) |case| {
@@ -1467,10 +1467,12 @@ test "underscore formatted URLs require exact active markers" {
         try processor.push(alloc, case.input, &out);
         try std.testing.expect(std.mem.indexOf(u8, out.items, case.url) != null);
         try std.testing.expect(std.mem.endsWith(u8, out.items, case.tail));
+        try std.testing.expect(std.mem.indexOf(u8, out.items, "\x1b[3m") == null);
+        try std.testing.expect(std.mem.indexOf(u8, out.items, "\x1b[1m") == null);
     }
 }
 
-test "underscore emphasis preserves code literals and closes unpaired spans" {
+test "underscore emphasis preserves code literals and keeps unpaired markers literal" {
     const alloc = std.testing.allocator;
     var processor = MarkdownProcessor{};
     defer processor.deinit(alloc);
@@ -1479,8 +1481,8 @@ test "underscore emphasis preserves code literals and closes unpaired spans" {
 
     try processor.push(alloc, "_unclosed\n__unclosed\n`_literal_ __literal__`\n", &out);
     try std.testing.expectEqualStrings(
-        "\x1b[3munclosed\x1b[23m\n" ++
-            "\x1b[1munclosed\x1b[22m\n" ++
+        "_unclosed\n" ++
+            "__unclosed\n" ++
             "\x1b[38;5;245m_literal_ __literal__\x1b[39m\n",
         out.items,
     );
@@ -3219,7 +3221,7 @@ test "flush emits pending line without newline" {
     try std.testing.expectEqualStrings("partial", out.items);
 }
 
-test "flush closes open styles" {
+test "flush keeps an unmatched emphasis opener literal" {
     const alloc = std.testing.allocator;
     var processor = MarkdownProcessor{};
     defer processor.deinit(alloc);
@@ -3228,10 +3230,10 @@ test "flush closes open styles" {
 
     try processor.push(alloc, "oops **never closed", &out);
     try processor.flush(alloc, &out);
-    try std.testing.expectEqualStrings("oops \x1b[1mnever closed\x1b[22m", out.items);
+    try std.testing.expectEqualStrings("oops **never closed", out.items);
 }
 
-test "flush closes an unpaired inline code span" {
+test "flush keeps an unpaired backtick literal" {
     const alloc = std.testing.allocator;
     var processor = MarkdownProcessor{};
     defer processor.deinit(alloc);
@@ -3240,7 +3242,46 @@ test "flush closes an unpaired inline code span" {
 
     try processor.push(alloc, "run `zig build", &out);
     try processor.flush(alloc, &out);
-    try std.testing.expectEqualStrings("run \x1b[38;5;245mzig build\x1b[39m", out.items);
+    try std.testing.expectEqualStrings("run `zig build", out.items);
+}
+
+test "unmatched asterisk and tilde openers stay literal while matched spans still style" {
+    const alloc = std.testing.allocator;
+    var processor = MarkdownProcessor{};
+    defer processor.deinit(alloc);
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(alloc);
+
+    try processor.push(
+        alloc,
+        "*not a list item\n" ++
+            "**bold** then **open\n" ++
+            "~~gone~~ and ~~stays\n" ++
+            "a ` b **bold**\n" ++
+            "**bold with `code` inside** *it*\n" ++
+            "***both*** and **`code`**\n",
+        &out,
+    );
+    try std.testing.expectEqualStrings(
+        "*not a list item\n" ++
+            "\x1b[1mbold\x1b[22m then **open\n" ++
+            "\x1b[9mgone\x1b[29m and ~~stays\n" ++
+            "a ` b \x1b[1mbold\x1b[22m\n" ++
+            "\x1b[1mbold with \x1b[38;5;245mcode\x1b[39m inside\x1b[22m \x1b[3mit\x1b[23m\n" ++
+            "\x1b[1m\x1b[3mboth\x1b[22m\x1b[23m and \x1b[1m\x1b[38;5;245mcode\x1b[39m\x1b[22m\n",
+        out.items,
+    );
+}
+
+test "heading with unmatched strong marker keeps it literal" {
+    const alloc = std.testing.allocator;
+    var processor = MarkdownProcessor{};
+    defer processor.deinit(alloc);
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(alloc);
+
+    try processor.push(alloc, "## 2 ** 8 and **strong**\n", &out);
+    try std.testing.expectEqualStrings("\x1b[1m2 ** 8 and strong\x1b[22m\n", out.items);
 }
 
 test "header with inline markdown" {

--- a/src/core/agent/assistant_presentation.zig
+++ b/src/core/agent/assistant_presentation.zig
@@ -3288,6 +3288,24 @@ test "underscore emphasis survives a multi backtick code span" {
     );
 }
 
+test "closer lookahead skips consumed links the same way the renderer does" {
+    const alloc = std.testing.allocator;
+    var processor = MarkdownProcessor{};
+    defer processor.deinit(alloc);
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(alloc);
+
+    // A backtick inside link text is not a code opener, so the bold pair after
+    // the link still styles. A star inside a real code span is not a closer,
+    // so the unmatched opener stays literal.
+    try processor.push(alloc, "[use `](https://example.com) **bold** `code`\n[use `](https://example.com) *open `code*`\n", &out);
+    const first = tu.nthLine(out.items, 0).?;
+    try std.testing.expect(std.mem.endsWith(u8, first, " \x1b[1mbold\x1b[22m \x1b[38;5;245mcode\x1b[39m"));
+    const second = tu.nthLine(out.items, 1).?;
+    try std.testing.expect(std.mem.endsWith(u8, second, " *open \x1b[38;5;245mcode*\x1b[39m"));
+    try std.testing.expect(std.mem.indexOf(u8, second, "\x1b[3m") == null);
+}
+
 test "long line of unmatched openers renders in linear time" {
     const alloc = std.testing.allocator;
     var processor = MarkdownProcessor{};

--- a/src/core/agent/assistant_presentation.zig
+++ b/src/core/agent/assistant_presentation.zig
@@ -1024,6 +1024,26 @@ test "unsafe bare URL renders literally" {
     try std.testing.expect(std.mem.find(u8, out.items, "\x1b]8;") == null);
 }
 
+test "bare URL punctuation never hides emphasis that follows the URL" {
+    const alloc = std.testing.allocator;
+    var processor = MarkdownProcessor{};
+    defer processor.deinit(alloc);
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(alloc);
+
+    // With no active style the whole URL is one link, including its backticks
+    // and star, and the bold pair after it still styles.
+    try processor.push(alloc, "https://example.com/`x*y` **bold** `code`\n*https://example.com/a*b* tail\n", &out);
+    const first = tu.nthLine(out.items, 0).?;
+    try std.testing.expect(std.mem.indexOf(u8, first, ";https://example.com/`x*y`\x1b\\") != null);
+    try std.testing.expect(std.mem.endsWith(u8, first, " \x1b[1mbold\x1b[22m \x1b[38;5;245mcode\x1b[39m"));
+    // With italic active the URL stops at its first star, which closes it.
+    const second = tu.nthLine(out.items, 1).?;
+    try std.testing.expect(std.mem.startsWith(u8, second, "\x1b[3m"));
+    try std.testing.expect(std.mem.indexOf(u8, second, ";https://example.com/a\x1b\\") != null);
+    try std.testing.expect(std.mem.endsWith(u8, second, "\x1b[23mb* tail"));
+}
+
 test "bare URLs leave closing emphasis delimiters for the inline scanner" {
     const alloc = std.testing.allocator;
     var processor = MarkdownProcessor{};

--- a/src/core/agent/assistant_presentation.zig
+++ b/src/core/agent/assistant_presentation.zig
@@ -1049,6 +1049,13 @@ test "bare URL punctuation never hides emphasis that follows the URL" {
     try std.testing.expect(std.mem.startsWith(u8, out.items, "text **** \x1b]8;"));
     try std.testing.expect(std.mem.startsWith(u8, tu.nthLine(out.items, 1).?, "text ~~~~ \x1b]8;"));
     try std.testing.expectEqualStrings("text **** here", tu.nthLine(out.items, 2).?);
+    // A run followed by whitespace cannot open even when a later closer exists.
+    out.clearRetainingCapacity();
+    try processor.push(alloc, "text **** here **bold** and ~~~~ then ~~gone~~ and *** https://example.com ***both***\n", &out);
+    try std.testing.expect(std.mem.startsWith(u8, out.items, "text **** here \x1b[1mbold\x1b[22m and ~~~~ then \x1b[9mgone\x1b[29m and *** \x1b]8;"));
+    try std.testing.expect(std.mem.endsWith(u8, out.items, " \x1b[1m\x1b[3mboth\x1b[22m\x1b[23m\n"));
+    out.clearRetainingCapacity();
+    try processor.push(alloc, "text **** https://example.com\ntext ~~~~ https://example.com\ntext **** here\n***both*** https://example.com\n", &out);
     try std.testing.expect(std.mem.startsWith(u8, tu.nthLine(out.items, 3).?, "\x1b[1m\x1b[3mboth\x1b[22m\x1b[23m \x1b]8;"));
 
     // After an active style ends the URL early, the rest of the line is

--- a/src/core/agent/assistant_presentation.zig
+++ b/src/core/agent/assistant_presentation.zig
@@ -1042,6 +1042,18 @@ test "bare URL punctuation never hides emphasis that follows the URL" {
     try std.testing.expect(std.mem.startsWith(u8, second, "\x1b[3m"));
     try std.testing.expect(std.mem.indexOf(u8, second, ";https://example.com/a\x1b\\") != null);
     try std.testing.expect(std.mem.endsWith(u8, second, "\x1b[23mb* tail"));
+
+    // After an active style ends the URL early, the rest of the line is
+    // ordinary markup again: a code span, a bold pair, and another code span.
+    out.clearRetainingCapacity();
+    try processor.push(alloc, "*https://example.com/a*`some code` **bold** `x`\n", &out);
+    try std.testing.expect(std.mem.startsWith(u8, out.items, "\x1b[3m"));
+    try std.testing.expect(std.mem.indexOf(u8, out.items, ";https://example.com/a\x1b\\") != null);
+    try std.testing.expect(std.mem.endsWith(
+        u8,
+        out.items,
+        "\x1b[23m\x1b[38;5;245msome code\x1b[39m \x1b[1mbold\x1b[22m \x1b[38;5;245mx\x1b[39m\n",
+    ));
 }
 
 test "bare URLs leave closing emphasis delimiters for the inline scanner" {
@@ -3339,13 +3351,27 @@ test "long line of unmatched openers renders in linear time" {
     try line.append(alloc, '\n');
 
     const io_mod = @import("../shared/io.zig");
-    const started = io_mod.nanoTimestamp();
+    var started = io_mod.nanoTimestamp();
     try processor.push(alloc, line.items, &out);
-    const elapsed_ms = @divTrunc(io_mod.nanoTimestamp() - started, std.time.ns_per_ms);
+    var elapsed_ms = @divTrunc(io_mod.nanoTimestamp() - started, std.time.ns_per_ms);
 
     try std.testing.expectEqualStrings(line.items, out.items);
     // The quadratic lookahead took hundreds of milliseconds for this input.
     try std.testing.expect(elapsed_ms < 200);
+
+    // A bare URL switches lookahead to the exact walk, whose per-line budget
+    // keeps a long malformed line bounded as well.
+    out.clearRetainingCapacity();
+    line.clearRetainingCapacity();
+    for (0..20_000) |_| try line.appendSlice(alloc, "*a https://example.com/b _c ~~d ");
+    try line.append(alloc, '\n');
+    started = io_mod.nanoTimestamp();
+    try processor.push(alloc, line.items, &out);
+    elapsed_ms = @divTrunc(io_mod.nanoTimestamp() - started, std.time.ns_per_ms);
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "\x1b[3m") == null);
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "\x1b[1m") == null);
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "\x1b[9m") == null);
+    try std.testing.expect(elapsed_ms < 500);
 }
 
 test "heading with unmatched strong marker keeps it literal" {

--- a/src/core/agent/assistant_presentation.zig
+++ b/src/core/agent/assistant_presentation.zig
@@ -3380,6 +3380,19 @@ test "long line of unmatched openers renders in linear time" {
     try std.testing.expect(std.mem.indexOf(u8, out.items, "\x1b[1m") == null);
     try std.testing.expect(std.mem.indexOf(u8, out.items, "\x1b[9m") == null);
     try std.testing.expect(elapsed_ms < 500);
+
+    // A long trailing marker run after a URL must not be rescanned per byte.
+    out.clearRetainingCapacity();
+    line.clearRetainingCapacity();
+    try line.appendSlice(alloc, "https://example.com ");
+    try line.appendNTimes(alloc, '*', 64 * 1024);
+    try line.append(alloc, '\n');
+    started = io_mod.nanoTimestamp();
+    try processor.push(alloc, line.items, &out);
+    elapsed_ms = @divTrunc(io_mod.nanoTimestamp() - started, std.time.ns_per_ms);
+    try std.testing.expect(std.mem.endsWith(u8, out.items, line.items["https://example.com".len..]));
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "\x1b[1m") == null);
+    try std.testing.expect(elapsed_ms < 200);
 }
 
 test "heading with unmatched strong marker keeps it literal" {

--- a/src/core/agent/assistant_presentation.zig
+++ b/src/core/agent/assistant_presentation.zig
@@ -1049,6 +1049,10 @@ test "bare URL punctuation never hides emphasis that follows the URL" {
     try std.testing.expect(std.mem.startsWith(u8, out.items, "text **** \x1b]8;"));
     try std.testing.expect(std.mem.startsWith(u8, tu.nthLine(out.items, 1).?, "text ~~~~ \x1b]8;"));
     try std.testing.expectEqualStrings("text **** here", tu.nthLine(out.items, 2).?);
+    // A run that cannot open bold still lets a later star close active italic.
+    out.clearRetainingCapacity();
+    try processor.push(alloc, "See *italic** plain\n", &out);
+    try std.testing.expectEqualStrings("See \x1b[3mitalic*\x1b[23m plain\n", out.items);
     // A run followed by whitespace cannot open even when a later closer exists.
     out.clearRetainingCapacity();
     try processor.push(alloc, "text **** here **bold** and ~~~~ then ~~gone~~ and *** https://example.com ***both***\n", &out);
@@ -3387,6 +3391,18 @@ test "long line of unmatched openers renders in linear time" {
     try std.testing.expect(std.mem.indexOf(u8, out.items, "\x1b[1m") == null);
     try std.testing.expect(std.mem.indexOf(u8, out.items, "\x1b[9m") == null);
     try std.testing.expect(elapsed_ms < 500);
+
+    // A long run followed by content is measured once, with or without a URL.
+    out.clearRetainingCapacity();
+    line.clearRetainingCapacity();
+    try line.appendSlice(alloc, "text ");
+    try line.appendNTimes(alloc, '*', 64 * 1024);
+    try line.appendSlice(alloc, "x\n");
+    started = io_mod.nanoTimestamp();
+    try processor.push(alloc, line.items, &out);
+    elapsed_ms = @divTrunc(io_mod.nanoTimestamp() - started, std.time.ns_per_ms);
+    try std.testing.expectEqualStrings(line.items, out.items);
+    try std.testing.expect(elapsed_ms < 200);
 
     // A long trailing marker run after a URL must not be rescanned per byte.
     out.clearRetainingCapacity();

--- a/src/core/agent/assistant_presentation.zig
+++ b/src/core/agent/assistant_presentation.zig
@@ -3273,6 +3273,43 @@ test "unmatched asterisk and tilde openers stay literal while matched spans stil
     );
 }
 
+test "underscore emphasis survives a multi backtick code span" {
+    const alloc = std.testing.allocator;
+    var processor = MarkdownProcessor{};
+    defer processor.deinit(alloc);
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(alloc);
+
+    try processor.push(alloc, "See _a ``b`c`` d_ end\n__x ``y`z`` w__ *p ``q`r`` s* \\_not_\n", &out);
+    try std.testing.expectEqualStrings(
+        "See \x1b[3ma \x1b[38;5;245mb`c\x1b[39m d\x1b[23m end\n" ++
+            "\x1b[1mx \x1b[38;5;245my`z\x1b[39m w\x1b[22m \x1b[3mp \x1b[38;5;245mq`r\x1b[39m s\x1b[23m _not_\n",
+        out.items,
+    );
+}
+
+test "long line of unmatched openers renders in linear time" {
+    const alloc = std.testing.allocator;
+    var processor = MarkdownProcessor{};
+    defer processor.deinit(alloc);
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(alloc);
+
+    var line: std.ArrayList(u8) = .empty;
+    defer line.deinit(alloc);
+    for (0..40_000) |_| try line.appendSlice(alloc, "*a _b ~~c ");
+    try line.append(alloc, '\n');
+
+    const io_mod = @import("../shared/io.zig");
+    const started = io_mod.nanoTimestamp();
+    try processor.push(alloc, line.items, &out);
+    const elapsed_ms = @divTrunc(io_mod.nanoTimestamp() - started, std.time.ns_per_ms);
+
+    try std.testing.expectEqualStrings(line.items, out.items);
+    // The quadratic lookahead took hundreds of milliseconds for this input.
+    try std.testing.expect(elapsed_ms < 200);
+}
+
 test "heading with unmatched strong marker keeps it literal" {
     const alloc = std.testing.allocator;
     var processor = MarkdownProcessor{};

--- a/src/core/agent/presentation/inline_render.zig
+++ b/src/core/agent/presentation/inline_render.zig
@@ -67,10 +67,17 @@ pub fn writeInline(
     var in_underscore_italic: bool = false;
     var in_strike: bool = false;
     var link_admission_suppressed_until: usize = 0;
-    const closers = CloserIndex.build(text);
+    var closers = CloserLookahead.init(text);
 
     while (i < text.len) {
         const c = text[i];
+        const styles: StyleState = .{
+            .bold = in_bold,
+            .italic = in_italic,
+            .underscore_bold = in_underscore_bold,
+            .underscore_italic = in_underscore_italic,
+            .strike = in_strike,
+        };
 
         if (c == '`') {
             if (codeSpanAt(text, i)) |span| {
@@ -183,7 +190,7 @@ pub fn writeInline(
                 try out.appendSlice(alloc, ansi.strike_close);
                 in_strike = false;
             } else {
-                if (i + 2 >= text.len or tu.isSpace(text[i + 2]) or !closers.hasAtOrAfter(.tilde2, i + 2)) {
+                if (i + 2 >= text.len or tu.isSpace(text[i + 2]) or !closers.hasCloser(text, .tilde2, i + 2, styles, link_admission_suppressed_until)) {
                     try out.append(alloc, c);
                     i += 1;
                     continue;
@@ -206,7 +213,7 @@ pub fn writeInline(
                 in_bold = false;
                 if (in_underscore_bold) try out.appendSlice(alloc, ansi.bold_open);
             } else {
-                if (i + 2 >= text.len or tu.isSpace(text[i + 2]) or !closers.hasAtOrAfter(.star2, i + 2)) {
+                if (i + 2 >= text.len or tu.isSpace(text[i + 2]) or !closers.hasCloser(text, .star2, i + 2, styles, link_admission_suppressed_until)) {
                     try out.append(alloc, c);
                     i += 1;
                     continue;
@@ -229,7 +236,7 @@ pub fn writeInline(
                 in_underscore_bold = false;
                 if (in_bold) try out.appendSlice(alloc, ansi.bold_open);
             } else {
-                if (!tu.isValidUnderscoreOpen(text, i, 2) or !closers.hasAtOrAfter(.under2, i + 2)) {
+                if (!tu.isValidUnderscoreOpen(text, i, 2) or !closers.hasCloser(text, .under2, i + 2, styles, link_admission_suppressed_until)) {
                     try out.append(alloc, c);
                     i += 1;
                     continue;
@@ -252,7 +259,7 @@ pub fn writeInline(
                 in_underscore_italic = false;
                 if (in_italic) try out.appendSlice(alloc, ansi.italic_open);
             } else {
-                if (!tu.isValidUnderscoreOpen(text, i, 1) or !closers.hasAtOrAfter(.under1, i + 1)) {
+                if (!tu.isValidUnderscoreOpen(text, i, 1) or !closers.hasCloser(text, .under1, i + 1, styles, link_admission_suppressed_until)) {
                     try out.append(alloc, c);
                     i += 1;
                     continue;
@@ -275,7 +282,7 @@ pub fn writeInline(
                 in_italic = false;
                 if (in_underscore_italic) try out.appendSlice(alloc, ansi.italic_open);
             } else {
-                if (i + 1 >= text.len or tu.isSpace(text[i + 1]) or !closers.hasAtOrAfter(.star1, i + 1)) {
+                if (i + 1 >= text.len or tu.isSpace(text[i + 1]) or !closers.hasCloser(text, .star1, i + 1, styles, link_admission_suppressed_until)) {
                     try out.append(alloc, c);
                     i += 1;
                     continue;
@@ -298,17 +305,49 @@ pub fn writeInline(
     if (in_strike) try out.appendSlice(alloc, ansi.strike_close);
 }
 
+/// Emphasis styles active in the inline renderer at one position. Bare URL
+/// boundaries depend on these, so lookahead must carry them.
+const StyleState = struct {
+    bold: bool = false,
+    italic: bool = false,
+    underscore_bold: bool = false,
+    underscore_italic: bool = false,
+    strike: bool = false,
+};
+
+const DelimiterKind = enum { star1, star2, tilde2, under1, under2 };
+
+/// True when the delimiter run at `i` would close `kind` in the renderer:
+/// a star or tilde run of sufficient length not preceded by a space, or a
+/// valid underscore close.
+fn isCloserAt(text: []const u8, i: usize, kind: DelimiterKind) bool {
+    const c = text[i];
+    switch (kind) {
+        .star1, .star2, .tilde2 => {
+            const marker: u8 = if (kind == .tilde2) '~' else '*';
+            if (c != marker or i == 0 or tu.isSpace(text[i - 1])) return false;
+            if (kind == .star1) return true;
+            return i + 1 < text.len and text[i + 1] == marker;
+        },
+        .under1 => return c == '_' and tu.isValidUnderscoreClose(text, i, 1),
+        .under2 => return c == '_' and tu.isValidUnderscoreClose(text, i, 2),
+    }
+}
+
 /// Walks the constructs the inline renderer consumes whole, so delimiter
 /// lookahead never counts a marker inside an escape, code span, image, link,
 /// autolink, or bare URL. Mirrors the renderer's malformed-link suppression.
 const ConsumedSpans = struct {
     suppressed_until: usize = 0,
+    /// Styles assumed active during the walk; they decide where a bare URL
+    /// ends. Null consumes URLs at their full extent.
+    styles: ?StyleState = null,
 
     const Consumed = union(enum) {
         /// Opaque construct; nothing inside can act as a delimiter.
         skip: usize,
-        /// Bare URL at its full extent. An active style would terminate the
-        /// URL at a delimiter inside it, so those bytes are still candidate
+        /// Bare URL. With no style context an active style could still end
+        /// the URL at a delimiter inside it, so those bytes remain candidate
         /// closers, but they are never code or link syntax.
         bare_url: usize,
     };
@@ -341,7 +380,13 @@ const ConsumedSpans = struct {
             self.suppress(angleAutolinkCandidateEnd(text, i));
         }
         if (i >= self.suppressed_until) {
-            if (parseBareUrl(text, i, false, false, false, false, false)) |link| return .{ .bare_url = link.end };
+            if (self.styles) |styles| {
+                if (parseBareUrl(text, i, styles.bold, styles.italic, styles.underscore_bold, styles.underscore_italic, styles.strike)) |link| {
+                    return .{ .skip = link.end };
+                }
+            } else if (parseBareUrl(text, i, false, false, false, false, false)) |link| {
+                return .{ .bare_url = link.end };
+            }
         }
         return null;
     }
@@ -351,12 +396,68 @@ const ConsumedSpans = struct {
     }
 };
 
+/// Answers "does a closer for this opener exist later on the line" without
+/// rescanning the line for every unmatched opener.
+///
+/// Lines without a bare URL use a one-pass index of the last valid closer per
+/// delimiter, which is exact because every other consumed construct is
+/// independent of emphasis state. Lines with a bare URL walk from the opener
+/// with the renderer's actual styles, since an active style ends a URL early
+/// and changes what follows; a per-line byte budget bounds that walk and
+/// falls back to the index when exhausted.
+const CloserLookahead = struct {
+    index: CloserIndex,
+    has_bare_url: bool,
+    walk_budget: usize = 256 * 1024,
+
+    fn init(text: []const u8) CloserLookahead {
+        return .{
+            .index = CloserIndex.build(text),
+            .has_bare_url = std.mem.find(u8, text, "://") != null,
+        };
+    }
+
+    fn hasCloser(
+        self: *CloserLookahead,
+        text: []const u8,
+        kind: DelimiterKind,
+        start: usize,
+        styles: StyleState,
+        suppressed_until: usize,
+    ) bool {
+        if (!self.has_bare_url or self.walk_budget == 0) return self.index.hasAtOrAfter(kind, start);
+
+        var walk_styles = styles;
+        switch (kind) {
+            .star1 => walk_styles.italic = true,
+            .star2 => walk_styles.bold = true,
+            .tilde2 => walk_styles.strike = true,
+            .under1 => walk_styles.underscore_italic = true,
+            .under2 => walk_styles.underscore_bold = true,
+        }
+        var consumed: ConsumedSpans = .{ .suppressed_until = suppressed_until, .styles = walk_styles };
+        var i = start;
+        while (i < text.len) {
+            if (self.walk_budget == 0) return self.index.hasAtOrAfter(kind, i);
+            const step_start = i;
+            defer self.walk_budget -|= i - step_start;
+            if (consumed.endAt(text, i)) |span| {
+                i = switch (span) {
+                    .skip, .bare_url => |next| next,
+                };
+                continue;
+            }
+            if (isCloserAt(text, i, kind)) return true;
+            i += 1;
+        }
+        return false;
+    }
+};
+
 /// Last position of a valid closing run for each emphasis delimiter, built in
 /// one pass per line so every opener check is constant time. An opener at `i`
 /// has a closer when the last valid closer sits at or after the opener's end.
 const CloserIndex = struct {
-    const Kind = enum { star1, star2, tilde2, under1, under2 };
-
     last: [5]?usize = .{ null, null, null, null, null },
 
     fn build(text: []const u8) CloserIndex {
@@ -404,11 +505,11 @@ const CloserIndex = struct {
         return i + 1;
     }
 
-    fn set(self: *CloserIndex, kind: Kind, pos: usize) void {
+    fn set(self: *CloserIndex, kind: DelimiterKind, pos: usize) void {
         self.last[@intFromEnum(kind)] = pos;
     }
 
-    fn hasAtOrAfter(self: CloserIndex, kind: Kind, start: usize) bool {
+    fn hasAtOrAfter(self: CloserIndex, kind: DelimiterKind, start: usize) bool {
         const pos = self.last[@intFromEnum(kind)] orelse return false;
         return pos >= start;
     }

--- a/src/core/agent/presentation/inline_render.zig
+++ b/src/core/agent/presentation/inline_render.zig
@@ -16,36 +16,32 @@ pub fn writeInlineNoBold(
     defer stripped.deinit(alloc);
 
     var i: usize = 0;
-    var in_code: bool = false;
     while (i < text.len) {
         const c = text[i];
         if (c == '`') {
-            if (!in_code) {
-                if (codeSpanAt(text, i)) |span| {
-                    try stripped.appendSlice(alloc, text[i..span.end]);
-                    i = span.end;
-                    continue;
-                }
+            if (codeSpanAt(text, i)) |span| {
+                try stripped.appendSlice(alloc, text[i..span.end]);
+                i = span.end;
+                continue;
             }
             const run = backtickRunLength(text, i);
-            if (run == 1) in_code = !in_code;
             try stripped.appendSlice(alloc, text[i .. i + run]);
             i += run;
             continue;
         }
-        if (!in_code and c == '\\' and i + 1 < text.len and tu.isEscapedPunctuationAt(text, i + 1)) {
+        if (c == '\\' and i + 1 < text.len and tu.isEscapedPunctuationAt(text, i + 1)) {
             try stripped.appendSlice(alloc, text[i .. i + 2]);
             i += 2;
             continue;
         }
-        if (!in_code and c == '_' and tu.isValidUnderscoreOpen(text, i, 2)) {
+        if (c == '_' and tu.isValidUnderscoreOpen(text, i, 2)) {
             if (tu.findUnderscoreCloser(text, i + 2, 2)) |closer| {
                 try stripped.appendSlice(alloc, text[i + 2 .. closer]);
                 i = closer + 2;
                 continue;
             }
         }
-        if (!in_code and i + 1 < text.len and c == '*' and text[i + 1] == '*') {
+        if (i + 1 < text.len and c == '*' and text[i + 1] == '*' and (i + 2 < text.len and !tu.isSpace(text[i + 2]) or (i > 0 and !tu.isSpace(text[i - 1])))) {
             i += 2;
             continue;
         }
@@ -70,43 +66,23 @@ pub fn writeInline(
     var in_underscore_bold: bool = false;
     var in_underscore_italic: bool = false;
     var in_strike: bool = false;
-    var in_code: bool = false;
     var link_admission_suppressed_until: usize = 0;
 
     while (i < text.len) {
         const c = text[i];
 
         if (c == '`') {
-            if (!in_code) {
-                if (codeSpanAt(text, i)) |span| {
-                    try out.appendSlice(alloc, ansi.inline_code_open);
-                    try out.appendSlice(alloc, text[span.content_start..span.content_end]);
-                    try out.appendSlice(alloc, ansi.inline_code_close);
-                    i = span.end;
-                    continue;
-                }
-            }
-            const run = backtickRunLength(text, i);
-            if (run > 1) {
-                // A longer run without a partner is literal text.
-                try out.appendSlice(alloc, text[i .. i + run]);
-                i += run;
+            if (codeSpanAt(text, i)) |span| {
+                try out.appendSlice(alloc, ansi.inline_code_open);
+                try out.appendSlice(alloc, text[span.content_start..span.content_end]);
+                try out.appendSlice(alloc, ansi.inline_code_close);
+                i = span.end;
                 continue;
             }
-            if (in_code) {
-                try out.appendSlice(alloc, ansi.inline_code_close);
-                in_code = false;
-            } else {
-                try out.appendSlice(alloc, ansi.inline_code_open);
-                in_code = true;
-            }
-            i += 1;
-            continue;
-        }
-
-        if (in_code) {
-            try out.append(alloc, c);
-            i += 1;
+            // A backtick run without a partner is literal text.
+            const run = backtickRunLength(text, i);
+            try out.appendSlice(alloc, text[i .. i + run]);
+            i += run;
             continue;
         }
 
@@ -206,7 +182,7 @@ pub fn writeInline(
                 try out.appendSlice(alloc, ansi.strike_close);
                 in_strike = false;
             } else {
-                if (i + 2 >= text.len or tu.isSpace(text[i + 2])) {
+                if (i + 2 >= text.len or tu.isSpace(text[i + 2]) or !hasRunCloser(text, i + 2, '~', 2)) {
                     try out.append(alloc, c);
                     i += 1;
                     continue;
@@ -229,7 +205,7 @@ pub fn writeInline(
                 in_bold = false;
                 if (in_underscore_bold) try out.appendSlice(alloc, ansi.bold_open);
             } else {
-                if (i + 2 >= text.len or tu.isSpace(text[i + 2])) {
+                if (i + 2 >= text.len or tu.isSpace(text[i + 2]) or !hasRunCloser(text, i + 2, '*', 2)) {
                     try out.append(alloc, c);
                     i += 1;
                     continue;
@@ -252,7 +228,7 @@ pub fn writeInline(
                 in_underscore_bold = false;
                 if (in_bold) try out.appendSlice(alloc, ansi.bold_open);
             } else {
-                if (!tu.isValidUnderscoreOpen(text, i, 2)) {
+                if (!tu.isValidUnderscoreOpen(text, i, 2) or tu.findUnderscoreCloser(text, i + 2, 2) == null) {
                     try out.append(alloc, c);
                     i += 1;
                     continue;
@@ -275,7 +251,7 @@ pub fn writeInline(
                 in_underscore_italic = false;
                 if (in_italic) try out.appendSlice(alloc, ansi.italic_open);
             } else {
-                if (!tu.isValidUnderscoreOpen(text, i, 1)) {
+                if (!tu.isValidUnderscoreOpen(text, i, 1) or tu.findUnderscoreCloser(text, i + 1, 1) == null) {
                     try out.append(alloc, c);
                     i += 1;
                     continue;
@@ -298,7 +274,7 @@ pub fn writeInline(
                 in_italic = false;
                 if (in_underscore_italic) try out.appendSlice(alloc, ansi.italic_open);
             } else {
-                if (i + 1 >= text.len or tu.isSpace(text[i + 1])) {
+                if (i + 1 >= text.len or tu.isSpace(text[i + 1]) or !hasRunCloser(text, i + 1, '*', 1)) {
                     try out.append(alloc, c);
                     i += 1;
                     continue;
@@ -319,7 +295,36 @@ pub fn writeInline(
     if (in_underscore_bold) try out.appendSlice(alloc, ansi.bold_close);
     if (in_underscore_italic) try out.appendSlice(alloc, ansi.italic_close);
     if (in_strike) try out.appendSlice(alloc, ansi.strike_close);
-    if (in_code) try out.appendSlice(alloc, ansi.inline_code_close);
+}
+
+/// True when a run of at least `run` `marker` bytes preceded by a non-space
+/// appears at or after `start` outside code spans and escapes.
+fn hasRunCloser(text: []const u8, start: usize, marker: u8, run: usize) bool {
+    var i = start;
+    while (i < text.len) {
+        const c = text[i];
+        if (c == '\\' and i + 1 < text.len) {
+            i += 2;
+            continue;
+        }
+        if (c == '`') {
+            if (codeSpanAt(text, i)) |span| {
+                i = span.end;
+            } else {
+                i += backtickRunLength(text, i);
+            }
+            continue;
+        }
+        if (c == marker) {
+            var end = i;
+            while (end < text.len and text[end] == marker) : (end += 1) {}
+            if (end - i >= run and i > 0 and !tu.isSpace(text[i - 1])) return true;
+            i = end;
+            continue;
+        }
+        i += 1;
+    }
+    return false;
 }
 
 const ParsedFootnoteReference = struct {

--- a/src/core/agent/presentation/inline_render.zig
+++ b/src/core/agent/presentation/inline_render.zig
@@ -304,37 +304,44 @@ pub fn writeInline(
 const ConsumedSpans = struct {
     suppressed_until: usize = 0,
 
-    /// Index just past the construct consumed at `i`, or null when `i` is an
-    /// ordinary byte the renderer inspects for delimiters.
-    fn endAt(self: *ConsumedSpans, text: []const u8, i: usize) ?usize {
+    const Consumed = union(enum) {
+        /// Opaque construct; nothing inside can act as a delimiter.
+        skip: usize,
+        /// Bare URL at its full extent. An active style would terminate the
+        /// URL at a delimiter inside it, so those bytes are still candidate
+        /// closers, but they are never code or link syntax.
+        bare_url: usize,
+    };
+
+    /// The construct consumed at `i`, or null when `i` is an ordinary byte the
+    /// renderer inspects for delimiters.
+    fn endAt(self: *ConsumedSpans, text: []const u8, i: usize) ?Consumed {
         const c = text[i];
         if (c == '\\' and i + 1 < text.len and tu.isEscapedPunctuationAt(text, i + 1)) {
             if (text[i + 1] == '<') self.suppress(angleAutolinkCandidateEnd(text, i + 1));
             if (text[i + 1] == '[') {
                 if (malformedInlineLinkCandidateEnd(text, i + 1)) |candidate_end| self.suppress(candidate_end);
             }
-            return i + 2;
+            return .{ .skip = i + 2 };
         }
-        if (c == '`') return if (codeSpanAt(text, i)) |span| span.end else i + backtickRunLength(text, i);
+        if (c == '`') return .{ .skip = if (codeSpanAt(text, i)) |span| span.end else i + backtickRunLength(text, i) };
         if (i >= self.suppressed_until and c == '!' and i + 1 < text.len and text[i + 1] == '[') {
-            if (parseInlineImage(text, i)) |image| return image.end;
+            if (parseInlineImage(text, i)) |image| return .{ .skip = image.end };
             if (malformedInlineLinkCandidateEnd(text, i + 1)) |candidate_end| self.suppress(candidate_end);
         }
         if (c == '[') {
-            if (parseFootnoteReference(text, i)) |reference| return reference.end;
+            if (parseFootnoteReference(text, i)) |reference| return .{ .skip = reference.end };
             if (i >= self.suppressed_until) {
-                if (parseInlineLink(text, i)) |link| return link.end;
+                if (parseInlineLink(text, i)) |link| return .{ .skip = link.end };
                 if (malformedInlineLinkCandidateEnd(text, i)) |candidate_end| self.suppress(candidate_end);
             }
         }
         if (i >= self.suppressed_until and c == '<') {
-            if (parseAngleAutolink(text, i)) |link| return link.end;
+            if (parseAngleAutolink(text, i)) |link| return .{ .skip = link.end };
             self.suppress(angleAutolinkCandidateEnd(text, i));
         }
         if (i >= self.suppressed_until) {
-            // Every delimiter terminates the URL here, so a closer that the
-            // renderer would see while a style is active is never hidden.
-            if (parseBareUrl(text, i, true, true, true, true, true)) |link| return link.end;
+            if (parseBareUrl(text, i, false, false, false, false, false)) |link| return .{ .bare_url = link.end };
         }
         return null;
     }
@@ -357,33 +364,44 @@ const CloserIndex = struct {
         var consumed: ConsumedSpans = .{};
         var i: usize = 0;
         while (i < text.len) {
-            if (consumed.endAt(text, i)) |next| {
-                i = next;
-                continue;
-            }
-            const c = text[i];
-            if (c == '*' or c == '~') {
-                var end = i;
-                while (end < text.len and text[end] == c) : (end += 1) {}
-                if (i > 0 and !tu.isSpace(text[i - 1])) {
-                    const run = end - i;
-                    if (c == '*') {
-                        index.set(.star1, i);
-                        if (run >= 2) index.set(.star2, i);
-                    } else if (run >= 2) {
-                        index.set(.tilde2, i);
-                    }
-                }
-                i = end;
-                continue;
-            }
-            if (c == '_') {
-                if (tu.isValidUnderscoreClose(text, i, 1)) index.set(.under1, i);
-                if (tu.isValidUnderscoreClose(text, i, 2)) index.set(.under2, i);
-            }
-            i += 1;
+            if (consumed.endAt(text, i)) |span| switch (span) {
+                .skip => |next| {
+                    i = next;
+                    continue;
+                },
+                .bare_url => |end| {
+                    while (i < end) i = index.record(text, i);
+                    continue;
+                },
+            };
+            i = index.record(text, i);
         }
         return index;
+    }
+
+    /// Records the delimiter run starting at `i`, if any, and returns the next
+    /// position to inspect.
+    fn record(self: *CloserIndex, text: []const u8, i: usize) usize {
+        const c = text[i];
+        if (c == '*' or c == '~') {
+            var end = i;
+            while (end < text.len and text[end] == c) : (end += 1) {}
+            if (i > 0 and !tu.isSpace(text[i - 1])) {
+                const run = end - i;
+                if (c == '*') {
+                    self.set(.star1, i);
+                    if (run >= 2) self.set(.star2, i);
+                } else if (run >= 2) {
+                    self.set(.tilde2, i);
+                }
+            }
+            return end;
+        }
+        if (c == '_') {
+            if (tu.isValidUnderscoreClose(text, i, 1)) self.set(.under1, i);
+            if (tu.isValidUnderscoreClose(text, i, 2)) self.set(.under2, i);
+        }
+        return i + 1;
     }
 
     fn set(self: *CloserIndex, kind: Kind, pos: usize) void {
@@ -402,10 +420,18 @@ fn findUnderscoreCloser(text: []const u8, start: usize, marker_len: usize) ?usiz
     var consumed: ConsumedSpans = .{};
     var i = start;
     while (i < text.len) {
-        if (consumed.endAt(text, i)) |next| {
-            i = next;
-            continue;
-        }
+        if (consumed.endAt(text, i)) |span| switch (span) {
+            .skip => |next| {
+                i = next;
+                continue;
+            },
+            .bare_url => |end| {
+                while (i < end) : (i += 1) {
+                    if (tu.isValidUnderscoreClose(text, i, marker_len)) return i;
+                }
+                continue;
+            },
+        };
         if (tu.isValidUnderscoreClose(text, i, marker_len)) return i;
         i += 1;
     }

--- a/src/core/agent/presentation/inline_render.zig
+++ b/src/core/agent/presentation/inline_render.zig
@@ -68,6 +68,9 @@ pub fn writeInline(
     var in_strike: bool = false;
     var link_admission_suppressed_until: usize = 0;
     var closers = CloserLookahead.init(text);
+    // End of the star or tilde run containing `i`, measured once per run so
+    // stepping through a long run byte by byte stays linear.
+    var run_end: usize = 0;
 
     while (i < text.len) {
         const c = text[i];
@@ -190,14 +193,12 @@ pub fn writeInline(
                 try out.appendSlice(alloc, ansi.strike_close);
                 in_strike = false;
             } else {
-                if (unopenableRunEnd(text, i, '~')) |end| {
-                    try out.appendSlice(alloc, text[i..end]);
-                    i = end;
-                    continue;
-                }
-                if (!closers.hasCloser(text, .tilde2, i + 2, styles, link_admission_suppressed_until)) {
-                    try out.append(alloc, c);
-                    i += 1;
+                if (i >= run_end) run_end = markerRunEnd(text, i);
+                // Nothing else is closed by a tilde, so a run that cannot open
+                // strikethrough is literal as a whole.
+                if (runIsUnopenable(text, run_end) or !closers.hasCloser(text, .tilde2, i + 2, styles, link_admission_suppressed_until)) {
+                    try out.appendSlice(alloc, text[i..run_end]);
+                    i = run_end;
                     continue;
                 }
                 try out.appendSlice(alloc, ansi.strike_open);
@@ -218,12 +219,16 @@ pub fn writeInline(
                 in_bold = false;
                 if (in_underscore_bold) try out.appendSlice(alloc, ansi.bold_open);
             } else {
-                if (unopenableRunEnd(text, i, '*')) |end| {
-                    try out.appendSlice(alloc, text[i..end]);
-                    i = end;
-                    continue;
-                }
-                if (!closers.hasCloser(text, .star2, i + 2, styles, link_admission_suppressed_until)) {
+                if (i >= run_end) run_end = markerRunEnd(text, i);
+                const unopenable = runIsUnopenable(text, run_end);
+                if (unopenable or !closers.hasCloser(text, .star2, i + 2, styles, link_admission_suppressed_until)) {
+                    // A later star in this run may still close italic or open
+                    // it, so only a run that can do neither is literal whole.
+                    if (!in_italic and (unopenable or !closers.hasCloser(text, .star1, i + 1, styles, link_admission_suppressed_until))) {
+                        try out.appendSlice(alloc, text[i..run_end]);
+                        i = run_end;
+                        continue;
+                    }
                     try out.append(alloc, c);
                     i += 1;
                     continue;
@@ -292,12 +297,7 @@ pub fn writeInline(
                 in_italic = false;
                 if (in_underscore_italic) try out.appendSlice(alloc, ansi.italic_open);
             } else {
-                if (unopenableRunEnd(text, i, '*')) |end| {
-                    try out.appendSlice(alloc, text[i..end]);
-                    i = end;
-                    continue;
-                }
-                if (!closers.hasCloser(text, .star1, i + 1, styles, link_admission_suppressed_until)) {
+                if (i + 1 >= text.len or tu.isSpace(text[i + 1]) or !closers.hasCloser(text, .star1, i + 1, styles, link_admission_suppressed_until)) {
                     try out.append(alloc, c);
                     i += 1;
                     continue;
@@ -320,14 +320,17 @@ pub fn writeInline(
     if (in_strike) try out.appendSlice(alloc, ansi.strike_close);
 }
 
-/// End of the marker run at `i` when that run cannot open a span because it
-/// is followed by whitespace or the end of the line, so the whole run is
-/// literal; null when the run is followed by content.
-fn unopenableRunEnd(text: []const u8, i: usize, marker: u8) ?usize {
+/// End of the run of `text[i]` bytes starting at `i`.
+fn markerRunEnd(text: []const u8, i: usize) usize {
+    const marker = text[i];
     var end = i;
     while (end < text.len and text[end] == marker) : (end += 1) {}
-    if (end >= text.len or tu.isSpace(text[end])) return end;
-    return null;
+    return end;
+}
+
+/// A run followed by whitespace or the end of the line cannot open a span.
+fn runIsUnopenable(text: []const u8, run_end: usize) bool {
+    return run_end >= text.len or tu.isSpace(text[run_end]);
 }
 
 /// Emphasis styles active in the inline renderer at one position. Bare URL

--- a/src/core/agent/presentation/inline_render.zig
+++ b/src/core/agent/presentation/inline_render.zig
@@ -445,7 +445,13 @@ const CloserLookahead = struct {
             .under1, .under2 => null,
         };
         if (run_marker) |marker| {
-            while (i < text.len and text[i] == marker) : (i += 1) {}
+            // The skip is walk work too: charge it to the budget and give up
+            // on a run longer than what remains so a long trailing run is
+            // not rescanned once per byte.
+            const skip_limit = @min(text.len, i + self.walk_budget);
+            while (i < skip_limit and text[i] == marker) : (i += 1) {}
+            self.walk_budget -|= i - start;
+            if (i < text.len and text[i] == marker) return self.index.hasAtOrAfter(kind, start);
         }
         while (i < text.len) {
             if (self.walk_budget == 0) return self.index.hasAtOrAfter(kind, i);

--- a/src/core/agent/presentation/inline_render.zig
+++ b/src/core/agent/presentation/inline_render.zig
@@ -436,7 +436,17 @@ const CloserLookahead = struct {
             .under2 => walk_styles.underscore_bold = true,
         }
         var consumed: ConsumedSpans = .{ .suppressed_until = suppressed_until, .styles = walk_styles };
+        // A run cannot close itself: skip the remainder of the opener's run
+        // so "****" stays literal instead of becoming an empty span.
         var i = start;
+        const run_marker: ?u8 = switch (kind) {
+            .star1, .star2 => '*',
+            .tilde2 => '~',
+            .under1, .under2 => null,
+        };
+        if (run_marker) |marker| {
+            while (i < text.len and text[i] == marker) : (i += 1) {}
+        }
         while (i < text.len) {
             if (self.walk_budget == 0) return self.index.hasAtOrAfter(kind, i);
             const step_start = i;

--- a/src/core/agent/presentation/inline_render.zig
+++ b/src/core/agent/presentation/inline_render.zig
@@ -35,7 +35,7 @@ pub fn writeInlineNoBold(
             continue;
         }
         if (c == '_' and tu.isValidUnderscoreOpen(text, i, 2)) {
-            if (tu.findUnderscoreCloser(text, i + 2, 2)) |closer| {
+            if (findUnderscoreCloser(text, i + 2, 2)) |closer| {
                 try stripped.appendSlice(alloc, text[i + 2 .. closer]);
                 i = closer + 2;
                 continue;
@@ -67,6 +67,7 @@ pub fn writeInline(
     var in_underscore_italic: bool = false;
     var in_strike: bool = false;
     var link_admission_suppressed_until: usize = 0;
+    const closers = CloserIndex.build(text);
 
     while (i < text.len) {
         const c = text[i];
@@ -182,7 +183,7 @@ pub fn writeInline(
                 try out.appendSlice(alloc, ansi.strike_close);
                 in_strike = false;
             } else {
-                if (i + 2 >= text.len or tu.isSpace(text[i + 2]) or !hasRunCloser(text, i + 2, '~', 2)) {
+                if (i + 2 >= text.len or tu.isSpace(text[i + 2]) or !closers.hasAtOrAfter(.tilde2, i + 2)) {
                     try out.append(alloc, c);
                     i += 1;
                     continue;
@@ -205,7 +206,7 @@ pub fn writeInline(
                 in_bold = false;
                 if (in_underscore_bold) try out.appendSlice(alloc, ansi.bold_open);
             } else {
-                if (i + 2 >= text.len or tu.isSpace(text[i + 2]) or !hasRunCloser(text, i + 2, '*', 2)) {
+                if (i + 2 >= text.len or tu.isSpace(text[i + 2]) or !closers.hasAtOrAfter(.star2, i + 2)) {
                     try out.append(alloc, c);
                     i += 1;
                     continue;
@@ -228,7 +229,7 @@ pub fn writeInline(
                 in_underscore_bold = false;
                 if (in_bold) try out.appendSlice(alloc, ansi.bold_open);
             } else {
-                if (!tu.isValidUnderscoreOpen(text, i, 2) or tu.findUnderscoreCloser(text, i + 2, 2) == null) {
+                if (!tu.isValidUnderscoreOpen(text, i, 2) or !closers.hasAtOrAfter(.under2, i + 2)) {
                     try out.append(alloc, c);
                     i += 1;
                     continue;
@@ -251,7 +252,7 @@ pub fn writeInline(
                 in_underscore_italic = false;
                 if (in_italic) try out.appendSlice(alloc, ansi.italic_open);
             } else {
-                if (!tu.isValidUnderscoreOpen(text, i, 1) or tu.findUnderscoreCloser(text, i + 1, 1) == null) {
+                if (!tu.isValidUnderscoreOpen(text, i, 1) or !closers.hasAtOrAfter(.under1, i + 1)) {
                     try out.append(alloc, c);
                     i += 1;
                     continue;
@@ -274,7 +275,7 @@ pub fn writeInline(
                 in_italic = false;
                 if (in_underscore_italic) try out.appendSlice(alloc, ansi.italic_open);
             } else {
-                if (i + 1 >= text.len or tu.isSpace(text[i + 1]) or !hasRunCloser(text, i + 1, '*', 1)) {
+                if (i + 1 >= text.len or tu.isSpace(text[i + 1]) or !closers.hasAtOrAfter(.star1, i + 1)) {
                     try out.append(alloc, c);
                     i += 1;
                     continue;
@@ -297,34 +298,79 @@ pub fn writeInline(
     if (in_strike) try out.appendSlice(alloc, ansi.strike_close);
 }
 
-/// True when a run of at least `run` `marker` bytes preceded by a non-space
-/// appears at or after `start` outside code spans and escapes.
-fn hasRunCloser(text: []const u8, start: usize, marker: u8, run: usize) bool {
+/// Skips a backslash escape or a backtick run at `i` the same way the inline
+/// walk does, so lookahead and rendering agree on what is literal.
+fn skipEscapeOrCode(text: []const u8, i: usize) ?usize {
+    const c = text[i];
+    if (c == '\\' and i + 1 < text.len) return i + 2;
+    if (c == '`') return if (codeSpanAt(text, i)) |span| span.end else i + backtickRunLength(text, i);
+    return null;
+}
+
+/// Last position of a valid closing run for each emphasis delimiter, built in
+/// one pass per line so every opener check is constant time. An opener at `i`
+/// has a closer when the last valid closer sits at or after the opener's end.
+const CloserIndex = struct {
+    const Kind = enum { star1, star2, tilde2, under1, under2 };
+
+    last: [5]?usize = .{ null, null, null, null, null },
+
+    fn build(text: []const u8) CloserIndex {
+        var index: CloserIndex = .{};
+        var i: usize = 0;
+        while (i < text.len) {
+            if (skipEscapeOrCode(text, i)) |next| {
+                i = next;
+                continue;
+            }
+            const c = text[i];
+            if (c == '*' or c == '~') {
+                var end = i;
+                while (end < text.len and text[end] == c) : (end += 1) {}
+                if (i > 0 and !tu.isSpace(text[i - 1])) {
+                    const run = end - i;
+                    if (c == '*') {
+                        index.set(.star1, i);
+                        if (run >= 2) index.set(.star2, i);
+                    } else if (run >= 2) {
+                        index.set(.tilde2, i);
+                    }
+                }
+                i = end;
+                continue;
+            }
+            if (c == '_') {
+                if (tu.isValidUnderscoreClose(text, i, 1)) index.set(.under1, i);
+                if (tu.isValidUnderscoreClose(text, i, 2)) index.set(.under2, i);
+            }
+            i += 1;
+        }
+        return index;
+    }
+
+    fn set(self: *CloserIndex, kind: Kind, pos: usize) void {
+        self.last[@intFromEnum(kind)] = pos;
+    }
+
+    fn hasAtOrAfter(self: CloserIndex, kind: Kind, start: usize) bool {
+        const pos = self.last[@intFromEnum(kind)] orelse return false;
+        return pos >= start;
+    }
+};
+
+/// First valid underscore closer at or after `start`, skipping code spans by
+/// their real run length so ``a`b`` does not desynchronize the search.
+fn findUnderscoreCloser(text: []const u8, start: usize, marker_len: usize) ?usize {
     var i = start;
     while (i < text.len) {
-        const c = text[i];
-        if (c == '\\' and i + 1 < text.len) {
-            i += 2;
+        if (skipEscapeOrCode(text, i)) |next| {
+            i = next;
             continue;
         }
-        if (c == '`') {
-            if (codeSpanAt(text, i)) |span| {
-                i = span.end;
-            } else {
-                i += backtickRunLength(text, i);
-            }
-            continue;
-        }
-        if (c == marker) {
-            var end = i;
-            while (end < text.len and text[end] == marker) : (end += 1) {}
-            if (end - i >= run and i > 0 and !tu.isSpace(text[i - 1])) return true;
-            i = end;
-            continue;
-        }
+        if (tu.isValidUnderscoreClose(text, i, marker_len)) return i;
         i += 1;
     }
-    return false;
+    return null;
 }
 
 const ParsedFootnoteReference = struct {

--- a/src/core/agent/presentation/inline_render.zig
+++ b/src/core/agent/presentation/inline_render.zig
@@ -298,14 +298,51 @@ pub fn writeInline(
     if (in_strike) try out.appendSlice(alloc, ansi.strike_close);
 }
 
-/// Skips a backslash escape or a backtick run at `i` the same way the inline
-/// walk does, so lookahead and rendering agree on what is literal.
-fn skipEscapeOrCode(text: []const u8, i: usize) ?usize {
-    const c = text[i];
-    if (c == '\\' and i + 1 < text.len) return i + 2;
-    if (c == '`') return if (codeSpanAt(text, i)) |span| span.end else i + backtickRunLength(text, i);
-    return null;
-}
+/// Walks the constructs the inline renderer consumes whole, so delimiter
+/// lookahead never counts a marker inside an escape, code span, image, link,
+/// autolink, or bare URL. Mirrors the renderer's malformed-link suppression.
+const ConsumedSpans = struct {
+    suppressed_until: usize = 0,
+
+    /// Index just past the construct consumed at `i`, or null when `i` is an
+    /// ordinary byte the renderer inspects for delimiters.
+    fn endAt(self: *ConsumedSpans, text: []const u8, i: usize) ?usize {
+        const c = text[i];
+        if (c == '\\' and i + 1 < text.len and tu.isEscapedPunctuationAt(text, i + 1)) {
+            if (text[i + 1] == '<') self.suppress(angleAutolinkCandidateEnd(text, i + 1));
+            if (text[i + 1] == '[') {
+                if (malformedInlineLinkCandidateEnd(text, i + 1)) |candidate_end| self.suppress(candidate_end);
+            }
+            return i + 2;
+        }
+        if (c == '`') return if (codeSpanAt(text, i)) |span| span.end else i + backtickRunLength(text, i);
+        if (i >= self.suppressed_until and c == '!' and i + 1 < text.len and text[i + 1] == '[') {
+            if (parseInlineImage(text, i)) |image| return image.end;
+            if (malformedInlineLinkCandidateEnd(text, i + 1)) |candidate_end| self.suppress(candidate_end);
+        }
+        if (c == '[') {
+            if (parseFootnoteReference(text, i)) |reference| return reference.end;
+            if (i >= self.suppressed_until) {
+                if (parseInlineLink(text, i)) |link| return link.end;
+                if (malformedInlineLinkCandidateEnd(text, i)) |candidate_end| self.suppress(candidate_end);
+            }
+        }
+        if (i >= self.suppressed_until and c == '<') {
+            if (parseAngleAutolink(text, i)) |link| return link.end;
+            self.suppress(angleAutolinkCandidateEnd(text, i));
+        }
+        if (i >= self.suppressed_until) {
+            // Every delimiter terminates the URL here, so a closer that the
+            // renderer would see while a style is active is never hidden.
+            if (parseBareUrl(text, i, true, true, true, true, true)) |link| return link.end;
+        }
+        return null;
+    }
+
+    fn suppress(self: *ConsumedSpans, until: usize) void {
+        self.suppressed_until = @max(self.suppressed_until, until);
+    }
+};
 
 /// Last position of a valid closing run for each emphasis delimiter, built in
 /// one pass per line so every opener check is constant time. An opener at `i`
@@ -317,9 +354,10 @@ const CloserIndex = struct {
 
     fn build(text: []const u8) CloserIndex {
         var index: CloserIndex = .{};
+        var consumed: ConsumedSpans = .{};
         var i: usize = 0;
         while (i < text.len) {
-            if (skipEscapeOrCode(text, i)) |next| {
+            if (consumed.endAt(text, i)) |next| {
                 i = next;
                 continue;
             }
@@ -361,9 +399,10 @@ const CloserIndex = struct {
 /// First valid underscore closer at or after `start`, skipping code spans by
 /// their real run length so ``a`b`` does not desynchronize the search.
 fn findUnderscoreCloser(text: []const u8, start: usize, marker_len: usize) ?usize {
+    var consumed: ConsumedSpans = .{};
     var i = start;
     while (i < text.len) {
-        if (skipEscapeOrCode(text, i)) |next| {
+        if (consumed.endAt(text, i)) |next| {
             i = next;
             continue;
         }

--- a/src/core/agent/presentation/inline_render.zig
+++ b/src/core/agent/presentation/inline_render.zig
@@ -190,7 +190,12 @@ pub fn writeInline(
                 try out.appendSlice(alloc, ansi.strike_close);
                 in_strike = false;
             } else {
-                if (i + 2 >= text.len or tu.isSpace(text[i + 2]) or !closers.hasCloser(text, .tilde2, i + 2, styles, link_admission_suppressed_until)) {
+                if (unopenableRunEnd(text, i, '~')) |end| {
+                    try out.appendSlice(alloc, text[i..end]);
+                    i = end;
+                    continue;
+                }
+                if (!closers.hasCloser(text, .tilde2, i + 2, styles, link_admission_suppressed_until)) {
                     try out.append(alloc, c);
                     i += 1;
                     continue;
@@ -213,7 +218,12 @@ pub fn writeInline(
                 in_bold = false;
                 if (in_underscore_bold) try out.appendSlice(alloc, ansi.bold_open);
             } else {
-                if (i + 2 >= text.len or tu.isSpace(text[i + 2]) or !closers.hasCloser(text, .star2, i + 2, styles, link_admission_suppressed_until)) {
+                if (unopenableRunEnd(text, i, '*')) |end| {
+                    try out.appendSlice(alloc, text[i..end]);
+                    i = end;
+                    continue;
+                }
+                if (!closers.hasCloser(text, .star2, i + 2, styles, link_admission_suppressed_until)) {
                     try out.append(alloc, c);
                     i += 1;
                     continue;
@@ -282,7 +292,12 @@ pub fn writeInline(
                 in_italic = false;
                 if (in_underscore_italic) try out.appendSlice(alloc, ansi.italic_open);
             } else {
-                if (i + 1 >= text.len or tu.isSpace(text[i + 1]) or !closers.hasCloser(text, .star1, i + 1, styles, link_admission_suppressed_until)) {
+                if (unopenableRunEnd(text, i, '*')) |end| {
+                    try out.appendSlice(alloc, text[i..end]);
+                    i = end;
+                    continue;
+                }
+                if (!closers.hasCloser(text, .star1, i + 1, styles, link_admission_suppressed_until)) {
                     try out.append(alloc, c);
                     i += 1;
                     continue;
@@ -303,6 +318,16 @@ pub fn writeInline(
     if (in_underscore_bold) try out.appendSlice(alloc, ansi.bold_close);
     if (in_underscore_italic) try out.appendSlice(alloc, ansi.italic_close);
     if (in_strike) try out.appendSlice(alloc, ansi.strike_close);
+}
+
+/// End of the marker run at `i` when that run cannot open a span because it
+/// is followed by whitespace or the end of the line, so the whole run is
+/// literal; null when the run is followed by content.
+fn unopenableRunEnd(text: []const u8, i: usize, marker: u8) ?usize {
+    var end = i;
+    while (end < text.len and text[end] == marker) : (end += 1) {}
+    if (end >= text.len or tu.isSpace(text[end])) return end;
+    return null;
 }
 
 /// Emphasis styles active in the inline renderer at one position. Bare URL

--- a/src/core/agent/presentation/text_util.zig
+++ b/src/core/agent/presentation/text_util.zig
@@ -98,19 +98,6 @@ pub fn isValidUnderscoreClose(text: []const u8, index: usize, marker_len: usize)
     return after >= text.len or !isAsciiWordByte(text[after]);
 }
 
-pub fn findUnderscoreCloser(text: []const u8, start: usize, marker_len: usize) ?usize {
-    var i = start;
-    var in_code = false;
-    while (i < text.len) : (i += 1) {
-        if (text[i] == '`') {
-            in_code = !in_code;
-            continue;
-        }
-        if (!in_code and isValidUnderscoreClose(text, i, marker_len)) return i;
-    }
-    return null;
-}
-
 pub fn nthLine(buf: []const u8, n: usize) ?[]const u8 {
     var idx: usize = 0;
     var start: usize = 0;

--- a/src/core/agent/runtime/assistant_stream.zig
+++ b/src/core/agent/runtime/assistant_stream.zig
@@ -1034,7 +1034,7 @@ fn assert_frozen_ansi_span_fixture() !void {
         "\x1b[1mName\x1b[22m \xe2\x94\x82 \x1b[1mAge\x1b[22m\n" ++
             "\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\xbc\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\n" ++
             "Ana  \xe2\x94\x82 30 \n",
-        "tail \x1b[1mopen\x1b[22m",
+        "tail **open",
     };
 
     try std.testing.expectEqual(expected_spans.len, capture.text_spans.items.len);

--- a/src/ui/resize_tests.zig
+++ b/src/ui/resize_tests.zig
@@ -2242,6 +2242,40 @@ test "streamed control character entity cannot erase transcript cells" {
     try expectRowTrimmedEquals(&h, row, "  keep x&#27;[2Ky and &#x9b;2J end");
 }
 
+test "streamed unmatched emphasis markers stay literal and unstyled" {
+    var h = try Harness.init(std.testing.allocator, 40, 40, 4);
+    defer h.deinit();
+    try h.shell.initViewport(&h.metrics, 1);
+
+    var processor = assistant_presentation.MarkdownProcessor{};
+    defer processor.deinit(h.alloc);
+    var formatted: std.ArrayList(u8) = .empty;
+    defer formatted.deinit(h.alloc);
+    try processor.push(h.alloc, "*not a list item\n**bold** then **open tail\nrun `zig build\n", &formatted);
+    try processor.flush(h.alloc, &formatted);
+
+    _ = try h.shell.streamAssistantChunk(h.alloc, &h.metrics, formatted.items);
+    try h.renderTranscriptFrame();
+    try h.flush();
+
+    const star_row = try findRowContaining(&h, "not a list");
+    try expectRowTrimmedEquals(&h, star_row, "  *not a list item");
+    const star_cell = h.vt.cellAt(star_row, 4) orelse return error.TestMissingCell;
+    try std.testing.expect(!star_cell.style.flags.italic);
+
+    const bold_row = try findRowContaining(&h, "then");
+    try expectRowTrimmedEquals(&h, bold_row, "  bold then **open tail");
+    const bold_cell = h.vt.cellAt(bold_row, 3) orelse return error.TestMissingCell;
+    try std.testing.expect(bold_cell.style.flags.bold);
+    const open_cell = h.vt.cellAt(bold_row, 15) orelse return error.TestMissingCell;
+    try std.testing.expect(!open_cell.style.flags.bold);
+
+    const code_row = try findRowContaining(&h, "zig build");
+    try expectRowTrimmedEquals(&h, code_row, "  run `zig build");
+    const code_cell = h.vt.cellAt(code_row, 8) orelse return error.TestMissingCell;
+    try std.testing.expect(code_cell.style.fg.eql(.default));
+}
+
 test "streamed inline code color survives shrink and grow" {
     const cases = [_]struct { light: bool, fg: u8 }{
         .{ .light = false, .fg = 245 },

--- a/src/ui/resize_tests.zig
+++ b/src/ui/resize_tests.zig
@@ -2276,6 +2276,36 @@ test "streamed unmatched emphasis markers stay literal and unstyled" {
     try std.testing.expect(code_cell.style.fg.eql(.default));
 }
 
+test "streamed underscore emphasis styles across a multi backtick code span" {
+    var h = try Harness.init(std.testing.allocator, 48, 40, 4);
+    defer h.deinit();
+    try h.shell.initViewport(&h.metrics, 1);
+
+    var processor = assistant_presentation.MarkdownProcessor{};
+    defer processor.deinit(h.alloc);
+    var formatted: std.ArrayList(u8) = .empty;
+    defer formatted.deinit(h.alloc);
+    try processor.push(h.alloc, "See _a ``b`c`` d_ end\n", &formatted);
+    try processor.flush(h.alloc, &formatted);
+
+    _ = try h.shell.streamAssistantChunk(h.alloc, &h.metrics, formatted.items);
+    try h.renderTranscriptFrame();
+    try h.flush();
+
+    const row = try findRowContaining(&h, "See ");
+    try expectRowTrimmedEquals(&h, row, "  See a b`c d end");
+    const a_cell = h.vt.cellAt(row, 7) orelse return error.TestMissingCell;
+    try std.testing.expect(a_cell.codepoint == 'a' and a_cell.style.flags.italic);
+    const tick_cell = h.vt.cellAt(row, 10) orelse return error.TestMissingCell;
+    try std.testing.expect(tick_cell.codepoint == '`' and tick_cell.style.fg.eql(.{ .indexed = 245 }));
+    const d_cell = h.vt.cellAt(row, 13) orelse return error.TestMissingCell;
+    try std.testing.expect(d_cell.codepoint == 'd' and d_cell.style.flags.italic);
+    const end_cell = h.vt.cellAt(row, 15) orelse return error.TestMissingCell;
+    try std.testing.expect(end_cell.codepoint == 'e' and !end_cell.style.flags.italic);
+    try expectGridNotContains(&h, "_a");
+    try expectGridNotContains(&h, "d_");
+}
+
 test "streamed inline code color survives shrink and grow" {
     const cases = [_]struct { light: bool, fg: u8 }{
         .{ .light = false, .fg = 245 },


### PR DESCRIPTION
## Summary

- A `**`, `*`, `__`, `_`, or `~~` opener with no matching closer on the same line renders as the literal characters instead of styling the rest of the line.
- A backtick with no closing backtick renders literally instead of turning the rest of the line into an inline code span.
- Matched spans, spans nested across marker styles, code spans that contain markers, and backslash-escaped markers render exactly as before.

This intentionally changes the earlier behavior where an unclosed opener stayed active to the end of the line; that behavior is what made a leading `*` or `_` in prose italicize whole sentences.

Stacked on #752.