### PR TITLE
Add native DeepSeek provider via the Responses API

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ fx login grok
 fx
 ```
 
-`fx login codex` and `fx login grok` select that provider and a model from its authenticated catalog. Inside fx, run `/provider` (alias `/setup`) to move between Gateway, Codex, and Grok: Enter on a subscription provider switches to it or starts its sign-in, and `vercel` opens further columns for the sign-in method, the API key to use, and the Vercel team. `/model` lists the active provider's fetched models. Subscription model IDs are the raw IDs returned by each authenticated catalog. Model discovery continues when its local version cache is unusable. Use `/logout codex` or `/logout grok` to remove that subscription session. Logging out of the active subscription switches to an already-connected provider, preferring Gateway and then the other subscription. If none is usable, fx stays signed out. Logging out of an inactive subscription keeps the active provider unchanged. Active subscription logout is unavailable while work is active or queued; choosing the provider again from `/provider` starts sign-in.
+`fx login codex` and `fx login grok` select that provider and a model from its authenticated catalog. Inside fx, run `/provider` (alias `/setup`) to move between Gateway, Codex, Grok, and DeepSeek: Enter on a subscription provider switches to it or starts its sign-in, and `vercel` opens further columns for the sign-in method, the API key to use, and the Vercel team. `/model` lists the active provider's fetched models. Subscription model IDs are the raw IDs returned by each authenticated catalog. Model discovery continues when its local version cache is unusable. Use `/logout codex` or `/logout grok` to remove that subscription session. Logging out of the active subscription switches to an already-connected provider, preferring Gateway and then the other subscription. If none is usable, fx stays signed out. Logging out of an inactive subscription keeps the active provider unchanged. Active subscription logout is unavailable while work is active or queued; choosing the provider again from `/provider` starts sign-in.
 
 If a saved credential cannot be checked, `/login`, `/provider`, and `/setup` still open and identify the unavailable source. You can type the provider name immediately after Enter; credential checks preserve your input and keep choices unavailable until checking finishes. Provider and team preparation also keeps typing and cancellation responsive while its catalog loads. Ctrl+C cancels preparation without changing the current provider. A prompt submitted during preparation waits for the selected provider; if preparation fails, the prompt stays pending for explicit recovery. While responses are active or queued, these commands immediately explain that provider switching is unavailable. Other credentials remain usable. Fix the saved credential and reopen `/provider` to retry. Storage or connection failures do not start another sign-in, and browser authorization reports success only after the new credential is saved.
 
@@ -57,6 +57,16 @@ The OpenAI Codex route uses ChatGPT subscription access directly and never sends
 
 The Grok route uses subscription access directly at xAI and never sends its OAuth token to Vercel AI Gateway or OpenAI. Its session is stored privately at `~/.fx/grok-auth.json`, refreshed when needed, and used only with the authenticated xAI catalog and Responses API.
 
+The DeepSeek route calls the DeepSeek API directly at `api.deepseek.com` (OpenAI Responses protocol) with your own API key:
+
+```bash
+export DEEPSEEK_API_KEY=sk-...
+fx login deepseek
+fx
+```
+
+fx never sends the DeepSeek API key to Vercel AI Gateway, OpenAI, or xAI; the key is read from the `DEEPSEEK_API_KEY` environment variable, no login session is stored, and `/logout deepseek` only confirms that nothing is saved. DeepSeek billing is pay-as-you-go through the DeepSeek Platform. Available models are `deepseek-v4-flash`, `deepseek-v4-pro`, and the image-capable `deepseek-v4-flash-vision-exp`; the thinking-mode chain of thought is stored with your sessions so continued tool use can pass it back to the API.
+
 Codex and Grok discover current stable client versions from upstream release metadata without requiring either CLI to be installed. fx caches release metadata for one minute. Opening `/model` or requesting ACP model options refreshes an expired subscription catalog. If a release lookup temporarily fails, fx uses the last successfully fetched version.
 
 To use an AI Gateway API key instead:
@@ -65,7 +75,7 @@ To use an AI Gateway API key instead:
 fx setup
 ```
 
-Embedding hosts that inject provider authentication at the network boundary can set `FX_AUTH_MODE=host-managed`. In this mode, fx does not read, refresh, or write local model-provider credentials and does not add authentication-owned headers to Gateway, Codex, or Grok requests. The host must authenticate those forwarded requests.
+Embedding hosts that inject provider authentication at the network boundary can set `FX_AUTH_MODE=host-managed`. In this mode, fx does not read, refresh, or write local model-provider credentials and does not add authentication-owned headers to Gateway, Codex, Grok, or DeepSeek requests. The host must authenticate those forwarded requests.
 
 Run fx from a project:
 

--- a/src/builtins/providers.zig
+++ b/src/builtins/providers.zig
@@ -6,6 +6,9 @@ const openai_codex_permission_reviewer = @import("../gateway/openai_codex_permis
 const xai_grok = @import("../gateway/xai_grok.zig");
 const xai_grok_models = @import("../gateway/xai_grok_models.zig");
 const xai_grok_permission_reviewer = @import("../gateway/xai_grok_permission_reviewer.zig");
+const deepseek = @import("../gateway/deepseek.zig");
+const deepseek_models = @import("../gateway/deepseek_models.zig");
+const deepseek_permission_reviewer = @import("../gateway/deepseek_permission_reviewer.zig");
 const provider_catalog = @import("../core/auth/provider_catalog.zig");
 
 pub const native = provider_set.Set{
@@ -25,5 +28,13 @@ pub const native = provider_set.Set{
         .cli_model_catalog = xai_grok_models.cli_model_catalog_provider,
         .model_catalog = xai_grok_models.model_catalog_provider,
         .permission_reviewer = xai_grok_permission_reviewer.provider,
+    },
+    .deepseek = .{
+        .presentation = provider_catalog.find(.deepseek),
+        .agent_stream = deepseek.agent_stream_provider,
+        .fallback_model_capabilities_fn = deepseek_models.fallbackCapabilities,
+        .cli_model_catalog = deepseek_models.cli_model_catalog_provider,
+        .model_catalog = deepseek_models.model_catalog_provider,
+        .permission_reviewer = deepseek_permission_reviewer.provider,
     },
 };

--- a/src/core/app/app_agent_runtime.zig
+++ b/src/core/app/app_agent_runtime.zig
@@ -1203,6 +1203,11 @@ pub fn Runtime(comptime App: type) type {
                         .agent_stream = tool_context.agent_stream_provider,
                         .permission_reviewer = tool_context.permission_reviewer_provider,
                     },
+                    .deepseek = .{
+                        .capabilities = tool_context.provider_capabilities,
+                        .agent_stream = tool_context.agent_stream_provider,
+                        .permission_reviewer = tool_context.permission_reviewer_provider,
+                    },
                 };
             return subagent_agent_adapter.run(.{
                 .host = app_session_runtime.Runtime(App).subagentHost(app) orelse

--- a/src/core/app/app_auth_runtime.zig
+++ b/src/core/app/app_auth_runtime.zig
@@ -165,6 +165,7 @@ pub fn Runtime(comptime App: type) type {
                         .gateway => credentials.missing_interactive_credential_message,
                         .codex => credentials.missing_chatgpt_interactive_credential_message,
                         .grok => credentials.missing_grok_interactive_credential_message,
+                        .deepseek => credentials.missing_deepseek_interactive_credential_message,
                     },
                 }, true),
                 .failed => |failure| {
@@ -187,7 +188,9 @@ pub fn Runtime(comptime App: type) type {
                 try app.writeDomainNotice(.{
                     .topic = "auth",
                     .tone = .warning,
-                    .body = if (provider == .grok)
+                    .body = if (provider == .deepseek)
+                        credentials.missing_deepseek_interactive_credential_message
+                    else if (provider == .grok)
                         credentials.missing_grok_interactive_credential_message
                     else
                         credentials.missing_chatgpt_interactive_credential_message,
@@ -1207,14 +1210,14 @@ pub fn Runtime(comptime App: type) type {
                     switch (target) {
                         .codex => try beginCodexSignInForProviderSwitch(app),
                         .grok => try beginGrokSignInForProviderSwitch(app),
-                        .gateway => {},
+                        .gateway, .deepseek => {},
                     }
                 }
                 if (target == .gateway or !request.allow_login) {
                     try app.writeDomainNotice(.{
                         .topic = "provider",
                         .tone = .warning,
-                        .body = if (intent == .post_oauth) "Subscription sign-in completed, but its saved credential is unavailable. The current provider is unchanged." else if (target == .codex) "Run fx login codex, then try switching again." else if (target == .grok) "Run fx login grok, then try switching again." else credentials.missing_interactive_credential_message,
+                        .body = if (intent == .post_oauth) "Subscription sign-in completed, but its saved credential is unavailable. The current provider is unchanged." else if (target == .codex) "Run fx login codex, then try switching again." else if (target == .grok) "Run fx login grok, then try switching again." else if (target == .deepseek) "Set DEEPSEEK_API_KEY, then try switching again." else credentials.missing_interactive_credential_message,
                     }, true);
                 }
                 return false;
@@ -1814,6 +1817,7 @@ pub fn Runtime(comptime App: type) type {
                 .grok_subscription => try beginGrokSignIn(app),
                 .vercel_oidc_token,
                 .ai_gateway_api_key,
+                .deepseek_api_key,
                 .stored_key,
                 .host_managed,
                 => {},
@@ -2221,7 +2225,7 @@ test "interactive subscription sign-in rejects active and queued work before OAu
             switch (provider) {
                 .codex => try Runtime(BusySignInApp).beginChatGptSignIn(&app),
                 .grok => try Runtime(BusySignInApp).beginGrokSignIn(&app),
-                .gateway => unreachable,
+                .gateway, .deepseek => unreachable,
             }
 
             try std.testing.expectEqual(@as(usize, 0), app.auth.start_count);

--- a/src/core/app/app_callbacks.zig
+++ b/src/core/app/app_callbacks.zig
@@ -1068,6 +1068,7 @@ pub fn Bindings(comptime App: type) type {
                             .chatgpt_subscription => "Reconnect Codex through /login to repair this source.",
                             .grok_subscription => "Reconnect Grok through /login to repair this source.",
                             .vercel_oidc_token, .ai_gateway_api_key, .stored_key => "Run /provider to repair this source.",
+                            .deepseek_api_key => "Set DEEPSEEK_API_KEY, then retry.",
                             .host_managed => credentials.host_managed_auth_message,
                         },
                     },

--- a/src/core/app/app_lifecycle.zig
+++ b/src/core/app/app_lifecycle.zig
@@ -1151,6 +1151,7 @@ fn configuredProviderSelection(
         .gateway => default_model,
         .codex => return error.CodexModelNotSelected,
         .grok => return error.GrokModelNotSelected,
+        .deepseek => return error.DeepSeekModelNotSelected,
     };
     return .{ .provider = provider, .model = model };
 }

--- a/src/core/auth/auth_runtime.zig
+++ b/src/core/auth/auth_runtime.zig
@@ -1446,6 +1446,10 @@ pub const StatusSnapshot = struct {
                 .cli => credentials.missing_grok_credential_message,
                 .interactive => credentials.missing_grok_interactive_credential_message,
             },
+            .deepseek_api_key => switch (surface) {
+                .cli => credentials.missing_deepseek_credential_message,
+                .interactive => credentials.missing_deepseek_interactive_credential_message,
+            },
             .host_managed => automatic_help,
         };
     }

--- a/src/core/auth/auth_transition.zig
+++ b/src/core/auth/auth_transition.zig
@@ -73,6 +73,7 @@ pub fn logoutFallbackProviders(facts: LogoutFacts) [2]?model_provider.ProviderId
                 facts.available_sources.contains(.stored_key),
             .codex => facts.available_sources.contains(.chatgpt_subscription),
             .grok => facts.available_sources.contains(.grok_subscription),
+            .deepseek => false,
         };
         if (!available) continue;
         candidates[count] = provider;
@@ -155,6 +156,7 @@ pub fn signInCompletion(
             .{ .switch_provider = .grok }
         else
             .{ .activate_source = .grok_subscription },
+        .deepseek => .{ .activate_source = .deepseek_api_key },
     };
 }
 

--- a/src/core/auth/credential_authority.zig
+++ b/src/core/auth/credential_authority.zig
@@ -23,6 +23,7 @@ pub fn derive(
     switch (source) {
         .vercel_oidc_token,
         .ai_gateway_api_key,
+        .deepseek_api_key,
         .fx_login,
         .stored_key,
         .host_managed,

--- a/src/core/auth/credentials.zig
+++ b/src/core/auth/credentials.zig
@@ -60,6 +60,7 @@ pub const CatalogPublicOnlyReason = std.meta.Tag(CatalogPublicOnly);
 pub const CatalogAuthenticatedSource = enum {
     vercel_oidc_token,
     ai_gateway_api_key,
+    deepseek_api_key,
     fx_login,
     stored_key,
     chatgpt_subscription,
@@ -69,6 +70,7 @@ pub const CatalogAuthenticatedSource = enum {
         return switch (self) {
             .vercel_oidc_token => .vercel_oidc_token,
             .ai_gateway_api_key => .ai_gateway_api_key,
+            .deepseek_api_key => .deepseek_api_key,
             .fx_login => .fx_login,
             .stored_key => .stored_key,
             .chatgpt_subscription => .chatgpt_subscription,
@@ -121,7 +123,8 @@ pub const CatalogAccess = union(enum) {
             .public_only => null,
             .authenticated => |access| if (access.authority == .explicit or
                 access.source == .chatgpt_subscription or
-                access.source == .grok_subscription)
+                access.source == .grok_subscription or
+                access.source == .deepseek_api_key)
                 null
             else
                 .{
@@ -217,6 +220,7 @@ pub fn catalogAccessForCredentialAndAccount(
     const authenticated_source: CatalogAuthenticatedSource = switch (selected_source) {
         .vercel_oidc_token => .vercel_oidc_token,
         .ai_gateway_api_key => .ai_gateway_api_key,
+        .deepseek_api_key => .deepseek_api_key,
         .stored_key => .stored_key,
         .chatgpt_subscription => .chatgpt_subscription,
         .grok_subscription => .grok_subscription,
@@ -255,6 +259,8 @@ pub const missing_chatgpt_credential_message = "fx needs a Codex subscription lo
 pub const missing_chatgpt_interactive_credential_message = "Codex needs a subscription login. Run /login, open Connections, then choose Codex subscription.";
 pub const missing_grok_credential_message = "fx needs a Grok subscription login for this model. Run fx login grok.";
 pub const missing_grok_interactive_credential_message = "Grok needs a subscription login. Run /login, open Connections, then choose Grok subscription.";
+pub const missing_deepseek_credential_message = "fx needs a DeepSeek API key for this model. Set DEEPSEEK_API_KEY.";
+pub const missing_deepseek_interactive_credential_message = "DeepSeek needs an API key. Run /login, open Connections, then choose DeepSeek API key; or set DEEPSEEK_API_KEY.";
 pub const unreadable_store_message = "fx could not read the stored API key from " ++ stored_key_backend_label ++ ". A key may be saved but unreadable. Set FX_TRACE_LOG for the failing step, or set AI_GATEWAY_API_KEY.";
 pub const host_managed_auth_message = "Authentication is managed by the host.";
 
@@ -521,6 +527,7 @@ pub fn loadSource(
     return switch (source) {
         .vercel_oidc_token => loadEnvCredential(alloc, "VERCEL_OIDC_TOKEN", source),
         .ai_gateway_api_key => loadEnvCredential(alloc, "AI_GATEWAY_API_KEY", source),
+        .deepseek_api_key => loadEnvCredential(alloc, "DEEPSEEK_API_KEY", source),
         .fx_login => loadFxLoginCredential(alloc, transport),
         .stored_key => loadStoredKeyCredential(alloc, secret_store),
         .chatgpt_subscription => loadChatGptCredential(alloc, transport, .if_needed),
@@ -538,6 +545,7 @@ pub fn sourceExists(
     return switch (source) {
         .vercel_oidc_token => nonEmptyEnvValue("VERCEL_OIDC_TOKEN") != null,
         .ai_gateway_api_key => nonEmptyEnvValue("AI_GATEWAY_API_KEY") != null,
+        .deepseek_api_key => nonEmptyEnvValue("DEEPSEEK_API_KEY") != null,
         .fx_login => blk: {
             const loaded = oauth_session.load(alloc) catch |err| switch (err) {
                 error.OutOfMemory => return err,
@@ -593,6 +601,10 @@ pub fn sourcePresence(
         else
             .missing,
         .ai_gateway_api_key => if (nonEmptyEnvValue("AI_GATEWAY_API_KEY") != null)
+            .present
+        else
+            .missing,
+        .deepseek_api_key => if (nonEmptyEnvValue("DEEPSEEK_API_KEY") != null)
             .present
         else
             .missing,
@@ -897,6 +909,7 @@ pub fn sourceLabel(source: Source) []const u8 {
     return switch (source) {
         .vercel_oidc_token => "VERCEL_OIDC_TOKEN",
         .ai_gateway_api_key => "AI_GATEWAY_API_KEY",
+        .deepseek_api_key => "DEEPSEEK_API_KEY",
         .fx_login => "fx login",
         .stored_key => "stored API key (" ++ stored_key_backend_label ++ ")",
         .chatgpt_subscription => "Codex subscription",

--- a/src/core/auth/provider_catalog.zig
+++ b/src/core/auth/provider_catalog.zig
@@ -42,6 +42,16 @@ pub const entries = [_]Entry{
         .subscription = true,
         .login_source = .grok_subscription,
     },
+    .{
+        .id = .deepseek,
+        .slug = "deepseek",
+        .aliases = &.{"deepseek-api"},
+        .name = "DeepSeek",
+        .route_name = "DeepSeek API",
+        .description = "DeepSeek API key billing",
+        .subscription = false,
+        .login_source = .deepseek_api_key,
+    },
 };
 
 pub fn parse(value: []const u8) ?model_provider.ProviderId {
@@ -66,9 +76,12 @@ test "auth provider catalog uses the model provider identity and explicit aliase
     try std.testing.expectEqual(model_provider.ProviderId.gateway, parse("gateway").?);
     try std.testing.expectEqual(model_provider.ProviderId.codex, parse("codex").?);
     try std.testing.expectEqual(model_provider.ProviderId.grok, parse("grok").?);
+    try std.testing.expectEqual(model_provider.ProviderId.deepseek, parse("deepseek").?);
+    try std.testing.expectEqual(model_provider.ProviderId.deepseek, parse("deepseek-api").?);
     try std.testing.expect(parse("openai-codex") == null);
     try std.testing.expect(parse("chatgpt") == null);
     try std.testing.expect(parse("unknown") == null);
     try std.testing.expect(find(.codex).subscription);
     try std.testing.expect(find(.grok).subscription);
+    try std.testing.expect(!find(.deepseek).subscription);
 }

--- a/src/core/auth/provider_picker_catalog.zig
+++ b/src/core/auth/provider_picker_catalog.zig
@@ -128,7 +128,7 @@ pub fn providerOptions(out: *[max_provider_options][]const u8) usize {
 pub fn providerMethods(id: model_provider.ProviderId) []const Method {
     return switch (id) {
         .gateway => &.{ .oauth, .api_key },
-        .codex, .grok => &.{},
+        .codex, .grok, .deepseek => &.{},
     };
 }
 
@@ -157,6 +157,7 @@ test "only the gateway offers a method column" {
     try std.testing.expectEqual(@as(usize, 2), providerMethods(.gateway).len);
     try std.testing.expectEqual(@as(usize, 0), providerMethods(.codex).len);
     try std.testing.expectEqual(@as(usize, 0), providerMethods(.grok).len);
+    try std.testing.expectEqual(@as(usize, 0), providerMethods(.deepseek).len);
 }
 
 test "method slugs round trip and stay single tokens" {

--- a/src/core/cli/cli_surface.zig
+++ b/src/core/cli/cli_surface.zig
@@ -701,6 +701,10 @@ fn runProviderLogin(alloc: Allocator, cfg: Config, provider: model_provider.Prov
         .gateway => try login_flow.runLogin(alloc, cfg.gateway_provider.oauth_transport, cfg.url_opener),
         .codex => try chatgpt_oauth.runLogin(alloc, cfg.gateway_provider.oauth_transport, cfg.url_opener),
         .grok => try grok_oauth.runLogin(alloc, cfg.gateway_provider.oauth_transport, cfg.url_opener),
+        .deepseek => {
+            const key = io_mod.getenv("DEEPSEEK_API_KEY") orelse return error.DeepSeekApiKeyRequired;
+            if (std.mem.trim(u8, key, " \t\r\n").len == 0) return error.DeepSeekApiKeyRequired;
+        },
     }
 }
 
@@ -717,6 +721,7 @@ fn writeProviderLoginFailure(alloc: Allocator, deps: RunDeps, provider: model_pr
         error.ClientIdMissing => "missing FX_OAUTH_CLIENT_ID; configure the fx Vercel App client id first",
         error.AccessDenied, error.ChatGptAuthorizationFailed, error.GrokAuthorizationFailed => "authorization denied",
         error.ExpiredToken, error.LoginTimedOut, error.ChatGptLoginTimedOut, error.GrokLoginTimedOut => "authorization expired; run fx login again",
+        error.DeepSeekApiKeyRequired => credentials.missing_deepseek_credential_message,
         else => "failed to sign in",
     });
 }
@@ -759,6 +764,7 @@ fn activateProviderSelectionFallible(
             .gateway => "Gateway is already selected.\n",
             .codex => "Codex is already selected.\n",
             .grok => "Grok is already selected.\n",
+            .deepseek => "DeepSeek is already selected.\n",
         });
         return true;
     }
@@ -792,6 +798,7 @@ fn activateProviderSelectionFallible(
                 .codex => "Codex credential is unavailable",
                 .grok => "Grok credential is unavailable",
                 .gateway => "configure a Gateway credential first",
+                .deepseek => credentials.missing_deepseek_credential_message,
             },
         );
         return false;
@@ -801,6 +808,7 @@ fn activateProviderSelectionFallible(
             .codex => "Codex model catalog is unavailable",
             .grok => "Grok model catalog is unavailable",
             .gateway => "Gateway model catalog is unavailable",
+            .deepseek => "DeepSeek model catalog is unavailable",
         });
         return false;
     };
@@ -867,13 +875,14 @@ fn activateProviderSelectionFallible(
     if (performed_login) |provider| switch (provider) {
         .codex => try writeStdout(deps, "Signed in with Codex.\n"),
         .grok => try writeStdout(deps, "Signed in with Grok.\n"),
-        .gateway => unreachable,
+        .gateway, .deepseek => unreachable,
     };
     if (caller == .provider_command) {
         try writeStdout(deps, switch (target) {
             .gateway => "Provider set to Gateway.\n",
             .codex => "Provider set to Codex.\n",
             .grok => "Provider set to Grok.\n",
+            .deepseek => "Provider set to DeepSeek.\n",
         });
     }
     return true;
@@ -993,7 +1002,7 @@ fn runNonInteractiveWithDeps(
         .issue => |rest| return runGithubWorkflow(alloc, rest, cfg, global_args.modifiers, deps, .issue),
         .login => |rest| {
             const maybe_login_provider = parseLoginProvider(rest) catch {
-                try writeStderr(deps, "usage: fx login [vercel|codex|grok]\n");
+                try writeStderr(deps, "usage: fx login [vercel|codex|grok|deepseek]\n");
                 return .handled_failure;
             };
             if (cfg.auth_mode == .host_managed) {
@@ -1018,12 +1027,13 @@ fn runNonInteractiveWithDeps(
                 .gateway => "Signed in to Vercel.\nAI Gateway access may still require billing or API setup for the selected account.\n",
                 .codex => "Signed in with Codex.\n",
                 .grok => "Signed in with Grok.\n",
+                .deepseek => "Selected DeepSeek.\n",
             });
             return .handled_success;
         },
         .logout => |rest| {
             const maybe_login_provider = parseLoginProvider(rest) catch {
-                try writeStderr(deps, "usage: fx logout [vercel|codex|grok]\n");
+                try writeStderr(deps, "usage: fx logout [vercel|codex|grok|deepseek]\n");
                 return .handled_failure;
             };
             if (cfg.auth_mode == .host_managed) {
@@ -1074,6 +1084,10 @@ fn runNonInteractiveWithDeps(
                         break :result .handled_failure;
                     },
                 };
+            }
+            if (login_provider == .deepseek) {
+                try writeStdout(deps, "DeepSeek uses the DEEPSEEK_API_KEY environment variable; nothing to sign out.\n");
+                return .handled_success;
             }
             const result = login_flow.logout(alloc, cfg.gateway_provider.oauth_transport) catch |err| switch (err) {
                 error.SessionDeleteFailed => {
@@ -1156,11 +1170,11 @@ fn runNonInteractiveWithDeps(
         },
         .provider => |rest| {
             if (rest.len != 1) {
-                try writeStderr(deps, "usage: fx provider <gateway|codex|grok>\n");
+                try writeStderr(deps, "usage: fx provider <gateway|codex|grok|deepseek>\n");
                 return .handled_failure;
             }
             const target = model_provider.parse(rest[0]) orelse {
-                try writeStderr(deps, "fx provider: expected gateway, codex, or grok\n");
+                try writeStderr(deps, "fx provider: expected gateway, codex, grok, or deepseek\n");
                 return .handled_failure;
             };
             return if (try activateProviderSelection(alloc, cfg, deps, target, .provider_command, null))
@@ -1279,6 +1293,7 @@ fn runNonInteractiveWithDeps(
                     .gateway => "fx models: Gateway model catalog is unavailable\n",
                     .codex => "fx models: Codex model catalog is unavailable\n",
                     .grok => "fx models: Grok model catalog is unavailable\n",
+                    .deepseek => "fx models: DeepSeek model catalog is unavailable\n",
                 });
                 return .handled_failure;
             };

--- a/src/core/config/config_runtime.zig
+++ b/src/core/config/config_runtime.zig
@@ -605,6 +605,7 @@ fn isProfileOnlySettingKey(key: []const u8) bool {
         "provider",
         "codex_model",
         "grok_model",
+        "deepseek_model",
         "effort",
         "fast_mode",
         "fast_mode_model_bound",
@@ -1369,6 +1370,12 @@ fn parseProfileOnlyFields(
         if (model_value != .string) return error.InvalidGrokModelType;
         settings_store.validateModel(model_value.string) catch return error.InvalidGrokModelValue;
         try settings.models.putCopy(alloc, .grok, model_value.string);
+    }
+
+    if (root.object.get("deepseek_model")) |model_value| {
+        if (model_value != .string) return error.InvalidDeepSeekModelType;
+        settings_store.validateModel(model_value.string) catch return error.InvalidDeepSeekModelValue;
+        try settings.models.putCopy(alloc, .deepseek, model_value.string);
     }
 
     if (root.object.get("models")) |models_value| {

--- a/src/core/config/model_provider.zig
+++ b/src/core/config/model_provider.zig
@@ -5,6 +5,7 @@ pub const ProviderId = enum {
     gateway,
     codex,
     grok,
+    deepseek,
 };
 
 pub const ProviderSelection = struct {
@@ -16,6 +17,7 @@ pub fn parse(value: []const u8) ?ProviderId {
     if (std.ascii.eqlIgnoreCase(value, "gateway")) return .gateway;
     if (std.ascii.eqlIgnoreCase(value, "codex")) return .codex;
     if (std.ascii.eqlIgnoreCase(value, "grok")) return .grok;
+    if (std.ascii.eqlIgnoreCase(value, "deepseek")) return .deepseek;
     return null;
 }
 
@@ -23,9 +25,10 @@ pub fn authorizesCredential(provider: ProviderId, source: ?types.CredentialSourc
     const selected = source orelse return false;
     if (selected == .host_managed) return true;
     return switch (provider) {
-        .gateway => selected != .chatgpt_subscription and selected != .grok_subscription,
+        .gateway => selected != .chatgpt_subscription and selected != .grok_subscription and selected != .deepseek_api_key,
         .codex => selected == .chatgpt_subscription,
         .grok => selected == .grok_subscription,
+        .deepseek => selected == .deepseek_api_key,
     };
 }
 
@@ -39,12 +42,17 @@ test "explicit providers authorize only their own credential origins" {
     try std.testing.expect(authorizesCredential(.grok, .grok_subscription));
     try std.testing.expect(!authorizesCredential(.grok, .chatgpt_subscription));
     try std.testing.expect(!authorizesCredential(.gateway, .grok_subscription));
+    try std.testing.expect(authorizesCredential(.deepseek, .deepseek_api_key));
+    try std.testing.expect(!authorizesCredential(.deepseek, .ai_gateway_api_key));
+    try std.testing.expect(!authorizesCredential(.deepseek, .chatgpt_subscription));
+    try std.testing.expect(!authorizesCredential(.deepseek, .grok_subscription));
 }
 
-test "provider parsing exposes gateway codex and grok" {
+test "provider parsing exposes gateway codex grok and deepseek" {
     try std.testing.expectEqual(ProviderId.gateway, parse("gateway").?);
     try std.testing.expectEqual(ProviderId.codex, parse("CODEX").?);
     try std.testing.expectEqual(ProviderId.grok, parse("GROK").?);
+    try std.testing.expectEqual(ProviderId.deepseek, parse("DEEPSEEK").?);
     try std.testing.expect(parse("openai-codex") == null);
     try std.testing.expect(parse("") == null);
 }

--- a/src/core/config/settings_store.zig
+++ b/src/core/config/settings_store.zig
@@ -1589,6 +1589,7 @@ fn putModelPreference(
         .gateway => "model",
         .codex => "codex_model",
         .grok => "grok_model",
+        .deepseek => "deepseek_model",
     };
     if (root.contains(legacy_key)) {
         _ = root.orderedRemove(legacy_key);
@@ -1834,6 +1835,10 @@ fn validateKnownSettingsObject(
         try validateModel(value.string);
     }
     if (object.get("grok_model")) |value| {
+        if (value != .string) return error.InvalidSettingsFormat;
+        try validateModel(value.string);
+    }
+    if (object.get("deepseek_model")) |value| {
         if (value != .string) return error.InvalidSettingsFormat;
         try validateModel(value.string);
     }

--- a/src/core/gateway/provider_set.zig
+++ b/src/core/gateway/provider_set.zig
@@ -51,12 +51,14 @@ pub const Set = struct {
     gateway: Bundle,
     codex: Bundle,
     grok: Bundle,
+    deepseek: Bundle,
 
     pub fn select(self: Set, provider: model_provider.ProviderId) Bundle {
         return switch (provider) {
             .gateway => self.gateway,
             .codex => self.codex,
             .grok => self.grok,
+            .deepseek => self.deepseek,
         };
     }
 
@@ -65,6 +67,7 @@ pub const Set = struct {
             .gateway = self.gateway.deferred_usage,
             .codex = self.codex.deferred_usage,
             .grok = self.grok.deferred_usage,
+            .deepseek = self.deepseek.deferred_usage,
         };
     }
 };
@@ -74,6 +77,7 @@ pub fn gateway_only(gateway: Bundle) Set {
         .gateway = gateway,
         .codex = .{},
         .grok = .{},
+        .deepseek = .{},
     };
 }
 
@@ -81,6 +85,7 @@ test "provider set selects each provider's complete route" {
     var gateway_tag: u8 = 0;
     var codex_tag: u8 = 0;
     var grok_tag: u8 = 0;
+    var deepseek_tag: u8 = 0;
 
     const Fake = struct {
         fn cli_catalog(
@@ -144,7 +149,16 @@ test "provider set selects each provider's complete route" {
         .model_catalog = .{ .context = &grok_tag, .fetch_fn = Fake.model_catalog_fetch },
         .permission_reviewer = .{ .context = &grok_tag, .review_fn = Fake.review },
     };
-    var providers = Set{ .gateway = gateway, .codex = codex, .grok = grok };
+    const deepseek = Bundle{
+        .agent_stream = stream_provider.Provider{
+            .context = &deepseek_tag,
+            .stream_fn = stream_provider.unavailable_provider.stream_fn,
+        },
+        .cli_model_catalog = .{ .context = &deepseek_tag, .fetch_fn = Fake.cli_catalog },
+        .model_catalog = .{ .context = &deepseek_tag, .fetch_fn = Fake.model_catalog_fetch },
+        .permission_reviewer = .{ .context = &deepseek_tag, .review_fn = Fake.review },
+    };
+    var providers = Set{ .gateway = gateway, .codex = codex, .grok = grok, .deepseek = deepseek };
 
     try std.testing.expect(providers.select(.gateway).agent_stream.?.context.? == @as(*anyopaque, @ptrCast(&gateway_tag)));
     try std.testing.expect(providers.select(.gateway).capabilities.fx_search);
@@ -157,6 +171,8 @@ test "provider set selects each provider's complete route" {
     try std.testing.expect(providers.select(.gateway).cli_model_catalog.?.context.? == @as(*anyopaque, @ptrCast(&gateway_tag)));
     try std.testing.expect(providers.select(.codex).model_catalog.?.context.? == @as(*anyopaque, @ptrCast(&codex_tag)));
     try std.testing.expect(providers.select(.grok).permission_reviewer.?.context.? == @as(*anyopaque, @ptrCast(&grok_tag)));
+    try std.testing.expect(providers.select(.deepseek).permission_reviewer.?.context.? == @as(*anyopaque, @ptrCast(&deepseek_tag)));
+    try std.testing.expect(providers.select(.deepseek).deferred_usage == null);
     try std.testing.expect(providers.select(.codex).agent_stream_or_unavailable().context.? == @as(*anyopaque, @ptrCast(&codex_tag)));
 
     providers.codex.model_catalog = null;

--- a/src/core/output/output_contracts.zig
+++ b/src/core/output/output_contracts.zig
@@ -853,6 +853,7 @@ pub const ModelListSnapshot = struct {
             .gateway => "gateway",
             .codex => provider_catalog.label(.codex),
             .grok => provider_catalog.label(.grok),
+            .deepseek => provider_catalog.label(.deepseek),
         };
     }
 

--- a/src/core/session/generation_usage_provider.zig
+++ b/src/core/session/generation_usage_provider.zig
@@ -85,6 +85,7 @@ pub const Set = struct {
     gateway: ?Provider = null,
     codex: ?Provider = null,
     grok: ?Provider = null,
+    deepseek: ?Provider = null,
 
     pub fn gatewayOnly(provider: Provider) Set {
         return .{ .gateway = provider };
@@ -95,6 +96,7 @@ pub const Set = struct {
             .gateway => self.gateway,
             .codex => self.codex,
             .grok => self.grok,
+            .deepseek => self.deepseek,
         };
     }
 };

--- a/src/core/session/session_usage.zig
+++ b/src/core/session/session_usage.zig
@@ -3359,6 +3359,7 @@ fn exactUsageOrigin(provider: model_provider.ProviderId) []const u8 {
         .gateway => "exact/gateway",
         .codex => "exact/codex",
         .grok => "exact/grok",
+        .deepseek => "exact/deepseek",
     };
 }
 

--- a/src/core/shared/types.zig
+++ b/src/core/shared/types.zig
@@ -91,6 +91,7 @@ test "context notice body drops legacy markers from every line" {
 pub const CredentialSource = enum {
     vercel_oidc_token,
     ai_gateway_api_key,
+    deepseek_api_key,
     fx_login,
     stored_key,
     chatgpt_subscription,

--- a/src/gateway/deepseek.zig
+++ b/src/gateway/deepseek.zig
@@ -1,0 +1,705 @@
+const std = @import("std");
+const debug_trace = @import("../core/shared/debug_trace.zig");
+const image_attachments = @import("../core/images/image_attachments.zig");
+const secret = @import("../core/auth/secret.zig");
+const stream_provider = @import("../core/agent/stream_provider.zig");
+const io_mod = @import("../core/shared/io.zig");
+const types = @import("../core/shared/types.zig");
+const gateway_client = @import("client.zig");
+const responses_protocol = @import("responses_protocol.zig");
+const sse_stream = @import("sse.zig");
+const model_tool_schema = @import("../core/tooling/model_tool_schema.zig");
+
+const Allocator = std.mem.Allocator;
+const endpoint = "https://api.deepseek.com/responses";
+const e2e_endpoint_env = "FX_E2E_DEEPSEEK_RESPONSES_URL";
+const max_error_body_bytes: usize = 256 * 1024;
+const max_sse_line_bytes: usize = 1024 * 1024;
+const max_sse_aggregate_bytes: usize = 64 * 1024 * 1024;
+const max_sse_events: usize = 100_000;
+const max_tool_calls: usize = 128;
+const max_tool_identity_bytes: usize = 1024;
+const max_tool_arguments_bytes: usize = 4 * 1024 * 1024;
+const max_provider_state_bytes: usize = 4 * 1024 * 1024;
+const transfer_buffer_bytes: usize = 256 * 1024;
+const connect_timeout_ms: i64 = 30_000;
+
+pub const agent_stream_provider = stream_provider.Provider{
+    .stream_fn = streamCompletion,
+    .build_request_fn = buildRequestForProvider,
+    .project_replay_fn = responses_protocol.selectReplayParts,
+};
+
+fn validateModel(model: []const u8) !void {
+    if (model.len == 0 or model.len > 256) return error.InvalidDeepSeekModel;
+    for (model) |byte| {
+        if (byte <= 0x20 or byte == 0x7f) return error.InvalidDeepSeekModel;
+    }
+}
+
+pub fn buildRequest(
+    alloc: Allocator,
+    request: stream_provider.RequestData,
+) ![]u8 {
+    try request.validatePrompt();
+    try validateModel(request.model);
+    const budget: image_attachments.CaptureBudget = if (request.budget) |value|
+        .{ .deadline = value.deadline, .cancel_flag = value.cancel_flag }
+    else
+        .{};
+    try budget.check();
+    const projected = try types.projectProviderReplay(alloc, request.messages, .{ .provider = .deepseek, .model = request.model });
+    defer if (projected) |messages| alloc.free(messages);
+    if (projected != null) debug_trace.logf("gateway", "provider_replay_omitted provider=deepseek reason=source_mismatch", .{});
+
+    var instructions: std.Io.Writer.Allocating = .init(alloc);
+    defer instructions.deinit();
+    for (request.instructions) |instruction| {
+        const text = instruction.content.?;
+        if (text.len == 0) continue;
+        if (instructions.written().len > 0) try instructions.writer.writeAll("\n\n");
+        try instructions.writer.writeAll(text);
+    }
+    if (instructions.written().len == 0) try instructions.writer.writeAll("You are a helpful assistant.");
+
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    errdefer out.deinit();
+    const writer = &out.writer;
+    try writer.writeAll("{\"model\":");
+    try std.json.Stringify.value(request.model, .{}, writer);
+    try writer.writeAll(",\"store\":false,\"stream\":true,\"instructions\":");
+    try std.json.Stringify.value(instructions.written(), .{}, writer);
+    try writer.writeAll(",\"input\":[");
+    try writeResponsesInput(writer, std.heap.c_allocator, projected orelse request.messages, request.verified_images, budget);
+    try writer.writeByte(']');
+
+    const tool_count = try responses_protocol.writeTools(writer, alloc, request.tools);
+    if (tool_count > 0) {
+        try writer.writeAll(",\"tool_choice\":");
+        try std.json.Stringify.value(request.tool_choice.label(), .{}, writer);
+    }
+    // DeepSeek ignores unsupported OpenAI fields and never returns encrypted
+    // reasoning; the plaintext chain of thought arrives on
+    // response.reasoning_text.delta events and reasoning items are replayed
+    // verbatim when a request carries tools.
+    if (request.response_format) |format| {
+        if (format.schema != .object) return error.InvalidStructuredResponseSchema;
+        try writer.writeAll(",\"text\":{\"format\":{\"type\":\"json_schema\",\"name\":");
+        try std.json.Stringify.value(format.name, .{}, writer);
+        try writer.writeAll(",\"description\":");
+        try std.json.Stringify.value(format.description, .{}, writer);
+        try writer.writeAll(",\"schema\":");
+        try std.json.Stringify.value(format.schema, .{}, writer);
+        try writer.writeAll(",\"strict\":true}}");
+    }
+    if (request.provider_options.reasoning) |effort| {
+        try writer.writeAll(",\"reasoning\":{\"effort\":");
+        try std.json.Stringify.value(effort.label(), .{}, writer);
+        try writer.writeByte('}');
+    }
+    if (request.max_output_tokens) |limit| try writer.print(",\"max_output_tokens\":{d}", .{limit});
+    try writer.writeByte('}');
+    return out.toOwnedSlice();
+}
+
+fn buildRequestForProvider(
+    _: ?*anyopaque,
+    alloc: Allocator,
+    request: stream_provider.RequestData,
+) anyerror![]u8 {
+    return buildRequest(alloc, request);
+}
+
+fn writeResponsesInput(
+    writer: *std.Io.Writer,
+    alloc: Allocator,
+    messages: []const types.ChatMessage,
+    images: ?[]const image_attachments.VerifiedSnapshot,
+    budget: image_attachments.CaptureBudget,
+) !void {
+    return responses_protocol.writeInput(writer, alloc, messages, images, .{
+        .tool_calls = max_tool_calls,
+        .tool_identity_bytes = max_tool_identity_bytes,
+        .tool_arguments_bytes = max_tool_arguments_bytes,
+        .provider_state_bytes = max_provider_state_bytes,
+    }, budget) catch |err| switch (err) {
+        error.ProviderStateTooLarge => error.DeepSeekProviderStateTooLarge,
+        error.InvalidProviderState => error.InvalidDeepSeekProviderState,
+        error.ToolCallLimitExceeded => error.DeepSeekToolCallLimitExceeded,
+        error.ToolArgumentsTooLarge => error.DeepSeekToolArgumentsTooLarge,
+        else => err,
+    };
+}
+
+fn streamCompletion(
+    _: ?*anyopaque,
+    alloc: Allocator,
+    request: stream_provider.ModelRequest,
+) !stream_provider.Result {
+    if (request.cancel_flag.load(.seq_cst)) return stream_provider.failResult(error.Cancelled);
+    if (request.credential.credentialSource() != .deepseek_api_key and
+        request.credential.credentialSource() != .host_managed)
+    {
+        return stream_provider.failResult(error.DeepSeekApiKeyCredentialRequired);
+    }
+    if (request.credential.credentialSource() != .host_managed) {
+        const direct = request.credential.direct;
+        if (direct.secret_bytes.len == 0) {
+            return stream_provider.failResult(error.DeepSeekApiKeyCredentialRequired);
+        }
+    }
+    try validateModel(request.model);
+    const payload = request.prepared_request_body orelse
+        try buildRequest(alloc, request.data());
+    defer if (request.prepared_request_body == null) alloc.free(payload);
+    var result = streamPrepared(alloc, request, payload) catch |err| {
+        if (request.cancel_flag.load(.seq_cst)) return stream_provider.failResult(error.Cancelled);
+        if (requestDeadlineExpired(request)) return stream_provider.failResult(error.Timeout);
+        request.attempt_evidence.network_failure = gateway_client.networkFailureEvidence(err, request.delivery.load());
+        return err;
+    };
+    if (requestDeadlineExpired(request)) {
+        result.deinit(alloc);
+        return stream_provider.failResult(error.Timeout);
+    }
+    return result;
+}
+
+fn requestDeadlineExpired(request: stream_provider.ModelRequest) bool {
+    const deadline = request.deadline orelse return false;
+    const now = std.Io.Clock.Timestamp.now(io_mod.getIo(), .awake);
+    return !std.Io.Clock.Timestamp.compare(now, .lt, deadline);
+}
+
+const OpenedRequest = struct {
+    request: ?std.http.Client.Request,
+
+    pub fn deinit(self: *OpenedRequest, _: Allocator) void {
+        if (self.request) |*request| request.deinit();
+        self.request = null;
+    }
+
+    pub fn take(self: *OpenedRequest) std.http.Client.Request {
+        const request = self.request.?;
+        self.request = null;
+        return request;
+    }
+};
+
+const OpenRequestOperation = struct {
+    client: *std.http.Client,
+    uri: std.Uri,
+    auth_header: ?[]const u8,
+    extra_headers: []const std.http.Header,
+
+    pub fn run(self: *@This()) !OpenedRequest {
+        var headers: std.http.Client.Request.Headers = .{
+            .content_type = .{ .override = "application/json" },
+            .accept_encoding = .omit,
+            .user_agent = .{ .override = gateway_client.user_agent },
+        };
+        if (self.auth_header) |authorization| {
+            headers.authorization = .{ .override = authorization };
+        }
+        return .{ .request = try self.client.request(.POST, self.uri, .{
+            .headers = headers,
+            .extra_headers = self.extra_headers,
+            .keep_alive = false,
+            .redirect_behavior = .unhandled,
+        }) };
+    }
+};
+
+const RequestAuthHeaders = struct {
+    authorization: ?[]u8 = null,
+
+    fn deinit(self: *RequestAuthHeaders, alloc: Allocator) void {
+        if (self.authorization) |value| secret.zeroAndFree(alloc, value);
+        self.* = .{};
+    }
+};
+
+fn requestAuthHeaders(alloc: Allocator, auth: stream_provider.CredentialLease) !RequestAuthHeaders {
+    return switch (auth) {
+        .host_managed => .{},
+        .direct => |direct| .{
+            .authorization = try std.fmt.allocPrint(alloc, "Bearer {s}", .{direct.secret_bytes}),
+        },
+    };
+}
+
+pub fn streamPrepared(
+    alloc: Allocator,
+    request: stream_provider.ModelRequest,
+    payload: []const u8,
+) !stream_provider.Result {
+    if (request.cancel_flag.load(.seq_cst)) return stream_provider.failResult(error.Cancelled);
+    var auth_headers = try requestAuthHeaders(alloc, request.credential);
+    defer auth_headers.deinit(alloc);
+    const request_endpoint = if (io_mod.getenv(e2e_endpoint_env)) |override| endpoint: {
+        if (!gateway_client.isLoopbackHttpUrl(override)) {
+            return stream_provider.failResult(error.InvalidE2EDeepSeekEndpoint);
+        }
+        break :endpoint override;
+    } else endpoint;
+    const uri = try std.Uri.parse(request_endpoint);
+
+    var extra_headers_buf: [4]std.http.Header = undefined;
+    var extra_count: usize = 0;
+    extra_headers_buf[extra_count] = .{ .name = "accept", .value = "text/event-stream" };
+    extra_count += 1;
+
+    var client: std.http.Client = .{ .allocator = alloc, .io = io_mod.getIo() };
+    defer client.deinit();
+    var open_operation = OpenRequestOperation{
+        .client = &client,
+        .uri = uri,
+        .auth_header = auth_headers.authorization,
+        .extra_headers = extra_headers_buf[0..extra_count],
+    };
+    var connect_deadline = std.Io.Clock.Timestamp.fromNow(io_mod.getIo(), .{
+        .clock = .awake,
+        .raw = .fromMilliseconds(connect_timeout_ms),
+    });
+    if (request.deadline) |deadline| {
+        if (std.Io.Clock.Timestamp.compare(deadline, .lt, connect_deadline)) {
+            connect_deadline = deadline;
+        }
+    }
+    try request.admission.admit();
+    var opened = try gateway_client.runBoundedHttpOperation(
+        OpenedRequest,
+        alloc,
+        request.cancel_flag,
+        connect_deadline,
+        &open_operation,
+    );
+    var http_request = opened.take();
+    defer http_request.deinit();
+    var cancel_watch_done = std.atomic.Value(bool).init(false);
+    const cancel_watcher = if (http_request.connection) |connection|
+        if (request.deadline) |deadline|
+            try gateway_client.spawnHttpCancelWatcherBounded(
+                &cancel_watch_done,
+                request.cancel_flag,
+                deadline,
+                connection.stream_writer.stream,
+            )
+        else
+            try gateway_client.spawnHttpCancelWatcher(
+                &cancel_watch_done,
+                request.cancel_flag,
+                connection.stream_writer.stream,
+            )
+    else
+        null;
+    defer {
+        cancel_watch_done.store(true, .seq_cst);
+        if (cancel_watcher) |thread| thread.join();
+    }
+    if (request.cancel_flag.load(.seq_cst)) return error.Cancelled;
+
+    http_request.transfer_encoding = .{ .content_length = payload.len };
+    var send_buffer: [8192]u8 = undefined;
+    request.delivery.markPossiblySent();
+    var body_writer = try http_request.sendBodyUnflushed(&send_buffer);
+    try body_writer.writer.writeAll(payload);
+    try body_writer.end();
+    if (http_request.connection) |connection| try connection.flush();
+    if (request.cancel_flag.load(.seq_cst)) return error.Cancelled;
+
+    var response = try http_request.receiveHead(&.{});
+    if (response.head.status != .ok) {
+        var transfer: [16 * 1024]u8 = undefined;
+        const reader = response.reader(&transfer);
+        const bounded_body = reader.allocRemaining(alloc, .limited(max_error_body_bytes + 1)) catch |err| switch (err) {
+            error.StreamTooLong => try alloc.dupe(u8, "DeepSeek error response exceeded the local limit"),
+            else => return err,
+        };
+        const body = if (bounded_body.len > max_error_body_bytes) body: {
+            alloc.free(bounded_body);
+            break :body try alloc.dupe(u8, "DeepSeek error response exceeded the local limit");
+        } else bounded_body;
+        return .{ .failed = .{
+            .kind = failureKind(response.head.status),
+            .detail = body,
+            .ownership = .owned,
+        } };
+    }
+
+    var transfer_buffer: [transfer_buffer_bytes]u8 = undefined;
+    const reader = response.reader(&transfer_buffer);
+    var events = request.events;
+    const completion = try consumeSse(
+        alloc,
+        reader,
+        &events,
+        EventBridge.content,
+        EventBridge.toolStart,
+        EventBridge.reasoning,
+        EventBridge.toolInput,
+        request.cancel_flag,
+        request.content_capture_limit,
+    );
+    errdefer {
+        var owned = stream_provider.Result{ .completed = .{
+            .completion = completion,
+            .ownership = .owned,
+        } };
+        owned.deinit(alloc);
+    }
+    return .{ .completed = .{
+        .completion = completion,
+        .usage = .{ .unavailable = .possibly_billed },
+        .ownership = .owned,
+    } };
+}
+
+const EventBridge = struct {
+    fn sink(raw: *anyopaque) *stream_provider.EventSink {
+        return @ptrCast(@alignCast(raw));
+    }
+
+    fn content(raw: *anyopaque, chunk: []const u8) void {
+        sink(raw).emit(.{ .content_delta = chunk });
+    }
+
+    fn reasoning(raw: *anyopaque, chunk: []const u8) void {
+        sink(raw).emit(.{ .reasoning_delta = chunk });
+    }
+
+    fn toolInput(raw: *anyopaque, chunk: []const u8) void {
+        sink(raw).emit(.{ .tool_input_delta = chunk });
+    }
+
+    fn toolStart(raw: *anyopaque, id: []const u8, name: []const u8, label: ?[]const u8) void {
+        sink(raw).emit(.{ .tool_started = .{ .id = id, .name = name, .label = label } });
+    }
+};
+
+fn failureKind(status: std.http.Status) stream_provider.FailureKind {
+    return switch (status) {
+        .bad_request => .invalid_request,
+        .unauthorized => .unauthorized,
+        .forbidden => .forbidden,
+        .payload_too_large => .request_too_large,
+        .too_many_requests => .rate_limited,
+        .internal_server_error => .server_error,
+        .bad_gateway => .bad_gateway,
+        .service_unavailable => .unavailable,
+        .gateway_timeout => .gateway_timeout,
+        else => .provider_error,
+    };
+}
+
+fn consumeSse(
+    alloc: Allocator,
+    reader: *std.Io.Reader,
+    callback_ctx: *anyopaque,
+    on_content_chunk: stream_provider.StreamCallback,
+    on_tool_start: ?stream_provider.ToolStartCallback,
+    on_reasoning_chunk: ?stream_provider.StreamCallback,
+    on_tool_input_chunk: ?stream_provider.StreamCallback,
+    cancel_flag: *std.atomic.Value(bool),
+    content_capture_limit: ?usize,
+) !types.ModelCompletion {
+    var reducer = responses_protocol.Reducer.init(alloc);
+    defer reducer.deinit(alloc);
+    var sse: sse_stream.Reader = .{ .max_event_bytes = max_sse_line_bytes, .max_total_bytes = max_sse_aggregate_bytes };
+    defer sse.deinit(alloc);
+    const callbacks = responses_protocol.StreamCallbacks{
+        .context = callback_ctx,
+        .on_content = on_content_chunk,
+        .on_tool_start = on_tool_start,
+        .on_reasoning = on_reasoning_chunk,
+        .on_tool_input = on_tool_input_chunk,
+    };
+    const stream_limits = responses_protocol.StreamLimits{
+        .aggregate_bytes = max_sse_aggregate_bytes,
+        .count_json_bytes = false,
+        .events = max_sse_events,
+        .tool_calls = max_tool_calls,
+        .tool_identity_bytes = max_tool_identity_bytes,
+        .tool_arguments_bytes = max_tool_arguments_bytes,
+        .provider_state_bytes = max_provider_state_bytes,
+    };
+    while (sse.next(alloc, reader, cancel_flag) catch |err| return mapReducerError(err)) |json_text| {
+        if (std.mem.eql(u8, json_text, "[DONE]")) break;
+        if (reducer.applyJson(
+            alloc,
+            json_text,
+            callbacks,
+            cancel_flag,
+            content_capture_limit,
+            stream_limits,
+        ) catch |err| return mapReducerError(err)) break;
+    }
+    return reducer.finish(alloc, cancel_flag, stream_limits) catch |err|
+        return mapReducerError(err);
+}
+
+fn mapReducerError(err: anyerror) anyerror {
+    return switch (err) {
+        error.EventTooLarge => error.DeepSeekSseEventTooLarge,
+        error.StreamTooLarge => error.DeepSeekResourceLimitExceeded,
+        error.InvalidEvent => error.InvalidDeepSeekSseEvent,
+        error.StreamIncomplete => error.DeepSeekStreamIncomplete,
+        error.ToolCallLimitExceeded => error.DeepSeekToolCallLimitExceeded,
+        error.ToolArgumentsTooLarge => error.DeepSeekToolArgumentsTooLarge,
+        error.ResourceLimitExceeded => error.DeepSeekResourceLimitExceeded,
+        else => err,
+    };
+}
+
+test "DeepSeek request uses Responses input and converts AI SDK tool schemas" {
+    const read_file_schema = model_tool_schema.FunctionSchema{
+        .name = "read_file",
+        .description = "Read",
+        .input_schema = .{},
+    };
+    const instructions = [_]types.ChatMessage{.{ .role = .system, .content = "Be concise." }};
+    const messages = [_]types.ChatMessage{
+        .{ .role = .user, .content = "Read it." },
+        .{
+            .role = .assistant,
+            .tool_calls = &.{.{ .id = "call_1", .name = "read_file", .arguments_json = "{\"path\":\"README.md\"}" }},
+            .provider_replay = .{ .source = .{ .provider = .deepseek, .model = "deepseek-v4-flash" }, .parts_json = "[{\"id\":\"rs_1\",\"type\":\"reasoning\",\"content\":[{\"type\":\"reasoning_text\",\"text\":\"Let me read it.\"}],\"summary\":[],\"encrypted_content\":\"rs-1\"}]" },
+        },
+        .{ .role = .tool, .tool_call_id = "call_1", .tool_name = "read_file", .content = "contents" },
+    };
+    const body = try buildRequest(std.testing.allocator, .{
+        .model = "deepseek-v4-flash",
+        .instructions = &instructions,
+        .messages = &messages,
+        .tools = .{ .additional_functions = &.{read_file_schema} },
+        .tool_choice = .auto,
+        .provider_options = .{ .reasoning = types.ReasoningEffort.literal("high") },
+        .max_output_tokens = 4096,
+    });
+    defer std.testing.allocator.free(body);
+
+    try std.testing.expect(std.mem.find(u8, body, "\"model\":\"deepseek-v4-flash\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"instructions\":\"Be concise.\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"type\":\"function_call_output\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"type\":\"reasoning\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"reasoning_text\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"parameters\":{\"type\":\"object\",\"properties\":{}}") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"reasoning\":{\"effort\":\"high\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"max_output_tokens\":4096") != null);
+    // DeepSeek never receives OpenAI encrypted-reasoning include or service
+    // tier fields: reasoning is plaintext on its own delta events.
+    try std.testing.expect(std.mem.find(u8, body, "\"include\"") == null);
+    try std.testing.expect(std.mem.find(u8, body, "\"service_tier\"") == null);
+    try std.testing.expect(std.mem.find(u8, body, "\"parallel_tool_calls\"") == null);
+    try std.testing.expect(std.mem.find(u8, body, "\"verbosity\"") == null);
+}
+
+test "DeepSeek standard requests omit tool choice and reasoning when unset" {
+    const messages = [_]types.ChatMessage{.{ .role = .user, .content = "Hello." }};
+    const body = try buildRequest(std.testing.allocator, .{
+        .model = "deepseek-v4-flash",
+        .messages = &messages,
+        .tool_choice = .none,
+        .provider_options = .{},
+    });
+    defer std.testing.allocator.free(body);
+
+    try std.testing.expect(std.mem.find(u8, body, "\"tool_choice\"") == null);
+    try std.testing.expect(std.mem.find(u8, body, "\"reasoning\"") == null);
+    try std.testing.expect(std.mem.find(u8, body, "\"include\"") == null);
+    try std.testing.expect(std.mem.find(u8, body, "\"parallel_tool_calls\"") == null);
+    try std.testing.expect(std.mem.find(u8, body, "\"verbosity\"") == null);
+}
+
+test "DeepSeek serializes each verified image directly once" {
+    const messages = [_]types.ChatMessage{.{ .role = .user, .content = "Describe it." }};
+    const images = [_]image_attachments.VerifiedSnapshot{.{
+        .bytes = @constCast(&[_]u8{ 1, 2, 3, 4 }),
+        .media_type = "image/png",
+    }};
+    const body = try buildRequest(std.testing.allocator, .{
+        .model = "deepseek-v4-flash-vision-exp",
+        .messages = &messages,
+        .tool_choice = .none,
+        .provider_options = .{},
+        .verified_images = &images,
+    });
+    defer std.testing.allocator.free(body);
+
+    const marker = "\"type\":\"input_image\"";
+    const start = std.mem.indexOf(u8, body, marker).?;
+    try std.testing.expect(std.mem.indexOfPos(u8, body, start + marker.len, marker) == null);
+    try std.testing.expect(std.mem.find(u8, body, "\"detail\":\"auto\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "data:image/png;base64,AQIDBA==") != null);
+}
+
+test "DeepSeek rejects a wrong-origin credential before network I/O" {
+    var cancelled = std.atomic.Value(bool).init(false);
+    var delivery = stream_provider.DeliveryCertainty.init();
+    var evidence: stream_provider.AttemptEvidence = .{};
+    var callback_context: u8 = 0;
+    try std.testing.expectError(
+        error.DeepSeekApiKeyCredentialRequired,
+        agent_stream_provider.stream(std.testing.allocator, .{
+            .credential = .{ .direct = .{ .secret_bytes = "gateway-key", .source = .ai_gateway_api_key } },
+            .model = "deepseek-v4-flash",
+            .retry_count = 1,
+            .messages = &.{},
+            .tool_choice = .none,
+            .provider_options = .{},
+            .trace_ctx = .{},
+            .content_capture_limit = null,
+            .delivery = &delivery,
+            .attempt_evidence = &evidence,
+            .events = .{ .context = &callback_context, .emit_fn = struct {
+                fn ignore(_: *anyopaque, _: stream_provider.Event) void {}
+            }.ignore },
+            .cancel_flag = &cancelled,
+        }),
+    );
+    try std.testing.expectEqual(stream_provider.DeliveryCertainty.State.definitely_unsent, delivery.load());
+}
+
+test "DeepSeek rejects an empty direct credential before network I/O" {
+    var cancelled = std.atomic.Value(bool).init(false);
+    var delivery = stream_provider.DeliveryCertainty.init();
+    var evidence: stream_provider.AttemptEvidence = .{};
+    var callback_context: u8 = 0;
+    try std.testing.expectError(
+        error.DeepSeekApiKeyCredentialRequired,
+        agent_stream_provider.stream(std.testing.allocator, .{
+            .credential = .{ .direct = .{ .secret_bytes = "", .source = .deepseek_api_key } },
+            .model = "deepseek-v4-flash",
+            .retry_count = 1,
+            .messages = &.{},
+            .tool_choice = .none,
+            .provider_options = .{},
+            .trace_ctx = .{},
+            .content_capture_limit = null,
+            .delivery = &delivery,
+            .attempt_evidence = &evidence,
+            .events = .{ .context = &callback_context, .emit_fn = struct {
+                fn ignore(_: *anyopaque, _: stream_provider.Event) void {}
+            }.ignore },
+            .cancel_flag = &cancelled,
+        }),
+    );
+    try std.testing.expectEqual(stream_provider.DeliveryCertainty.State.definitely_unsent, delivery.load());
+}
+
+test "host-managed DeepSeek request auth omits the bearer header" {
+    var headers = try requestAuthHeaders(std.testing.allocator, .host_managed);
+    defer headers.deinit(std.testing.allocator);
+
+    try std.testing.expect(headers.authorization == null);
+}
+
+test "DeepSeek SSE maps plaintext reasoning tools and usage" {
+    // Mirrors the live event sequence from api.deepseek.com: reasoning text
+    // deltas arrive plaintext, every data payload carries a sequence_number,
+    // and the stream ends with response.completed carrying the response object.
+    const sse_text =
+        "data: {\"type\":\"response.created\",\"sequence_number\":0,\"response\":{\"id\":\"resp_smoke\",\"status\":\"in_progress\"}}\n\n" ++
+        "data: {\"type\":\"response.output_item.added\",\"sequence_number\":1,\"output_index\":0,\"item\":{\"id\":\"rs_1\",\"type\":\"reasoning\",\"status\":\"in_progress\"}}\n\n" ++
+        "data: {\"type\":\"response.reasoning_text.delta\",\"sequence_number\":2,\"output_index\":0,\"delta\":\"Let me \"}\n\n" ++
+        "data: {\"type\":\"response.reasoning_text.delta\",\"sequence_number\":3,\"output_index\":0,\"delta\":\"read it.\"}\n\n" ++
+        "data: {\"type\":\"response.output_item.done\",\"sequence_number\":4,\"output_index\":0,\"item\":{\"id\":\"rs_1\",\"type\":\"reasoning\",\"status\":\"completed\",\"content\":[{\"type\":\"reasoning_text\",\"text\":\"Let me read it.\"}],\"summary\":[],\"encrypted_content\":\"resp_smoke-0\"}}\n\n" ++
+        "data: {\"type\":\"response.output_item.added\",\"sequence_number\":5,\"output_index\":1,\"item\":{\"type\":\"message\",\"status\":\"in_progress\",\"phase\":\"final_answer\",\"role\":\"assistant\"}}\n\n" ++
+        "data: {\"type\":\"response.output_text.delta\",\"sequence_number\":6,\"output_index\":1,\"delta\":\"hello\"}\n\n" ++
+        "data: {\"type\":\"response.output_item.done\",\"sequence_number\":7,\"output_index\":1,\"item\":{\"type\":\"message\",\"id\":\"msg_1\",\"status\":\"completed\",\"phase\":\"commentary\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"text\":\"hello\"}]}}\n\n" ++
+        "data: {\"type\":\"response.output_item.added\",\"sequence_number\":8,\"output_index\":2,\"item\":{\"type\":\"function_call\",\"call_id\":\"call_1\",\"name\":\"read_file\",\"status\":\"in_progress\"}}\n\n" ++
+        "data: {\"type\":\"response.function_call_arguments.delta\",\"sequence_number\":9,\"output_index\":2,\"delta\":\"{\\\"path\\\":\\\"README.md\\\"}\"}\n\n" ++
+        "data: {\"type\":\"response.completed\",\"sequence_number\":10,\"response\":{\"id\":\"resp_smoke\",\"status\":\"completed\",\"usage\":{\"input_tokens\":10,\"output_tokens\":4,\"output_tokens_details\":{\"reasoning_tokens\":3}}}}\n\n";
+    var reader: std.Io.Reader = .fixed(sse_text);
+    var cancelled = std.atomic.Value(bool).init(false);
+    const Capture = struct {
+        content: std.ArrayList(u8) = .empty,
+        reasoning: std.ArrayList(u8) = .empty,
+        saw_read_file: bool = false,
+
+        fn contentChunk(raw: *anyopaque, chunk: []const u8) void {
+            const self: *@This() = @ptrCast(@alignCast(raw));
+            self.content.appendSlice(std.testing.allocator, chunk) catch unreachable;
+        }
+        fn reasoningChunk(raw: *anyopaque, chunk: []const u8) void {
+            const self: *@This() = @ptrCast(@alignCast(raw));
+            self.reasoning.appendSlice(std.testing.allocator, chunk) catch unreachable;
+        }
+        fn toolStart(raw: *anyopaque, _: []const u8, name: []const u8, _: ?[]const u8) void {
+            const self: *@This() = @ptrCast(@alignCast(raw));
+            self.saw_read_file = std.mem.eql(u8, name, "read_file");
+        }
+    };
+    var capture: Capture = .{};
+    defer capture.content.deinit(std.testing.allocator);
+    defer capture.reasoning.deinit(std.testing.allocator);
+    const completion = try consumeSse(
+        std.testing.allocator,
+        &reader,
+        &capture,
+        Capture.contentChunk,
+        Capture.toolStart,
+        Capture.reasoningChunk,
+        null,
+        &cancelled,
+        null,
+    );
+    defer {
+        if (completion.content) |value| std.testing.allocator.free(@constCast(value));
+        types.freeToolCallSlice(std.testing.allocator, @constCast(completion.tool_calls));
+        if (completion.generation_id) |value| std.testing.allocator.free(@constCast(value));
+        if (completion.provider_state_json) |value| std.testing.allocator.free(@constCast(value));
+    }
+    try std.testing.expectEqualStrings("hello", capture.content.items);
+    try std.testing.expectEqualStrings("Let me read it.", capture.reasoning.items);
+    try std.testing.expect(capture.saw_read_file);
+    try std.testing.expectEqual(@as(usize, 1), completion.tool_calls.len);
+    try std.testing.expectEqualStrings("call_1", completion.tool_calls[0].id);
+    try std.testing.expectEqualStrings("{\"path\":\"README.md\"}", completion.tool_calls[0].arguments_json);
+    try std.testing.expectEqual(@as(?u64, 10), completion.usage.input_tokens);
+    try std.testing.expectEqual(@as(?u64, 3), completion.usage.reasoning_tokens);
+    try std.testing.expectEqualStrings("resp_smoke", completion.generation_id.?);
+    // DeepSeek marks reasoning output items with a placeholder encrypted
+    // content string, so the provider state keeps the full plaintext item
+    // verbatim for thinking-mode tool-loop pass-back.
+    try std.testing.expect(completion.provider_state_json != null);
+    try std.testing.expect(std.mem.find(u8, completion.provider_state_json.?, "\"reasoning_text\"") != null);
+    try std.testing.expect(std.mem.find(u8, completion.provider_state_json.?, "\"Let me read it.\"") != null);
+    try std.testing.expectEqual(types.ProviderFinishReason.tool_calls, completion.finish_reason.?);
+}
+
+fn consumeDeepSeekTestSse(sse_text: []const u8) !types.ModelCompletion {
+    var reader: std.Io.Reader = .fixed(sse_text);
+    var cancelled = std.atomic.Value(bool).init(false);
+    var callback_context: u8 = 0;
+    return consumeSse(
+        std.testing.allocator,
+        &reader,
+        &callback_context,
+        struct {
+            fn ignore(_: *anyopaque, _: []const u8) void {}
+        }.ignore,
+        null,
+        null,
+        null,
+        &cancelled,
+        null,
+    );
+}
+
+fn freeDeepSeekTestCompletion(completion: types.ModelCompletion) void {
+    if (completion.content) |value| std.testing.allocator.free(@constCast(value));
+    types.freeToolCallSlice(std.testing.allocator, @constCast(completion.tool_calls));
+    if (completion.generation_id) |value| std.testing.allocator.free(@constCast(value));
+    if (completion.provider_state_json) |value| std.testing.allocator.free(@constCast(value));
+}
+
+test "DeepSeek SSE completes without a DONE marker and tolerates reasoning-free turns" {
+    const terminal_json = "{\"type\":\"response.completed\",\"response\":{\"status\":\"completed\",\"usage\":{\"input_tokens\":5,\"output_tokens\":2,\"output_tokens_details\":{\"reasoning_tokens\":0}}}}";
+    const completion = try consumeDeepSeekTestSse("data: " ++ terminal_json ++ "\n\n");
+    defer freeDeepSeekTestCompletion(completion);
+
+    try std.testing.expectEqual(types.ProviderFinishReason.stop, completion.finish_reason.?);
+    try std.testing.expectEqual(@as(?u64, 5), completion.usage.input_tokens);
+    try std.testing.expect(completion.generation_id == null);
+}

--- a/src/gateway/deepseek_models.zig
+++ b/src/gateway/deepseek_models.zig
@@ -1,0 +1,211 @@
+const std = @import("std");
+const credentials = @import("../core/auth/credentials.zig");
+const model_catalog = @import("../core/gateway/model_catalog.zig");
+const gateway_provider = @import("../core/gateway/gateway_provider.zig");
+const model_provider = @import("../core/config/model_provider.zig");
+const types = @import("../core/shared/types.zig");
+
+const Allocator = std.mem.Allocator;
+
+/// The reviewer model for unresolved automatic-permission actions. It must
+/// support function calling with tool_choice "required".
+pub const reviewer_model = "deepseek-v4-flash";
+
+const model_specs = [_]ModelSpec{
+    .{
+        .id = "deepseek-v4-flash",
+        .context_window = 1_048_576,
+        .max_tokens = 384_000,
+        .vision = false,
+    },
+    .{
+        .id = "deepseek-v4-pro",
+        .context_window = 1_048_576,
+        .max_tokens = 384_000,
+        .vision = false,
+    },
+    .{
+        .id = "deepseek-v4-flash-vision-exp",
+        .context_window = 1_048_576,
+        .max_tokens = 384_000,
+        .vision = true,
+    },
+};
+
+const ModelSpec = struct {
+    id: []const u8,
+    context_window: u32,
+    max_tokens: u32,
+    vision: bool,
+};
+
+pub const model_catalog_provider = model_catalog.Provider{
+    .fetch_fn = fetchCatalogForProvider,
+    .provider_id = .deepseek,
+};
+
+pub const cli_model_catalog_provider = gateway_provider.CliModelCatalogProvider{
+    .fetch_fn = fetchCliModelCatalog,
+};
+
+fn fetchCliModelCatalog(
+    _: ?*anyopaque,
+    alloc: std.mem.Allocator,
+    input: gateway_provider.CliModelCatalogInput,
+) gateway_provider.CliModelCatalogResult {
+    return switch (model_catalog.fetchWithPublicFallback(model_catalog_provider, alloc, .{
+        .access = input.access,
+        .endpoint = input.endpoint,
+        .cancel_flag = input.cancel_flag,
+        .view = .full,
+    })) {
+        .loaded => |loaded| blk: {
+            var catalog = loaded.catalog;
+            defer model_catalog.freeModelCatalog(alloc, &catalog);
+            const ids = model_catalog.projectModelIds(alloc, catalog.items) catch return .{ .failure = .{
+                .access = loaded.provenance.access,
+                .anonymous_fallback_used = false,
+                .failure = .{ .category = .resource_exhausted },
+            } };
+            break :blk .{ .loaded = .{
+                .ids = ids,
+                .provenance = loaded.provenance,
+            } };
+        },
+        .failed => |failure| .{ .failure = failure },
+    };
+}
+
+/// The DeepSeek platform model set is small and its server enforces an exact
+/// allow list (verified live: an unknown model name returns 400 listing the
+/// three supported ids), so the catalog is served from a curated static table
+/// mirroring the documented Responses API models rather than a network fetch.
+fn fetchCatalogForProvider(
+    _: ?*anyopaque,
+    alloc: std.mem.Allocator,
+    input: model_catalog.FetchInput,
+) std.mem.Allocator.Error!model_catalog.ProviderResult {
+    const access = input.access;
+    const authenticated = switch (access) {
+        .host_managed => true,
+        .authenticated => |state| state.source == .deepseek_api_key and state.credential.len > 0,
+        .public_only => false,
+    };
+    if (!authenticated) {
+        return .{ .failure = .{ .category = .authentication, .http_status = .unauthorized } };
+    }
+    if (input.cancel_flag) |cancel_flag| if (cancel_flag.load(.seq_cst)) {
+        return .{ .failure = .{ .category = .cancellation } };
+    };
+
+    var entries: std.ArrayList(model_catalog.ModelCatalogEntry) = .empty;
+    errdefer model_catalog.freeModelCatalog(alloc, &entries);
+    for (model_specs) |spec| {
+        try appendEntry(alloc, &entries, spec);
+    }
+    return .{ .catalog = entries };
+}
+
+fn appendEntry(alloc: Allocator, entries: *std.ArrayList(model_catalog.ModelCatalogEntry), spec: ModelSpec) !void {
+    const id = try alloc.dupe(u8, spec.id);
+    errdefer alloc.free(id);
+    const model_type = try alloc.dupe(u8, "language");
+    errdefer alloc.free(model_type);
+    var reasoning_efforts: std.ArrayList(types.ReasoningEffort) = .empty;
+    errdefer reasoning_efforts.deinit(alloc);
+    try reasoning_efforts.append(alloc, types.ReasoningEffort.literal("low"));
+    try reasoning_efforts.append(alloc, types.ReasoningEffort.literal("high"));
+    try reasoning_efforts.append(alloc, types.ReasoningEffort.literal("max"));
+    try entries.append(alloc, .{
+        .id = id,
+        .model_type = model_type,
+        .has_tool_use = true,
+        .has_reasoning = true,
+        .reasoning_efforts = reasoning_efforts,
+        .supports_fast_mode = false,
+        .has_vision = spec.vision,
+        .has_file_input = false,
+        .context_window = spec.context_window,
+        .max_tokens = spec.max_tokens,
+    });
+}
+
+pub fn fallbackCapabilities(model: []const u8) @import("../core/config/model_capabilities.zig").Capabilities {
+    var capabilities: @import("../core/config/model_capabilities.zig").Capabilities = .{};
+    for (model_specs) |spec| {
+        if (std.mem.eql(u8, model, spec.id)) {
+            capabilities.supports_tool_use = true;
+            capabilities.supports_vision = spec.vision;
+            capabilities.context_window = spec.context_window;
+            capabilities.max_output_tokens = spec.max_tokens;
+            return capabilities;
+        }
+    }
+    return capabilities;
+}
+
+test "DeepSeek catalog lists the three documented Responses models" {
+    var entries: std.ArrayList(model_catalog.ModelCatalogEntry) = .empty;
+    defer model_catalog.freeModelCatalog(std.testing.allocator, &entries);
+    for (model_specs) |spec| try appendEntry(std.testing.allocator, &entries, spec);
+
+    try std.testing.expectEqual(@as(usize, 3), entries.items.len);
+    try std.testing.expectEqualStrings("deepseek-v4-flash", entries.items[0].id);
+    try std.testing.expectEqualStrings("deepseek-v4-pro", entries.items[1].id);
+    try std.testing.expectEqualStrings("deepseek-v4-flash-vision-exp", entries.items[2].id);
+    try std.testing.expect(entries.items[0].has_tool_use);
+    try std.testing.expect(entries.items[0].has_reasoning);
+    try std.testing.expectEqual(@as(usize, 3), entries.items[0].reasoning_efforts.items.len);
+    try std.testing.expectEqualStrings("low", entries.items[0].reasoning_efforts.items[0].label());
+    try std.testing.expectEqualStrings("high", entries.items[0].reasoning_efforts.items[1].label());
+    try std.testing.expectEqualStrings("max", entries.items[0].reasoning_efforts.items[2].label());
+    try std.testing.expect(!entries.items[0].supports_fast_mode);
+    try std.testing.expect(!entries.items[0].has_vision);
+    try std.testing.expect(entries.items[2].has_vision);
+    try std.testing.expect(!entries.items[2].has_file_input);
+    try std.testing.expectEqual(@as(u32, 1_048_576), entries.items[0].context_window);
+    try std.testing.expectEqual(@as(u32, 384_000), entries.items[0].max_tokens);
+}
+
+test "DeepSeek catalog fetch requires an authenticated DeepSeek credential" {
+    const fetch = model_catalog.Provider{
+        .context = null,
+        .fetch_fn = fetchCatalogForProvider,
+        .provider_id = .deepseek,
+    };
+    var missing = try fetch.fetch(std.testing.allocator, .{
+        .access = .{ .public_only = .no_credential },
+        .endpoint = "",
+    });
+    switch (missing) {
+        .catalog => |*catalog| {
+            model_catalog.freeModelCatalog(std.testing.allocator, catalog);
+            return error.TestExpectedDeepSeekCatalogFailure;
+        },
+        .failure => |failure| try std.testing.expectEqual(model_catalog.FailureCategory.authentication, failure.category),
+    }
+
+    var loaded = try fetch.fetch(std.testing.allocator, .{
+        .access = credentials.catalogAccessForCredential(.deepseek_api_key, "sk-test", null),
+        .endpoint = "",
+    });
+    switch (loaded) {
+        .failure => return error.DeepSeekCatalogFetchFailedUnexpectedly,
+        .catalog => |*catalog| {
+            defer model_catalog.freeModelCatalog(std.testing.allocator, catalog);
+            try std.testing.expectEqual(@as(usize, 3), catalog.items.len);
+        },
+    }
+}
+
+test "DeepSeek fallback capabilities cover the documented models" {
+    const flash = fallbackCapabilities("deepseek-v4-flash");
+    try std.testing.expect(flash.supports_tool_use);
+    try std.testing.expect(!flash.supports_vision);
+    try std.testing.expectEqual(@as(?u32, 1_048_576), flash.context_window);
+    const vision = fallbackCapabilities("deepseek-v4-flash-vision-exp");
+    try std.testing.expect(vision.supports_vision);
+    const unknown = fallbackCapabilities("deepseek-other");
+    try std.testing.expect(!unknown.supports_tool_use);
+    _ = model_provider.ProviderId;
+}

--- a/src/gateway/deepseek_permission_reviewer.zig
+++ b/src/gateway/deepseek_permission_reviewer.zig
@@ -1,0 +1,81 @@
+const std = @import("std");
+const permission_auto_classifier = @import("../core/permissions/auto_classifier.zig");
+const stream_provider = @import("../core/agent/stream_provider.zig");
+const types = @import("../core/shared/types.zig");
+const deepseek = @import("deepseek.zig");
+const deepseek_models = @import("deepseek_models.zig");
+const responses_reviewer = @import("responses_permission_reviewer.zig");
+
+const Allocator = std.mem.Allocator;
+
+pub const provider = permission_auto_classifier.Provider{
+    .review_fn = reviewDeepSeek,
+};
+
+fn reviewDeepSeek(
+    _: ?*anyopaque,
+    alloc: Allocator,
+    input: permission_auto_classifier.ProviderInput,
+    request: permission_auto_classifier.ReviewRequest,
+) anyerror!permission_auto_classifier.ParseOutcome {
+    return responses_reviewer.review(alloc, input, request, .{
+        .source = .deepseek_api_key,
+        .model = deepseek_models.reviewer_model,
+        .validate_fn = validateCredential,
+        .build_fn = deepseek.buildRequest,
+        .send_fn = sendPrepared,
+    });
+}
+
+fn validateCredential(
+    _: Allocator,
+    input: permission_auto_classifier.ProviderInput,
+) !void {
+    if (input.credential.len == 0) {
+        return error.InvalidDeepSeekCredential;
+    }
+}
+
+fn sendPrepared(
+    alloc: Allocator,
+    request: stream_provider.ModelRequest,
+    payload: []const u8,
+) anyerror!stream_provider.Result {
+    return deepseek.streamPrepared(alloc, request, payload);
+}
+
+test "DeepSeek reviewer builds a direct Responses request with deepseek-v4-flash" {
+    const instructions = [_]types.ChatMessage{.{ .role = .system, .content = "Review the pending action." }};
+    const messages = [_]types.ChatMessage{
+        .{ .role = .user, .content = "User requested the change." },
+        .{
+            .role = .assistant,
+            .tool_calls = &.{.{
+                .id = "call_review",
+                .name = "write_file",
+                .arguments_json = "{\"path\":\"a.txt\"}",
+            }},
+        },
+    };
+    var cancelled = std.atomic.Value(bool).init(false);
+    const body = try responses_reviewer.buildPayloadForTest(
+        std.testing.allocator,
+        deepseek_models.reviewer_model,
+        &instructions,
+        &messages,
+        "call_review",
+        std.Io.Clock.Timestamp.fromNow(@import("../core/shared/io.zig").getIo(), .{
+            .clock = .awake,
+            .raw = .fromSeconds(5),
+        }),
+        &cancelled,
+        deepseek.buildRequest,
+    );
+    defer std.testing.allocator.free(body);
+
+    try std.testing.expect(std.mem.find(u8, body, "\"model\":\"deepseek-v4-flash\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"tool_choice\":\"required\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"type\":\"function_call_output\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "ai-gateway") == null);
+    try std.testing.expect(std.mem.find(u8, body, "\"include\"") == null);
+}

--- a/src/gateway/responses_protocol.zig
+++ b/src/gateway/responses_protocol.zig
@@ -1130,10 +1130,12 @@ pub const Reducer = struct {
         };
         if (low < self.message_items.items.len and self.message_items.items[low].output_index == output_index) {
             const prior = &self.message_items.items[low];
-            if (phase) |value| {
-                if (prior.phase) |old| if (old != value) return error.ResponsesTextConflict;
-                prior.phase = value;
-            }
+            // Providers may publish a provisional phase on output_item.added
+            // and correct it on output_item.done (DeepSeek announces
+            // "final_answer" first and completes the same item as
+            // "commentary"). The completed phase is authoritative, so adopt
+            // the latest phase instead of treating the change as a conflict.
+            if (phase) |value| prior.phase = value;
             if (id_hash != null) prior.id_hash = id_hash;
             return prior;
         }
@@ -2189,7 +2191,7 @@ test "Responses captures assistant phase from terminal output" {
     try std.testing.expectEqualStrings("final_answer", replay.value.array.items[0].object.get("phase").?.string);
 }
 
-test "Responses omits unknown phases and rejects contradictory phases within one message" {
+test "Responses omits unknown phases and adopts the completed phase over a provisional one" {
     var unknown = ToolRecordTest.init(std.testing.allocator);
     defer unknown.deinit();
     try unknown.apply(
@@ -2200,14 +2202,23 @@ test "Responses omits unknown phases and rejects contradictory phases within one
     defer unknown.freeCompletion(unknown_completion);
     try std.testing.expect(unknown_completion.provider_state_json == null);
 
-    var conflicting = ToolRecordTest.init(std.testing.allocator);
-    defer conflicting.deinit();
-    try conflicting.apply(
-        "{\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"message\",\"phase\":\"commentary\"}}",
+    var corrected = ToolRecordTest.init(std.testing.allocator);
+    defer corrected.deinit();
+    try corrected.apply(
+        "{\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"message\",\"phase\":\"final_answer\"}}",
     );
-    try std.testing.expectError(error.ResponsesTextConflict, conflicting.apply(
-        "{\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"message\",\"phase\":\"final_answer\",\"content\":[]}}",
-    ));
+    try corrected.apply(
+        "{\"type\":\"response.output_text.delta\",\"output_index\":0,\"delta\":\"I will inspect the file first.\"}",
+    );
+    try corrected.apply(
+        "{\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"message\",\"phase\":\"commentary\",\"content\":[{\"type\":\"output_text\",\"text\":\"I will inspect the file first.\"}]}}",
+    );
+    try corrected.apply(ToolRecordTest.terminal);
+    const corrected_completion = try corrected.finish();
+    defer corrected.freeCompletion(corrected_completion);
+    const replay = try std.json.parseFromSlice(std.json.Value, corrected.alloc, corrected_completion.provider_state_json.?, .{});
+    defer replay.deinit();
+    try std.testing.expectEqualStrings("commentary", replay.value.array.items[0].object.get("phase").?.string);
 }
 
 test "Responses rejects conflicting completed tool records" {

--- a/src/ui/footer/model_menu_presentation.zig
+++ b/src/ui/footer/model_menu_presentation.zig
@@ -419,6 +419,7 @@ fn loadedCatalogStatusText(state: model_cache_runtime.ModelMenuCatalogState) ?[]
             .stored_key => "Gateway catalog: authenticated with the stored API key.",
             .chatgpt_subscription => "Codex catalog: authenticated with a subscription.",
             .grok_subscription => "Grok catalog: authenticated with a subscription.",
+            .deepseek_api_key => "DeepSeek catalog: authenticated with DEEPSEEK_API_KEY.",
             .host_managed => "Provider catalog: authentication is managed by the host.",
         };
     }


### PR DESCRIPTION
## Summary

Adds **DeepSeek** as a native model provider that fx talks to directly. Requests route straight from fx to the DeepSeek API (`api.deepseek.com`) over the OpenAI Responses protocol with your own key, never through Vercel AI Gateway, OpenAI, or xAI.

## Registering DeepSeek with `fx login deepseek`

DeepSeek is pay-as-you-go and key-based, so there is no OAuth browser sign-in. Configure it from the terminal:

```bash
export DEEPSEEK_API_KEY=sk-...   # create a key in the DeepSeek Platform console
fx login deepseek                # validates the key and selects DeepSeek
fx
```

Notes on how this flow behaves, so the docs and copy stay honest:

- `fx login deepseek` checks the `DEEPSEEK_API_KEY` environment variable, fetches the authenticated DeepSeek model catalog with it, and persists only the provider/model selection (profile settings under `~/.fx`).
- The key itself is read from the environment on every request. fx saves no DeepSeek login session, does not write the key to the macOS Keychain or to any `~/.fx` file, and never sends it to Vercel, OpenAI, or xAI.
- `fx logout deepseek` prints that nothing is stored.
- `fx login deepseek` reports `fx needs a DeepSeek API key for this model. Set DEEPSEEK_API_KEY.` when the variable is missing or empty, and `fx provider deepseek` and `/provider` can select DeepSeek the same way.

## What changes

- New `deepseek` provider id wired into the CLI, TUI provider menu, model catalog, credential resolution, and permission review.
- `src/gateway/deepseek.zig`: DeepSeek transport over the Responses API, including streaming, tool use, and image input; `src/gateway/deepseek_models.zig`: authenticated model catalog; `src/gateway/deepseek_permission_reviewer.zig`: permission review for direct DeepSeek traffic.
- Thinking-mode chain of thought is stored with your sessions so continued tool use can pass it back to the API.
- README usage docs for the new provider.

## Verification

- `zig build -Doptimize=ReleaseSafe` succeeds on this head; the built binary reports `0.0.8` and runs.
- Local unit/e2e suites and Full CI have not been run yet for this head; this PR is a draft pending the Full CI run on all four native runners.

Required label: `type: feature` (external contributor cannot apply labels on this repo; please add it during review).
