### PR TITLE
Complete directory shortcuts without trailing slashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ fx
 
 The current directory becomes the primary workspace. Enter a prompt, or run `/help` to browse interactive commands. While fx is working, you can submit a multiline update with Enter; it steers the active turn at its next safe model boundary. When no tool is running, your message appears in the transcript immediately. Updates waiting for a running tool show their first two lines with a dotted rail and an ellipsis when more text is hidden. Press Escape to interrupt the active work and apply the update as soon as the turn settles.
 
+Type `@` to find workspace files. Use `@~`, `@.`, or `@..` to browse your home, current workspace, or parent directory without typing a trailing slash. Tab or Enter inserts the selected path; selecting a directory continues browsing inside it.
+
 Use `/resume` to choose a saved conversation. The picker shares its catalog across workspace views and reuses unchanged session summaries between launches. The first catalog build, or recovery from missing cache data, scans saved sessions automatically. Changed sessions are checked again, and closing the picker stops obsolete loading work.
 
 Tool calls are expanded by default. Enable `Collapse tool calls` in `/settings`, or set `"collapse_tool_calls": true` in `~/.fx/settings.json`, to show one summary per tool-call group in the main transcript. Individual calls remain available in the full transcript with Ctrl+O. Follow-up activity for captured shell commands shows the original command, such as `Observed zig build`, while tool results keep the same execution handle.

--- a/src/core/workspace/path_completion.zig
+++ b/src/core/workspace/path_completion.zig
@@ -23,10 +23,7 @@ const ParsedQuery = struct {
 };
 
 pub fn queryMode(query: []const u8) QueryMode {
-    for (query) |byte| {
-        if (std.fs.path.isSep(byte)) return .explicit_path;
-    }
-    return .workspace_index;
+    return if (parseExplicitQuery(query) != null) .explicit_path else .workspace_index;
 }
 
 pub fn complete(
@@ -114,6 +111,13 @@ pub fn isCurrentCandidateKind(
 }
 
 fn parseExplicitQuery(query: []const u8) ?ParsedQuery {
+    inline for (.{ "~", ".", ".." }) |shortcut| {
+        if (std.mem.eql(u8, query, shortcut)) return .{
+            .parent = query,
+            .display_prefix = shortcut ++ "/",
+            .basename_prefix = "",
+        };
+    }
     var separator_index: ?usize = null;
     for (query, 0..) |byte, index| {
         if (std.fs.path.isSep(byte)) separator_index = index;
@@ -206,7 +210,7 @@ fn writeTestFile(dir: std.Io.Dir, path: []const u8) !void {
 
 test "path completion classifies and splits only path-shaped queries" {
     try std.testing.expectEqual(QueryMode.workspace_index, queryMode("main"));
-    try std.testing.expectEqual(QueryMode.workspace_index, queryMode("~"));
+    try std.testing.expectEqual(QueryMode.explicit_path, queryMode("~"));
     try std.testing.expectEqual(QueryMode.explicit_path, queryMode("~/Dow"));
     try std.testing.expectEqual(QueryMode.explicit_path, queryMode("/tmp/fi"));
     try std.testing.expectEqual(QueryMode.explicit_path, queryMode("./src/"));
@@ -217,6 +221,47 @@ test "path completion classifies and splits only path-shaped queries" {
     try std.testing.expectEqualStrings("../shared", parsed.parent);
     try std.testing.expectEqualStrings("../shared/", parsed.display_prefix);
     try std.testing.expectEqualStrings("na", parsed.basename_prefix);
+}
+
+test "path completion treats only exact directory shortcuts as roots" {
+    inline for (.{ "~", ".", ".." }) |shortcut| {
+        try std.testing.expectEqual(QueryMode.explicit_path, queryMode(shortcut));
+        const parsed = parseExplicitQuery(shortcut).?;
+        const with_slash = parseExplicitQuery(shortcut ++ "/").?;
+        try std.testing.expectEqualStrings(shortcut, parsed.parent);
+        try std.testing.expectEqualStrings(shortcut ++ "/", parsed.display_prefix);
+        try std.testing.expectEqualStrings("", parsed.basename_prefix);
+        try std.testing.expectEqualStrings(with_slash.parent, parsed.parent);
+        try std.testing.expectEqualStrings(with_slash.display_prefix, parsed.display_prefix);
+        try std.testing.expectEqualStrings(with_slash.basename_prefix, parsed.basename_prefix);
+    }
+    for ([_][]const u8{ "", ".gitignore", "...", "..notes", "~notes", "main", "readme.md" }) |query| {
+        try std.testing.expectEqual(QueryMode.workspace_index, queryMode(query));
+        try std.testing.expect(parseExplicitQuery(query) == null);
+    }
+}
+
+test "path completion browses bare current and parent directories" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeTestFile(tmp.dir, "workspace/local.txt");
+    try writeTestFile(tmp.dir, "parent.txt");
+    const root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "workspace");
+    defer alloc.free(root);
+    var results: [4]file_index.SearchResult = undefined;
+    var spans: [4]file_index.MatchSpan = undefined;
+    var paths: [4 * file_index.max_path_len]u8 = undefined;
+
+    try std.testing.expectEqual(@as(usize, 1), try complete(root, ".", &results, &spans, &paths));
+    try std.testing.expectEqualStrings("./local.txt", results[0].path);
+    try std.testing.expectEqual(@as(usize, 0), results[0].matched_spans.len);
+    try std.testing.expect(isCurrentCandidateKind(root, results[0].path, .file));
+
+    try std.testing.expectEqual(@as(usize, 2), try complete(root, "..", &results, &spans, &paths));
+    try std.testing.expectEqualStrings("../parent.txt", results[0].path);
+    try std.testing.expectEqualStrings("../workspace", results[1].path);
+    try std.testing.expect(isCurrentCandidateKind(root, results[1].path, .directory));
 }
 
 test "path completion enumerates immediate entries with deterministic bounded order" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -4209,6 +4209,7 @@ test {
     _ = @import("core/auth/oauth.zig");
     _ = @import("core/auth/oauth_session.zig");
     _ = @import("core/workspace/file_index.zig");
+    _ = @import("core/workspace/path_completion.zig");
     _ = @import("gateway/vercel_protocol.zig");
     _ = @import("core/gateway/provider_set.zig");
     _ = @import("core/github/git_context.zig");

--- a/tests/e2e/tui-file-picker.test.ts
+++ b/tests/e2e/tui-file-picker.test.ts
@@ -1596,6 +1596,98 @@ describe("@ file picker", () => {
   );
 
   tmuxTest(
+    "browses bare directory shortcuts from startup through submission and exit",
+    async () => {
+      const current = createFixture("fx-file-picker-shortcuts-");
+      initGit(current.workspace);
+      writeFileSync(join(current.home, "home-target.txt"), "DO_NOT_ATTACH_HOME_CONTENT");
+      writeFileSync(join(current.workspace, "local-target.txt"), "local");
+      writeFileSync(join(current.workspace, ".gitignore"), "ignored/\n");
+      writeFileSync(join(current.root, "parent-target.txt"), "parent");
+      git(current.workspace, "add", "local-target.txt", ".gitignore");
+      gateway = startFakeGateway([fakeGatewayFinalText("SHORTCUT_FLOW_OK")]);
+      session = await TmuxSession.create({
+        cmd: FX_BIN,
+        cwd: current.workspace,
+        env: mockFxEnvironment(current, gateway),
+        isolated: true,
+        width: 112,
+        height: 32,
+        stderrPath: current.stderrPath,
+      });
+      const active = session;
+      await active.waitForComposer(TIMEOUT);
+
+      for (const [shortcut, label] of [
+        ["~", "~/home-target.txt"],
+        [".", "./local-target.txt"],
+        ["..", "../parent-target.txt"],
+      ] as const) {
+        await clearComposer(active);
+        await active.sendLiteral(`@${shortcut}`);
+        await active.waitForText(label, TIMEOUT);
+        expect(await composerPlainText(active)).toBe(`@${shortcut}`);
+        await active.sendLiteral("/");
+        await active.waitForText(label, TIMEOUT);
+        await active.sendKeys("BSpace");
+        await active.waitForPane((pane) =>
+          composerTextFromPane(pane) === `@${shortcut}` && pane.includes(label), TIMEOUT);
+        await active.sendKeys("Escape");
+        await active.waitForPane((pane) => !pane.includes(label), TIMEOUT);
+      }
+
+      await clearComposer(active);
+      await active.sendLiteral("@.gitig");
+      await active.waitForText(".gitignore", TIMEOUT);
+      await active.sendKeys("Tab");
+      expect(await composerPlainText(active)).toBe("@.gitignore");
+      await clearComposer(active);
+      await active.sendLiteral("@lcltrgt");
+      await active.waitForText("local-target.txt", TIMEOUT);
+      await active.sendKeys("Enter");
+      expect(await composerPlainText(active)).toBe("@local-target.txt");
+
+      await clearComposer(active);
+      await active.sendLiteral("@~");
+      await active.waitForText("~/home-target.txt", TIMEOUT);
+      await active.sendKeys("Down Enter");
+      expect(await composerPlainText(active)).toBe("@~/home-target.txt");
+      expect(gateway?.requests).toHaveLength(0);
+      await active.sendLiteral(" Reply with the words SHORTCUT, FLOW, and OK joined by underscores.");
+      await active.sendKeys("Enter");
+      await active.waitForText("SHORTCUT_FLOW_OK", TIMEOUT);
+      await active.waitForStableComposer(TIMEOUT);
+      expect(gateway?.requests).toHaveLength(1);
+      const request = JSON.parse(gateway!.requests[0]!.body);
+      expect(request.prompt.at(-1)).toEqual({
+        role: "user",
+        content: [{ type: "text", text: "@~/home-target.txt Reply with the words SHORTCUT, FLOW, and OK joined by underscores." }],
+      });
+      expect(gateway!.requests[0]!.body).not.toContain("DO_NOT_ATTACH_HOME_CONTENT");
+      const scrollback = await active.captureFullScrollbackEscapes();
+      expect(scrollback).toContain("SHORTCUT_FLOW_OK");
+      expect(scrollback).not.toContain("no matching files");
+      expectCleanRuntime(current, active);
+      await active.sendText("/quit");
+      await active.waitForSessionEnd(TIMEOUT);
+      expect(active.paneStatus()).toEqual({ dead: true, status: 0 });
+      expect(readFileSync(current.stderrPath, "utf8")).toBe("");
+
+      const replay = await runFx(["replay", current.tapePath, "--frames"], {
+        cwd: current.workspace,
+        env: { HOME: current.home },
+        timeoutMs: TIMEOUT,
+      });
+      expect(replay.code).toBe(0);
+      expect(replay.stderr).toBe("");
+      for (const text of ["~/home-target.txt", "./local-target.txt", "../parent-target.txt", "SHORTCUT_FLOW_OK"]) {
+        expect(replay.stdout).toContain(text);
+      }
+    },
+    120_000,
+  );
+
+  tmuxTest(
     "browses current, parent, home, and absolute filesystem paths",
     async () => {
       const current = createFixture("fx-file-picker-filesystem-");
@@ -1879,7 +1971,7 @@ describe("@ file picker", () => {
   );
 
   liveTmuxTest(
-    "browses a home path and submits through the live Gateway",
+    "browses a bare home shortcut through the live Gateway and exits cleanly",
     async () => {
       const current = createFixture("fx-file-picker-live-");
       initGit(current.workspace);
@@ -1900,16 +1992,20 @@ describe("@ file picker", () => {
           FX_MODEL: process.env.FX_FILE_PICKER_LIVE_MODEL ?? "anthropic/claude-sonnet-4.6",
           FX_TRACE_LOG: current.tracePath,
           FX_TRACE_SCOPES: "input,prompt,gateway",
+          FX_RECORD: current.tapePath,
         },
+        isolated: true,
         width: 112,
         height: 32,
         stderrPath: current.stderrPath,
         startupWaitMs: 1000,
       });
       await session.waitForComposer(TIMEOUT);
-      await session.sendLiteral('@"~/live');
-      await session.waitForText("live space/", TIMEOUT);
-      await session.sendKeys("Tab");
+      await session.sendLiteral('@"~');
+      await session.waitForText("~/live space/", TIMEOUT);
+      expect(await composerPlainText(session)).toBe('@"~');
+      await session.sendKeys("Down Tab");
+      expect(await composerPlainText(session)).toBe('@"~/live space/');
       await session.sendLiteral("live-context");
       await session.waitForText("live-context.txt", TIMEOUT);
       await session.sendKeys("Enter");
@@ -1918,7 +2014,22 @@ describe("@ file picker", () => {
       );
       await session.sendKeys("Enter");
       await session.waitForText("LIVE_PICKER_OK", 180_000);
+      await session.waitForStableComposer(TIMEOUT);
+      expect(await session.captureFullScrollback()).toContain("LIVE_PICKER_OK");
       expectCleanRuntime(current, session);
+      await session.sendText("/quit");
+      await session.waitForSessionEnd(TIMEOUT);
+      expect(session.paneStatus()).toEqual({ dead: true, status: 0 });
+      expect(readFileSync(current.stderrPath, "utf8")).toBe("");
+      const replay = await runFx(["replay", current.tapePath, "--frames"], {
+        cwd: current.workspace,
+        env: { HOME: current.home },
+        timeoutMs: TIMEOUT,
+      });
+      expect(replay.code).toBe(0);
+      expect(replay.stderr).toBe("");
+      expect(replay.stdout).toContain("~/live space/");
+      expect(replay.stdout).toContain("LIVE_PICKER_OK");
     },
     180_000,
   );


### PR DESCRIPTION
## Summary

- Browse the home directory with `@~` without typing a trailing slash.
- Browse the current workspace with `@.` without typing a trailing slash.
- Browse the parent directory with `@..` without typing a trailing slash.
