### PR TITLE
Show resource paths in pending skill activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Skills are advertised in a stable catalog sized to the selected model's context 
 
 Explicit `$skill-name` mentions load the selected instructions before the model starts work. The `skill` tool accepts an advertised `location` and an optional relative `resource`, returning the complete document or a visible failure. Omitting `resource` or passing an empty string reads `SKILL.md`. File and tool-result limits still apply, and an explicit `skill_chunk_bytes` limit blocks a complete read that would exceed it. Existing named, offset-based calls remain supported.
 
-In the interactive shell, explicitly requested skills show a named load summary before the assistant replies. Full failure details are available in Ctrl+O. These automatic loads are not counted as tool calls; a loaded status confirms prepared instructions, not that the model followed them.
+In the interactive shell, explicitly requested skills show a named load summary before the assistant replies. Pending skill resource reads show the relative resource path once the tool arguments arrive, without exposing the internal skill location. Full failure details are available in Ctrl+O. These automatic loads are not counted as tool calls; a loaded status confirms prepared instructions, not that the model followed them.
 
 ## Documentation
 

--- a/src/builtins/gateway.zig
+++ b/src/builtins/gateway.zig
@@ -671,8 +671,8 @@ const EventBridge = struct {
         sink(raw).emit(.{ .tool_input_delta = chunk });
     }
 
-    fn toolStart(raw: *anyopaque, id: []const u8, name: []const u8, label: ?[]const u8) void {
-        sink(raw).emit(.{ .tool_started = .{ .id = id, .name = name, .label = label } });
+    fn toolStart(raw: *anyopaque, id: []const u8, name: []const u8, label: ?[]const u8, arguments_json: ?[]const u8) void {
+        sink(raw).emit(.{ .tool_started = .{ .id = id, .name = name, .label = label, .arguments_json = arguments_json } });
     }
 };
 

--- a/src/core/agent/runtime/assistant_stream.zig
+++ b/src/core/agent/runtime/assistant_stream.zig
@@ -292,7 +292,7 @@ pub fn pushTokenProgressUpdate(stream_ctx: *StreamChunkContext, update: runtime_
     }
 }
 
-pub fn onStreamToolStart(ctx: *anyopaque, tool_id: []const u8, tool_name: []const u8, label_value: ?[]const u8) void {
+pub fn onStreamToolStart(ctx: *anyopaque, tool_id: []const u8, tool_name: []const u8, label_value: ?[]const u8, arguments_json: ?[]const u8) void {
     const stream_ctx: *StreamChunkContext = @ptrCast(@alignCast(ctx));
     const first_tool_in_step = !stream_ctx.saw_tool_start;
     recordStreamToolStart(ctx, tool_name);
@@ -331,6 +331,7 @@ pub fn onStreamToolStart(ctx: *anyopaque, tool_id: []const u8, tool_name: []cons
             metadata.activity_kind,
             metadata.action_label,
             label_value,
+            arguments_json,
         ) catch {},
     }
 }
@@ -953,7 +954,7 @@ test "provider callbacks publish each activity phase transition once" {
     onStreamReasoningChunk(&stream_ctx, " continues");
     onStreamContentChunk(&stream_ctx, "response");
     onStreamContentChunk(&stream_ctx, " continues\n");
-    onStreamToolStart(&stream_ctx, "command_1", "shell", null);
+    onStreamToolStart(&stream_ctx, "command_1", "shell", null, null);
 
     try std.testing.expectEqualSlices(
         types.TurnPhase,
@@ -1056,15 +1057,15 @@ test "streamed tool starts emit lifecycle only for identified read-only tools" {
     };
     defer stream_ctx.deinit();
 
-    onStreamToolStart(&stream_ctx, "write_1", "write_file", "file1.txt");
-    onStreamToolStart(&stream_ctx, "edit_1", "edit_file", "file2.txt");
-    onStreamToolStart(&stream_ctx, "ask_1", "request_user_input", null);
-    onStreamToolStart(&stream_ctx, "", "read_file", "src/main.zig");
+    onStreamToolStart(&stream_ctx, "write_1", "write_file", "file1.txt", null);
+    onStreamToolStart(&stream_ctx, "edit_1", "edit_file", "file2.txt", null);
+    onStreamToolStart(&stream_ctx, "ask_1", "request_user_input", null, null);
+    onStreamToolStart(&stream_ctx, "", "read_file", "src/main.zig", null);
 
     try std.testing.expect(stream_ctx.first_model_output_at_ms != null);
     try std.testing.expectEqual(@as(usize, 0), capture.lifecycle_events.items.len);
 
-    onStreamToolStart(&stream_ctx, "read_1", "read_file", "src/main.zig");
+    onStreamToolStart(&stream_ctx, "read_1", "read_file", "src/main.zig", null);
 
     try std.testing.expectEqual(@as(usize, 2), capture.lifecycle_events.items.len);
     try std.testing.expectEqualStrings(
@@ -1090,7 +1091,7 @@ test "streamed unknown tool start preserves the buffered stream boundary" {
     defer stream_ctx.deinit();
 
     try streamAssistantChunk(&stream_ctx, "buffered text");
-    onStreamToolStart(&stream_ctx, "unknown_1", "unknown_tool", null);
+    onStreamToolStart(&stream_ctx, "unknown_1", "unknown_tool", null, null);
 
     try std.testing.expect(stream_ctx.first_model_output_at_ms == null);
     try std.testing.expectEqualStrings("buffered text", stream_ctx.raw_text.items);
@@ -1361,7 +1362,7 @@ test "streamed setext heading waits for its underline and flushes before a tool"
     try streamAssistantChunk(&stream_ctx, "-");
     try std.testing.expectEqual(@as(usize, 0), capture.text_spans.items.len);
 
-    onStreamToolStart(&stream_ctx, "read_1", "read_file", null);
+    onStreamToolStart(&stream_ctx, "read_1", "read_file", null, null);
 
     try std.testing.expectEqualStrings("Streamed title\n---", stream_ctx.raw_text.items);
     try std.testing.expectEqual(@as(usize, 0), capture.thematic_rule_count);
@@ -1392,7 +1393,7 @@ test "streamed definition list retains source and clears before a tool" {
     try streamAssistantChunk(&stream_ctx, "Sta");
     try streamAssistantChunk(&stream_ctx, "tus\n: **Run");
     try streamAssistantChunk(&stream_ctx, "ning**\n");
-    onStreamToolStart(&stream_ctx, "read_1", "read_file", null);
+    onStreamToolStart(&stream_ctx, "read_1", "read_file", null, null);
     try streamAssistantChunk(&stream_ctx, ": stale\n");
     try flushAssistantStream(&stream_ctx);
 
@@ -1456,7 +1457,7 @@ test "streamed footnotes retain raw source and flush before a tool" {
             "| api | [^status] |\n",
     );
     try streamAssistantChunk(&stream_ctx, "[^status]: OBSERVER_FOOTNOTE_PROJECTION\n");
-    onStreamToolStart(&stream_ctx, "read_1", "read_file", null);
+    onStreamToolStart(&stream_ctx, "read_1", "read_file", null, null);
 
     try std.testing.expectEqualStrings(
         "The deployment is stable[^status].\n" ++
@@ -1524,7 +1525,7 @@ test "streamed tool start flushes presentation before separator and lifecycle" {
         defer stream_ctx.deinit();
 
         try streamAssistantChunk(&stream_ctx, "partial");
-        onStreamToolStart(&stream_ctx, case.id, case.name, null);
+        onStreamToolStart(&stream_ctx, case.id, case.name, null, null);
 
         try std.testing.expectEqual(@as(usize, 2), capture.text_spans.items.len);
         try std.testing.expectEqualStrings("partial", capture.text_spans.items[0]);
@@ -1559,7 +1560,7 @@ test "streamed tool start flushes presentation before separator and lifecycle" {
     defer newline_stream_ctx.deinit();
 
     try streamAssistantChunk(&newline_stream_ctx, "complete line\n");
-    onStreamToolStart(&newline_stream_ctx, "read_newline", "read_file", null);
+    onStreamToolStart(&newline_stream_ctx, "read_newline", "read_file", null, null);
 
     try std.testing.expectEqual(@as(usize, 1), newline_capture.text_spans.items.len);
     try std.testing.expectEqualStrings("complete line\n", newline_capture.text_spans.items[0]);
@@ -1588,7 +1589,7 @@ test "assistant prose before the first tool starts a new presentation group" {
     defer stream_ctx.deinit();
 
     try streamAssistantChunk(&stream_ctx, "new batch");
-    onStreamToolStart(&stream_ctx, "read_1", "read_file", null);
+    onStreamToolStart(&stream_ctx, "read_1", "read_file", null, null);
 
     try std.testing.expectEqual(
         types.ToolPresentationGroupId{ .turn_id = 7, .anchor_step_id = 12 },
@@ -1612,9 +1613,9 @@ test "assistant prose between streamed sibling tools keeps their presentation gr
     };
     defer stream_ctx.deinit();
 
-    onStreamToolStart(&stream_ctx, "read_1", "read_file", null);
+    onStreamToolStart(&stream_ctx, "read_1", "read_file", null, null);
     try streamAssistantChunk(&stream_ctx, "provider bridge");
-    onStreamToolStart(&stream_ctx, "read_2", "read_file", null);
+    onStreamToolStart(&stream_ctx, "read_2", "read_file", null, null);
 
     const expected = types.ToolPresentationGroupId{
         .turn_id = 7,
@@ -1668,7 +1669,7 @@ test "semantic table flushes before a tool without visible text or extra separat
             "|------|------:|\n" ++
             "| api | 7 |\n",
     );
-    onStreamToolStart(&stream_ctx, "read_1", "read_file", null);
+    onStreamToolStart(&stream_ctx, "read_1", "read_file", null, null);
 
     try std.testing.expectEqual(@as(usize, 1), capture.tables.items.len);
     try std.testing.expectEqual(@as(usize, 0), capture.text_spans.items.len);
@@ -1715,7 +1716,7 @@ test "semantic thematic rule flushes at EOF before a tool after a blank separato
     defer stream_ctx.deinit();
 
     try streamAssistantChunk(&stream_ctx, "Before rule.\n\n---");
-    onStreamToolStart(&stream_ctx, "read_1", "read_file", null);
+    onStreamToolStart(&stream_ctx, "read_1", "read_file", null, null);
 
     try std.testing.expectEqualStrings("Before rule.\n\n---", stream_ctx.raw_text.items);
     try std.testing.expectEqual(@as(usize, 1), capture.thematic_rule_count);
@@ -1899,7 +1900,7 @@ test "streamed prefix without a code opener is discarded before a tool boundary"
     defer stream_ctx.deinit();
 
     try streamAssistantChunk(&stream_ctx, "   ");
-    onStreamToolStart(&stream_ctx, "read_1", "read_file", "src/main.zig");
+    onStreamToolStart(&stream_ctx, "read_1", "read_file", "src/main.zig", null);
     try streamAssistantChunk(&stream_ctx, "after tool\n");
 
     try std.testing.expectEqualStrings("   after tool\n", stream_ctx.raw_text.items);
@@ -2071,7 +2072,7 @@ test "streamed presentation suppresses callback-time failures" {
         var stream_ctx = StreamChunkContext{ .hooks = &hook_set, .turn_id = 1, .alloc = alloc };
         defer stream_ctx.deinit();
 
-        onStreamToolStart(&stream_ctx, "read_1", "read_file", null);
+        onStreamToolStart(&stream_ctx, "read_1", "read_file", null, null);
 
         try std.testing.expectEqual(@as(usize, 1), capture.lifecycle_calls);
         try std.testing.expectEqual(@as(usize, 0), capture.lifecycle_events.items.len);

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -4117,6 +4117,7 @@ fn onRequiredVisionStreamToolStart(
     tool_id: []const u8,
     tool_name: []const u8,
     label_value: ?[]const u8,
+    arguments_json: ?[]const u8,
 ) void {
     if (!std.mem.eql(u8, tool_name, "vision")) {
         runtime_assistant_stream.recordStreamToolStart(ctx, tool_name);
@@ -4127,6 +4128,7 @@ fn onRequiredVisionStreamToolStart(
         tool_id,
         tool_name,
         label_value,
+        arguments_json,
     );
 }
 
@@ -4142,9 +4144,9 @@ fn onProviderEvent(raw: *anyopaque, event: agent_stream_provider.Event) void {
         .reasoning_delta => |chunk| runtime_assistant_stream.onStreamReasoningChunk(ctx.stream, chunk),
         .tool_input_delta => |chunk| runtime_assistant_stream.onStreamToolInputChunk(ctx.stream, chunk),
         .tool_started => |tool| if (ctx.required_vision)
-            onRequiredVisionStreamToolStart(ctx.stream, tool.id, tool.name, tool.label)
+            onRequiredVisionStreamToolStart(ctx.stream, tool.id, tool.name, tool.label, tool.arguments_json)
         else
-            runtime_assistant_stream.onStreamToolStart(ctx.stream, tool.id, tool.name, tool.label),
+            runtime_assistant_stream.onStreamToolStart(ctx.stream, tool.id, tool.name, tool.label, tool.arguments_json),
     }
 }
 

--- a/src/core/agent/runtime/tool_presentation.zig
+++ b/src/core/agent/runtime/tool_presentation.zig
@@ -5,6 +5,7 @@ const permission_auto_classifier = @import("../../permissions/auto_classifier.zi
 const types = @import("../../shared/types.zig");
 const text_utils = @import("../../shared/text_utils.zig");
 const tool_dispatch = @import("../../tooling/tool_dispatch.zig");
+const tool_args = @import("../../tooling/tool_args.zig");
 const tool_specs = @import("../../tooling/tool_specs.zig");
 const tooling_presentation = @import("../../tooling/tool_presentation.zig");
 const debug_trace = @import("../../shared/debug_trace.zig");
@@ -118,6 +119,7 @@ pub const ProvisionalToolStatuses = struct {
         activity_kind: types.ToolActivityKind,
         action_label: []const u8,
         label_value: ?[]const u8,
+        arguments_json: ?[]const u8,
     ) !void {
         if (tool_id.len == 0) {
             debug_trace.logf(
@@ -129,19 +131,38 @@ pub const ProvisionalToolStatuses = struct {
         }
 
         var buf: [512]u8 = undefined;
-        const label = try formatProvisionalProgressLabel(&buf, action_label, label_value);
+        var scratch = std.heap.ArenaAllocator.init(alloc);
+        defer scratch.deinit();
+        const is_skill = std.mem.eql(u8, tool_name, "skill");
+        var observed_label = if (is_skill) null else label_value;
+        var observed_kind = activity_kind;
+        const resource_label: ?[]const u8 = if (is_skill) resource: {
+            const json = arguments_json orelse break :resource null;
+            const args = tool_args.parseToolArgsObject(scratch.allocator(), json) catch break :resource null;
+            const spec = hooks.tool_registry.lookup(tool_name) orelse break :resource null;
+            const presentation = tool_dispatch.presentationForArgs(spec.*, args);
+            if (presentation.label_arg_kind != .resource) break :resource null;
+            const value = tool_dispatch.presentationLabelValue(presentation, args) orelse break :resource null;
+            const encoded = text_utils.encodeTerminalSafe(scratch.allocator(), value, buf.len) catch break :resource null;
+            if (encoded.truncated) break :resource null;
+            const formatted = formatProvisionalProgressLabel(&buf, presentation.action_label, encoded.bytes) catch break :resource null;
+            observed_label = value;
+            observed_kind = presentation.activity_kind;
+            break :resource formatted;
+        } else null;
+        const label = resource_label orelse try formatProvisionalProgressLabel(&buf, action_label, observed_label);
         const recorded = try self.recordTracked(
             alloc,
             tool_id,
             tool_name,
-            label_value,
+            observed_label,
         );
         hooks.push_tool_lifecycle(hooks.ctx, .{
             .provisional = .{
                 .id = .{ .turn_id = turn_id, .call_id = tool_id },
                 .presentation_group_id = self.presentation_group_id,
                 .tool_name = tool_name,
-                .activity_kind = activity_kind,
+                .activity_kind = observed_kind,
             },
         }) catch |err| {
             if (recorded) self.forget(alloc, tool_id);
@@ -1423,6 +1444,7 @@ const test_tools = [_]tool_dispatch.Tool{
     test_builtin_tools.edit_file,
     test_builtin_tools.shell,
     test_builtin_tools.ask_user_question,
+    test_builtin_tools.skill,
 };
 const test_tool_registry = tool_dispatch.Registry{ .tools = test_tools[0..] };
 const custom_activity_tool = blk: {
@@ -1706,8 +1728,8 @@ test "provisional lifecycle formats labeled and unlabeled eligible tools" {
     var statuses = ProvisionalToolStatuses{};
     defer statuses.deinit(alloc);
 
-    try statuses.publish(&hooks, alloc, 7, "read_1", "read_file", activityKind(hooks.tool_registry, "read_file"), eligibleActionLabel("read_file"), "src/main.zig");
-    try statuses.publish(&hooks, alloc, 7, "list_1", "glob_files", activityKind(hooks.tool_registry, "glob_files"), eligibleActionLabel("glob_files"), null);
+    try statuses.publish(&hooks, alloc, 7, "read_1", "read_file", activityKind(hooks.tool_registry, "read_file"), eligibleActionLabel("read_file"), "src/main.zig", null);
+    try statuses.publish(&hooks, alloc, 7, "list_1", "glob_files", activityKind(hooks.tool_registry, "glob_files"), eligibleActionLabel("glob_files"), null, null);
 
     try std.testing.expectEqual(@as(usize, 4), capture.events.items.len);
     switch (capture.events.items[0]) {
@@ -1736,6 +1758,114 @@ test "provisional lifecycle formats labeled and unlabeled eligible tools" {
     }
 }
 
+test "provisional skill labels select complete resource arguments and ignore opaque hints" {
+    const cases = [_]struct {
+        arguments_json: ?[]const u8,
+        hint: ?[]const u8 = "skill:opaque/location",
+        resource: ?[]const u8 = null,
+    }{
+        .{ .arguments_json = "{\"location\":\"skill:opaque/location\",\"resource\":\"references/types.md\"}", .resource = "references/types.md" },
+        .{ .arguments_json = "{\"resource\":\"references/types.md\",\"location\":\"skill:opaque/location\"}", .resource = "references/types.md" },
+        .{ .arguments_json = "{\"resource\":\"references/types.md\"}", .hint = null, .resource = "references/types.md" },
+        .{ .arguments_json = null },
+        .{ .arguments_json = "" },
+        .{ .arguments_json = "{\"resource\":\"partial" },
+        .{ .arguments_json = "[]" },
+        .{ .arguments_json = "null" },
+        .{ .arguments_json = "\"references/types.md\"" },
+        .{ .arguments_json = "{\"resource\":null}" },
+        .{ .arguments_json = "{\"resource\":42}" },
+        .{ .arguments_json = "{\"resource\":false}" },
+        .{ .arguments_json = "{\"resource\":[]}" },
+        .{ .arguments_json = "{\"resource\":{}}" },
+        .{ .arguments_json = "{\"resource\":\"\"}" },
+        .{ .arguments_json = "{\"resource\":\"SKILL.md\"}" },
+        .{ .arguments_json = "{\"resource\":\"SKILL.md\",\"offset\":1}" },
+        .{ .arguments_json = "{\"location\":\"skill:opaque/location\"}" },
+        .{ .arguments_json = "{\"name\":\"root-skill\"}" },
+        .{ .arguments_json = "{}" },
+    };
+    const alloc = std.testing.allocator;
+    for (cases) |case| {
+        var capture = ProvisionalStatusTestCapture{ .alloc = alloc };
+        defer capture.deinit();
+        const hooks = capture.hooks();
+        var statuses = ProvisionalToolStatuses{};
+        defer statuses.deinit(alloc);
+        try statuses.publish(&hooks, alloc, 7, "skill_1", "skill", .read, eligibleActionLabel("skill"), case.hint, case.arguments_json);
+        try std.testing.expectEqual(@as(usize, 2), capture.events.items.len);
+        try std.testing.expectEqual(types.ToolActivityKind.read, capture.events.items[0].provisional.activity_kind);
+        try std.testing.expectEqualStrings("skill_1", capture.events.items[1].progress.id.call_id);
+        var expected_buf: [512]u8 = undefined;
+        const expected = try formatProvisionalProgressLabel(&expected_buf, if (case.resource != null) "Reading skill resource" else "Loading skill", case.resource);
+        try std.testing.expectEqualStrings(expected, capture.events.items[1].progress.text);
+        if (case.resource) |resource| {
+            try std.testing.expectEqualStrings(resource, statuses.tracked.items[0].label_value.?);
+        } else {
+            try std.testing.expect(statuses.tracked.items[0].label_value == null);
+        }
+    }
+}
+
+test "provisional skill labels decode escaped UTF-8 and encode terminal controls before copying" {
+    const alloc = std.testing.allocator;
+    var capture = ProvisionalStatusTestCapture{ .alloc = alloc };
+    defer capture.deinit();
+    const hooks = capture.hooks();
+    var statuses = ProvisionalToolStatuses{};
+    defer statuses.deinit(alloc);
+    {
+        const json = try alloc.dupe(u8, "{\"location\":\"skill:opaque/location\",\"resource\":\"r/\\u00e9\\u4e2d\\\"\\u001b[31m\\n\\r\\t\\u0000\\u0080.md\"}");
+        defer alloc.free(json);
+        try statuses.publish(&hooks, alloc, 7, "skill_1", "skill", .read, eligibleActionLabel("skill"), "skill:opaque/location", json);
+    }
+    try std.testing.expectEqualStrings(
+        "● Reading skill resource\x1b[0m \x1b[38;5;245mr/é中\"\\x1b[31m\\x0a\\x0d\\x09\\x00\\u{0080}.md\x1b[0m",
+        capture.events.items[1].progress.text,
+    );
+    try std.testing.expectEqualStrings("r/é中\"\x1b[31m\n\r\t\x00\u{0080}.md", statuses.tracked.items[0].label_value.?);
+}
+
+test "provisional skill labels fall back when encoded resource exceeds the progress buffer" {
+    const alloc = std.testing.allocator;
+    const max_detail = 512 - "● Reading skill resource\x1b[0m \x1b[38;5;245m\x1b[0m".len;
+    for ([_]usize{ max_detail, max_detail + 1, 512, 513, 4096 }) |len| {
+        var capture = ProvisionalStatusTestCapture{ .alloc = alloc };
+        defer capture.deinit();
+        const hooks = capture.hooks();
+        var statuses = ProvisionalToolStatuses{};
+        defer statuses.deinit(alloc);
+        const resource = try alloc.alloc(u8, len);
+        defer alloc.free(resource);
+        @memset(resource, 'a');
+        const json = try std.fmt.allocPrint(alloc, "{{\"resource\":\"{s}\"}}", .{resource});
+        defer alloc.free(json);
+        try statuses.publish(&hooks, alloc, 7, "skill_1", "skill", .read, eligibleActionLabel("skill"), "skill:opaque/location", json);
+        const text = capture.events.items[1].progress.text;
+        if (len == max_detail) {
+            try std.testing.expectEqual(@as(usize, 512), text.len);
+            try std.testing.expectEqualStrings(resource, statuses.tracked.items[0].label_value.?);
+        } else {
+            try std.testing.expectEqualStrings("● Loading skill\x1b[0m", text);
+            try std.testing.expect(statuses.tracked.items[0].label_value == null);
+        }
+    }
+}
+
+test "provisional non-skill labels retain hints regardless of completed arguments" {
+    const alloc = std.testing.allocator;
+    for ([_]?[]const u8{ null, "not JSON", "{\"path\":\"different.txt\",\"resource\":\"references/types.md\"}" }) |json| {
+        var capture = ProvisionalStatusTestCapture{ .alloc = alloc };
+        defer capture.deinit();
+        const hooks = capture.hooks();
+        var statuses = ProvisionalToolStatuses{};
+        defer statuses.deinit(alloc);
+        try statuses.publish(&hooks, alloc, 7, "read_1", "read_file", .read, eligibleActionLabel("read_file"), "original.txt", json);
+        try std.testing.expectEqualStrings("● Reading\x1b[0m \x1b[38;5;245moriginal.txt\x1b[0m", capture.events.items[1].progress.text);
+        try std.testing.expectEqualStrings("original.txt", statuses.tracked.items[0].label_value.?);
+    }
+}
+
 test "tracked provisional cancellation retains labels without exposing registered names" {
     const alloc = std.testing.allocator;
     var arena_state = std.heap.ArenaAllocator.init(alloc);
@@ -1747,10 +1877,10 @@ test "tracked provisional cancellation retains labels without exposing registere
     var statuses = ProvisionalToolStatuses{};
     defer statuses.deinit(alloc);
 
-    try statuses.publish(&hooks, alloc, 9, "read_1", "read_file", .read, "Reading", null);
-    try statuses.publish(&hooks, alloc, 9, "read_1", "read_file", .read, "Reading", "src/main.zig");
-    try statuses.publish(&hooks, alloc, 9, "command_1", "run_command", .command, "Running", null);
-    try statuses.publish(&hooks, alloc, 9, "mcp_1", "mcp_custom", .read, "Running", null);
+    try statuses.publish(&hooks, alloc, 9, "read_1", "read_file", .read, "Reading", null, null);
+    try statuses.publish(&hooks, alloc, 9, "read_1", "read_file", .read, "Reading", "src/main.zig", null);
+    try statuses.publish(&hooks, alloc, 9, "command_1", "run_command", .command, "Running", null, null);
+    try statuses.publish(&hooks, alloc, 9, "mcp_1", "mcp_custom", .read, "Running", null, null);
     try statuses.finishTrackedCancelled(&hooks, alloc, arena, 9);
 
     var terminal_count: usize = 0;
@@ -1787,8 +1917,8 @@ test "unmatched recovery starts hide registered names but retain unknown identit
     var statuses = ProvisionalToolStatuses{};
     defer statuses.deinit(alloc);
 
-    try statuses.publish(&hooks, alloc, 9, "command_1", "run_command", .command, "Running", null);
-    try statuses.publish(&hooks, alloc, 9, "mcp_1", "mcp_custom", .read, "Running", null);
+    try statuses.publish(&hooks, alloc, 9, "command_1", "run_command", .command, "Running", null, null);
+    try statuses.publish(&hooks, alloc, 9, "mcp_1", "mcp_custom", .read, "Running", null, null);
     try statuses.finishUnmatchedRecoveryStarts(&hooks, alloc, arena, 9, &.{});
 
     var terminal_count: usize = 0;
@@ -1826,7 +1956,7 @@ test "provisional lifecycle remains distinct from authoritative lifecycle" {
     defer statuses.deinit(alloc);
 
     const call = testToolCall("read_1", "read_file");
-    try statuses.publish(&hooks, alloc, 1, call.id, call.name, activityKind(hooks.tool_registry, call.name), eligibleActionLabel(call.name), null);
+    try statuses.publish(&hooks, alloc, 1, call.id, call.name, activityKind(hooks.tool_registry, call.name), eligibleActionLabel(call.name), null, null);
     try std.testing.expect(try startToolVisibleLifecycle(
         &hooks,
         arena,
@@ -1867,7 +1997,7 @@ test "provisional lifecycle rolls back a newly tracked id when provisional publi
 
     try std.testing.expectError(
         error.TestProvisionalPublicationFailure,
-        statuses.publish(&hooks, alloc, 1, "read_1", "read_file", activityKind(hooks.tool_registry, "read_file"), eligibleActionLabel("read_file"), null),
+        statuses.publish(&hooks, alloc, 1, "read_1", "read_file", activityKind(hooks.tool_registry, "read_file"), eligibleActionLabel("read_file"), null, null),
     );
     try std.testing.expect(!statuses.has("read_1"));
     try std.testing.expectEqual(@as(usize, 0), capture.events.items.len);
@@ -1881,7 +2011,7 @@ test "provisional lifecycle keeps a tracked id when progress publication fails" 
     var statuses = ProvisionalToolStatuses{};
     defer statuses.deinit(alloc);
 
-    try statuses.publish(&hooks, alloc, 1, "read_1", "read_file", activityKind(hooks.tool_registry, "read_file"), eligibleActionLabel("read_file"), null);
+    try statuses.publish(&hooks, alloc, 1, "read_1", "read_file", activityKind(hooks.tool_registry, "read_file"), eligibleActionLabel("read_file"), null, null);
     try std.testing.expect(statuses.has("read_1"));
     try std.testing.expectEqual(@as(usize, 1), capture.events.items.len);
     try std.testing.expect(capture.events.items[0] == .provisional);
@@ -2135,7 +2265,7 @@ fn checkProvisionalLifecycleAllocationFailures(alloc: Allocator) !void {
     var statuses = ProvisionalToolStatuses{};
     defer statuses.deinit(alloc);
 
-    try statuses.publish(&hooks, alloc, 1, "read_1", "read_file", activityKind(hooks.tool_registry, "read_file"), eligibleActionLabel("read_file"), null);
+    try statuses.publish(&hooks, alloc, 1, "read_1", "read_file", activityKind(hooks.tool_registry, "read_file"), eligibleActionLabel("read_file"), null, null);
     try std.testing.expect(statuses.has("read_1"));
     var arena_state = std.heap.ArenaAllocator.init(alloc);
     defer arena_state.deinit();

--- a/src/core/agent/stream_provider.zig
+++ b/src/core/agent/stream_provider.zig
@@ -18,6 +18,7 @@ pub const ToolStartCallback = *const fn (
     tool_id: []const u8,
     tool_name: []const u8,
     label_value: ?[]const u8,
+    arguments_json: ?[]const u8,
 ) void;
 
 pub const Event = union(enum) {
@@ -27,6 +28,8 @@ pub const Event = union(enum) {
         id: []const u8,
         name: []const u8,
         label: ?[]const u8 = null,
+        /// Complete arguments borrowed only for synchronous event delivery.
+        arguments_json: ?[]const u8 = null,
     },
     tool_input_delta: []const u8,
 };

--- a/src/gateway/client.zig
+++ b/src/gateway/client.zig
@@ -3411,7 +3411,7 @@ fn consumeSseStreamTraced(
                 return err;
             };
             if (name.len > 0) {
-                if (on_tool_start) |cb| cb(callback_ctx, id, name, null);
+                if (on_tool_start) |cb| cb(callback_ctx, id, name, null, null);
             }
         } else if (std.mem.eql(u8, event_type, "tool-input-delta") or
             std.mem.eql(u8, event_type, "tool-input-end"))
@@ -3583,10 +3583,8 @@ fn consumeSseStreamTraced(
                     acc.argument_integrity == .valid)
                 {
                     if (on_tool_start) |cb| {
-                        if (extractFirstJsonStringValue(acc.arguments.items)) |value| {
-                            record.label_sent = true;
-                            cb(callback_ctx, record.id.items, record.name.items, value);
-                        }
+                        record.label_sent = true;
+                        cb(callback_ctx, record.id.items, record.name.items, extractFirstJsonStringValue(acc.arguments.items), acc.arguments.items);
                     }
                 }
             }
@@ -4455,7 +4453,7 @@ test "consumeSseStream traces every SSE event with keyless metadata" {
             if (std.mem.eql(u8, chunk, "answer")) self.content_chunks += 1;
         }
 
-        fn onToolStart(ctx: *anyopaque, _: []const u8, _: []const u8, _: ?[]const u8) void {
+        fn onToolStart(ctx: *anyopaque, _: []const u8, _: []const u8, _: ?[]const u8, _: ?[]const u8) void {
             const self: *@This() = @ptrCast(@alignCast(ctx));
             self.tool_starts += 1;
         }
@@ -5003,7 +5001,7 @@ test "consumeSseStream does not publish labels from malformed streamed arguments
 
         fn onContent(_: *anyopaque, _: []const u8) void {}
 
-        fn onToolStart(ctx: *anyopaque, _: []const u8, _: []const u8, label: ?[]const u8) void {
+        fn onToolStart(ctx: *anyopaque, _: []const u8, _: []const u8, label: ?[]const u8, _: ?[]const u8) void {
             const self: *@This() = @ptrCast(@alignCast(ctx));
             const value = label orelse return;
             self.labels += 1;
@@ -5270,7 +5268,7 @@ test "consumeSseStream isolates interleaved streamed inputs by exact event id" {
 
         fn onContent(_: *anyopaque, _: []const u8) void {}
 
-        fn onToolStart(ctx: *anyopaque, _: []const u8, _: []const u8, label: ?[]const u8) void {
+        fn onToolStart(ctx: *anyopaque, _: []const u8, _: []const u8, label: ?[]const u8, _: ?[]const u8) void {
             const self: *@This() = @ptrCast(@alignCast(ctx));
             if (label == null) {
                 self.starts += 1;
@@ -5305,6 +5303,59 @@ test "consumeSseStream isolates interleaved streamed inputs by exact event id" {
     try std.testing.expectEqualStrings("{\"pattern\":\"needle-B\"}", completion.tool_calls[1].arguments_json);
     try std.testing.expect(completion.tool_calls[1].provisional_id == null);
     try std.testing.expect(completion.provider_result_identity_failure == null);
+}
+
+test "consumeSseStream observes complete skill arguments before finish even without a label hint" {
+    const Capture = struct {
+        expected_json: []const u8,
+        expected_hint: ?[]const u8,
+        starts: usize = 0,
+        updates: usize = 0,
+        matched: bool = true,
+
+        fn content(_: *anyopaque, _: []const u8) void {}
+        fn toolStart(raw: *anyopaque, id: []const u8, name: []const u8, hint: ?[]const u8, arguments_json: ?[]const u8) void {
+            const self: *@This() = @ptrCast(@alignCast(raw));
+            self.matched = self.matched and std.mem.eql(u8, id, "skill_1") and std.mem.eql(u8, name, "skill");
+            if (arguments_json) |json| {
+                self.updates += 1;
+                self.matched = self.matched and std.mem.eql(u8, self.expected_json, json);
+                self.matched = self.matched and if (self.expected_hint) |expected|
+                    if (hint) |actual| std.mem.eql(u8, expected, actual) else false
+                else
+                    hint == null;
+            } else {
+                self.starts += 1;
+                self.matched = self.matched and hint == null;
+            }
+        }
+    };
+    const cases = [_]struct { json: []const u8, hint: ?[]const u8 }{
+        .{ .json = "{\"location\":\"skill:opaque/location\",\"resource\":\"references/types.md\"}", .hint = "skill:opaque/location" },
+        .{ .json = "{\"resource\":\"references/types.md\",\"location\":\"skill:opaque/location\"}", .hint = "references/types.md" },
+        .{ .json = "{\"offset\":0,\"location\":\"skill:opaque/location\",\"resource\":\"references/types.md\"}", .hint = null },
+    };
+    const alloc = std.testing.allocator;
+    for (cases) |case| {
+        const payload = try std.fmt.allocPrint(
+            alloc,
+            "data: {{\"type\":\"tool-input-start\",\"id\":\"skill_1\",\"toolName\":\"skill\"}}\n\n" ++
+                "data: {{\"type\":\"tool-input-end\",\"id\":\"skill_1\"}}\n\n" ++
+                "data: {{\"type\":\"tool-call\",\"toolCallId\":\"skill_1\",\"toolName\":\"skill\",\"input\":{s}}}\n\n",
+            .{case.json},
+        );
+        defer alloc.free(payload);
+        var reader = std.Io.Reader.fixed(payload);
+        var cancelled = std.atomic.Value(bool).init(false);
+        var capture = Capture{ .expected_json = case.json, .expected_hint = case.hint };
+        var completion = try consumeSseStream(alloc, &reader, &capture, Capture.content, Capture.toolStart, &cancelled);
+        defer deinitGatewayCompletion(alloc, &completion);
+        try std.testing.expect(capture.matched);
+        try std.testing.expectEqual(@as(usize, 1), capture.starts);
+        try std.testing.expectEqual(@as(usize, 1), capture.updates);
+        try std.testing.expect(completion.finish_reason == null);
+        try std.testing.expectEqualStrings(case.json, completion.tool_calls[0].arguments_json);
+    }
 }
 
 test "consumeSseStream ignores conflicting and late stream events without mutation" {
@@ -5343,7 +5394,7 @@ test "consumeSseStream ignores conflicting and late stream events without mutati
 
         fn onContent(_: *anyopaque, _: []const u8) void {}
 
-        fn onToolStart(ctx: *anyopaque, _: []const u8, _: []const u8, label: ?[]const u8) void {
+        fn onToolStart(ctx: *anyopaque, _: []const u8, _: []const u8, label: ?[]const u8, _: ?[]const u8) void {
             const self: *@This() = @ptrCast(@alignCast(ctx));
             if (label == null) {
                 self.starts += 1;
@@ -5896,7 +5947,7 @@ fn checkConsumeSseAllocationFailures(alloc: std.mem.Allocator) !void {
 
     const Noop = struct {
         fn chunk(_: *anyopaque, _: []const u8) void {}
-        fn toolStart(_: *anyopaque, _: []const u8, _: []const u8, _: ?[]const u8) void {}
+        fn toolStart(_: *anyopaque, _: []const u8, _: []const u8, _: ?[]const u8, _: ?[]const u8) void {}
     };
 
     var reader = std.Io.Reader.fixed(payload);
@@ -5944,7 +5995,7 @@ test "consumeSseStream frees streamed state on cancellation after a start" {
 
         fn chunk(_: *anyopaque, _: []const u8) void {}
 
-        fn toolStart(ctx: *anyopaque, _: []const u8, _: []const u8, _: ?[]const u8) void {
+        fn toolStart(ctx: *anyopaque, _: []const u8, _: []const u8, _: ?[]const u8, _: ?[]const u8) void {
             const self: *@This() = @ptrCast(@alignCast(ctx));
             self.cancel_flag.store(true, .seq_cst);
         }

--- a/src/gateway/host_stream_provider.zig
+++ b/src/gateway/host_stream_provider.zig
@@ -272,8 +272,8 @@ const EventBridge = struct {
         sink(raw).emit(.{ .reasoning_delta = chunk });
     }
 
-    fn toolStart(raw: *anyopaque, id: []const u8, name: []const u8, label: ?[]const u8) void {
-        sink(raw).emit(.{ .tool_started = .{ .id = id, .name = name, .label = label } });
+    fn toolStart(raw: *anyopaque, id: []const u8, name: []const u8, label: ?[]const u8, arguments_json: ?[]const u8) void {
+        sink(raw).emit(.{ .tool_started = .{ .id = id, .name = name, .label = label, .arguments_json = arguments_json } });
     }
 };
 

--- a/src/gateway/openai_codex.zig
+++ b/src/gateway/openai_codex.zig
@@ -418,8 +418,8 @@ const EventBridge = struct {
         sink(raw).emit(.{ .tool_input_delta = chunk });
     }
 
-    fn toolStart(raw: *anyopaque, id: []const u8, name: []const u8, label: ?[]const u8) void {
-        sink(raw).emit(.{ .tool_started = .{ .id = id, .name = name, .label = label } });
+    fn toolStart(raw: *anyopaque, id: []const u8, name: []const u8, label: ?[]const u8, arguments_json: ?[]const u8) void {
+        sink(raw).emit(.{ .tool_started = .{ .id = id, .name = name, .label = label, .arguments_json = arguments_json } });
     }
 };
 
@@ -738,7 +738,7 @@ test "OpenAI Codex SSE maps text reasoning tools and usage" {
             const self: *@This() = @ptrCast(@alignCast(raw));
             self.reasoning.appendSlice(std.testing.allocator, chunk) catch unreachable;
         }
-        fn toolStart(raw: *anyopaque, _: []const u8, name: []const u8, _: ?[]const u8) void {
+        fn toolStart(raw: *anyopaque, _: []const u8, name: []const u8, _: ?[]const u8, _: ?[]const u8) void {
             const self: *@This() = @ptrCast(@alignCast(raw));
             self.saw_read_file = std.mem.eql(u8, name, "read_file");
         }

--- a/src/gateway/responses_protocol.zig
+++ b/src/gateway/responses_protocol.zig
@@ -938,7 +938,7 @@ pub const Reducer = struct {
                         try appendToolArguments(alloc, &tool.arguments, value.string, limits.tool_arguments_bytes);
                     }
                     if (callbacks.on_tool_start) |callback| {
-                        callback(callbacks.context, call_id, name, null);
+                        callback(callbacks.context, call_id, name, null, null);
                     }
                 } else {
                     const index = findTool(self.tools.items, output_index).?;

--- a/src/gateway/xai_grok.zig
+++ b/src/gateway/xai_grok.zig
@@ -420,8 +420,8 @@ const EventBridge = struct {
         sink(raw).emit(.{ .tool_input_delta = chunk });
     }
 
-    fn toolStart(raw: *anyopaque, id: []const u8, name: []const u8, label: ?[]const u8) void {
-        sink(raw).emit(.{ .tool_started = .{ .id = id, .name = name, .label = label } });
+    fn toolStart(raw: *anyopaque, id: []const u8, name: []const u8, label: ?[]const u8, arguments_json: ?[]const u8) void {
+        sink(raw).emit(.{ .tool_started = .{ .id = id, .name = name, .label = label, .arguments_json = arguments_json } });
     }
 };
 
@@ -672,7 +672,7 @@ test "xAI Grok SSE maps text reasoning tools and usage" {
             const self: *@This() = @ptrCast(@alignCast(raw));
             self.reasoning.appendSlice(std.testing.allocator, chunk) catch unreachable;
         }
-        fn toolStart(raw: *anyopaque, _: []const u8, name: []const u8, _: ?[]const u8) void {
+        fn toolStart(raw: *anyopaque, _: []const u8, name: []const u8, _: ?[]const u8, _: ?[]const u8) void {
             const self: *@This() = @ptrCast(@alignCast(raw));
             self.saw_read_file = std.mem.eql(u8, name, "read_file");
         }

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -31,6 +31,7 @@ import {
   type GatewayRequest,
 } from "./conditional-guidance-oracle";
 import { expectPermissionModeContext } from "./permission-mode-context";
+import { stdoutFrames } from "./render-lab/tape";
 import {
   fakeGatewayFinalText,
   fakeGatewaySse,
@@ -2319,6 +2320,188 @@ describe("gateway stream lifecycle", () => {
       rmSync(root.root, { recursive: true, force: true });
     }
   }, 45_000);
+
+  for (const scenario of [
+    { source: "model-selected", resourceFirst: false, cancel: false },
+    { source: "model-selected", resourceFirst: true, cancel: false },
+    { source: "$skill attachment", resourceFirst: false, cancel: false },
+    { source: "$skill attachment", resourceFirst: true, cancel: false },
+    { source: "$skill attachment", resourceFirst: false, cancel: true },
+  ]) {
+    test.skipIf(!tmuxAvailable())(
+      `held skill resource label: ${scenario.source}, ${scenario.resourceFirst ? "resource-first" : "location-first"}, ${scenario.cancel ? "cancel" : "finish"}`,
+      async () => {
+        const binary = process.env.FX_TEST_PRODUCT_EXE ?? FX_BIN;
+        const root = createFixtureRoot("held-skill-resource-label");
+        const skillName = "streamed-workflow";
+        const skillDirectory = join(root.home, ".fx", "skills", skillName);
+        const resource = "references/contract-design.md";
+        const resourcePath = join(skillDirectory, resource);
+        const mainSentinel = "HELD_SKILL_MAIN_INSTRUCTIONS";
+        const earlySentinel = "RESOURCE_BEFORE_PROVIDER_FINISH";
+        const resourceSentinel = "RESOURCE_AT_PROVIDER_FINISH";
+        const mainCallId = "held_skill_main";
+        const resourceCallId = "held_skill_resource";
+        const attached = scenario.source === "$skill attachment";
+        const heldRequestCount = attached ? 1 : 2;
+        const stderrPath = join(root.root, "stderr.log");
+        const tapePath = join(root.root, "session.fxtape");
+        mkdirSync(join(skillDirectory, "references"), { recursive: true });
+        writeFileSync(join(skillDirectory, "SKILL.md"),
+          `---\nname: ${skillName}\ndescription: Streamed resource label fixture\n---\n${mainSentinel}\nRead ${resource} before answering.\n`);
+        writeFileSync(resourcePath, `${earlySentinel}\n`);
+
+        let location = "";
+        let requestIndex = 0;
+        let stream: ReadableStreamDefaultController<Uint8Array> | undefined;
+        let streamClosed = false;
+        let finishReleased = false;
+        const encoder = new TextEncoder();
+        const send = (event: object) => {
+          stream!.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
+        };
+        const releaseFinish = () => {
+          finishReleased = true;
+          if (streamClosed) return;
+          send({ type: "finish", finishReason: { unified: "tool-calls", raw: "tool-calls" } });
+          stream!.enqueue(encoder.encode("data: [DONE]\n\n"));
+          stream!.close();
+          streamClosed = true;
+        };
+        const gateway = startDynamicFakeGateway((body) => {
+          const index = requestIndex++;
+          if (index === 0) {
+            const locations = advertisedSkillLocations(body, skillName);
+            expect(locations).toHaveLength(1);
+            location = locations[0]!;
+            expect(location).toMatch(/^skill:[0-9a-f]{16}:\d+\//);
+            expect(advertisedSkillPath(body, location)).toBe(skillDirectory);
+            if (!attached) return fakeGatewayToolCall(mainCallId, "skill", { location });
+            expect(promptText(body)).toContain("Explicitly invoked skill content");
+            expect(promptText(body)).toContain(mainSentinel);
+          }
+          if (index === heldRequestCount - 1) {
+            if (!attached) expect(toolResultOutput(body, mainCallId)).toContain(mainSentinel);
+            expect(body).not.toContain(earlySentinel);
+            expect(body).not.toContain(resourceSentinel);
+            return new Response(new ReadableStream<Uint8Array>({
+              start(controller) {
+                stream = controller;
+                send({ type: "tool-input-start", id: resourceCallId, toolName: "skill" });
+              },
+              cancel() { streamClosed = true; },
+            }), { headers: { "content-type": "text/event-stream" } });
+          }
+          expect(finishReleased).toBe(true);
+          if (!scenario.cancel && index === heldRequestCount) {
+            const result = toolResultOutput(body, resourceCallId);
+            expect(result).toContain(resourceSentinel);
+            expect(result).not.toContain(earlySentinel);
+            return fakeGatewayFinalText("HELD_SKILL_RESOURCE_COMPLETE");
+          }
+          expect(promptText(body)).toContain("Confirm later input still works.");
+          if (scenario.cancel) {
+            expect(body).not.toContain(earlySentinel);
+            expect(body).not.toContain(resourceSentinel);
+            expect(hasCurrentToolResult(body, resourceCallId)).toBe(false);
+          }
+          return fakeGatewayFinalText("HELD_SKILL_LATER_INPUT_OK");
+        }, { models: [{ id: MODEL, type: "language", tags: ["tool-use"] }] });
+        let tui: TmuxSession | null = null;
+        try {
+          tui = await TmuxSession.create({
+            cmd: binary,
+            cwd: root.workspace,
+            isolated: true,
+            remainOnExit: true,
+            width: 140,
+            height: 40,
+            stderrPath,
+            env: {
+              ...fixtureEnv(root, gateway, join(root.root, "trace.log")),
+              FX_AUTO_UPGRADE: "0",
+              FX_PERMISSION_MODE: "auto",
+              FX_RECORD: tapePath,
+            },
+          });
+          await tui.waitForStableComposer(15_000);
+          await tui.sendText(attached
+            ? `$${skillName} read its supporting resource.`
+            : "Load streamed-workflow and read its supporting resource.");
+          await tui.waitForPane((pane) => stream !== undefined && pane.includes("Loading skill"), 15_000);
+          expect(gateway.requestCount()).toBe(heldRequestCount);
+          expect(await tui.captureFullScrollback()).not.toContain(location);
+
+          // Keep streamed input location-first even when final argument keys are reversed.
+          send({ type: "tool-input-delta", id: resourceCallId, delta: JSON.stringify({ location, resource }) });
+          send({ type: "tool-input-end", id: resourceCallId });
+          send({
+            type: "tool-call", toolCallId: resourceCallId, toolName: "skill",
+            input: scenario.resourceFirst ? { resource, location } : { location, resource },
+          });
+          await tui.waitForPane((pane) =>
+            pane.includes(`Reading skill resource ${resource}`) ||
+            pane.includes(location) || pane.includes(`Loading skill ${resource}`), 10_000);
+          // Observe a held interval, not just the first render, without releasing finish.
+          const heldUntil = Date.now() + 250;
+          while (Date.now() < heldUntil) {
+            expect(gateway.requestCount()).toBe(heldRequestCount);
+            expect(tui.paneStatus().dead).toBe(false);
+            await Bun.sleep(25);
+          }
+          const held = await tui.captureFullScrollback();
+          expect(held).not.toContain(location);
+          expect(held).toContain(`Reading skill resource ${resource}`);
+          expect(held).not.toContain(`Read skill resource ${resource}`);
+          expect(finishReleased).toBe(false);
+          expect(gateway.requestCount()).toBe(heldRequestCount);
+
+          // An early resource read would return the old sentinel after finish.
+          writeFileSync(resourcePath, `${resourceSentinel}\n`);
+          if (scenario.cancel) {
+            await tui.sendKeys("C-c");
+            await tui.waitForText("What can fx do differently?", 10_000);
+            await tui.waitForStableComposer(10_000);
+            expect(gateway.requestCount()).toBe(heldRequestCount);
+            releaseFinish();
+          } else {
+            releaseFinish();
+            await tui.waitForText("HELD_SKILL_RESOURCE_COMPLETE", 15_000);
+            await tui.waitForStableComposer(10_000);
+            const completed = await tui.captureFullScrollback();
+            expect(completed).toContain(`Read skill resource ${resource}`);
+            expect(completed).not.toContain(location);
+            if (!attached) expect(completed).toContain(`Loaded skill ${skillName}`);
+            expect(gateway.requestCount()).toBe(heldRequestCount + 1);
+          }
+          await tui.sendText("Confirm later input still works.");
+          await tui.waitForText("HELD_SKILL_LATER_INPUT_OK", 15_000);
+          await tui.waitForStableComposer(10_000);
+          expect(gateway.requestCount()).toBe(heldRequestCount + (scenario.cancel ? 1 : 2));
+          const scrollback = await tui.captureFullScrollback();
+          expect(scrollback).not.toContain(location);
+          if (scenario.cancel) {
+            expect(scrollback).not.toContain(`Read skill resource ${resource}`);
+            expect(scrollback).not.toContain("HELD_SKILL_RESOURCE_COMPLETE");
+          }
+          await tui.sendText("/quit");
+          await tui.waitForPane(() => paneExitMatches(tui!.paneStatus(), 0), 10_000);
+          expect(tui.paneStatus()).toMatchObject({ dead: true, status: 0 });
+          expect(readFileSync(stderrPath, "utf8")).toBe("");
+          // Inspect every output frame, including provisional rows later overwritten in place.
+          const output = Buffer.concat(stdoutFrames(tapePath).map((frame) => frame.payload)).toString("utf8");
+          expect(output).toContain(resource);
+          expect(output).not.toMatch(/skill:[0-9a-f]{16}:\d+\//);
+        } finally {
+          if (stream && !streamClosed) stream.close();
+          if (tui) await tui.kill();
+          gateway.stop();
+          rmSync(root.root, { recursive: true, force: true });
+        }
+      },
+      90_000,
+    );
+  }
 
   test("dynamic model-context values stay data", async () => {
     const root = createFixtureRoot(


### PR DESCRIPTION
## Summary

- Show relative resource paths in pending skill reads instead of opaque skill locations.
- Keep initial skill loads generic until fx resolves their names.