### PR TITLE
Show compaction in the live activity row

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,9 @@ Context estimates adjust to observed provider usage, including when a local esti
 
 While compaction runs, the activity row shows `Compacting` with elapsed time instead of the ordinary turn label and token counts. Manual `/compact` returns to an idle composer without sending a prompt; automatic compaction continues the current turn. Cancellation and failure feedback stays in the status area, not the transcript.
 
-Compaction handoffs remain internal context for the model. Resuming a session and opening its full transcript show the conversation and tool activity, not internal summaries, compaction notices, or operation ledgers.
+Compaction handoffs remain internal context for the model. Resuming a session and opening its full transcript show the conversation and tool activity, not internal summaries, compaction notices, or operation ledgers. Cancelling automatic compaction records its origin so reopening does not add a cancellation marker; ordinary turn cancellations still appear.
+
+Existing sessions load without migration. Sessions saved after cancelling automatic compaction contain new cancellation metadata; reopen them with the same or a newer fx build, since older builds may reject that metadata.
 
 Saved conversations preserve original assistant replies and compatible provider continuation data. Display formatting does not rewrite saved text, and hook-driven continuation keeps earlier replies separate from the final response.
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,9 @@ fx automatically summarizes a long session into a fresh context window when the 
 
 Context estimates adjust to observed provider usage, including when a local estimate is too high. Compaction budgets the recent reasoning history it keeps and can retain fewer complete exchanges when needed to leave room for the summary.
 
-Compaction handoffs remain internal context for the model. Resuming a session and opening its full transcript show the conversation and tool activity, not internal summaries or operation ledgers.
+While compaction runs, the activity row shows `Compacting` with elapsed time instead of the ordinary turn label and token counts. Manual `/compact` returns to an idle composer without sending a prompt; automatic compaction continues the current turn. Cancellation and failure feedback stays in the status area, not the transcript.
+
+Compaction handoffs remain internal context for the model. Resuming a session and opening its full transcript show the conversation and tool activity, not internal summaries, compaction notices, or operation ledgers.
 
 Saved conversations preserve original assistant replies and compatible provider continuation data. Display formatting does not rewrite saved text, and hook-driven continuation keeps earlier replies separate from the final response.
 

--- a/scripts/pgso/corpus.json
+++ b/scripts/pgso/corpus.json
@@ -108,6 +108,7 @@
     {"name": "verify-auto-mode-reliability", "argv": ["bun", "test", "--max-concurrency", "1", "./auto-mode-reliability.test.ts"], "test_file": "auto-mode-reliability.test.ts"},
     {"name": "verify-oauth-keychain-migration", "argv": ["bun", "test", "--max-concurrency", "1", "./oauth-keychain-migration.test.ts"], "test_file": "oauth-keychain-migration.test.ts", "allow_keychain": true},
     {"name": "verify-tui-auth-source-selection", "argv": ["bun", "test", "--max-concurrency", "1", "./tui-auth-source-selection.test.ts"], "test_file": "tui-auth-source-selection.test.ts"},
+    {"name": "verify-tui-compaction-activity", "argv": ["bun", "test", "--max-concurrency", "1", "./tui-compaction-activity.test.ts"], "test_file": "tui-compaction-activity.test.ts"},
     {"name": "verify-tui-composer-edit-contracts", "argv": ["bun", "test", "--max-concurrency", "1", "./tui-composer-edit-contracts.test.ts"], "test_file": "tui-composer-edit-contracts.test.ts"},
     {"name": "verify-tui-cost", "argv": ["bun", "test", "--max-concurrency", "1", "./tui-cost.test.ts"], "test_file": "tui-cost.test.ts"},
     {"name": "verify-tui-decision-prompts", "argv": ["bun", "test", "--max-concurrency", "1", "./tui-decision-prompts.test.ts"], "test_file": "tui-decision-prompts.test.ts"},

--- a/scripts/pgso/tests/test_corpus.py
+++ b/scripts/pgso/tests/test_corpus.py
@@ -56,6 +56,7 @@ VERIFICATION_E2E_TESTS = (
     "auto-mode-reliability.test.ts",
     "oauth-keychain-migration.test.ts",
     "tui-auth-source-selection.test.ts",
+    "tui-compaction-activity.test.ts",
     "tui-composer-edit-contracts.test.ts",
     "tui-cost.test.ts",
     "tui-decision-prompts.test.ts",
@@ -365,7 +366,7 @@ class PgsoCorpusTests(unittest.TestCase):
             tuple(test_file for test_file, _ in corpus.intentional_exclusions),
         )
         self.assertEqual(35, len(corpus.scenarios))
-        self.assertEqual(52, len(corpus.candidate_scenarios))
+        self.assertEqual(53, len(corpus.candidate_scenarios))
         self.assertEqual(
             {
                 "direct-help": 100,

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -332,7 +332,9 @@ stores remain terminal-only host integrations.
 During `/compact` and automatic compaction, the terminal shows a live
 `Compacting` activity row with elapsed time. Input and cancellation remain
 responsive while the summary request is pending. Compaction progress and
-outcomes do not add transcript entries.
+outcomes do not add transcript entries, including cancellation after resume.
+Stored snapshots retain cancellation-origin metadata; keep them opaque and
+resume with the same or a newer SDK build. Older snapshots remain readable.
 
 ## Security
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -329,6 +329,11 @@ The terminal runtime exposes `interactive`, `exited`, `write`, `resize`, and
 `abort`. Terminal session, config, OAuth, prompt-history, URL, and workspace
 stores remain terminal-only host integrations.
 
+During `/compact` and automatic compaction, the terminal shows a live
+`Compacting` activity row with elapsed time. Input and cancellation remain
+responsive while the summary request is pending. Compaction progress and
+outcomes do not add transcript entries.
+
 ## Security
 
 Treat `nativeAddon` and `gatewayChatUrl` as trusted host

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test:term": "node test-xterm-adapter.mjs && node --experimental-wasm-jspi test-term-config-restore.mjs && node --experimental-wasm-jspi test-term-headless.mjs && node --experimental-wasm-jspi test-term-table-stream.mjs && node --experimental-wasm-jspi test-term-lifecycle.mjs && node --experimental-wasm-jspi test-term-features.mjs && node --experimental-wasm-jspi test-term-history.mjs && node --experimental-wasm-jspi test-term-workspace.mjs"
+    "test:term": "node test-xterm-adapter.mjs && node --experimental-wasm-jspi test-term-config-restore.mjs && node --experimental-wasm-jspi test-term-headless.mjs && node --experimental-wasm-jspi test-term-table-stream.mjs && node --experimental-wasm-jspi test-term-lifecycle.mjs && node --experimental-wasm-jspi test-term-compaction.mjs && node --experimental-wasm-jspi test-term-features.mjs && node --experimental-wasm-jspi test-term-history.mjs && node --experimental-wasm-jspi test-term-workspace.mjs"
   },
   "devDependencies": {
     "@xterm/headless": "6.0.0"

--- a/sdk/node/test-term-compaction.mjs
+++ b/sdk/node/test-term-compaction.mjs
@@ -1,0 +1,289 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import xtermHeadless from "@xterm/headless";
+import { createFxTerminal, supportsJspi, xtermAdapter } from "../node.js";
+
+const script = fileURLToPath(import.meta.url);
+const wasmPath = resolve(process.argv[2] || fileURLToPath(new URL("../../zig-out/bin/fx-term.wasm", import.meta.url)));
+if (!supportsJspi()) {
+  console.error("JSPI is required: node --experimental-wasm-jspi sdk/node/test-term-compaction.mjs");
+  process.exit(2);
+}
+const scenario = process.argv[3];
+if (scenario) {
+  assert(["success", "cancel-headers", "cancel-body"].includes(scenario));
+  await runScenario(scenario);
+} else {
+  // A blocked cooperative loop must fail the test, not hang the entire SDK lane.
+  for (const name of ["success", "cancel-headers", "cancel-body"]) {
+    const child = spawn(process.execPath, ["--experimental-wasm-jspi", script, wasmPath, name], {
+      env: { PATH: process.env.PATH ?? "/usr/bin:/bin", FX_SOUND: "0", FX_E2E_DISABLE_DOTENV: "1" },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "", stderr = "";
+    child.stdout.setEncoding("utf8").on("data", (chunk) => { stdout += chunk; });
+    child.stderr.setEncoding("utf8").on("data", (chunk) => { stderr += chunk; });
+    const result = await new Promise((resolveResult, reject) => {
+      const timer = setTimeout(() => child.kill("SIGKILL"), 60_000);
+      child.once("error", (error) => { clearTimeout(timer); reject(error); });
+      child.once("exit", (code, signal) => { clearTimeout(timer); resolveResult({ code, signal }); });
+    });
+    assert.equal(result.code, 0, `${name}: ${JSON.stringify(result)}\n${stdout}\n${stderr}`);
+    assert.equal(stderr, "", name);
+    assert(stdout.includes(`term compaction ${name} passed`));
+    process.stdout.write(stdout);
+  }
+}
+
+function finalText(text) {
+  return new Response([
+    { type: "text-delta", id: "answer", delta: text },
+    { type: "finish", finishReason: { unified: "stop", raw: "stop" }, usage: { inputTokens: { total: 3 }, outputTokens: { total: 5 } } },
+  ].map((event) => `data: ${JSON.stringify(event)}\n\n`).join("") + "data: [DONE]\n\n", {
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+function heldSummary(signal) {
+  let resolveHeaders, rejectHeaders, controller;
+  let headersReleased = false, bodyRead = false, aborted = false, finished = false;
+  const response = new Promise((resolve, reject) => { resolveHeaders = resolve; rejectHeaders = reject; });
+  const abort = () => {
+    if (finished) return;
+    aborted = true;
+    finished = true;
+    const error = new DOMException("synthetic request aborted", "AbortError");
+    if (headersReleased) controller.error(error);
+    else rejectHeaders(error);
+  };
+  signal.addEventListener("abort", abort, { once: true });
+  if (signal.aborted) abort();
+  return {
+    response,
+    get bodyRead() { return bodyRead; },
+    get aborted() { return aborted; },
+    releaseHeaders() {
+      assert(!headersReleased && !finished);
+      headersReleased = true;
+      resolveHeaders(new Response(new ReadableStream({
+        start(value) { controller = value; },
+        pull() { bodyRead = true; },
+      }, { highWaterMark: 0 }), { headers: { "content-type": "text/event-stream" } }));
+    },
+    async releaseBody(text) {
+      assert(headersReleased && bodyRead && !finished);
+      finished = true;
+      signal.removeEventListener("abort", abort);
+      controller.enqueue(new Uint8Array(await finalText(text).arrayBuffer()));
+      controller.close();
+    },
+  };
+}
+
+function grid(terminal) {
+  const lines = [];
+  for (let row = 0; row < terminal.buffer.active.length; row++) {
+    lines.push(terminal.buffer.active.getLine(row)?.translateToString(true) ?? "");
+  }
+  return lines.join("\n");
+}
+
+async function runScenario(name) {
+  const { Terminal } = xtermHeadless;
+  const wasm = await readFile(wasmPath);
+  const head = "HOST_HISTORY_HEAD_73b4", tail = "HOST_HISTORY_TAIL_b149";
+  const handoff = `HOST_INTERNAL_HANDOFF_268a: preserve ${head}; follow the latest request.`;
+  // Several ordinary exchanges leave older history outside the retained suffix,
+  // without pushing a cancelled attempt's followup over the automatic threshold.
+  const seedTurns = 3;
+  const seedReply = (turn) => `${turn === 1 ? head : `HOST_HISTORY_MIDDLE_${turn}`}\n${"history alpha beta gamma delta sample line\n".repeat(400)}HOST_SEED_DONE_${turn}${turn === seedTurns ? `\n${tail}` : ""}`;
+  const activity = /Compacting \((?:\d+h)?(?:\d+m)?\d+s\)/;
+  const forbidden = /Compacting|compaction|Context compacted|No context to compact|Your existing context was kept|HOST_INTERNAL_HANDOFF_268a/i;
+  const emptyComposer = (text) => text.split("\n").some((line) => /^[ \t]*(?:┃|❯|>)[ \t]*$/.test(line));
+  const records = new Map();
+  const requests = [];
+  let revision = 0, commits = 0, summaries = 0, ordinary = 0;
+  let phase = "seed", hold;
+  let active;
+  const sessionStore = {
+    load(id) {
+      const record = records.get(id);
+      return record ? { bytes: record.bytes.slice(), revision: record.revision } : null;
+    },
+    commit(id, bytes, expectedRevision) {
+      const current = records.get(id);
+      if (current?.revision !== expectedRevision) {
+        throw Object.assign(new Error("session revision conflict"), { code: "FX_SESSION_REVISION_CONFLICT" });
+      }
+      const next = String(++revision);
+      records.set(id, { bytes: bytes.slice(), revision: next, updatedAtMs: Date.now() });
+      commits++;
+      return { revision: next };
+    },
+    list() { return [...records].map(([id, value]) => ({ id, updatedAtMs: value.updatedAtMs })); },
+    remove(id) { records.delete(id); },
+  };
+  const fetch = async (_url, init = {}) => {
+    if ((init.method ?? "GET") === "GET") {
+      return Response.json({ data: [{ id: "openai/gpt-5", type: "language", tags: ["tool-use"], context_window: 128000, max_tokens: 8192 }] });
+    }
+    const body = JSON.parse(typeof init.body === "string" ? init.body : new TextDecoder().decode(init.body));
+    requests.push(body);
+    if (body.toolChoice?.type === "none" && body.tools?.length === 0) {
+      summaries++;
+      if (summaries === 1) {
+        hold = heldSummary(init.signal);
+        return hold.response;
+      }
+      return finalText(handoff);
+    }
+    ordinary++;
+    return finalText(phase === "seed"
+      ? seedReply(ordinary)
+      : phase === "reopen" ? "HOST_REOPEN_OK_732a" : "HOST_FOLLOWUP_OK_781c");
+  };
+  async function waitFor(predicate, label, timeout = 10_000) {
+    const deadline = performance.now() + timeout;
+    while (true) {
+      await new Promise((resolve) => active.terminal.write("", resolve));
+      if (predicate()) return;
+      assert(performance.now() < deadline, `${name}: timed out waiting for ${label}\n${grid(active.terminal).slice(-6000)}`);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+  }
+  async function start(args = []) {
+    const terminal = new Terminal({ cols: 90, rows: 32, allowProposedApi: true, scrollback: 4000 });
+    const adapter = xtermAdapter(terminal);
+    const state = { terminal, writes: 0, stderr: "", events: [], runtime: undefined };
+    active = state;
+    state.runtime = await createFxTerminal({
+      backend: "wasm", wasm, args,
+      terminal: {
+        ...adapter,
+        get cols() { return adapter.cols; },
+        get rows() { return adapter.rows; },
+        write(bytes) { state.writes++; adapter.write(bytes); },
+      },
+      env: {
+        AI_GATEWAY_API_KEY: "synthetic-host-compaction-key", FX_MODEL: "openai/gpt-5",
+        FX_SOUND: "0", FX_AUTO_UPGRADE: "0", FX_DISABLE_KEYCHAIN: "1", FX_SKIP_ONBOARDING: "1",
+      },
+      fetch, sessionStore,
+      configStore: { get(id) { return id === "model" ? "openai/gpt-5" : null; }, set() {} },
+      stderr(bytes) { state.stderr += new TextDecoder().decode(bytes); },
+      onEvent(event) { state.events.push(event); },
+    });
+    await waitFor(() => grid(terminal).includes(args.length ? "Session resumed" : "Run /help for commands") && emptyComposer(grid(terminal)), "terminal startup");
+    return state;
+  }
+  async function stop() {
+    const state = active;
+    state.runtime.write("/exit\r");
+    const code = await Promise.race([
+      state.runtime.exited,
+      new Promise((_, reject) => { const timer = setTimeout(() => reject(new Error("terminal exit timeout")), 5000); timer.unref(); }),
+    ]);
+    assert.equal(code, 0);
+    assert.equal(state.stderr, "");
+    assert.equal(state.events.filter((event) => event.type === "runtime.exit").length, 1);
+    state.terminal.dispose();
+    active = undefined;
+  }
+  async function ticking(label) {
+    await waitFor(() => activity.test(grid(active.terminal)), `${label} activity`);
+    const first = grid(active.terminal).match(activity)[0];
+    const writes = active.writes;
+    const markerStates = new Set();
+    await waitFor(() => {
+      const rows = grid(active.terminal).split("\n").filter((line) => activity.test(line));
+      assert.equal(rows.length, 1, "exactly one live activity row");
+      assert(!/[↑↓]|tokens|chunk|%/i.test(rows[0]), "compaction must not show a token suffix");
+      markerStates.add(rows[0].includes("•"));
+      return markerStates.size === 2 && !rows[0].includes(first) && active.writes >= writes + 2;
+    }, `${label} marker blink and elapsed time`, 5000);
+  }
+  async function silentTranscript() {
+    assert(!forbidden.test(grid(active.terminal)), "compaction output leaked into inline scrollback");
+    active.runtime.write("\x0f");
+    await waitFor(() => active.terminal.buffer.active.type === "alternate" && grid(active.terminal).includes("Full detail"), "full transcript");
+    assert(!forbidden.test(grid(active.terminal)), "compaction output leaked into Ctrl+O");
+    active.runtime.write("\x0f");
+    await waitFor(() => active.terminal.buffer.active.type === "normal" && emptyComposer(grid(active.terminal)), "inline restoration");
+  }
+  try {
+    await start();
+    for (let turn = 1; turn <= seedTurns; turn++) {
+      active.runtime.write(`Seed ordinary historical turn ${turn}.\r`);
+      await waitFor(() => commits === turn && grid(active.terminal).includes(`HOST_SEED_DONE_${turn}`) && emptyComposer(grid(active.terminal)), `saved history turn ${turn}`, 20_000);
+      assert.equal(ordinary, turn);
+      assert.equal(summaries, 0, "seed history must stay below automatic compaction");
+    }
+    assert.equal(records.size, 1);
+    const sessionId = [...records.keys()][0];
+    await stop();
+    phase = "attempt";
+    await start(["--resume", sessionId]);
+    const beforeCommits = commits;
+    const beforeBytes = [...records.values()][0].bytes.slice();
+    active.runtime.write("/compact\r");
+    await waitFor(() => summaries === 1 && hold, "summary held before headers");
+    await ticking("held headers");
+    assert.equal(commits, beforeCommits, "checkpoint before headers released");
+    assert.deepEqual([...records.values()][0].bytes, beforeBytes);
+    assert.equal(ordinary, seedTurns, "manual compaction created an ordinary prompt");
+    assert(JSON.stringify(requests.at(-1)).includes(head), "summary must receive real older history");
+    if (name !== "cancel-headers") {
+      hold.releaseHeaders();
+      await waitFor(() => hold.bodyRead, "summary body read reached");
+      await ticking("held body");
+      assert.equal(commits, beforeCommits, "checkpoint before summary body released");
+    }
+    if (name === "success") {
+      await hold.releaseBody(handoff);
+      await waitFor(() => commits > beforeCommits && !activity.test(grid(active.terminal)) && emptyComposer(grid(active.terminal)), "published summary and idle composer");
+      assert.equal(ordinary, seedTurns, "manual completion created a synthetic prompt");
+      assert.notDeepEqual(records.get(sessionId).bytes, beforeBytes, "success must publish a changed checkpoint");
+    } else {
+      active.runtime.write("\x03");
+      await waitFor(() => hold.aborted, "Ctrl+C reaches summary AbortSignal");
+      await waitFor(() => !activity.test(grid(active.terminal)) && grid(active.terminal).includes("Compaction cancelled.") && emptyComposer(grid(active.terminal)), "scoped cancellation feedback");
+      assert.equal(commits, beforeCommits, "cancelled summary committed a checkpoint");
+      assert.deepEqual(records.get(sessionId).bytes, beforeBytes, "cancelled summary changed saved history");
+      active.runtime.write("\x1b");
+      await waitFor(() => !/compact/i.test(grid(active.terminal)), "feedback dismissal");
+    }
+    await silentTranscript();
+    phase = "followup";
+    active.runtime.write("Follow the latest request.\r");
+    await waitFor(() => grid(active.terminal).includes("HOST_FOLLOWUP_OK_781c") && emptyComposer(grid(active.terminal)), "followup");
+    assert.equal(ordinary, seedTurns + 1);
+    assert.equal(summaries, 1, "followup must not trigger automatic compaction");
+    const followup = JSON.stringify(requests.at(-1));
+    assert(followup.includes(head) && followup.includes(tail));
+    assert.equal(followup.includes("HOST_INTERNAL_HANDOFF_268a"), name === "success");
+    await silentTranscript();
+    await stop();
+    phase = "reopen";
+    await start(["--resume", sessionId]);
+    assert.equal(records.size, 1, "reopen must use the same saved history");
+    active.runtime.write("Continue after reopening.\r");
+    await waitFor(() => grid(active.terminal).includes("HOST_REOPEN_OK_732a") && emptyComposer(grid(active.terminal)), "reopened prompt");
+    assert.equal(ordinary, seedTurns + 2);
+    assert.equal(summaries, 1, "reopen must not trigger automatic compaction");
+    const reopened = JSON.stringify(requests.at(-1));
+    assert(reopened.includes(head) && reopened.includes(tail));
+    assert.equal(reopened.includes("HOST_INTERNAL_HANDOFF_268a"), name === "success");
+    await silentTranscript();
+    await stop();
+    console.log(`term compaction ${name} passed`);
+  } finally {
+    if (active) {
+      active.runtime?.abort();
+      active.terminal.dispose();
+    }
+  }
+}

--- a/sdk/node/test-term-compaction.mjs
+++ b/sdk/node/test-term-compaction.mjs
@@ -13,13 +13,14 @@ if (!supportsJspi()) {
   console.error("JSPI is required: node --experimental-wasm-jspi sdk/node/test-term-compaction.mjs");
   process.exit(2);
 }
+const scenarios = ["success", "cancel-headers", "cancel-body", "auto-cancel-headers"];
 const scenario = process.argv[3];
 if (scenario) {
-  assert(["success", "cancel-headers", "cancel-body"].includes(scenario));
+  assert(scenarios.includes(scenario));
   await runScenario(scenario);
 } else {
   // A blocked cooperative loop must fail the test, not hang the entire SDK lane.
-  for (const name of ["success", "cancel-headers", "cancel-body"]) {
+  for (const name of scenarios) {
     const child = spawn(process.execPath, ["--experimental-wasm-jspi", script, wasmPath, name], {
       env: { PATH: process.env.PATH ?? "/usr/bin:/bin", FX_SOUND: "0", FX_E2E_DISABLE_DOTENV: "1" },
       stdio: ["ignore", "pipe", "pipe"],
@@ -99,8 +100,9 @@ async function runScenario(name) {
   let handoff;
   // Several ordinary exchanges leave older history outside the retained suffix,
   // without pushing a cancelled attempt's followup over the automatic threshold.
-  const seedTurns = 3;
-  const seedReply = (turn) => `${turn === 1 ? head : `HOST_HISTORY_MIDDLE_${turn}`}\n${"history alpha beta gamma delta sample line\n".repeat(400)}HOST_SEED_DONE_${turn}${turn === seedTurns ? `\n${tail}` : ""}`;
+  const automatic = name === "auto-cancel-headers";
+  const seedTurns = automatic ? 1 : 3;
+  const seedReply = (turn) => `${turn === 1 ? head : `HOST_HISTORY_MIDDLE_${turn}`}\n${"history alpha beta gamma delta sample line\n".repeat(automatic ? 18_000 : 400)}HOST_SEED_DONE_${turn}${turn === seedTurns ? `\n${tail}` : ""}`;
   const activity = /Compacting \((?:\d+h)?(?:\d+m)?\d+s\)/;
   const forbidden = /Compacting|compaction|Context compacted|No context to compact|Your existing context was kept|HOST_INTERNAL_HANDOFF_268a/i;
   const emptyComposer = (text) => text.split("\n").some((line) => /^[ \t]*(?:┃|❯|>)[ \t]*$/.test(line));
@@ -231,16 +233,23 @@ async function runScenario(name) {
     await stop();
     phase = "attempt";
     await start(["--resume", sessionId]);
+    if (automatic) {
+      active.runtime.write("/model\r");
+      await waitFor(() => grid(active.terminal).includes("128K context") && grid(active.terminal).includes("Tab Provider"), "model capabilities loaded");
+      active.runtime.write("\x1b");
+      await waitFor(() => !grid(active.terminal).includes("Tab Provider") && emptyComposer(grid(active.terminal)), "model catalog closed");
+    }
     const beforeCommits = commits;
     const beforeBytes = [...records.values()][0].bytes.slice();
-    active.runtime.write("/compact\r");
+    const cancelledPrompt = "Cancel this automatic summary before headers.";
+    active.runtime.write(automatic ? `${cancelledPrompt}\r` : "/compact\r");
     await waitFor(() => summaries === 1 && hold, "summary held before headers");
     await ticking("held headers");
     assert.equal(commits, beforeCommits, "checkpoint before headers released");
     assert.deepEqual([...records.values()][0].bytes, beforeBytes);
     assert.equal(ordinary, seedTurns, "manual compaction created an ordinary prompt");
-    assert(JSON.stringify(requests.at(-1)).includes(head), "summary must receive real older history");
-    if (name !== "cancel-headers") {
+    assert(JSON.stringify(requests.at(-1)).includes(automatic ? "Seed ordinary historical turn 1." : head), `summary must receive real older history: ${JSON.stringify(requests.at(-1)).slice(-4000)}`);
+    if (name !== "cancel-headers" && !automatic) {
       hold.releaseHeaders();
       await waitFor(() => hold.bodyRead, "summary body read reached");
       await ticking("held body");
@@ -255,12 +264,38 @@ async function runScenario(name) {
       active.runtime.write("\x03");
       await waitFor(() => hold.aborted, "Ctrl+C reaches summary AbortSignal");
       await waitFor(() => !activity.test(grid(active.terminal)) && grid(active.terminal).includes("Compaction cancelled.") && emptyComposer(grid(active.terminal)), "scoped cancellation feedback");
-      assert.equal(commits, beforeCommits, "cancelled summary committed a checkpoint");
-      assert.deepEqual(records.get(sessionId).bytes, beforeBytes, "cancelled summary changed saved history");
+      if (automatic) {
+        await waitFor(() => commits === beforeCommits + 1, "automatic interruption persisted");
+        const saved = new TextDecoder().decode(records.get(sessionId).bytes);
+        assert.equal(saved.match(/"cancellation_origin"\s*:\s*"compaction"/g)?.length, 1, "save one compaction-origin interruption");
+        assert(saved.includes(cancelledPrompt), "save the interrupted prompt");
+        assert(!saved.includes("HOST_INTERNAL_HANDOFF_268a"), "unacknowledged summary must not enter history");
+        assert.equal(ordinary, seedTurns, "cancelled automatic turn must not request an ordinary reply");
+      } else {
+        assert.equal(commits, beforeCommits, "cancelled summary committed a checkpoint");
+        assert.deepEqual(records.get(sessionId).bytes, beforeBytes, "cancelled summary changed saved history");
+      }
       active.runtime.write("\x1b");
       await waitFor(() => !/compact/i.test(grid(active.terminal)), "feedback dismissal");
     }
     await silentTranscript();
+    if (automatic) {
+      await stop();
+      phase = "reopen";
+      await start(["--resume", sessionId]);
+      active.runtime.write("\x0f");
+      await waitFor(() => active.terminal.buffer.active.type === "alternate" && grid(active.terminal).includes("Full detail"), "reopened full transcript");
+      active.runtime.write("\x1b[F");
+      await waitFor(() => grid(active.terminal).includes(cancelledPrompt), "replayed interrupted prompt");
+      assert(!/cancelled|compaction|HOST_INTERNAL_HANDOFF_268a/i.test(grid(active.terminal)), "compaction cancellation must replay silently");
+      active.runtime.write("\x0f");
+      await waitFor(() => active.terminal.buffer.active.type === "normal" && emptyComposer(grid(active.terminal)), "reopened inline restoration");
+      await stop();
+      assert.equal(summaries, 1);
+      assert.equal(ordinary, seedTurns);
+      console.log(`term compaction ${name} passed`);
+      return;
+    }
     phase = "followup";
     active.runtime.write("Follow the latest request.\r");
     await waitFor(() => grid(active.terminal).includes("HOST_FOLLOWUP_OK_781c") && emptyComposer(grid(active.terminal)), "followup");

--- a/sdk/node/test-term-compaction.mjs
+++ b/sdk/node/test-term-compaction.mjs
@@ -96,7 +96,7 @@ async function runScenario(name) {
   const { Terminal } = xtermHeadless;
   const wasm = await readFile(wasmPath);
   const head = "HOST_HISTORY_HEAD_73b4", tail = "HOST_HISTORY_TAIL_b149";
-  const handoff = `HOST_INTERNAL_HANDOFF_268a: preserve ${head}; follow the latest request.`;
+  let handoff;
   // Several ordinary exchanges leave older history outside the retained suffix,
   // without pushing a cancelled attempt's followup over the automatic threshold.
   const seedTurns = 3;
@@ -129,12 +129,16 @@ async function runScenario(name) {
   };
   const fetch = async (_url, init = {}) => {
     if ((init.method ?? "GET") === "GET") {
-      return Response.json({ data: [{ id: "openai/gpt-5", type: "language", tags: ["tool-use"], context_window: 128000, max_tokens: 8192 }] });
+      return Response.json({ data: [{ id: "fixture/test-model", type: "language", tags: ["tool-use"], context_window: 128000, max_tokens: 8192 }] });
     }
     const body = JSON.parse(typeof init.body === "string" ? init.body : new TextDecoder().decode(init.body));
     requests.push(body);
     if (body.toolChoice?.type === "none" && body.tools?.length === 0) {
       summaries++;
+      // Retained windows vary by model; summarize only markers actually supplied.
+      const source = JSON.stringify(body);
+      const markers = [head, tail].filter((marker) => source.includes(marker));
+      handoff = `HOST_INTERNAL_HANDOFF_268a: preserve ${markers.join(" and ")}; follow the latest request.`;
       if (summaries === 1) {
         hold = heldSummary(init.signal);
         return hold.response;
@@ -169,11 +173,11 @@ async function runScenario(name) {
         write(bytes) { state.writes++; adapter.write(bytes); },
       },
       env: {
-        AI_GATEWAY_API_KEY: "synthetic-host-compaction-key", FX_MODEL: "openai/gpt-5",
+        AI_GATEWAY_API_KEY: "synthetic-host-compaction-key", FX_MODEL: "fixture/test-model",
         FX_SOUND: "0", FX_AUTO_UPGRADE: "0", FX_DISABLE_KEYCHAIN: "1", FX_SKIP_ONBOARDING: "1",
       },
       fetch, sessionStore,
-      configStore: { get(id) { return id === "model" ? "openai/gpt-5" : null; }, set() {} },
+      configStore: { get(id) { return id === "model" ? "fixture/test-model" : null; }, set() {} },
       stderr(bytes) { state.stderr += new TextDecoder().decode(bytes); },
       onEvent(event) { state.events.push(event); },
     });
@@ -263,7 +267,11 @@ async function runScenario(name) {
     assert.equal(ordinary, seedTurns + 1);
     assert.equal(summaries, 1, "followup must not trigger automatic compaction");
     const followup = JSON.stringify(requests.at(-1));
-    assert(followup.includes(head) && followup.includes(tail));
+    assert(followup.includes(head) && followup.includes(tail), JSON.stringify(requests.map((request) => ({
+      summary: request.toolChoice?.type === "none" && request.tools?.length === 0,
+      head: JSON.stringify(request).includes(head), tail: JSON.stringify(request).includes(tail),
+      handoff: JSON.stringify(request).includes("HOST_INTERNAL_HANDOFF_268a"),
+    }))));
     assert.equal(followup.includes("HOST_INTERNAL_HANDOFF_268a"), name === "success");
     await silentTranscript();
     await stop();

--- a/sdk/tests/test-node-wasm.mjs
+++ b/sdk/tests/test-node-wasm.mjs
@@ -9,6 +9,7 @@ const termScripts = [
   "test-term-headless.mjs",
   "test-term-table-stream.mjs",
   "test-term-lifecycle.mjs",
+  "test-term-compaction.mjs",
   "test-term-features.mjs",
   "test-term-history.mjs",
   "test-term-workspace.mjs",

--- a/src/core/agent/runtime/context_compaction.zig
+++ b/src/core/agent/runtime/context_compaction.zig
@@ -23,6 +23,7 @@ const max_summary_chunks: usize = 64;
 
 pub const Request = struct {
     stream_provider: agent_stream_provider.Provider,
+    cooperative_transport_pulse: ?agent_stream_provider.CooperativePulse = null,
     model: []const u8,
     api_key: []const u8,
     credential_source: ?types.CredentialSource = null,
@@ -401,6 +402,7 @@ fn runSummaryCall(
                 .admission = .{},
                 .cancel_flag = request.cancel_flag,
                 .trace_ctx = request.trace_ctx,
+                .cooperative_pulse = request.cooperative_transport_pulse,
             },
             request.usage,
             request.usage_allocator,
@@ -515,6 +517,7 @@ const FakeProvider = struct {
         request: agent_stream_provider.ModelRequest,
     ) !agent_stream_provider.Result {
         const self: *FakeProvider = @ptrCast(@alignCast(raw.?));
+        if (request.cooperative_pulse) |pulse| try pulse.pulse();
         if (self.request_count < self.retry_counts.len) self.retry_counts[self.request_count] = request.retry_count;
         self.request_count += 1;
         if (self.request_count == 1) {
@@ -562,6 +565,38 @@ const FakeProvider = struct {
         } } };
     }
 };
+
+test "compaction activity forwards cooperative pulse through summary retry and cancellation" {
+    const Pulse = struct {
+        calls: usize = 0,
+        cancel: ?*std.atomic.Value(bool) = null,
+        fn run(raw: *anyopaque) !void {
+            const self: *@This() = @ptrCast(@alignCast(raw));
+            self.calls += 1;
+            if (self.cancel) |flag| flag.store(true, .seq_cst);
+        }
+    };
+    var pulse: Pulse = .{};
+    var provider: FakeProvider = .{ .response = "", .retry_response = "The requested work was recorded." };
+    var cancel = std.atomic.Value(bool).init(false);
+    const request: Request = .{
+        .stream_provider = provider.provider(),
+        .cooperative_transport_pulse = .{ .ctx = &pulse, .run = Pulse.run },
+        .model = "fixture/model",
+        .api_key = "fixture-key",
+        .retry_count = 1,
+        .cancel_flag = &cancel,
+        .accepted_tokens = 100,
+        .generation_tokens = 100,
+        .trace_ctx = .{},
+    };
+    const result = try runSummaryCall(std.testing.allocator, request, "source", 100, 1000);
+    defer std.testing.allocator.free(result.text);
+    try std.testing.expectEqual(@as(usize, 2), pulse.calls);
+    pulse.cancel = &cancel;
+    try std.testing.expectError(error.Cancelled, runSummaryCall(std.testing.allocator, request, "source", 100, 1000));
+    try std.testing.expectEqual(@as(usize, 3), pulse.calls);
+}
 
 test "compaction result exposes only caller-consumed state" {
     try std.testing.expect(!@hasField(Result, "usage"));

--- a/src/core/agent/runtime/deps.zig
+++ b/src/core/agent/runtime/deps.zig
@@ -14,6 +14,7 @@ const tool_admission = @import("../../tooling/tool_admission.zig");
 const tool_dispatch = @import("../../tooling/tool_dispatch.zig");
 const tool_contracts = @import("tool_contracts.zig");
 const context_contract = @import("../../workspace/context_contract.zig");
+const compaction_activity = @import("../../output/compaction_activity.zig");
 
 const Allocator = std.mem.Allocator;
 const ChatMessage = types.ChatMessage;
@@ -33,6 +34,13 @@ pub const LiveToolAuthority = tool_contracts.LiveToolAuthority;
 
 pub const RecoveryCheckpointEffect = struct {
     set: *const fn (ctx: *anyopaque, checkpoint: session_codec.RecoveryCheckpoint) anyerror!void,
+};
+
+/// Presentation only. Called outside history publication's worker critical section.
+pub const CompactionActivityEffect = struct {
+    begin: *const fn (ctx: *anyopaque, origin: compaction_activity.Origin, turn_id: ?u64) compaction_activity.OperationId,
+    running: *const fn (ctx: *anyopaque, id: compaction_activity.OperationId, stage: compaction_activity.Stage) void,
+    settle: *const fn (ctx: *anyopaque, id: compaction_activity.OperationId, feedback: compaction_activity.Feedback) void,
 };
 
 pub const ContextCompactionCommitEffect = struct {
@@ -220,6 +228,9 @@ pub const AgentRuntimeDeps = struct {
     publish_deferred_tool_completion: ?*const fn (ctx: *anyopaque, completion: DeferredToolCompletion) TransportPublicationOutcome = null,
     propagate_history_turn: *const fn (ctx: *anyopaque, turn: HistoryTurn) anyerror!void,
     commit_context_compaction: ?ContextCompactionCommitEffect = null,
+    compaction_activity: ?CompactionActivityEffect = null,
+    /// Call-scoped output for the exact error returned through compaction, never retained.
+    compaction_failure: ?*?compaction_activity.ErrorProvenance = null,
     recovery_checkpoint: ?RecoveryCheckpointEffect = null,
     propagate_grant: *const fn (ctx: *anyopaque, tool_name: []const u8, target_path: []const u8) anyerror!void,
     push_event: *const fn (ctx: *anyopaque, event: WorkerEvent) anyerror!void,

--- a/src/core/agent/runtime/interruption.zig
+++ b/src/core/agent/runtime/interruption.zig
@@ -44,6 +44,35 @@ pub fn persistInterruptedTurnOnce(
         retained_candidate,
         terminal_materializing,
         null,
+        .turn,
+    );
+}
+
+pub fn persistCompactionInterruptedTurnOnce(
+    hooks: *const AgentRuntimeDeps,
+    finalization: *TurnFinalizationGuard,
+    job: QueuedPrompt,
+    completed_tool_names: [][]u8,
+    persisted: *bool,
+    trace_ctx: TraceContext,
+    current_turn_messages: []const types.ChatMessage,
+    retained_candidate: ?[]const u8,
+    terminal_materializing: *bool,
+) !void {
+    return persistInterruptedTurnWithPresentation(
+        hooks,
+        finalization,
+        job,
+        null,
+        null,
+        completed_tool_names,
+        persisted,
+        trace_ctx,
+        current_turn_messages,
+        retained_candidate,
+        terminal_materializing,
+        null,
+        .compaction,
     );
 }
 
@@ -74,6 +103,7 @@ pub fn persistInterruptedCommandTurnOnce(
         retained_candidate,
         terminal_materializing,
         cancelled_command,
+        .turn,
     );
 }
 
@@ -90,6 +120,7 @@ fn persistInterruptedTurnWithPresentation(
     retained_candidate: ?[]const u8,
     terminal_materializing: *bool,
     cancelled_command: ?types.CancelledCommandPresentation,
+    cancellation_origin: types.CancellationOrigin,
 ) !void {
     if (persisted.*) return;
 
@@ -128,6 +159,7 @@ fn persistInterruptedTurnWithPresentation(
             .completed_tool_names = completed_tool_names,
             .execution = execution,
             .cancelled_command = cancelled_command,
+            .cancellation_origin = cancellation_origin,
         } };
         const finished = try types.dupeFinishedPrompt(
             std.heap.c_allocator,
@@ -170,6 +202,7 @@ fn persistInterruptedTurnWithPresentation(
         .completed_tool_names = completed_tool_names,
         .execution = execution,
         .cancelled_command = cancelled_command,
+        .cancellation_origin = cancellation_origin,
     } };
 
     var propagation_error: ?anyerror = null;

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -6729,12 +6729,10 @@ fn processQueuedPromptLoop(
                             }) catch |err| {
                                 if (err == error.Cancelled and config.cancel_flag.load(.seq_cst)) {
                                     runtime_telemetry.traceCancelObserved(step_ctx, false);
-                                    try runtime_interruption.persistInterruptedTurnOnce(
+                                    try runtime_interruption.persistCompactionInterruptedTurnOnce(
                                         deps,
                                         finalization,
                                         job,
-                                        null,
-                                        null,
                                         completed_tool_names.items,
                                         &interrupted_persisted,
                                         step_ctx,

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -44,6 +44,7 @@ const runtime_deps = @import("deps.zig");
 const runtime_lifecycle = @import("lifecycle.zig");
 const runtime_prompt_context = @import("prompt_context.zig");
 const runtime_context_compaction = @import("context_compaction.zig");
+const compaction_activity = @import("../../output/compaction_activity.zig");
 const runtime_telemetry = @import("telemetry.zig");
 const runtime_tool_contracts = @import("tool_contracts.zig");
 const runtime_gateway_step = @import("gateway_step.zig");
@@ -4479,6 +4480,7 @@ pub fn processAgentPrompt(
     config: Config,
     job: QueuedPrompt,
 ) !void {
+    if (deps.compaction_failure) |out| out.* = null;
     var effective_job = job;
     if (effective_job.turn_id == 0) {
         effective_job.turn_id = debug_trace.nextTurnId();
@@ -4504,7 +4506,10 @@ pub fn processAgentPrompt(
 
     processQueuedPromptInner(deps, semantic_presentation, effective_lifecycle, effective_config, effective_job, &finalization, agent) catch |err| {
         if (finalization.state == .open) {
-            finalization.finish(.failed, null, null) catch |finalization_err| return finalization_err;
+            finalization.finish(.failed, null, null) catch |finalization_err| {
+                if (deps.compaction_failure) |out| out.* = null;
+                return finalization_err;
+            };
         }
         return err;
     };
@@ -4955,7 +4960,10 @@ fn processQueuedPromptInner(
                 stop_state.retained_candidate,
                 stop_state.latest_partial,
                 &stop_state.terminal_materializing,
-            ) catch |secondary_err| return secondary_err;
+            ) catch |secondary_err| {
+                if (deps.compaction_failure) |out| out.* = null;
+                return secondary_err;
+            };
         } else if (!stop_state.terminal_materializing and
             finalization.state == .open)
         {
@@ -4969,7 +4977,10 @@ fn processQueuedPromptInner(
                 &finish_trace,
                 &stop_state.terminal_materializing,
                 "error",
-            ) catch |secondary_err| return secondary_err;
+            ) catch |secondary_err| {
+                if (deps.compaction_failure) |out| out.* = null;
+                return secondary_err;
+            };
         }
         return err;
     };
@@ -5577,6 +5588,9 @@ test "manual compaction fixed context measures prepared skills and host instruct
 
 pub const ContextCompactionTransactionRequest = struct {
     trigger: runtime_prompt_context.CompactionTrigger,
+    operation_id: ?compaction_activity.OperationId = null,
+    activity_origin: ?compaction_activity.Origin = null,
+    failure_provenance: ?*?compaction_activity.ErrorProvenance = null,
     provider: model_provider.ProviderId,
     working_capabilities: model_capabilities.Capabilities,
     request_tokens: usize,
@@ -5615,6 +5629,19 @@ pub fn compactContextTransaction(
     deps: *const AgentRuntimeDeps,
     request: ContextCompactionTransactionRequest,
 ) !?ContextCompactionTransactionResult {
+    if (request.failure_provenance) |out| out.* = null;
+    const operation_id = if (deps.compaction_activity) |effect|
+        request.operation_id orelse effect.begin(deps.ctx, request.activity_origin orelse if (request.trigger == .manual) .manual else .automatic, request.trace_ctx.turn_id)
+    else
+        null;
+    var stage: compaction_activity.Stage = .preparation;
+    if (operation_id) |id| deps.compaction_activity.?.running(deps.ctx, id, stage);
+    errdefer |err| {
+        if (operation_id) |id| {
+            deps.compaction_activity.?.settle(deps.ctx, id, compaction_activity.failure(err, stage, request.cancel_flag.load(.seq_cst)));
+            if (request.failure_provenance) |out| out.* = .{ .operation_id = id, .turn_id = request.trace_ctx.turn_id, .err = err };
+        }
+    }
     if (request.cancel_flag.load(.seq_cst)) return error.Cancelled;
     var plan_input = runtime_prompt_context.CompactionPlanInput{
         .trigger = request.trigger,
@@ -5623,7 +5650,10 @@ pub fn compactContextTransaction(
         .source_tokens = request.source_tokens,
         .newest_exchange_tokens = request.newest_exchange_tokens,
     };
-    if (runtime_prompt_context.planCompaction(plan_input).decision == .no_op) return null;
+    if (runtime_prompt_context.planCompaction(plan_input).decision == .no_op) {
+        if (operation_id) |id| deps.compaction_activity.?.settle(deps.ctx, id, .{ .outcome = .no_op });
+        return null;
+    }
     const fixed_cost = try request.continuation.measure(alloc, deps.agent_stream_provider, "");
     plan_input.protected_tokens = fixed_cost.estimated_input_tokens;
     const plan = runtime_prompt_context.planCompaction(plan_input);
@@ -5651,18 +5681,14 @@ pub fn compactContextTransaction(
         request.uncertain_source_message_count,
     );
     if (request.cancel_flag.load(.seq_cst)) return error.Cancelled;
-    if (deps.push_interactive_notice) |push_notice| {
-        try push_notice(deps.ctx, .{
-            .topic = "context",
-            .tone = .neutral,
-            .body = "Compacting context…",
-        });
-    }
+    stage = .summary;
+    if (operation_id) |id| deps.compaction_activity.?.running(deps.ctx, id, stage);
     var compacted = try runtime_context_compaction.compact(
         alloc,
         request.source_messages,
         .{
             .stream_provider = deps.agent_stream_provider,
+            .cooperative_transport_pulse = deps.cooperative_transport_pulse,
             .model = compaction_model,
             .api_key = request.api_key,
             .credential_source = request.credential_source,
@@ -5688,28 +5714,233 @@ pub fn compactContextTransaction(
         },
     );
     errdefer compacted.deinit(alloc);
+    stage = .validation;
+    if (operation_id) |id| deps.compaction_activity.?.running(deps.ctx, id, stage);
     if (request.cancel_flag.load(.seq_cst)) return error.Cancelled;
     const candidate_cost = try request.continuation.measure(alloc, deps.agent_stream_provider, compacted.handoff);
     if (candidate_cost.estimated_input_tokens > fixed_cost.estimated_input_tokens +| accepted_tokens) {
         return error.ContextCapacityExceeded;
     }
     if (request.cancel_flag.load(.seq_cst)) return error.Cancelled;
+    stage = .publication;
+    if (operation_id) |id| deps.compaction_activity.?.running(deps.ctx, id, stage);
     try commitContextCompaction(deps, .{
         .summary = compacted.handoff,
         .removed_turn_count = request.removed_turn_count,
         .compaction_count = request.compaction_count,
     }, request.active_prefix, request.retained_from);
-    if (deps.push_interactive_notice) |push_notice| {
-        push_notice(deps.ctx, .{
-            .topic = "context",
-            .tone = .neutral,
-            .body = "Context compacted.",
-        }) catch |err| debug_trace.logf("context_compaction", "completed notice unavailable err={s}", .{@errorName(err)});
-    }
+    // A successful acknowledgement wins even if cancellation arrived during publication.
+    if (operation_id) |id| deps.compaction_activity.?.settle(deps.ctx, id, .{
+        .outcome = .succeeded,
+        .stage = .publication,
+        .publication = .committed,
+    });
     return .{
         .compacted = compacted,
         .accepted_tokens = accepted_tokens,
     };
+}
+
+test "compaction activity automatic error provenance excludes secondary finalization errors" {
+    const support = @import("tests/support.zig");
+    const Host = struct {
+        fake: support.FakeAgentRuntimeDeps,
+        activity: compaction_activity.State = .{},
+        fn from(raw: *anyopaque) *@This() {
+            const fake: *support.FakeAgentRuntimeDeps = @ptrCast(@alignCast(raw));
+            return @fieldParentPtr("fake", fake);
+        }
+        fn begin(raw: *anyopaque, origin: compaction_activity.Origin, turn_id: ?u64) compaction_activity.OperationId {
+            return from(raw).activity.begin(origin, turn_id, 0);
+        }
+        fn running(raw: *anyopaque, id: compaction_activity.OperationId, stage: compaction_activity.Stage) void {
+            from(raw).activity.running(id, stage);
+        }
+        fn settle(raw: *anyopaque, id: compaction_activity.OperationId, feedback: compaction_activity.Feedback) void {
+            from(raw).activity.settle(id, feedback, 1);
+        }
+    };
+    const alloc = std.testing.allocator;
+    for ([_]bool{ false, true }) |bound| {
+        for ([_]bool{ false, true }) |secondary_failure| {
+            var host: Host = .{ .fake = support.FakeAgentRuntimeDeps.init(alloc) };
+            defer host.fake.deinit();
+            const model = "provider/compaction-provenance";
+            host.fake.available_capability_overrides = &.{.{ .model = model, .capabilities = .{ .context_window = 45_000 } }};
+            if (secondary_failure) host.fake.finalization_error = error.ContextCapacityExceeded;
+            var gateway = support.FakeGateway.init(alloc, &.{.{ .content = "\"" ** 10_000 }});
+            defer gateway.deinit();
+            var fixture: support.PromptFixture = .{};
+            var job = fixture.job();
+            job.turn_id = 31;
+            job.model = @constCast(model);
+            var history = [_]HistoryTurn{.{ .assistant = .{
+                .user = .{ .text = @constCast("earlier request") },
+                .assistant = @constCast("history " ** 19_000),
+            } }};
+            job.history = &history;
+            var deps = host.fake.deps();
+            deps.agent_stream_provider = gateway.provider();
+            if (bound) deps.compaction_activity = .{ .begin = Host.begin, .running = Host.running, .settle = Host.settle };
+            var provenance: ?compaction_activity.ErrorProvenance = null;
+            deps.compaction_failure = &provenance;
+            var agent: runtime_agent.Agent = .{};
+            defer agent.deinit(alloc);
+            try agent.restoreHistory(alloc, job.history);
+            try std.testing.expectError(error.ContextCapacityExceeded, processAgentPrompt(&agent, &deps, null, support.testLifecycleContext(hooks.RuntimeView.empty(), alloc, fixture.config().workspace_root), fixture.config(), job));
+            try std.testing.expectEqual(@as(usize, 1), gateway.index);
+            if (bound) {
+                const op = host.activity.snapshot.operation.?;
+                try std.testing.expectEqual(compaction_activity.Origin.automatic, op.origin);
+                try std.testing.expectEqual(error.ContextCapacityExceeded, op.phase.terminal.err.?);
+                if (!secondary_failure) {
+                    try std.testing.expectEqual(op.id, provenance.?.operation_id);
+                    try std.testing.expectEqual(@as(?u64, 31), provenance.?.turn_id);
+                }
+            }
+            if (!bound or secondary_failure) try std.testing.expect(provenance == null);
+        }
+    }
+}
+
+test "compaction activity transaction settles only after publication and preserves failures" {
+    const support = @import("tests/support.zig");
+    const Host = struct {
+        fake: support.FakeAgentRuntimeDeps,
+        worker: worker_runtime.WorkerRuntime = .{},
+        cancel: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+        commit_error: ?anyerror = null,
+        provider_error: ?anyerror = null,
+        cancel_at_commit: bool = false,
+        provider_returned: bool = false,
+        acknowledged: bool = false,
+
+        fn from(raw: *anyopaque) *@This() {
+            const fake: *support.FakeAgentRuntimeDeps = @ptrCast(@alignCast(raw));
+            return @fieldParentPtr("fake", fake);
+        }
+        fn begin(raw: *anyopaque, origin: compaction_activity.Origin, turn_id: ?u64) compaction_activity.OperationId {
+            return from(raw).worker.beginCompactionActivity(origin, turn_id);
+        }
+        fn running(raw: *anyopaque, id: compaction_activity.OperationId, stage: compaction_activity.Stage) void {
+            from(raw).worker.runCompactionActivity(id, stage);
+        }
+        fn settle(raw: *anyopaque, id: compaction_activity.OperationId, feedback: compaction_activity.Feedback) void {
+            const self = from(raw);
+            if (feedback.outcome == .succeeded) std.debug.assert(self.acknowledged);
+            self.worker.settleCompactionActivity(id, feedback);
+        }
+        fn commit(raw: *anyopaque, _: types.CompactedSummaryHistoryTurn, _: ?types.AssistantHistoryTurn, _: ?types.ContextHistoryCut) !void {
+            const self = from(raw);
+            try std.testing.expect(self.provider_returned);
+            try std.testing.expectEqual(compaction_activity.Stage.publication, self.worker.compactionActivitySnapshot().operation.?.phase.running);
+            if (self.cancel_at_commit) self.cancel.store(true, .seq_cst);
+            if (self.commit_error) |err| return err;
+            self.acknowledged = true;
+        }
+        fn stream(raw: ?*anyopaque, _: Allocator, request: agent_stream_provider.ModelRequest) !agent_stream_provider.Result {
+            const self: *@This() = @ptrCast(@alignCast(raw.?));
+            try std.testing.expectEqual(compaction_activity.Stage.summary, self.worker.compactionActivitySnapshot().operation.?.phase.running);
+            if (self.provider_error) |err| return err;
+            try request.admission.admit();
+            request.delivery.markPossiblySent();
+            self.provider_returned = true;
+            return .{ .completed = .{ .completion = .{ .content = "The user requested the recorded change.", .finish_reason = .stop } } };
+        }
+    };
+    const alloc = std.testing.allocator;
+    for (0..7) |case| {
+        var host: Host = .{ .fake = support.FakeAgentRuntimeDeps.init(alloc) };
+        defer host.fake.deinit();
+        defer host.worker.deinit(alloc);
+        switch (case) {
+            0 => {},
+            1 => host.cancel_at_commit = true,
+            2 => host.commit_error = error.SessionPersistenceUncertain,
+            3 => {
+                host.commit_error = error.Aborted;
+                host.cancel_at_commit = true;
+            },
+            4 => host.commit_error = error.TestPersistenceFailure,
+            5 => host.provider_error = error.Timeout,
+            6 => host.cancel.store(true, .seq_cst),
+            else => unreachable,
+        }
+        var deps = host.fake.deps();
+        var gateway = support.FakeGateway.init(alloc, &.{});
+        defer gateway.deinit();
+        deps.agent_stream_provider = gateway.provider();
+        deps.agent_stream_provider.context = &host;
+        deps.agent_stream_provider.stream_fn = Host.stream;
+        deps.compaction_activity = .{ .begin = Host.begin, .running = Host.running, .settle = Host.settle };
+        deps.commit_context_compaction = .{ .commit = Host.commit };
+        deps.push_interactive_notice = null;
+        var source = [_]ChatMessage{.{ .role = .user, .content = "recorded source " ** 100 }};
+        var provenance: ?compaction_activity.ErrorProvenance = null;
+        const request: ContextCompactionTransactionRequest = .{
+            .trigger = .manual,
+            .activity_origin = .manual,
+            .provider = .gateway,
+            .working_capabilities = .{ .context_window = 100_000, .max_output_tokens = 4096 },
+            .request_tokens = 10_000,
+            .source_tokens = 10_000,
+            .continuation = .{
+                .request = .{ .model = "fixture/model", .messages = &.{.{ .role = .user, .content = "" }}, .tool_choice = .none, .provider_options = .{} },
+                .handoff_message_index = 0,
+            },
+            .source_messages = &source,
+            .result_storage = .unavailable,
+            .api_key = "fixture-key",
+            .credential_source = .ai_gateway_api_key,
+            .retry_count = 1,
+            .cancel_flag = &host.cancel,
+            .trace_ctx = .{ .turn_id = 19 },
+            .removed_turn_count = 1,
+            .compaction_count = 1,
+            .failure_provenance = &provenance,
+        };
+        const result = compactContextTransaction(alloc, &deps, request);
+        if (case < 2) {
+            var transaction = (try result).?;
+            defer transaction.deinit(alloc);
+            try std.testing.expect(provenance == null);
+            try std.testing.expectEqual(compaction_activity.Publication.committed, host.worker.compactionActivitySnapshot().operation.?.phase.terminal.publication);
+        } else {
+            const expected: anyerror = switch (case) {
+                2 => error.SessionPersistenceUncertain,
+                3 => error.Aborted,
+                4 => error.TestPersistenceFailure,
+                5 => error.Timeout,
+                6 => error.Cancelled,
+                else => unreachable,
+            };
+            try std.testing.expectError(expected, result);
+            const op = host.worker.compactionActivitySnapshot().operation.?;
+            try std.testing.expectEqual(op.id, provenance.?.operation_id);
+            try std.testing.expectEqual(@as(?u64, 19), provenance.?.turn_id);
+            try std.testing.expectEqual(expected, provenance.?.err);
+            try std.testing.expectEqual(expected, op.phase.terminal.err.?);
+            try std.testing.expectEqual(if (case == 3 or case == 6) compaction_activity.Outcome.cancelled else .failed, op.phase.terminal.outcome);
+            if (case == 2) try std.testing.expectEqual(compaction_activity.Publication.uncertain, op.phase.terminal.publication);
+        }
+        const terminal = host.worker.compactionActivitySnapshot();
+        host.worker.finishProcessing();
+        try std.testing.expectEqualDeep(terminal, host.worker.compactionActivitySnapshot());
+
+        host.cancel.store(false, .seq_cst);
+        var no_op = request;
+        no_op.source_tokens = 0;
+        try std.testing.expect((try compactContextTransaction(alloc, &deps, no_op)) == null);
+        try std.testing.expect(provenance == null);
+        try std.testing.expectEqual(compaction_activity.Outcome.no_op, host.worker.compactionActivitySnapshot().operation.?.phase.terminal.outcome);
+
+        // Unbound callers keep the same original cancellation result and no presentation output.
+        deps.compaction_activity = null;
+        provenance = null;
+        host.cancel.store(true, .seq_cst);
+        try std.testing.expectError(error.Cancelled, compactContextTransaction(alloc, &deps, request));
+        try std.testing.expect(provenance == null);
+    }
 }
 
 fn processQueuedPromptLoop(
@@ -6469,8 +6700,11 @@ fn processQueuedPromptLoop(
                             const next_compaction_history_tail = window.retained_messages;
                             const next_compaction_count = compaction_count + 1;
                             const next_history = try arena.alloc(HistoryTurn, window.retained_history.len + 1);
+                            var compaction_failure: ?compaction_activity.ErrorProvenance = null;
                             const transaction_result = compactContextTransaction(arena, deps, .{
                                 .trigger = compaction_trigger,
+                                .activity_origin = if (context_overflow_recovery == .pending) .provider_overflow else .automatic,
+                                .failure_provenance = &compaction_failure,
                                 .provider = job.provider,
                                 .working_capabilities = request_capabilities,
                                 .request_tokens = request_cost.estimated_input_tokens,
@@ -6511,6 +6745,7 @@ fn processQueuedPromptLoop(
                                     finish_trace.finish("interrupted");
                                     return;
                                 }
+                                if (deps.compaction_failure) |out| out.* = compaction_failure;
                                 return err;
                             };
                             const transaction = transaction_result orelse

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -5803,6 +5803,158 @@ test "compaction activity automatic error provenance excludes secondary finaliza
     }
 }
 
+test "automatic compaction interruption persists transport cancellation and preserves publication authority" {
+    const support = @import("tests/support.zig");
+    const Host = struct {
+        fake: support.FakeAgentRuntimeDeps,
+        activity: compaction_activity.State = .{},
+        cancel: *std.atomic.Value(bool),
+        summary_error: ?anyerror = null,
+        publication_error: ?anyerror = null,
+        cancel_at_publication: bool = false,
+        summary_calls: usize = 0,
+        publication_calls: usize = 0,
+
+        fn from(raw: *anyopaque) *@This() {
+            const fake: *support.FakeAgentRuntimeDeps = @ptrCast(@alignCast(raw));
+            return @fieldParentPtr("fake", fake);
+        }
+        fn begin(raw: *anyopaque, origin: compaction_activity.Origin, turn_id: ?u64) compaction_activity.OperationId {
+            return from(raw).activity.begin(origin, turn_id, 0);
+        }
+        fn running(raw: *anyopaque, id: compaction_activity.OperationId, stage: compaction_activity.Stage) void {
+            from(raw).activity.running(id, stage);
+        }
+        fn settle(raw: *anyopaque, id: compaction_activity.OperationId, feedback: compaction_activity.Feedback) void {
+            from(raw).activity.settle(id, feedback, 1);
+        }
+        fn commit(raw: *anyopaque, summary: types.CompactedSummaryHistoryTurn, prefix: ?types.AssistantHistoryTurn, cut: ?types.ContextHistoryCut) !void {
+            const self = from(raw);
+            self.publication_calls += 1;
+            try std.testing.expectEqual(compaction_activity.Stage.publication, self.activity.snapshot.operation.?.phase.running);
+            if (self.cancel_at_publication) self.cancel.store(true, .seq_cst);
+            if (self.publication_error) |err| return err;
+            const deps = self.fake.deps();
+            try deps.commit_context_compaction.?.commit(raw, summary, prefix, cut);
+        }
+        fn stream(raw: ?*anyopaque, _: Allocator, request: agent_stream_provider.ModelRequest) !agent_stream_provider.Result {
+            const self: *@This() = @ptrCast(@alignCast(raw.?));
+            self.summary_calls += 1;
+            try std.testing.expectEqual(compaction_activity.Stage.summary, self.activity.snapshot.operation.?.phase.running);
+            try std.testing.expect(!request.cancel_flag.load(.seq_cst));
+            try request.admission.admit();
+            request.delivery.markPossiblySent();
+            if (self.summary_error) |err| return err;
+            return .{ .completed = .{ .completion = .{ .content = "Preserve the earlier request and follow the latest request.", .finish_reason = .stop } } };
+        }
+    };
+    const alloc = std.testing.allocator;
+    const cases = [_]struct {
+        summary_error: ?anyerror = null,
+        publication_error: ?anyerror = null,
+        cancel_at_publication: bool = false,
+        expected_error: ?anyerror = null,
+        committed: bool = false,
+    }{
+        .{ .publication_error = error.Aborted, .cancel_at_publication = true },
+        .{ .summary_error = error.Cancelled },
+        .{ .publication_error = error.Aborted, .expected_error = error.Aborted },
+        .{ .publication_error = error.SessionPersistenceUncertain, .cancel_at_publication = true, .expected_error = error.SessionPersistenceUncertain },
+        .{ .publication_error = error.TestPersistenceFailure, .cancel_at_publication = true, .expected_error = error.TestPersistenceFailure },
+        .{ .cancel_at_publication = true, .committed = true },
+    };
+    for (cases) |case| {
+        var fixture: support.PromptFixture = .{};
+        var host: Host = .{
+            .fake = support.FakeAgentRuntimeDeps.init(alloc),
+            .cancel = &fixture.cancel_flag,
+            .summary_error = case.summary_error,
+            .publication_error = case.publication_error,
+            .cancel_at_publication = case.cancel_at_publication,
+        };
+        defer host.fake.deinit();
+        const model = "provider/compaction-interruption";
+        host.fake.available_capability_overrides = &.{.{ .model = model, .capabilities = .{ .context_window = 45_000 } }};
+        var gateway = support.FakeGateway.init(alloc, &.{});
+        defer gateway.deinit();
+        var deps = host.fake.deps();
+        deps.agent_stream_provider = gateway.provider();
+        deps.agent_stream_provider.context = &host;
+        deps.agent_stream_provider.stream_fn = Host.stream;
+        deps.compaction_activity = .{ .begin = Host.begin, .running = Host.running, .settle = Host.settle };
+        deps.commit_context_compaction = .{ .commit = Host.commit };
+        var provenance: ?compaction_activity.ErrorProvenance = null;
+        deps.compaction_failure = &provenance;
+        var job = fixture.job();
+        job.turn_id = 37;
+        job.model = @constCast(model);
+        var history = [_]HistoryTurn{.{ .assistant = .{
+            .user = .{ .text = @constCast("earlier request") },
+            .assistant = @constCast("history " ** 19_000),
+        } }};
+        job.history = &history;
+        var agent: runtime_agent.Agent = .{};
+        defer agent.deinit(alloc);
+        try agent.restoreHistory(alloc, job.history);
+        const result = processAgentPrompt(&agent, &deps, null, support.testLifecycleContext(hooks.RuntimeView.empty(), alloc, fixture.config().workspace_root), fixture.config(), job);
+        if (case.committed) {
+            // The next request build observes cancellation outside the committed transaction.
+            try std.testing.expectError(error.Cancelled, result);
+            try std.testing.expectEqual(types.TurnPresentationOutcome.failed, host.fake.finalized_outcome.?);
+            try std.testing.expectEqual(@as(usize, 0), host.fake.interrupted_history_count);
+            try std.testing.expectEqual(@as(usize, 0), host.fake.interrupted_event_count);
+            try std.testing.expectEqual(@as(usize, 0), host.fake.finish_event_count);
+            try std.testing.expectEqual(@as(usize, 1), host.fake.history_turns.items.len);
+            try std.testing.expect(host.fake.history_turns.items[0] == .compacted_summary);
+            try std.testing.expect(provenance == null);
+        } else if (case.expected_error) |err| {
+            try std.testing.expectError(err, result);
+            try std.testing.expectEqual(types.TurnPresentationOutcome.failed, host.fake.finalized_outcome.?);
+            try std.testing.expectEqual(@as(usize, 0), host.fake.interrupted_history_count);
+            try std.testing.expectEqual(@as(usize, 0), host.fake.interrupted_event_count);
+            try std.testing.expectEqual(@as(usize, 0), host.fake.finish_event_count);
+            try std.testing.expectEqual(@as(usize, 0), host.fake.history_turns.items.len);
+            try std.testing.expectEqual(err, provenance.?.err);
+        } else {
+            try result;
+            try std.testing.expectEqual(types.TurnPresentationOutcome.interrupted, host.fake.finalized_outcome.?);
+            try std.testing.expectEqual(@as(usize, 1), host.fake.interrupted_history_count);
+            try std.testing.expectEqual(@as(usize, 1), host.fake.interrupted_event_count);
+            try std.testing.expectEqual(@as(usize, 1), host.fake.finish_event_count);
+            try std.testing.expectEqual(@as(usize, 1), host.fake.history_turns.items.len);
+            const interrupted = host.fake.history_turns.items[0].interrupted;
+            try std.testing.expectEqualStrings(job.prompt, interrupted.user.text);
+            try std.testing.expectEqual(types.CancellationOrigin.compaction, interrupted.cancellation_origin);
+            try std.testing.expect(provenance == null);
+        }
+        try std.testing.expectEqual(case.cancel_at_publication, fixture.cancel_flag.load(.seq_cst));
+        try std.testing.expectEqual(@as(usize, 1), host.summary_calls);
+        try std.testing.expectEqual(@as(usize, if (case.summary_error == null) 1 else 0), host.publication_calls);
+        try std.testing.expectEqual(@as(usize, 1), host.fake.finalization_count);
+        const op = host.activity.snapshot.operation.?;
+        try std.testing.expectEqual(compaction_activity.Origin.automatic, op.origin);
+        try std.testing.expectEqual(@as(?u64, 37), op.turn_id);
+        const expected_outcome: compaction_activity.Outcome = if (case.committed) .succeeded else if (case.expected_error != null) .failed else .cancelled;
+        const expected_publication: compaction_activity.Publication = if (case.committed)
+            .committed
+        else if (case.publication_error) |err|
+            if (err == error.SessionPersistenceUncertain) .uncertain else .not_published
+        else
+            .not_published;
+        try std.testing.expectEqual(expected_outcome, op.phase.terminal.outcome);
+        try std.testing.expectEqual(expected_publication, op.phase.terminal.publication);
+        const expected_stage: compaction_activity.Stage = if (case.summary_error != null) .summary else .publication;
+        try std.testing.expectEqual(expected_stage, op.phase.terminal.stage);
+        if (case.summary_error) |err| {
+            try std.testing.expectEqual(err, op.phase.terminal.err.?);
+        } else if (case.publication_error) |err| {
+            try std.testing.expectEqual(err, op.phase.terminal.err.?);
+        } else {
+            try std.testing.expect(op.phase.terminal.err == null);
+        }
+    }
+}
+
 test "compaction activity transaction settles only after publication and preserves failures" {
     const support = @import("tests/support.zig");
     const Host = struct {
@@ -6727,7 +6879,7 @@ fn processQueuedPromptLoop(
                                 .removed_turn_count = window.cut.turns,
                                 .compaction_count = next_compaction_count,
                             }) catch |err| {
-                                if (err == error.Cancelled and config.cancel_flag.load(.seq_cst)) {
+                                if (compaction_activity.failure(err, .preparation, config.cancel_flag.load(.seq_cst)).outcome == .cancelled) {
                                     runtime_telemetry.traceCancelObserved(step_ctx, false);
                                     try runtime_interruption.persistCompactionInterruptedTurnOnce(
                                         deps,

--- a/src/core/agent/worker_runtime.zig
+++ b/src/core/agent/worker_runtime.zig
@@ -18,6 +18,7 @@ const command_output_content = @import("../tooling/command_output_content.zig");
 const types = @import("../shared/types.zig");
 const model_provider = @import("../config/model_provider.zig");
 const assistant_presentation = @import("assistant_presentation.zig");
+const compaction_activity = @import("../output/compaction_activity.zig");
 
 pub const AgentTurnSettings = struct {
     max_tool_result_bytes: usize = tool_result_limits.default_max_tool_result_bytes,
@@ -123,6 +124,7 @@ pub const QueuedPrompt = struct {
 
 pub const ContextCompactionTask = struct {
     turn_id: u64 = 0,
+    operation_id: ?compaction_activity.OperationId = null,
     model: []u8,
     provider: model_provider.ProviderId = .gateway,
     api_key: []u8,
@@ -559,6 +561,76 @@ pub const WorkerRuntime = struct {
     active_prompt_snapshot_ownership: ?*ActivePromptSnapshotOwnership = null,
     preserve_prompt_snapshot_turn_id: ?u64 = null,
 
+    /// Presentation metadata only; all access is protected by worker_mutex.
+    compaction_presentation: compaction_activity.State = .{},
+
+    pub fn beginCompactionActivity(self: *WorkerRuntime, origin: compaction_activity.Origin, turn_id: ?u64) compaction_activity.OperationId {
+        self.worker_mutex.lockUncancelable(io_mod.getIo());
+        defer self.worker_mutex.unlock(io_mod.getIo());
+        return self.compaction_presentation.begin(origin, turn_id, io_mod.milliTimestamp());
+    }
+
+    /// A rejected intent must not hide an already-running compaction.
+    pub fn rejectCompactionActivity(self: *WorkerRuntime, outcome: compaction_activity.Outcome) void {
+        self.worker_mutex.lockUncancelable(io_mod.getIo());
+        defer self.worker_mutex.unlock(io_mod.getIo());
+        if (self.compaction_presentation.snapshot.operation) |op| if (op.active()) return;
+        const now = io_mod.milliTimestamp();
+        const id = self.compaction_presentation.begin(.manual, null, now);
+        self.compaction_presentation.settle(id, .{ .outcome = outcome }, now);
+    }
+
+    pub fn runCompactionActivity(self: *WorkerRuntime, id: compaction_activity.OperationId, stage: compaction_activity.Stage) void {
+        self.worker_mutex.lockUncancelable(io_mod.getIo());
+        defer self.worker_mutex.unlock(io_mod.getIo());
+        self.compaction_presentation.running(id, stage);
+    }
+
+    pub fn settleCompactionActivity(self: *WorkerRuntime, id: compaction_activity.OperationId, feedback: compaction_activity.Feedback) void {
+        self.worker_mutex.lockUncancelable(io_mod.getIo());
+        defer self.worker_mutex.unlock(io_mod.getIo());
+        self.compaction_presentation.settle(id, feedback, io_mod.milliTimestamp());
+    }
+
+    /// Cheap by-value read; does not clone permissions or allocate.
+    pub fn compactionActivitySnapshot(self: *WorkerRuntime) compaction_activity.Snapshot {
+        self.worker_mutex.lockUncancelable(io_mod.getIo());
+        defer self.worker_mutex.unlock(io_mod.getIo());
+        return self.compaction_presentation.snapshot;
+    }
+
+    pub fn dismissCompactionActivity(self: *WorkerRuntime, id: compaction_activity.OperationId, revision: u64) bool {
+        self.worker_mutex.lockUncancelable(io_mod.getIo());
+        defer self.worker_mutex.unlock(io_mod.getIo());
+        return self.compaction_presentation.dismiss(id, revision);
+    }
+
+    pub fn expireCompactionActivity(self: *WorkerRuntime, id: compaction_activity.OperationId, revision: u64, now_ms: i64) bool {
+        self.worker_mutex.lockUncancelable(io_mod.getIo());
+        defer self.worker_mutex.unlock(io_mod.getIo());
+        return self.compaction_presentation.expire(id, revision, now_ms);
+    }
+
+    fn stopCompactionActivityLocked(self: *WorkerRuntime) void {
+        const op = self.compaction_presentation.snapshot.operation orelse return;
+        if (op.turn_id != self.active_turn_id or !self.worker_processing) return;
+        self.compaction_presentation.stopping(op.id);
+    }
+
+    fn finishCompactionActivityLocked(self: *WorkerRuntime, turn_id: u64) void {
+        const op = self.compaction_presentation.snapshot.operation orelse return;
+        if (op.turn_id != turn_id or !op.active()) return;
+        debug_trace.logf("context_compaction", "unsettled operation at worker finish turn_id={d}", .{turn_id});
+        var feedback = compaction_activity.failure(
+            if (self.isCancelRequested()) error.Cancelled else error.CompactionInterrupted,
+            op.stage(),
+            self.isCancelRequested(),
+        );
+        // No transaction acknowledgement survived this fallback; do not promise rollback.
+        if (op.stage() == .publication) feedback.publication = .uncertain;
+        self.compaction_presentation.settle(op.id, feedback, io_mod.milliTimestamp());
+    }
+
     fn queuedWorkCountLocked(self: *const WorkerRuntime) usize {
         return self.queued_prompts.items.len +
             @intFromBool(self.queued_context_compaction != null);
@@ -591,6 +663,10 @@ pub const WorkerRuntime = struct {
     pub fn requestStop(self: *WorkerRuntime) void {
         self.worker_mutex.lockUncancelable(io_mod.getIo());
         self.worker_stop_requested = true;
+        if (self.queued_context_compaction) |task| {
+            if (task.operation_id) |id| self.compaction_presentation.settle(id, .{ .outcome = .cancelled }, io_mod.milliTimestamp());
+        }
+        self.stopCompactionActivityLocked();
         self.worker_cond.broadcast(io_mod.getIo());
         self.worker_mutex.unlock(io_mod.getIo());
     }
@@ -620,6 +696,7 @@ pub const WorkerRuntime = struct {
         defer self.worker_mutex.unlock(io_mod.getIo());
         self.steering_cancel_turn_id = null;
         self.worker_cancel_requested.store(true, .seq_cst);
+        self.stopCompactionActivityLocked();
         self.worker_cond.broadcast(io_mod.getIo());
     }
 
@@ -643,6 +720,7 @@ pub const WorkerRuntime = struct {
         });
         self.steering_cancel_turn_id = null;
         self.worker_cancel_requested.store(true, .seq_cst);
+        self.stopCompactionActivityLocked();
         self.worker_cond.broadcast(io_mod.getIo());
     }
 
@@ -652,6 +730,7 @@ pub const WorkerRuntime = struct {
 
         self.steering_cancel_turn_id = null;
         self.worker_cancel_requested.store(true, .seq_cst);
+        self.stopCompactionActivityLocked();
         _ = self.resolvePendingPermissionLocked(
             permission_request.OwnedPermissionResponse.init(
                 std.heap.c_allocator,
@@ -776,6 +855,7 @@ pub const WorkerRuntime = struct {
         self.worker_stop_requested = true;
         self.steering_cancel_turn_id = null;
         self.worker_cancel_requested.store(true, .seq_cst);
+        self.stopCompactionActivityLocked();
         self.worker_cond.broadcast(io_mod.getIo());
     }
 
@@ -829,6 +909,8 @@ pub const WorkerRuntime = struct {
         {
             return error.WorkerBusy;
         }
+        if (queued.operation_id == null) queued.operation_id = self.compaction_presentation.begin(.manual, queued.turn_id, io_mod.milliTimestamp());
+        self.compaction_presentation.queued(queued.operation_id.?, queued.turn_id, io_mod.milliTimestamp());
         self.queued_context_compaction = queued;
         debug_trace.eventf(
             "worker",
@@ -855,6 +937,7 @@ pub const WorkerRuntime = struct {
         self.worker_mutex.lockUncancelable(io_mod.getIo());
         if (self.queued_context_compaction) |task| {
             self.queued_context_compaction = null;
+            if (task.operation_id) |id| self.compaction_presentation.settle(id, .{ .outcome = .cancelled }, io_mod.milliTimestamp());
             self.worker_cond.broadcast(io_mod.getIo());
             self.worker_mutex.unlock(io_mod.getIo());
             freeContextCompactionTask(alloc, task);
@@ -869,6 +952,7 @@ pub const WorkerRuntime = struct {
         }
         if (self.active_context_compaction) {
             self.worker_cancel_requested.store(true, .seq_cst);
+            self.stopCompactionActivityLocked();
             self.worker_cond.broadcast(io_mod.getIo());
             self.worker_mutex.unlock(io_mod.getIo());
             debug_trace.eventf(
@@ -1174,6 +1258,7 @@ pub const WorkerRuntime = struct {
             self.active_turn_id = task.turn_id;
             self.tool_phase_step_id = null;
             self.active_context_compaction = true;
+            if (task.operation_id) |id| self.compaction_presentation.running(id, .preparation);
             debug_trace.eventf(
                 "worker",
                 "context_compaction_begin",
@@ -1267,6 +1352,7 @@ pub const WorkerRuntime = struct {
         // Close steering admission without moving entries, preserving the exact
         // order in which steering and ordinary prompts were submitted.
         const finished_turn_id = self.active_turn_id;
+        self.finishCompactionActivityLocked(finished_turn_id);
         for (self.queued_prompts.items) |*prompt| {
             if (prompt.delivery.activeTurnId() == finished_turn_id) {
                 prompt.delivery = .continuation;
@@ -1545,6 +1631,7 @@ pub const WorkerRuntime = struct {
         types.freeHistoryTurnSlice(alloc, self.queued_history);
         self.queued_history = &.{};
         if (self.queued_context_compaction) |task| {
+            if (task.operation_id) |id| self.compaction_presentation.settle(id, .{ .outcome = .cancelled }, io_mod.milliTimestamp());
             freeContextCompactionTask(alloc, task);
             self.queued_context_compaction = null;
         }
@@ -2737,6 +2824,34 @@ test "session and checkpoint transfer preserve active and finished prompt snapsh
     }
 }
 
+test "compaction activity survives worker finish without allocating a permission snapshot" {
+    var runtime: WorkerRuntime = .{};
+    defer runtime.deinit(std.testing.allocator);
+    try std.testing.expect(runtime.beginDirectProcessing(17));
+    const first = runtime.beginCompactionActivity(.automatic, 17);
+    runtime.runCompactionActivity(first, .publication);
+    runtime.requestInteractiveCancel();
+    try std.testing.expect(runtime.compactionActivitySnapshot().operation.?.phase == .stopping);
+    runtime.settleCompactionActivity(first, .{ .outcome = .succeeded, .stage = .publication, .publication = .committed });
+    runtime.finishProcessing();
+    try std.testing.expectEqual(@as(u64, 0), runtime.activeTurnId());
+    const terminal = runtime.compactionActivitySnapshot();
+    try std.testing.expectEqual(first, terminal.operation.?.id);
+    try std.testing.expectEqual(compaction_activity.Outcome.succeeded, terminal.operation.?.phase.terminal.outcome);
+    runtime.settleCompactionActivity(first, .{ .outcome = .cancelled });
+    try std.testing.expectEqualDeep(terminal, runtime.compactionActivitySnapshot());
+
+    const next = runtime.beginCompactionActivity(.manual, null);
+    const started = runtime.compactionActivitySnapshot();
+    runtime.rejectCompactionActivity(.busy);
+    try std.testing.expectEqualDeep(started, runtime.compactionActivitySnapshot());
+    try std.testing.expect(!runtime.dismissCompactionActivity(first, terminal.revision));
+    runtime.settleCompactionActivity(first, compaction_activity.failure(error.Aborted, .publication, true));
+    try std.testing.expectEqual(next, runtime.compactionActivitySnapshot().operation.?.id);
+    runtime.settleCompactionActivity(next, compaction_activity.failure(error.OutOfMemory, .preparation, false));
+    try std.testing.expectEqual(error.OutOfMemory, runtime.compactionActivitySnapshot().operation.?.phase.terminal.err.?);
+}
+
 test "manual compaction is a typed worker item and not a prompt" {
     const alloc = std.testing.allocator;
     var runtime = WorkerRuntime{};
@@ -2753,6 +2868,52 @@ test "manual compaction is a typed worker item and not a prompt" {
         return error.TestExpectedQueuedWork;
     defer freeWorkItem(alloc, taken);
     try std.testing.expect(taken == .compact_context);
+    const snapshot = runtime.compactionActivitySnapshot();
+    try std.testing.expectEqual(taken.compact_context.operation_id.?, snapshot.operation.?.id);
+    try std.testing.expectEqual(taken.compact_context.turn_id, snapshot.operation.?.turn_id.?);
+    try std.testing.expect(snapshot.operation.?.phase == .running);
+    runtime.finishProcessing();
+    try std.testing.expectEqual(error.CompactionInterrupted, runtime.compactionActivitySnapshot().operation.?.phase.terminal.err.?);
+}
+
+test "session transition queue clearing settles only the dropped compaction identity" {
+    const alloc = std.testing.allocator;
+    for ([_]bool{ false, true }) |retain_snapshots| {
+        for ([_]bool{ false, true }) |newer_activity| {
+            var runtime: WorkerRuntime = .{};
+            defer runtime.deinit(alloc);
+            try runtime.enqueueContextCompaction(.{
+                .turn_id = 41,
+                .model = try alloc.dupe(u8, "provider/model"),
+                .api_key = try alloc.dupe(u8, "key"),
+                .history = try alloc.alloc(types.HistoryTurn, 0),
+            });
+            const queued = runtime.compactionActivitySnapshot();
+            if (newer_activity) _ = runtime.beginCompactionActivity(.manual, null);
+            const observed = runtime.compactionActivitySnapshot();
+
+            if (retain_snapshots) {
+                runtime.clearQueuedPromptsForSessionTransition(alloc, 41, &.{});
+            } else {
+                runtime.clearQueuedPrompts(alloc, &.{});
+            }
+            try std.testing.expectEqual(ContextCompactionStatus.idle, runtime.contextCompactionStatus());
+            try std.testing.expectEqual(@as(usize, 0), runtime.queuedPromptCount());
+            try std.testing.expect((try runtime.tryTakeNextWork(alloc)) == null);
+            try std.testing.expect(!runtime.isCancelRequested());
+            const settled = runtime.compactionActivitySnapshot();
+            if (newer_activity) {
+                try std.testing.expectEqualDeep(observed, settled);
+            } else {
+                try std.testing.expectEqual(queued.operation.?.id, settled.operation.?.id);
+                try std.testing.expectEqual(compaction_activity.Outcome.cancelled, settled.operation.?.phase.terminal.outcome);
+                try std.testing.expect(!settled.operation.?.active());
+                try std.testing.expect(settled.revision > queued.revision);
+            }
+            runtime.clearQueuedPrompts(alloc, &.{});
+            try std.testing.expectEqualDeep(settled, runtime.compactionActivitySnapshot());
+        }
+    }
 }
 
 test "queued manual compaction can be cancelled before worker execution" {
@@ -2772,6 +2933,7 @@ test "queued manual compaction can be cancelled before worker execution" {
     try std.testing.expectEqual(ContextCompactionStatus.idle, runtime.contextCompactionStatus());
     try std.testing.expectEqual(@as(usize, 0), runtime.queuedPromptCount());
     try std.testing.expect((try runtime.tryTakeNextWork(alloc)) == null);
+    try std.testing.expectEqual(compaction_activity.Outcome.cancelled, runtime.compactionActivitySnapshot().operation.?.phase.terminal.outcome);
 }
 
 test "running manual compaction cancellation uses the worker cancel flag" {
@@ -2792,7 +2954,10 @@ test "running manual compaction cancellation uses the worker cancel flag" {
     try std.testing.expectEqual(ContextCompactionStatus.running, runtime.contextCompactionStatus());
     try std.testing.expect(runtime.cancelContextCompaction(alloc));
     try std.testing.expect(runtime.isCancelRequested());
+    try std.testing.expect(runtime.compactionActivitySnapshot().operation.?.phase == .stopping);
     runtime.finishProcessing();
+    try std.testing.expectEqual(@as(u64, 0), runtime.activeTurnId());
+    try std.testing.expectEqual(compaction_activity.Outcome.cancelled, runtime.compactionActivitySnapshot().operation.?.phase.terminal.outcome);
     try std.testing.expectEqual(ContextCompactionStatus.idle, runtime.contextCompactionStatus());
 }
 

--- a/src/core/app/app_agent_runtime.zig
+++ b/src/core/app/app_agent_runtime.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const agent_runtime = @import("../agent/agent_runtime.zig");
 const agent_stream_provider = @import("../agent/stream_provider.zig");
 const runtime_context_compaction = @import("../agent/runtime/context_compaction.zig");
+const compaction_activity = @import("../output/compaction_activity.zig");
 const runtime_prompt_context = @import("../agent/runtime/prompt_context.zig");
 const command_admission = @import("../permissions/command_admission.zig");
 const permission_auto_classifier = @import("../permissions/auto_classifier.zig");
@@ -945,7 +946,9 @@ pub fn Runtime(comptime App: type) type {
             queued_job: worker_runtime.QueuedPrompt,
             gateway_retry_count: usize,
             gateway_chat_url: []const u8,
+            failure_provenance: ?*?compaction_activity.ErrorProvenance,
         ) !void {
+            if (failure_provenance) |out| out.* = null;
             var job = queued_job;
             var fresh_history: ?worker_runtime.FreshPromptHistory = null;
             defer if (fresh_history) |*snapshot| snapshot.deinit(std.heap.c_allocator);
@@ -1031,7 +1034,8 @@ pub fn Runtime(comptime App: type) type {
                 else
                     null;
 
-            const deps = app_callbacks.Bindings(App).agentRuntimeDeps(app);
+            var deps = app_callbacks.Bindings(App).agentRuntimeDeps(app);
+            deps.compaction_failure = failure_provenance;
             const semantic_presentation = app_callbacks.Bindings(App).semanticPresentationSink(app);
             const config = buildQueuedPromptConfig(
                 app,
@@ -1051,7 +1055,19 @@ pub fn Runtime(comptime App: type) type {
             app: *App,
             job: worker_runtime.ContextCompactionTask,
             gateway_retry_count: usize,
-        ) !void {
+            failure_provenance: ?*?compaction_activity.ErrorProvenance,
+        ) anyerror!void {
+            if (failure_provenance) |out| out.* = null;
+            const operation_id = job.operation_id orelse app.worker.beginCompactionActivity(.manual, job.turn_id);
+            app.worker.runCompactionActivity(operation_id, .preparation);
+            // Covers early cancellation before the transaction; acknowledged settlement wins.
+            defer if (app.worker.isCancelRequested()) {
+                app.worker.settleCompactionActivity(operation_id, .{ .outcome = .cancelled });
+            };
+            errdefer |err| {
+                app.worker.settleCompactionActivity(operation_id, compaction_activity.failure(err, .preparation, app.worker.isCancelRequested()));
+                if (failure_provenance) |out| out.* = .{ .operation_id = operation_id, .turn_id = job.turn_id, .err = err };
+            }
             var arena_state = std.heap.ArenaAllocator.init(std.heap.c_allocator);
             defer arena_state.deinit();
             const arena = arena_state.allocator();
@@ -1112,7 +1128,7 @@ pub fn Runtime(comptime App: type) type {
                 continuation.request.messages = continuation_messages;
                 const refine = window.refine_budget(arena, deps.agent_stream_provider, continuation, capabilities, source_tokens, &retention_target) catch |err| {
                     if (err == error.Cancelled and app.worker.worker_cancel_requested.load(.seq_cst)) return;
-                    return err;
+                    return @as(anyerror!void, err);
                 };
                 if (refine) continue;
                 var compaction_count: usize = 0;
@@ -1127,6 +1143,8 @@ pub fn Runtime(comptime App: type) type {
                 };
                 const transaction = agent_runtime.compactContextTransaction(arena, &deps, .{
                     .trigger = .manual,
+                    .operation_id = operation_id,
+                    .activity_origin = .manual,
                     .provider = job.provider,
                     .working_capabilities = capabilities,
                     .request_tokens = source_tokens,
@@ -1153,16 +1171,9 @@ pub fn Runtime(comptime App: type) type {
                     {
                         return;
                     }
-                    return err;
+                    return @as(anyerror!void, err);
                 };
-                _ = transaction orelse {
-                    try app_worker_runtime.Runtime(App).pushSemanticNotice(app, .{
-                        .topic = "context",
-                        .tone = .neutral,
-                        .body = "No context to compact.",
-                    });
-                    return;
-                };
+                _ = transaction;
                 return;
             }
         }
@@ -2627,7 +2638,7 @@ test "queued fresh prompt closes only a still-paused turn before provider execut
         cancel_after_prepare: bool = false,
 
         fn run(self: *@This(), job: worker_runtime.QueuedPrompt) void {
-            Runtime(FakeApp).processQueuedPrompt(self.app, job, 1, test_gateway_chat_url) catch |err| {
+            Runtime(FakeApp).processQueuedPrompt(self.app, job, 1, test_gateway_chat_url, null) catch |err| {
                 self.failure = err;
             };
             self.returned.store(true, .release);
@@ -2855,7 +2866,7 @@ test "manual compaction worker call commits a checkpoint without a continuation"
         failure: ?anyerror = null,
 
         fn run(self: *@This(), target: *FakeApp, task: worker_runtime.ContextCompactionTask) void {
-            Runtime(FakeApp).processContextCompaction(target, task, 1) catch |err| {
+            Runtime(FakeApp).processContextCompaction(target, task, 1, null) catch |err| {
                 self.failure = err;
             };
             self.returned.store(true, .release);
@@ -2877,17 +2888,19 @@ test "manual compaction worker call commits a checkpoint without a continuation"
     defer events.deinit(std.heap.c_allocator);
     defer for (events.items) |event| worker_runtime.freeWorkerEvent(std.heap.c_allocator, event);
     const deadline = io_mod.milliTimestamp() + 5_000;
-    while (events.items.len < 2) {
+    while (events.items.len == 0) {
         var batch = app.worker.takeEvents();
         defer batch.deinit(std.heap.c_allocator);
         try events.appendSlice(std.heap.c_allocator, batch.items);
         if (io_mod.milliTimestamp() >= deadline) return error.TestExpectedCompactionEvent;
-        if (events.items.len < 2) io_mod.sleep(std.time.ns_per_ms);
+        if (events.items.len == 0) io_mod.sleep(std.time.ns_per_ms);
     }
-    try std.testing.expect(events.items[1] == .context_compaction);
+    try std.testing.expect(events.items[0] == .context_compaction);
     try std.testing.expect(!worker.returned.load(.acquire));
+    const pending_activity = app.worker.compactionActivitySnapshot();
+    try std.testing.expectEqual(compaction_activity.Stage.publication, pending_activity.operation.?.phase.running);
     try std.testing.expectEqual(@as(usize, 2), app.session.historyLen());
-    app.worker.resolveContextCompaction(std.heap.c_allocator, events.items[1].context_compaction, &app, Worker.commit);
+    app.worker.resolveContextCompaction(std.heap.c_allocator, events.items[0].context_compaction, &app, Worker.commit);
     thread.join();
     joined = true;
     if (worker.failure) |err| return err;
@@ -2899,16 +2912,25 @@ test "manual compaction worker call commits a checkpoint without a continuation"
     try std.testing.expectEqual(@as(usize, 1), gateway.request_count);
     try std.testing.expect(gateway.saw_no_tools);
     try std.testing.expectEqualStrings("test-model", gateway.observed_model.?);
-    try std.testing.expectEqual(@as(usize, 3), events.items.len);
-    try std.testing.expect(events.items[0] == .semantic_notice);
-    try std.testing.expectEqualStrings("Compacting context…", events.items[0].semantic_notice.body);
-    try std.testing.expect(events.items[1] == .context_compaction);
-    try std.testing.expect(events.items[1].context_compaction.active_prefix == null);
-    try std.testing.expect(events.items[2] == .semantic_notice);
-    try std.testing.expectEqualStrings("Context compacted.", events.items[2].semantic_notice.body);
+    try std.testing.expectEqual(@as(usize, 1), events.items.len);
+    try std.testing.expect(events.items[0] == .context_compaction);
+    try std.testing.expect(events.items[0].context_compaction.active_prefix == null);
+
+    const completed_activity = app.worker.compactionActivitySnapshot();
+    try std.testing.expectEqual(pending_activity.operation.?.id, completed_activity.operation.?.id);
+    try std.testing.expectEqual(compaction_activity.Outcome.succeeded, completed_activity.operation.?.phase.terminal.outcome);
+    try std.testing.expect(completed_activity.revision > pending_activity.revision);
+    app.worker.finishProcessing();
+    try std.testing.expectEqualDeep(completed_activity, app.worker.compactionActivitySnapshot());
 
     app.snapshot_custom_guidance = "fixed tool guidance " ** 20_000;
-    try std.testing.expectError(error.ContextCapacityExceeded, Runtime(FakeApp).processContextCompaction(&app, job, 1));
+    var provenance: ?compaction_activity.ErrorProvenance = null;
+    try std.testing.expectError(error.ContextCapacityExceeded, Runtime(FakeApp).processContextCompaction(&app, job, 1, &provenance));
+    const failed_activity = app.worker.compactionActivitySnapshot();
+    try std.testing.expectEqual(failed_activity.operation.?.id, provenance.?.operation_id);
+    try std.testing.expectEqual(error.ContextCapacityExceeded, provenance.?.err);
+    try std.testing.expectEqual(error.ContextCapacityExceeded, failed_activity.operation.?.phase.terminal.err.?);
+    try std.testing.expect(failed_activity.operation.?.id != completed_activity.operation.?.id);
     try std.testing.expectEqual(@as(usize, 1), gateway.request_count);
     try std.testing.expectEqual(@as(usize, 0), app.worker.worker_events.items.len);
 }
@@ -2923,7 +2945,7 @@ test "app agent runtime processes a cancelled queued prompt" {
     const job = try makeQueuedPrompt(alloc);
     defer worker_runtime.freeQueuedPrompt(alloc, job);
 
-    try Runtime(FakeApp).processQueuedPrompt(&app, job, 1, test_gateway_chat_url);
+    try Runtime(FakeApp).processQueuedPrompt(&app, job, 1, test_gateway_chat_url, null);
 
     try std.testing.expectEqual(@as(usize, 0), app.append_context_count);
     try std.testing.expectEqual(@as(usize, 1), app.snapshot_tools_count);
@@ -2972,7 +2994,7 @@ test "app direct ask delivers semantic presentation through the runtime sink" {
 
     app.agent_stream_provider = testAgentStreamProvider(Gateway.stream);
 
-    try Runtime(FakeApp).processQueuedPrompt(&app, job, 1, test_gateway_chat_url);
+    try Runtime(FakeApp).processQueuedPrompt(&app, job, 1, test_gateway_chat_url, null);
 
     var events = app.worker.takeEvents();
     defer events.deinit(std.heap.c_allocator);
@@ -3040,7 +3062,7 @@ test "app agent runtime clears active turn settings when queued prompt setup fai
     };
     job.permission_mode = .yolo;
 
-    try std.testing.expectError(error.TestExpectedEqual, Runtime(FakeApp).processQueuedPrompt(&app, job, 1, test_gateway_chat_url));
+    try std.testing.expectError(error.TestExpectedEqual, Runtime(FakeApp).processQueuedPrompt(&app, job, 1, test_gateway_chat_url, null));
     try std.testing.expectEqual(
         @as(?PermissionMode, .yolo),
         app.snapshot_permission_mode,
@@ -3264,7 +3286,7 @@ test "app agent runtime settles queued snapshot ownership when prompt admission 
                 .invalid_writer => error.SessionCommitFailed,
                 .uncertain_checkpoint => error.SessionPersistenceUncertain,
             },
-            Runtime(FakeApp).processQueuedPrompt(&app, job, 1, test_gateway_chat_url),
+            Runtime(FakeApp).processQueuedPrompt(&app, job, 1, test_gateway_chat_url, null),
         );
         if (admission == .uncertain_checkpoint) {
             try std.Io.Dir.accessAbsolute(std.testing.io, snapshot_path, .{});
@@ -3320,7 +3342,7 @@ test "app agent runtime discards every snapshot in a failed multi-image prefligh
 
     try std.testing.expectError(
         error.TestExpectedEqual,
-        Runtime(FakeApp).processQueuedPrompt(&app, job, 1, test_gateway_chat_url),
+        Runtime(FakeApp).processQueuedPrompt(&app, job, 1, test_gateway_chat_url, null),
     );
     try std.testing.expectError(
         error.FileNotFound,

--- a/src/core/app/app_auth_runtime.zig
+++ b/src/core/app/app_auth_runtime.zig
@@ -94,6 +94,10 @@ pub const PendingPromptCredentialReadiness = enum {
 
 pub fn Runtime(comptime App: type) type {
     return struct {
+        fn compactionOwnsCredentialFeedback(app: *const App) bool {
+            return if (comptime @hasField(App, "submission")) app.submission.compaction_pending else false;
+        }
+
         fn ensurePromptCredential(app: *App) !bool {
             if (try rejectPendingPreparation(app)) return false;
             if (comptime provider_runtime.supported(App) and
@@ -104,6 +108,7 @@ pub fn Runtime(comptime App: type) type {
                     const selection = selectProviderCredential(app, provider) catch |err| {
                         if (err == error.OutOfMemory) return err;
                         debug_trace.logf("auth", "prompt credential preference load failed err={s}", .{@errorName(err)});
+                        if (compactionOwnsCredentialFeedback(app)) return false;
                         try writeAuthNotice(app, .{
                             .topic = "auth",
                             .tone = .@"error",
@@ -184,6 +189,7 @@ pub fn Runtime(comptime App: type) type {
 
         fn missingPromptCredential(app: *App, provider: model_provider.ProviderId) !bool {
             if (provider != .gateway) {
+                if (compactionOwnsCredentialFeedback(app)) return false;
                 try app.writeDomainNotice(.{
                     .topic = "auth",
                     .tone = .warning,
@@ -198,6 +204,7 @@ pub fn Runtime(comptime App: type) type {
 
             const auth_view = app.auth.view();
             if (auth_view.onboarding_skipped) {
+                if (compactionOwnsCredentialFeedback(app)) return false;
                 try app.writeDomainNotice(.{
                     .topic = "auth",
                     .tone = .@"error",
@@ -1692,6 +1699,7 @@ pub fn Runtime(comptime App: type) type {
         pub fn admitPromptCredential(app: *App) !bool {
             if (comptime !oauthAuthEnabled(App)) {
                 if (app.auth.apiKey() != null) return true;
+                if (compactionOwnsCredentialFeedback(app)) return false;
                 try app.writeDomainNotice(.{
                     .topic = "auth",
                     .tone = .warning,
@@ -1860,8 +1868,7 @@ pub fn Runtime(comptime App: type) type {
                 app.auth.recordCredentialFailure(failure)
             else
                 true;
-            const for_compaction = if (comptime @hasField(App, "submission")) app.submission.compaction_pending else false;
-            if (for_compaction or !first_observation) return false;
+            if (compactionOwnsCredentialFeedback(app) or !first_observation) return false;
             const recovery = try credentialRecoveryText(app.alloc, failure);
             defer app.alloc.free(recovery);
             try app.writeDomainNotice(.{
@@ -2271,6 +2278,7 @@ const TestAuth = struct {
     refresh_error: ?anyerror = null,
     selected_source: ?credentials.Source = null,
     active_source: ?credentials.Source = .ai_gateway_api_key,
+    onboarding_skipped: bool = false,
     refresh_count: usize = 0,
     logout_reconcile_count: usize = 0,
     source_inventory_refresh_count: usize = 0,
@@ -2311,7 +2319,7 @@ const TestAuth = struct {
                 false,
             .stored_key_status = .not_attempted,
             .fx_login_status = .not_attempted,
-            .onboarding_skipped = false,
+            .onboarding_skipped = self.onboarding_skipped,
         };
     }
 
@@ -3356,6 +3364,35 @@ test "prompt credential refresh allows only OutOfMemory to escape" {
     try std.testing.expect(!app.shell.render_requests.footer_requested);
     try std.testing.expectEqual(@as(usize, 0), app.auth.source_inventory_refresh_count);
     try std.testing.expect(!app.auth.picker_opened);
+}
+
+test "manual compaction missing credentials leave transcript feedback to its owner" {
+    for ([_]model_provider.ProviderId{ .gateway, .codex, .grok }) |provider| {
+        for ([_]bool{ false, true }) |for_compaction| {
+            var app: TestApp = .{};
+            defer app.deinit();
+            app.auth.active_source = null;
+            app.auth.onboarding_skipped = true;
+            app.submission.compaction_pending = for_compaction;
+
+            try std.testing.expect(!try Runtime(TestApp).missingPromptCredential(&app, provider));
+            try std.testing.expectEqual(@as(usize, if (for_compaction) 0 else 1), app.notice_write_count);
+            try std.testing.expectEqual(for_compaction, app.transcript.items.len == 0);
+            try std.testing.expect(!app.auth.picker_opened);
+        }
+    }
+}
+
+test "manual compaction missing credentials preserves onboarding when it is enabled" {
+    var app: TestApp = .{};
+    defer app.deinit();
+    app.auth.active_source = null;
+    app.submission.compaction_pending = true;
+
+    try std.testing.expect(!try Runtime(TestApp).missingPromptCredential(&app, .gateway));
+    try std.testing.expect(app.auth.picker_opened);
+    try std.testing.expectEqual(@as(usize, 1), app.auth.source_inventory_refresh_count);
+    try std.testing.expectEqual(@as(usize, 0), app.notice_write_count);
 }
 
 test "manual compaction credential failure leaves feedback to its lifecycle owner" {

--- a/src/core/app/app_auth_runtime.zig
+++ b/src/core/app/app_auth_runtime.zig
@@ -1861,8 +1861,8 @@ pub fn Runtime(comptime App: type) type {
             else
                 true;
             const for_compaction = if (comptime @hasField(App, "submission")) app.submission.compaction_pending else false;
-            if (!first_observation and !for_compaction) return false;
-            const recovery = try credentialRecoveryText(app.alloc, failure, for_compaction);
+            if (for_compaction or !first_observation) return false;
+            const recovery = try credentialRecoveryText(app.alloc, failure);
             defer app.alloc.free(recovery);
             try app.writeDomainNotice(.{
                 .topic = "auth",
@@ -1876,20 +1876,8 @@ pub fn Runtime(comptime App: type) type {
         fn credentialRecoveryText(
             alloc: std.mem.Allocator,
             failure: auth_runtime.CredentialFailure,
-            for_compaction: bool,
         ) ![]u8 {
             const source_label = credentials.sourceLabel(failure.source);
-            if (for_compaction) {
-                const reason = if (auth_runtime.preparationError(failure)) |err|
-                    auth_runtime.preparationFailureNotice(err).?
-                else
-                    "Sign-in expired.";
-                return std.fmt.allocPrint(
-                    alloc,
-                    "{s}: {s} Your conversation is unchanged. Check /status and repair authentication with /provider, then run /compact again.",
-                    .{ source_label, reason },
-                );
-            }
             return switch (failure.reason) {
                 .invalid_credential => std.fmt.allocPrint(
                     alloc,
@@ -2617,6 +2605,7 @@ const TestUrlOpener = struct {
 
 const TestApp = struct {
     alloc: std.mem.Allocator = std.testing.allocator,
+    submission: @import("input_submit_runtime.zig").State = .{},
     selected_provider: model_provider.ProviderId = .gateway,
     auth: TestAuth = .{},
     input_runtime: @import("../input/runtime.zig").Runtime = .{},
@@ -3369,18 +3358,15 @@ test "prompt credential refresh allows only OutOfMemory to escape" {
     try std.testing.expect(!app.auth.picker_opened);
 }
 
-test "manual compaction credential failure guidance does not promise a saved prompt" {
-    const alloc = std.testing.allocator;
-    const failure = auth_runtime.classifyCredentialFailure(.fx_login, error.CredentialRefreshUnavailable);
-    const manual = try Runtime(TestApp).credentialRecoveryText(alloc, failure, true);
-    defer alloc.free(manual);
-    try std.testing.expect(std.mem.find(u8, manual, "Your conversation is unchanged.") != null);
-    try std.testing.expect(std.mem.find(u8, manual, "/compact again") != null);
-    try std.testing.expect(std.mem.find(u8, manual, "Your prompt is saved.") == null);
-    const prompt = try Runtime(TestApp).credentialRecoveryText(alloc, failure, false);
-    defer alloc.free(prompt);
-    try std.testing.expect(std.mem.find(u8, prompt, "Your prompt is saved.") != null);
-    try std.testing.expect(std.mem.find(u8, prompt, "/compact") == null);
+test "manual compaction credential failure leaves feedback to its lifecycle owner" {
+    var app: TestApp = .{};
+    defer app.deinit();
+    app.submission.compaction_pending = true;
+    app.auth.active_source = .fx_login;
+    try std.testing.expect(!try Runtime(TestApp).recoverCredentialFailure(&app, .fx_login, error.CredentialRefreshUnavailable));
+    try std.testing.expect(app.auth.credential_failure != null);
+    try std.testing.expectEqual(@as(usize, 0), app.notice_write_count);
+    try std.testing.expectEqual(@as(usize, 0), app.transcript.items.len);
 }
 
 test "prompt credential refresh falls back when its task cannot start" {

--- a/src/core/app/app_auth_runtime.zig
+++ b/src/core/app/app_auth_runtime.zig
@@ -1863,12 +1863,13 @@ pub fn Runtime(comptime App: type) type {
                 "credential failure source={t} reason={t} retryable={s}",
                 .{ failure.source, failure.reason, if (failure.retryable()) "true" else "false" },
             );
-            const first_observation = if (app.auth.credentialSource() == source and
+            const notify = !compactionOwnsCredentialFeedback(app);
+            const should_notify = if (app.auth.credentialSource() == source and
                 comptime @hasDecl(@TypeOf(app.auth), "recordCredentialFailure"))
-                app.auth.recordCredentialFailure(failure)
+                app.auth.recordCredentialFailure(failure, .{ .notify = notify })
             else
-                true;
-            if (compactionOwnsCredentialFeedback(app) or !first_observation) return false;
+                notify;
+            if (!should_notify) return false;
             const recovery = try credentialRecoveryText(app.alloc, failure);
             defer app.alloc.free(recovery);
             try app.writeDomainNotice(.{
@@ -2283,6 +2284,7 @@ const TestAuth = struct {
     logout_reconcile_count: usize = 0,
     source_inventory_refresh_count: usize = 0,
     credential_failure: ?auth_runtime.CredentialFailure = null,
+    credential_notice_claimed: bool = false,
     picker_opened: bool = false,
     picker_provider: model_provider.ProviderId = .gateway,
     picker_closed: bool = false,
@@ -2507,15 +2509,18 @@ const TestAuth = struct {
     fn recordCredentialFailure(
         self: *TestAuth,
         failure: auth_runtime.CredentialFailure,
+        options: struct { notify: bool = true },
     ) bool {
-        if (self.credential_failure) |current| {
-            if (current.source == failure.source and
-                current.reason == failure.reason)
-            {
-                return false;
-            }
+        const same_failure = if (self.credential_failure) |current|
+            current.source == failure.source and current.reason == failure.reason
+        else
+            false;
+        if (!same_failure) {
+            self.credential_failure = failure;
+            self.credential_notice_claimed = false;
         }
-        self.credential_failure = failure;
+        if (!options.notify or self.credential_notice_claimed) return false;
+        self.credential_notice_claimed = true;
         return true;
     }
 
@@ -3404,6 +3409,71 @@ test "manual compaction credential failure leaves feedback to its lifecycle owne
     try std.testing.expect(app.auth.credential_failure != null);
     try std.testing.expectEqual(@as(usize, 0), app.notice_write_count);
     try std.testing.expectEqual(@as(usize, 0), app.transcript.items.len);
+}
+
+test "compaction credential failure preserves the first ordinary recovery notice" {
+    const AuthApp = struct {
+        alloc: std.mem.Allocator = std.testing.allocator,
+        auth: auth_runtime.Runtime = .{},
+        submission: @import("input_submit_runtime.zig").State = .{},
+        shell: struct { render_requests: TestRenderRequests = .{} } = .{},
+        notice_write_count: usize = 0,
+        transcript: std.ArrayList(u8) = .empty,
+
+        fn writeDomainNotice(self: *@This(), notice: types.SemanticNotice, _: bool) !void {
+            try std.testing.expectEqualStrings("auth", notice.topic);
+            try self.transcript.appendSlice(self.alloc, notice.body);
+            self.notice_write_count += 1;
+        }
+    };
+    var app: AuthApp = .{};
+    defer app.auth.deinit(app.alloc);
+    defer app.transcript.deinit(app.alloc);
+    var credential: credentials.Credential = .{
+        .token = try app.alloc.dupe(u8, "login-token"),
+        .source = .fx_login,
+    };
+    defer credential.deinit(app.alloc);
+    _ = app.auth.adoptCredential(app.alloc, &credential);
+    const runtime = Runtime(AuthApp);
+    const failure = auth_runtime.classifyCredentialFailure(.fx_login, error.OAuthRequestFailed);
+
+    app.submission.compaction_pending = true;
+    try std.testing.expect(!try runtime.recoverCredentialFailure(&app, .fx_login, error.OAuthRequestFailed));
+    try std.testing.expectEqual(@as(usize, 0), app.notice_write_count);
+    try std.testing.expectEqual(@as(usize, 0), app.transcript.items.len);
+    try std.testing.expectEqual(failure, app.auth.credentialFailure().?);
+    try std.testing.expectEqual(
+        credentials.CatalogPublicOnlyReason.credential_refresh_failed,
+        app.auth.modelCatalogAccess().publicOnlyReason().?,
+    );
+
+    app.submission.compaction_pending = false;
+    app.auth.cancelPromptCredentialRefresh();
+    app.submission.pending = .{
+        .draft = .{
+            .turn_id = 1,
+            .prompt = try app.alloc.dupe(u8, "keep this ordinary prompt"),
+            .images = &.{},
+            .skill_display_spans = &.{},
+        },
+        .phase = .awaiting_auth,
+    };
+    defer app.submission.pending.?.deinit(app.alloc);
+    try std.testing.expect(!try runtime.recoverCredentialFailure(&app, .fx_login, error.OAuthRequestFailed));
+    try std.testing.expectEqual(@as(usize, 1), app.notice_write_count);
+    try std.testing.expectEqualStrings(
+        "fx login credential refresh failed.\nPress Enter to retry. Your prompt is saved.",
+        app.transcript.items,
+    );
+    try std.testing.expectEqualStrings("keep this ordinary prompt", app.submission.pending.?.draft.prompt);
+    try std.testing.expectEqual(@as(u64, 1), app.submission.pending.?.draft.turn_id);
+    try std.testing.expectEqual(.awaiting_auth, app.submission.pending.?.phase);
+    try std.testing.expectEqual(failure, app.auth.credentialFailure().?);
+    try std.testing.expect(app.shell.render_requests.footer_requested);
+
+    try std.testing.expect(!try runtime.recoverCredentialFailure(&app, .fx_login, error.OAuthRequestFailed));
+    try std.testing.expectEqual(@as(usize, 1), app.notice_write_count);
 }
 
 test "prompt credential refresh falls back when its task cannot start" {

--- a/src/core/app/app_callbacks.zig
+++ b/src/core/app/app_callbacks.zig
@@ -34,6 +34,7 @@ const types = @import("../shared/types.zig");
 const worker_runtime = @import("../agent/worker_runtime.zig");
 const assistant_presentation = @import("../agent/assistant_presentation.zig");
 const activity_runtime = @import("../output/activity_runtime.zig");
+const compaction_activity = @import("../output/compaction_activity.zig");
 const assistant_pacer = @import("../../ui/assistant/pacer.zig");
 const ui_render = @import("../../ui/render.zig");
 const render_request = @import("../../ui/render_request.zig");
@@ -318,6 +319,11 @@ pub fn Bindings(comptime App: type) type {
                 .publish_committed_file_handoff = agentPublishCommittedFileHandoff,
                 .propagate_history_turn = agentPropagateHistoryTurn,
                 .commit_context_compaction = .{ .commit = agentCommitContextCompaction },
+                .compaction_activity = if (comptime @hasDecl(@TypeOf(app.worker), "beginCompactionActivity")) .{
+                    .begin = beginCompactionActivity,
+                    .running = runCompactionActivity,
+                    .settle = settleCompactionActivity,
+                } else null,
                 .recovery_checkpoint = if (comptime @hasField(App, "session_persistence"))
                     if (app.session_persistence.writable != null)
                         .{
@@ -913,6 +919,21 @@ pub fn Bindings(comptime App: type) type {
         fn agentPropagateHistoryTurn(ctx: *anyopaque, turn: HistoryTurn) !void {
             const app: *App = @ptrCast(@alignCast(ctx));
             try app_worker_runtime.Runtime(App).propagateHistoryTurn(app, turn, app.session.max_history_turns);
+        }
+
+        fn beginCompactionActivity(ctx: *anyopaque, origin: compaction_activity.Origin, turn_id: ?u64) compaction_activity.OperationId {
+            const app: *App = @ptrCast(@alignCast(ctx));
+            return app.worker.beginCompactionActivity(origin, turn_id);
+        }
+
+        fn runCompactionActivity(ctx: *anyopaque, id: compaction_activity.OperationId, stage: compaction_activity.Stage) void {
+            const app: *App = @ptrCast(@alignCast(ctx));
+            app.worker.runCompactionActivity(id, stage);
+        }
+
+        fn settleCompactionActivity(ctx: *anyopaque, id: compaction_activity.OperationId, feedback: compaction_activity.Feedback) void {
+            const app: *App = @ptrCast(@alignCast(ctx));
+            app.worker.settleCompactionActivity(id, feedback);
         }
 
         fn agentCommitContextCompaction(

--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -2895,6 +2895,10 @@ pub fn Runtime(comptime App: type) type {
                     app.shell.render_requests.request(.footer);
                     return;
                 }
+                if (interrupt_rt.dismissCompactionFeedback(app)) {
+                    _ = disarmEscapeClear(app);
+                    return;
+                }
                 if (!interrupt_rt.pauseActiveRecovery(app)) {
                     try interrupt_rt.cancelActiveOperation(app);
                 }
@@ -2919,6 +2923,10 @@ pub fn Runtime(comptime App: type) type {
             if (completion_rt.dismissVisibleInlinePicker(app)) {
                 _ = disarmEscapeClear(app);
                 app.shell.render_requests.request(.footer);
+                return;
+            }
+            if (interrupt_rt.dismissCompactionFeedback(app)) {
+                _ = disarmEscapeClear(app);
                 return;
             }
             if (!draftHasState(app)) {
@@ -3308,6 +3316,8 @@ const RoutingUpgradeStatus = struct {
 };
 
 const RoutingWorker = struct {
+    compaction: @import("../output/compaction_activity.zig").State = .{},
+
     submitted_permission: ?ToolPermissionDecision = null,
     submitted_permission_feedback: [64]u8 = undefined,
     submitted_permission_feedback_len: usize = 0,
@@ -3327,6 +3337,14 @@ const RoutingWorker = struct {
     queued_count: usize = 0,
     synced_permission_mode: ?types.PermissionMode = null,
     permission_mode_sync_count: usize = 0,
+
+    pub fn compactionActivitySnapshot(self: *RoutingWorker) @import("../output/compaction_activity.zig").Snapshot {
+        return self.compaction.snapshot;
+    }
+
+    pub fn dismissCompactionActivity(self: *RoutingWorker, id: @import("../output/compaction_activity.zig").OperationId, revision: u64) bool {
+        return self.compaction.dismiss(id, revision);
+    }
 
     pub fn queuedPromptCount(self: *const RoutingWorker) usize {
         return self.queued_count;
@@ -8116,6 +8134,21 @@ test "app_input_runtime ctrl+c clears an image-only draft" {
     try std.testing.expectEqual(@as(usize, 0), app.submitted_prompt_count);
 }
 
+test "Escape dismisses idle compaction feedback without clearing the draft or cancelling a turn" {
+    const alloc = std.testing.allocator;
+    var app = try RoutingFakeApp.init(alloc);
+    defer app.deinit();
+    try app.input_runtime.textReplacementState().replace(alloc, "keep this draft");
+    const id = app.worker.compaction.begin(.manual, null, 1);
+    app.worker.compaction.settle(id, .{ .outcome = .failed }, 2);
+    try Runtime(RoutingFakeApp).resolveEscape(&app, false, 3);
+    try std.testing.expect(app.worker.compaction.snapshot.operation.?.dismissed);
+    try std.testing.expectEqualStrings("keep this draft", app.input_runtime.edit_state.input.items);
+    try std.testing.expect(!app.worker.cancel_requested);
+    try std.testing.expect(!app.input_runtime.gestures.escapeClearArmed());
+    try std.testing.expect(app.shell.render_requests.hasReason(.footer));
+}
+
 test "app_input_runtime double escape clears an image-only draft" {
     const alloc = std.testing.allocator;
     var app = try RoutingFakeApp.init(alloc);
@@ -10333,6 +10366,24 @@ test "app_input_runtime active Ctrl-C cancels stream and arms exit window" {
     try std.testing.expect(app.input_runtime.gestures.ctrlCExitArmedAt() != null);
     try std.testing.expect(!app.should_exit);
     try std.testing.expect(app.shell.render_requests.hasReason(.footer));
+}
+
+test "automatic compaction cancellation is silent only while compaction is active" {
+    const alloc = std.testing.allocator;
+    for ([_]bool{ false, true }) |settled| {
+        var app = try RoutingFakeApp.init(alloc);
+        defer app.deinit();
+        app.stream.active = true;
+        const id = app.worker.compaction.begin(.automatic, 1, 1);
+        app.worker.compaction.running(id, .summary);
+        if (settled) app.worker.compaction.settle(id, .{ .outcome = .succeeded }, 2);
+        try Runtime(RoutingFakeApp).resolveEscape(&app, true, 100);
+        try std.testing.expect(app.worker.cancel_requested);
+        var rendered = try app.shell.prepareTranscriptSource(alloc, null);
+        defer rendered.deinit(alloc);
+        try std.testing.expectEqual(settled, std.mem.find(u8, rendered.bytes, "What can fx do differently?") != null);
+        try std.testing.expectEqualStrings("", app.notice_body.items);
+    }
 }
 
 test "app_input_runtime active tool Escape presents final cancellation immediately" {

--- a/src/core/app/app_process_runtime.zig
+++ b/src/core/app/app_process_runtime.zig
@@ -4,6 +4,26 @@ const image_attachments = @import("../images/image_attachments.zig");
 const tool_result_errors = @import("../tooling/tool_result_errors.zig");
 const types = @import("../shared/types.zig");
 const worker_runtime = @import("../agent/worker_runtime.zig");
+const compaction_activity = @import("../output/compaction_activity.zig");
+const debug_trace = @import("../shared/debug_trace.zig");
+
+fn compactionErrorHandled(work: worker_runtime.WorkItem, provenance: ?compaction_activity.ErrorProvenance, err: anyerror) bool {
+    const failure = provenance orelse return false;
+    if (failure.err != err) return false;
+    return switch (work) {
+        .prompt => |job| failure.turn_id == job.turn_id,
+        .compact_context => |task| failure.turn_id == task.turn_id and task.operation_id == failure.operation_id,
+    };
+}
+
+fn settleCompactionWorkFailure(worker: *worker_runtime.WorkerRuntime, work: worker_runtime.WorkItem, err: anyerror) void {
+    switch (work) {
+        .compact_context => |task| if (task.operation_id) |id| {
+            worker.settleCompactionActivity(id, compaction_activity.failure(err, .preparation, worker.isCancelRequested()));
+        },
+        .prompt => {},
+    }
+}
 
 pub fn Runtime(comptime App: type) type {
     return struct {
@@ -20,6 +40,8 @@ pub fn Runtime(comptime App: type) type {
         ) !void {
             const work = (try app.worker.tryTakeNextWork(std.heap.c_allocator)) orelse return;
             defer worker_runtime.freeWorkItem(std.heap.c_allocator, work);
+            defer app.worker.finishProcessing();
+            errdefer |err| settleCompactionWorkFailure(&app.worker, work, err);
 
             try app_worker_runtime.Runtime(App).tick(
                 app,
@@ -27,8 +49,12 @@ pub fn Runtime(comptime App: type) type {
             );
             try flush_frame(app);
 
-            app.processQueuedWork(work) catch |err| {
-                if (err != error.RouteRecoveryStopped) {
+            var failure_provenance: ?compaction_activity.ErrorProvenance = null;
+            app.processQueuedWork(work, &failure_provenance) catch |err| {
+                settleCompactionWorkFailure(&app.worker, work, err);
+                if (compactionErrorHandled(work, failure_provenance, err)) {
+                    debug_trace.logf("context_compaction", "interactive error retained err={s}", .{@errorName(err)});
+                } else if (err != error.RouteRecoveryStopped) {
                     const body = try formatErrorBody(std.heap.c_allocator, "request failed", err);
                     defer std.heap.c_allocator.free(body);
                     try app.worker.pushEvent(std.heap.c_allocator, .{ .error_text = .{
@@ -38,7 +64,6 @@ pub fn Runtime(comptime App: type) type {
                     } });
                 }
             };
-            app.worker.finishProcessing();
         }
 
         pub fn formatToolExecutionError(alloc: std.mem.Allocator, tool_name: []const u8, err: anyerror) ![]u8 {
@@ -125,8 +150,13 @@ pub fn Runtime(comptime App: type) type {
                 const work = (try app.worker.waitAndTakeNextWork(std.heap.c_allocator)) orelse return;
 
                 defer worker_runtime.freeWorkItem(std.heap.c_allocator, work);
-                app.processQueuedWork(work) catch |err| {
-                    if (err != error.RouteRecoveryStopped) {
+                defer app.worker.finishProcessing();
+                var failure_provenance: ?compaction_activity.ErrorProvenance = null;
+                app.processQueuedWork(work, &failure_provenance) catch |err| {
+                    settleCompactionWorkFailure(&app.worker, work, err);
+                    if (compactionErrorHandled(work, failure_provenance, err)) {
+                        debug_trace.logf("context_compaction", "interactive error retained err={s}", .{@errorName(err)});
+                    } else if (err != error.RouteRecoveryStopped) {
                         const body = try formatErrorBody(std.heap.c_allocator, "request failed", err);
                         defer std.heap.c_allocator.free(body);
                         try app.worker.pushEvent(std.heap.c_allocator, .{ .error_text = .{
@@ -136,11 +166,44 @@ pub fn Runtime(comptime App: type) type {
                         } });
                     }
                 };
-
-                app.worker.finishProcessing();
             }
         }
     };
+}
+
+test "compaction activity error routing requires exact operation and turn provenance" {
+    const id: compaction_activity.OperationId = @enumFromInt(1);
+    const task: worker_runtime.WorkItem = .{ .compact_context = .{
+        .operation_id = id,
+        .turn_id = 7,
+        .model = @constCast("model"),
+        .api_key = @constCast("fixture"),
+        .history = &.{},
+    } };
+    const provenance: compaction_activity.ErrorProvenance = .{ .operation_id = id, .turn_id = 7, .err = error.InvalidCompactionHandoff };
+    try std.testing.expect(compactionErrorHandled(task, provenance, error.InvalidCompactionHandoff));
+    try std.testing.expect(!compactionErrorHandled(task, null, error.InvalidCompactionHandoff));
+    try std.testing.expect(!compactionErrorHandled(task, provenance, error.OutOfMemory));
+    var stale = provenance;
+    stale.operation_id = @enumFromInt(2);
+    try std.testing.expect(!compactionErrorHandled(task, stale, provenance.err));
+    stale = provenance;
+    stale.turn_id = 8;
+    try std.testing.expect(!compactionErrorHandled(task, stale, provenance.err));
+    const prompt: worker_runtime.WorkItem = .{ .prompt = .{
+        .turn_id = 7,
+        .prompt = @constCast("next"),
+        .images = &.{},
+        .model = @constCast("model"),
+        .api_key = @constCast("fixture"),
+        .permission_mode = .ask,
+        .history = &.{},
+        .grants = &.{},
+    } };
+    try std.testing.expect(compactionErrorHandled(prompt, provenance, provenance.err));
+    try std.testing.expect(!compactionErrorHandled(prompt, stale, provenance.err));
+    // An unrelated error of even the same error set has no call-scoped provenance.
+    try std.testing.expect(!compactionErrorHandled(prompt, null, provenance.err));
 }
 
 const DummyApp = struct {
@@ -289,7 +352,7 @@ const TestWorkerApp = struct {
         self.worker.deinit(std.heap.c_allocator);
     }
 
-    fn processQueuedWork(self: *TestWorkerApp, work: worker_runtime.WorkItem) !void {
+    fn processQueuedWork(self: *TestWorkerApp, work: worker_runtime.WorkItem, _: *?compaction_activity.ErrorProvenance) !void {
         self.processed_count += 1;
         if (self.processed_count >= self.shutdown_after_count) self.worker.requestShutdown();
         if (self.processed_count == 1) {

--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -688,6 +688,7 @@ pub fn Runtime(comptime App: type) type {
             return .{
                 .slash_registry = app.slashRegistry(),
                 .stream = visible_stream,
+                .compaction = if (comptime @hasDecl(@TypeOf(app.worker), "compactionActivitySnapshot")) app.worker.compactionActivitySnapshot() else .{},
                 .pending_prompt_activity = pendingPromptActivityVisible(app),
                 .completed_assistant_presentation_tail = app.pacer.hasCompletedAssistantPresentationTail(),
                 .writing_response = app.pacer.hasPending(),

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -1441,10 +1441,19 @@ pub fn Runtime(comptime App: type) type {
             }
         }
 
+        fn retireLiveSessionCompaction(app: *App) void {
+            // Called after the worker is idle, before installing the next session.
+            const observed = app.worker.compactionActivitySnapshot();
+            if (observed.operation) |op| {
+                _ = app.worker.dismissCompactionActivity(op.id, observed.revision);
+            }
+        }
+
         fn applyIdleLiveSessionTransition(
             app: *App,
             background_policy: BackgroundSessionPolicy,
         ) void {
+            retireLiveSessionCompaction(app);
             clearCachedSessionTitle(app);
             app.worker.discardEvents(std.heap.c_allocator);
 
@@ -4757,6 +4766,98 @@ const TestResumeTarget = union(enum) {
         self.* = .last;
     }
 };
+
+test "session transition retires queued and running compaction only after worker idle" {
+    const App = struct {
+        alloc: Allocator = std.heap.c_allocator,
+        worker: worker_runtime.WorkerRuntime = .{},
+        pacer: struct {
+            fn clear(_: *@This(), _: Allocator) void {}
+        } = .{},
+    };
+    for ([_]bool{ false, true }) |running| {
+        var app: App = .{};
+        defer app.worker.deinit(app.alloc);
+        try app.worker.enqueueContextCompaction(.{
+            .turn_id = 41,
+            .model = try app.alloc.dupe(u8, "provider/model"),
+            .api_key = try app.alloc.dupe(u8, "key"),
+            .history = try app.alloc.alloc(types.HistoryTurn, 0),
+        });
+        const work = if (running) (try app.worker.tryTakeNextWork(app.alloc)).? else null;
+        defer if (work) |item| worker_runtime.freeWorkItem(app.alloc, item);
+        const old = app.worker.compactionActivitySnapshot();
+        Runtime(App).beginLiveSessionCancellation(&app);
+        try std.testing.expect(app.worker.isCancelRequested());
+        if (running) {
+            try std.testing.expect(app.worker.isProcessing());
+            try std.testing.expect(app.worker.compactionActivitySnapshot().operation.?.phase == .stopping);
+            Runtime(App).retireLiveSessionCompaction(&app);
+            try std.testing.expect(!app.worker.compactionActivitySnapshot().operation.?.dismissed);
+            app.worker.finishProcessing();
+        }
+        app.worker.waitUntilIdle();
+        const terminal = app.worker.compactionActivitySnapshot();
+        try std.testing.expect(!terminal.operation.?.active());
+        try std.testing.expectEqual(@import("../output/compaction_activity.zig").Outcome.cancelled, terminal.operation.?.phase.terminal.outcome);
+        Runtime(App).retireLiveSessionCompaction(&app);
+        const retired = app.worker.compactionActivitySnapshot();
+        try std.testing.expectEqual(old.operation.?.id, retired.operation.?.id);
+        try std.testing.expect(retired.operation.?.dismissed);
+        try std.testing.expect(!retired.operation.?.visible(io_mod.milliTimestamp()));
+        try std.testing.expect(retired.revision > terminal.revision);
+        try std.testing.expect(app.worker.isCancelRequested());
+        Runtime(App).retireLiveSessionCompaction(&app);
+        try std.testing.expectEqualDeep(retired, app.worker.compactionActivitySnapshot());
+
+        try app.worker.enqueueContextCompaction(.{
+            .turn_id = 42,
+            .model = try app.alloc.dupe(u8, "provider/model"),
+            .api_key = try app.alloc.dupe(u8, "key"),
+            .history = try app.alloc.alloc(types.HistoryTurn, 0),
+        });
+        const next = app.worker.compactionActivitySnapshot();
+        try std.testing.expect(@intFromEnum(next.operation.?.id) > @intFromEnum(old.operation.?.id));
+        try std.testing.expect(next.revision > retired.revision);
+        app.worker.settleCompactionActivity(old.operation.?.id, .{ .outcome = .failed });
+        try std.testing.expect(!app.worker.dismissCompactionActivity(old.operation.?.id, terminal.revision));
+        try std.testing.expectEqualDeep(next, app.worker.compactionActivitySnapshot());
+        const next_work = (try app.worker.tryTakeNextWork(app.alloc)).?;
+        defer worker_runtime.freeWorkItem(app.alloc, next_work);
+        try std.testing.expect(!app.worker.isCancelRequested());
+        app.worker.finishProcessing();
+    }
+}
+
+test "session transition retirement preserves a newer compaction snapshot race" {
+    const compaction_activity = @import("../output/compaction_activity.zig");
+    const App = struct {
+        worker: struct {
+            runtime: worker_runtime.WorkerRuntime = .{},
+
+            pub fn compactionActivitySnapshot(self: *@This()) compaction_activity.Snapshot {
+                const observed = self.runtime.compactionActivitySnapshot();
+                const next = self.runtime.beginCompactionActivity(.manual, null);
+                self.runtime.settleCompactionActivity(next, .{ .outcome = .failed });
+                return observed;
+            }
+
+            pub fn dismissCompactionActivity(self: *@This(), id: compaction_activity.OperationId, revision: u64) bool {
+                return self.runtime.dismissCompactionActivity(id, revision);
+            }
+        } = .{},
+    };
+    var app: App = .{};
+    defer app.worker.runtime.deinit(std.testing.allocator);
+    const old = app.worker.runtime.beginCompactionActivity(.manual, null);
+    app.worker.runtime.settleCompactionActivity(old, .{ .outcome = .cancelled });
+    Runtime(App).retireLiveSessionCompaction(&app);
+    const current = app.worker.runtime.compactionActivitySnapshot();
+    try std.testing.expect(current.operation.?.id != old);
+    try std.testing.expect(!current.operation.?.dismissed);
+    try std.testing.expect(current.operation.?.visible(io_mod.milliTimestamp()));
+    try std.testing.expectEqual(compaction_activity.Outcome.failed, current.operation.?.phase.terminal.outcome);
+}
 
 const FakeWorker = struct {
     model: std.ArrayList(u8) = .empty,

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -3477,7 +3477,7 @@ pub fn Runtime(comptime App: type) type {
                             try writeCancelledCommandPresentation(app, sink, entry.tool_call.?, presentation);
                         }
                         switch (entry.terminal_reason) {
-                            .cancelled => if (entry.cancelled_command == null) {
+                            .cancelled => if (entry.cancelled_command == null and entry.cancellation_origin == .turn) {
                                 try sink.appendTurnCancellation();
                             },
                             .failed => try sink.appendNotice(

--- a/src/core/app/app_worker_runtime.zig
+++ b/src/core/app/app_worker_runtime.zig
@@ -788,16 +788,12 @@ pub fn Runtime(comptime App: type) type {
             if (app.shell.worker_status_state().expire_transient(now_ms)) {
                 app.shell.render_requests.request(.footer);
             }
-            if (!app.approval_prompt.isActive() and
-                !app.question_prompt.isActive())
-            {
-                _ = advanceVisibleAnimation(
-                    app,
-                    event_handlers.tool_lifecycle,
-                    now_ms,
-                    std.Io.Clock.Timestamp.now(io_mod.getIo(), .awake),
-                );
-            }
+            _ = advanceVisibleAnimation(
+                app,
+                event_handlers.tool_lifecycle,
+                now_ms,
+                std.Io.Clock.Timestamp.now(io_mod.getIo(), .awake),
+            );
         }
 
         fn advanceVisibleAnimation(
@@ -806,9 +802,17 @@ pub fn Runtime(comptime App: type) type {
             now_ms: i64,
             now_awake: std.Io.Clock.Timestamp,
         ) bool {
+            const compaction: @import("../output/compaction_activity.zig").Snapshot = if (comptime @hasDecl(@TypeOf(app.worker), "compactionActivitySnapshot")) app.worker.compactionActivitySnapshot() else .{};
+            app.shell.render_requests.observeCompactionRevision(compaction.revision);
+            if (comptime @hasDecl(@TypeOf(app.worker), "expireCompactionActivity")) {
+                if (compaction.operation) |op| {
+                    if (app.worker.expireCompactionActivity(op.id, compaction.revision, now_ms)) app.shell.render_requests.request(.footer);
+                }
+            }
+            const compaction_active = if (compaction.operation) |op| op.active() and op.visible(now_ms) else false;
             const status_changed = app.shell.worker_status_state().refresh_route_recovery(now_awake);
             if (status_changed) app.shell.render_requests.request(.footer);
-            if (!app.stream.active and !app.pacer.hasCompletedAssistantPresentationTail()) {
+            if (!compaction_active and !app.stream.active and !app.pacer.hasCompletedAssistantPresentationTail()) {
                 return status_changed;
             }
             if (app.approval_prompt.isActive() or
@@ -819,7 +823,7 @@ pub fn Runtime(comptime App: type) type {
             }
 
             var label_buf: [256]u8 = undefined;
-            _ = activityShimmerLabel(app, presenter, &label_buf) orelse return status_changed;
+            _ = activityShimmerLabel(app, presenter, compaction, now_ms, &label_buf) orelse return status_changed;
             const previous_deadline = app.shell.render_requests.animation_next_deadline_ms;
             if (!app.shell.render_requests.requestAnimationDue(now_ms)) return status_changed;
             debug_trace.logf(
@@ -833,8 +837,18 @@ pub fn Runtime(comptime App: type) type {
         fn activityShimmerLabel(
             app: *App,
             presenter: activity_runtime.LifecyclePresenter,
+            compaction: @import("../output/compaction_activity.zig").Snapshot,
+            now_ms: i64,
             buf: []u8,
         ) ?[]const u8 {
+            switch (app.shell.activityProjection()) {
+                .turn_thinking => |thinking| if (thinking.tone != .thinking) return null,
+                .none, .tool_slot => {},
+            }
+            switch (activity_status.compactionProjection(buf, compaction, app.stream, now_ms)) {
+                .turn_thinking => |thinking| return if (thinking.tone == .thinking) thinking.label else null,
+                .none, .tool_slot => {},
+            }
             // Existence guard only: pass no clock so the label skips the counter.
             if (!app.stream.active and app.pacer.hasCompletedAssistantPresentationTail()) {
                 return activity_status.buildTurnLabel(buf, .{ .active = true }, 0);
@@ -1396,6 +1410,9 @@ const FakeQuestionSnapshot = struct {
 };
 
 const FakeWorker = struct {
+    compaction: @import("../output/compaction_activity.zig").State = .{},
+    compaction_reads: usize = 0,
+
     worker_cancel_requested: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     events: std.ArrayList(WorkerEvent) = .empty,
     queued_count: usize = 0,
@@ -1410,6 +1427,15 @@ const FakeWorker = struct {
     propagated_grants: usize = 0,
     reset_cancel_after_take_events: bool = false,
     admission_snapshot: worker_runtime.InteractiveAdmissionSnapshot = .open,
+
+    fn compactionActivitySnapshot(self: *FakeWorker) @import("../output/compaction_activity.zig").Snapshot {
+        self.compaction_reads += 1;
+        return self.compaction.snapshot;
+    }
+
+    fn expireCompactionActivity(self: *FakeWorker, id: @import("../output/compaction_activity.zig").OperationId, revision: u64, now_ms: i64) bool {
+        return self.compaction.expire(id, revision, now_ms);
+    }
 
     fn resolveFreshPrompt(_: *FakeWorker, alloc: std.mem.Allocator, value: worker_runtime.FreshPromptPreparation, ctx: *anyopaque, handler: worker_runtime.FreshPromptHandler) void {
         var result = handler(ctx, value) catch return;
@@ -2411,6 +2437,30 @@ test "core.app_worker_runtime next admitted model step returns running to thinki
 
     try std.testing.expectEqual(types.TurnPhase.thinking, app.stream.phase);
     try std.testing.expectEqual(@as(u64, 13), app.stream.phase_step_id);
+}
+
+test "manual compaction schedules initial repaint animation and terminal expiry without a stream" {
+    var app = FakeApp.init(std.testing.allocator);
+    defer app.deinit();
+    const id = app.worker.compaction.begin(.manual, null, 1_000);
+    app.worker.compaction.running(id, .summary);
+    const presenter = NoopBridge.lifecyclePresenter(&app);
+    try std.testing.expect(!Runtime(FakeApp).advanceVisibleAnimation(&app, presenter, 1_000, test_awake_timestamp(1_000)));
+    try std.testing.expect(app.shell.render_requests.hasReason(.footer));
+    try std.testing.expectEqual(@as(usize, 1), app.worker.compaction_reads);
+    try std.testing.expect(!app.stream.active);
+    app.shell.shimmer_active = true;
+    app.shell.render_requests.animation_visible = true;
+    app.shell.render_requests.animation_next_deadline_ms = 1_050;
+    try std.testing.expect(Runtime(FakeApp).advanceVisibleAnimation(&app, presenter, 1_050, test_awake_timestamp(1_050)));
+    try std.testing.expect(app.shell.render_requests.hasReason(.animation));
+    app.shell.render_requests.clearReason(.animation);
+    app.worker.compaction.settle(id, .{ .outcome = .no_op }, 1_100);
+    try std.testing.expect(!Runtime(FakeApp).advanceVisibleAnimation(&app, presenter, 2_599, test_awake_timestamp(2_599)));
+    try std.testing.expect(!app.worker.compaction.snapshot.operation.?.dismissed);
+    try std.testing.expect(!Runtime(FakeApp).advanceVisibleAnimation(&app, presenter, 2_600, test_awake_timestamp(2_600)));
+    try std.testing.expect(app.worker.compaction.snapshot.operation.?.dismissed);
+    try std.testing.expect(!app.stream.active);
 }
 
 test "core.app_worker_runtime advances visible animation exactly at its deadline" {

--- a/src/core/app/input_interrupt_runtime.zig
+++ b/src/core/app/input_interrupt_runtime.zig
@@ -54,6 +54,16 @@ pub fn InterruptRuntime(comptime App: type) type {
             return activeCancellationTarget(app) != .none;
         }
 
+        pub fn dismissCompactionFeedback(app: *App) bool {
+            if (comptime !@hasDecl(@TypeOf(app.worker), "compactionActivitySnapshot")) return false;
+            const observed = app.worker.compactionActivitySnapshot();
+            const op = observed.operation orelse return false;
+            if (!op.visible(@import("../shared/io.zig").milliTimestamp())) return false;
+            if (!app.worker.dismissCompactionActivity(op.id, observed.revision)) return false;
+            app.shell.render_requests.request(.footer);
+            return true;
+        }
+
         pub fn cancelActiveOperation(app: *App) !void {
             if (comptime @hasField(App, "auth")) {
                 if (comptime @hasDecl(@TypeOf(app.auth), "cancelProviderPreparation")) {
@@ -75,11 +85,6 @@ pub fn InterruptRuntime(comptime App: type) type {
                 if (!cancelled) return;
                 app.pacer.clear(app.alloc);
                 if (comptime @hasDecl(App, "playCancelSound")) app.playCancelSound();
-                try app.writeDomainNotice(.{
-                    .topic = "context",
-                    .tone = .neutral,
-                    .body = "Context compaction cancelled.",
-                }, true);
                 app.shell.render_requests.request(.footer);
                 return;
             }
@@ -87,6 +92,10 @@ pub fn InterruptRuntime(comptime App: type) type {
             // Pending approval keeps the stream active until resolution.
             // Avoid duplicate cancellation notices once the worker is cancelled.
             if (app.worker.isCancelRequested()) return;
+            const compacting = if (comptime @hasDecl(@TypeOf(app.worker), "compactionActivitySnapshot")) blk: {
+                const observed = app.worker.compactionActivitySnapshot();
+                break :blk if (observed.operation) |op| op.active() else false;
+            } else false;
             const tool_active = activeToolStatusCount(app) > 0;
             debug_trace.logf("input", "cancel active operation queued={d}", .{app.worker.queuedPromptCount()});
             traceInterruptRequested(app, "input_active_stream");
@@ -97,6 +106,10 @@ pub fn InterruptRuntime(comptime App: type) type {
             }
             app.pacer.clear(app.alloc);
             if (comptime @hasDecl(App, "playCancelSound")) app.playCancelSound();
+            if (compacting) {
+                app.shell.render_requests.request(.footer);
+                return;
+            }
             if (tool_active) {
                 _ = try shell_runtime.presentActiveToolCancellation(
                     app.alloc,
@@ -173,6 +186,22 @@ pub fn InterruptRuntime(comptime App: type) type {
             return cancellationTarget(app.stream.active, status);
         }
     };
+}
+
+test "idle compaction feedback dismissal is scoped and never cancels active work" {
+    const FakeApp = struct {
+        worker: worker_runtime.WorkerRuntime = .{},
+        shell: struct { render_requests: @import("../../ui/render_request.zig").RenderRequestState = .{} } = .{},
+    };
+    var app: FakeApp = .{};
+    defer app.worker.deinit(std.testing.allocator);
+    const id = app.worker.beginCompactionActivity(.manual, null);
+    try std.testing.expect(!InterruptRuntime(FakeApp).dismissCompactionFeedback(&app));
+    app.worker.settleCompactionActivity(id, .{ .outcome = .cancelled });
+    try std.testing.expect(InterruptRuntime(FakeApp).dismissCompactionFeedback(&app));
+    try std.testing.expect(app.shell.render_requests.hasReason(.footer));
+    try std.testing.expect(!app.worker.isCancelRequested());
+    try std.testing.expect(!InterruptRuntime(FakeApp).dismissCompactionFeedback(&app));
 }
 
 test "interactive connectivity wait maps try later to recovery pause" {

--- a/src/core/app/input_submit_runtime.zig
+++ b/src/core/app/input_submit_runtime.zig
@@ -8,6 +8,7 @@ const debug_trace = @import("../shared/debug_trace.zig");
 const entity_spans = @import("../shared/entity_spans.zig");
 const types = @import("../shared/types.zig");
 const worker_runtime = @import("../agent/worker_runtime.zig");
+const compaction_activity = @import("../output/compaction_activity.zig");
 const input_completion_runtime = @import("input_completion_runtime.zig");
 const input_limit_feedback = @import("input_limit_feedback.zig");
 
@@ -81,6 +82,8 @@ pub const State = struct {
     pending: ?PendingSubmission = null,
     retry_after_auth: bool = false,
     compaction_pending: bool = false,
+    /// Identity only; auth retains its existing pending execution flag.
+    compaction_operation: ?compaction_activity.OperationId = null,
 };
 
 fn buildPendingPromptDraft(
@@ -135,22 +138,24 @@ pub fn SubmitRuntime(comptime App: type) type {
     return struct {
         pub fn request_context_compaction(app: *App) !void {
             if (app.submission.compaction_pending) return;
+            const observed = app.worker.compactionActivitySnapshot();
+            if (observed.operation) |op| if (op.active()) return;
+            defer app.shell.render_requests.request(.footer);
             if (!app.hasContextToCompact()) {
-                try app.writeDomainNotice(.{ .topic = "context", .tone = .neutral, .body = "No context to compact." }, true);
+                app.worker.rejectCompactionActivity(.no_op);
                 return;
             }
             if (app.submission.pending != null or app.worker.isProcessing() or
                 app.worker.queuedPromptCount() > 0 or app.worker.contextCompactionStatus() != .idle)
             {
-                try app.writeDomainNotice(.{ .topic = "context", .tone = .warning, .body = "Wait for the active work to finish before compacting context." }, true);
+                app.worker.rejectCompactionActivity(.busy);
                 return;
             }
+            app.submission.compaction_operation = app.worker.beginCompactionActivity(.manual, null);
             app.submission.compaction_pending = true;
-            errdefer clear_context_compaction(app, "notice_failed");
             collect_context_compaction(app);
             if (app.submission.compaction_pending) {
                 debug_trace.logf("input", "manual_compaction_auth_pending", .{});
-                try app.writeDomainNotice(.{ .topic = "context", .tone = .neutral, .body = "Preparing authentication for compaction. Press Ctrl+C to cancel." }, true);
             }
         }
 
@@ -158,14 +163,11 @@ pub fn SubmitRuntime(comptime App: type) type {
             if (comptime !@hasDecl(App, "enqueueContextCompaction")) return;
             if (!app.submission.compaction_pending) return;
             admit_context_compaction(app) catch |err| {
+                settle_pending_compaction(app, if (err == error.WorkerBusy) .{ .outcome = .busy } else compaction_activity.failure(err, .preparation, false));
                 clear_context_compaction(app, "admission_failed");
                 app.submission.retry_after_auth = false;
                 debug_trace.logf("input", "manual compaction admission failed err={s}", .{@errorName(err)});
-                var buffer: [256]u8 = undefined;
-                const body = std.fmt.bufPrint(&buffer, "Compaction was not started ({s}). Your conversation is unchanged. Check authentication and try /compact again.", .{@errorName(err)}) catch "Compaction was not started. Your conversation is unchanged. Try /compact again.";
-                app.writeDomainNotice(.{ .topic = "context", .tone = .@"error", .body = body }, true) catch |notice_err| {
-                    debug_trace.logf("input", "manual compaction failure notice failed err={s}", .{@errorName(notice_err)});
-                };
+                app.shell.render_requests.request(.footer);
             };
         }
 
@@ -173,26 +175,31 @@ pub fn SubmitRuntime(comptime App: type) type {
             switch (try App.collectPendingPromptCredential(app)) {
                 .pending => return,
                 .rejected => {
+                    settle_pending_compaction(app, compaction_activity.failure(error.CompactionAuthenticationRejected, .preparation, false));
                     clear_context_compaction(app, "auth_rejected");
                     app.submission.retry_after_auth = false;
                     return;
                 },
                 .current => {},
             }
+            const queued = try app.enqueueContextCompaction(app.submission.compaction_operation.?);
+            if (!queued) settle_pending_compaction(app, .{ .outcome = .busy });
             app.submission.compaction_pending = false;
-            const queued = try app.enqueueContextCompaction();
-            app.writeDomainNotice(.{
-                .topic = "context",
-                .tone = if (queued) .neutral else .warning,
-                .body = if (queued) "Compaction queued." else "Wait for the active work to finish before compacting context.",
-            }, true) catch |err| {
-                debug_trace.logf("input", "manual compaction admission notice failed queued={} err={s}", .{ queued, @errorName(err) });
-            };
+            app.submission.compaction_operation = null;
+            app.shell.render_requests.request(.footer);
+        }
+
+        fn settle_pending_compaction(app: *App, feedback: compaction_activity.Feedback) void {
+            if (comptime !@hasDecl(@TypeOf(app.worker), "settleCompactionActivity")) return;
+            const id = app.submission.compaction_operation orelse return;
+            app.worker.settleCompactionActivity(id, feedback);
         }
 
         fn clear_context_compaction(app: *App, reason: []const u8) void {
             if (!app.submission.compaction_pending) return;
+            settle_pending_compaction(app, .{ .outcome = .cancelled });
             app.submission.compaction_pending = false;
+            app.submission.compaction_operation = null;
             debug_trace.logf("input", "manual compaction intent cleared reason={s}", .{reason});
             if (comptime @hasField(App, "auth")) {
                 if (comptime @hasDecl(@TypeOf(app.auth), "cancelPromptCredentialRefresh")) app.auth.cancelPromptCredentialRefresh();
@@ -422,9 +429,6 @@ pub fn SubmitRuntime(comptime App: type) type {
             if (comptime !@hasField(App, "submission")) return false;
             if (app.submission.compaction_pending) {
                 clear_context_compaction(app, "cancelled");
-                app.writeDomainNotice(.{ .topic = "context", .tone = .neutral, .body = "Context compaction cancelled." }, true) catch |err| {
-                    debug_trace.logf("input", "manual compaction cancellation notice failed err={s}", .{@errorName(err)});
-                };
                 app.shell.render_requests.request(.footer);
                 return true;
             }
@@ -622,6 +626,14 @@ pub fn SubmitRuntime(comptime App: type) type {
         }
 
         pub fn submit(app: *App, max_prompt_history: usize) !void {
+            if (comptime @hasField(App, "worker")) {
+                if (comptime @hasDecl(@TypeOf(app.worker), "compactionActivitySnapshot")) {
+                    const observed = app.worker.compactionActivitySnapshot();
+                    if (observed.operation) |op| {
+                        if (app.worker.dismissCompactionActivity(op.id, observed.revision)) app.shell.render_requests.request(.footer);
+                    }
+                }
+            }
             if (comptime @hasField(App, "submission")) {
                 if (app.submission.compaction_pending and !pendingAuthRoutesLocalCommand(app)) return;
                 if (app.submission.pending) |pending| {
@@ -2236,7 +2248,22 @@ const CompactionAdmissionFake = struct {
         busy: bool = false,
         queued: usize = 0,
         status: worker_runtime.ContextCompactionStatus = .idle,
+        activity: compaction_activity.State = .{},
         released_holds: usize = 0,
+
+        pub fn compactionActivitySnapshot(self: *@This()) compaction_activity.Snapshot {
+            return self.activity.snapshot;
+        }
+        pub fn beginCompactionActivity(self: *@This(), origin: compaction_activity.Origin, turn_id: ?u64) compaction_activity.OperationId {
+            return self.activity.begin(origin, turn_id, 0);
+        }
+        pub fn settleCompactionActivity(self: *@This(), id: compaction_activity.OperationId, feedback: compaction_activity.Feedback) void {
+            self.activity.settle(id, feedback, 0);
+        }
+        pub fn rejectCompactionActivity(self: *@This(), outcome: compaction_activity.Outcome) void {
+            const id = self.activity.begin(.manual, null, 0);
+            self.activity.settle(id, .{ .outcome = outcome }, 0);
+        }
         pub fn isProcessing(self: *@This()) bool {
             return self.busy;
         }
@@ -2266,8 +2293,10 @@ const CompactionAdmissionFake = struct {
         if (self.readiness_error) |err| return err;
         return self.readiness;
     }
-    pub fn enqueueContextCompaction(self: *CompactionAdmissionFake) !bool {
+    pub fn enqueueContextCompaction(self: *CompactionAdmissionFake, id: compaction_activity.OperationId) !bool {
         if (self.enqueue_error) |err| return err;
+        std.debug.assert(id == self.submission.compaction_operation.?);
+        self.worker.activity.queued(id, 1, 10);
         self.enqueue_count += 1;
         return true;
     }
@@ -2283,7 +2312,10 @@ test "manual compaction admission waits for authentication and enqueues once" {
     defer app.deinit();
     const Runtime = SubmitRuntime(CompactionAdmissionFake);
     try Runtime.request_context_compaction(&app);
+    const accepted = app.worker.activity.snapshot;
     try Runtime.request_context_compaction(&app);
+    try std.testing.expectEqualDeep(accepted, app.worker.activity.snapshot);
+    try std.testing.expect(accepted.operation.?.phase == .preparing);
     try std.testing.expect(app.submission.compaction_pending);
     try std.testing.expectEqual(@as(usize, 1), app.credential_checks);
     try std.testing.expectEqual(@as(usize, 0), app.enqueue_count);
@@ -2293,6 +2325,9 @@ test "manual compaction admission waits for authentication and enqueues once" {
     try std.testing.expect(!app.submission.compaction_pending);
     try std.testing.expectEqual(@as(usize, 1), app.enqueue_count);
     try std.testing.expectEqual(@as(usize, 0), app.auth.cancelled);
+    try std.testing.expectEqual(accepted.operation.?.id, app.worker.activity.snapshot.operation.?.id);
+    try std.testing.expectEqual(@as(i64, 10), app.worker.activity.snapshot.operation.?.started_at_ms);
+    try std.testing.expectEqual(@as(?u64, 1), app.worker.activity.snapshot.operation.?.turn_id);
 }
 
 test "manual compaction empty and busy admission does not prepare authentication" {
@@ -2310,6 +2345,8 @@ test "manual compaction empty and busy admission does not prepare authentication
         try std.testing.expect(!app.submission.compaction_pending);
         try std.testing.expectEqual(@as(usize, 0), app.credential_checks);
         try std.testing.expectEqual(@as(usize, 0), app.enqueue_count);
+        const feedback = app.worker.activity.snapshot.operation.?.phase.terminal;
+        try std.testing.expectEqual(if (case == 0) compaction_activity.Outcome.no_op else .busy, feedback.outcome);
     }
 }
 
@@ -2333,17 +2370,24 @@ test "manual compaction admission errors stay local and release pending ownershi
         try SubmitRuntime(CompactionAdmissionFake).request_context_compaction(&app);
         try std.testing.expect(!app.submission.compaction_pending);
         try std.testing.expectEqual(@as(usize, 0), app.enqueue_count);
-        try std.testing.expect(std.mem.find(u8, app.notices.items, "Your conversation is unchanged.") != null);
+        try std.testing.expectEqual(@as(usize, 0), app.notices.items.len);
+        const feedback = app.worker.activity.snapshot.operation.?.phase.terminal;
+        try std.testing.expectEqual(compaction_activity.Outcome.failed, feedback.outcome);
+        try std.testing.expectEqual(if (after_readiness) @as(anyerror, error.MissingApiKey) else error.OutOfMemory, feedback.err.?);
     }
 }
 
-test "manual compaction queued work is not reported unstarted after a notice failure" {
+test "manual compaction queued work never produces a transcript notice" {
     var app: CompactionAdmissionFake = .{ .readiness = .current, .notice_error = true };
     defer app.deinit();
     try SubmitRuntime(CompactionAdmissionFake).request_context_compaction(&app);
     try std.testing.expectEqual(@as(usize, 1), app.enqueue_count);
-    try std.testing.expectEqual(@as(usize, 1), app.notice_count);
+    try std.testing.expectEqual(@as(usize, 0), app.notice_count);
     try std.testing.expect(!app.submission.compaction_pending);
+    const accepted = app.worker.activity.snapshot;
+    try SubmitRuntime(CompactionAdmissionFake).request_context_compaction(&app);
+    try std.testing.expectEqualDeep(accepted, app.worker.activity.snapshot);
+    try std.testing.expectEqual(@as(usize, 1), app.enqueue_count);
 }
 
 test "manual compaction cancellation and transition clearing prevent late enqueue" {
@@ -2364,6 +2408,7 @@ test "manual compaction cancellation and transition clearing prevent late enqueu
         try std.testing.expectEqual(@as(usize, 1), app.auth.cancelled);
         try std.testing.expectEqual(@as(usize, 0), app.enqueue_count);
         try std.testing.expectEqual(@as(usize, 0), app.worker.released_holds);
+        try std.testing.expectEqual(compaction_activity.Outcome.cancelled, app.worker.activity.snapshot.operation.?.phase.terminal.outcome);
     }
 }
 

--- a/src/core/auth/auth_runtime.zig
+++ b/src/core/auth/auth_runtime.zig
@@ -1605,7 +1605,10 @@ pub const Runtime = struct {
     secret_store: host.SecretStore = host.unavailable_secret_store,
     auth_mode: credentials.AuthMode = .local,
     selected_credential: ?credentials.Credential = null,
-    credential_failure: ?CredentialFailure = null,
+    credential_failure: ?struct {
+        failure: CredentialFailure,
+        notice_claimed: bool,
+    } = null,
     source_inventory: SourceSet = .empty,
     unavailable_sources: SourceSet = .empty,
     stored_key_status: credentials.StoredKeyReadStatus = .not_attempted,
@@ -1782,24 +1785,28 @@ pub const Runtime = struct {
         return credentials.catalogAccessAt(self.selected_credential, io_mod.milliTimestamp());
     }
 
-    /// Returns true only for the first observation of this failure episode.
-    pub fn recordCredentialFailure(self: *Self, failure: CredentialFailure) bool {
+    /// Records recovery state even when silent. Returns true only when claiming
+    /// the first requested notice of this failure episode.
+    pub fn recordCredentialFailure(
+        self: *Self,
+        failure: CredentialFailure,
+        options: struct { notify: bool = true },
+    ) bool {
         std.debug.assert(self.credentialSource() == failure.source);
-        if (self.credential_failure) |current| {
-            if (current.source == failure.source and
-                current.reason == failure.reason)
-            {
-                return false;
-            }
-        }
-        self.credential_failure = failure;
+        const same_failure = if (self.credential_failure) |current|
+            current.failure.source == failure.source and current.failure.reason == failure.reason
+        else
+            false;
+        if (!same_failure) self.credential_failure = .{ .failure = failure, .notice_claimed = false };
+        if (!options.notify or self.credential_failure.?.notice_claimed) return false;
+        self.credential_failure.?.notice_claimed = true;
         return true;
     }
 
     /// Recovery and catalog access concern only the selected credential.
     pub fn credentialFailure(self: *const Self) ?CredentialFailure {
-        const failure = self.credential_failure orelse return null;
-        return if (self.credentialSource() == failure.source) failure else null;
+        const episode = self.credential_failure orelse return null;
+        return if (self.credentialSource() == episode.failure.source) episode.failure else null;
     }
 
     pub fn credentialSource(self: *const Self) ?credentials.Source {
@@ -1847,8 +1854,8 @@ pub const Runtime = struct {
         const grok_connected = self.source_inventory.contains(.grok_subscription);
         const credential = self.selected_credential orelse return .{
             .required_source = requestedSource(provider, preferred),
-            .failure = if (self.credential_failure) |failure|
-                if (model_provider.authorizesCredential(provider, failure.source)) failure else null
+            .failure = if (self.credential_failure) |episode|
+                if (model_provider.authorizesCredential(provider, episode.failure.source)) episode.failure else null
             else
                 null,
             .stored_key_status = if (provider == .gateway) self.stored_key_status else .not_attempted,
@@ -1894,10 +1901,10 @@ pub const Runtime = struct {
         self.fx_login_status = fx_login_status;
         self.onboarding_skipped = onboarding_skipped;
         if (self.auth_mode == .local and self.selected_credential == null) {
-            self.credential_failure = if (load_failure) |failure|
-                classifyCredentialFailure(failure.source, failure.err)
-            else
-                null;
+            self.credential_failure = if (load_failure) |failure| .{
+                .failure = classifyCredentialFailure(failure.source, failure.err),
+                .notice_claimed = true,
+            } else null;
         }
     }
 
@@ -2032,7 +2039,8 @@ pub const Runtime = struct {
         }
         if (self.credentialSource()) |source| {
             if (source != .host_managed and !inventory.unavailable.contains(source)) self.source_inventory.insert(source);
-        } else if (self.credential_failure) |failure| {
+        } else if (self.credential_failure) |episode| {
+            const failure = episode.failure;
             if (!inventory.available.contains(failure.source) and !inventory.unavailable.contains(failure.source)) {
                 debug_trace.logf("auth", "credential load failure cleared source={t} reason=source_absent", .{failure.source});
                 self.credential_failure = null;
@@ -3304,7 +3312,7 @@ test "catalog access records a refresh failure until another credential is adopt
     _ = runtime.recordCredentialFailure(classifyCredentialFailure(
         .fx_login,
         error.OAuthRequestFailed,
-    ));
+    ), .{});
 
     const failed = runtime.modelCatalogAccess();
     try std.testing.expectEqual(credentials.CatalogPublicOnlyReason.credential_refresh_failed, failed.publicOnlyReason().?);
@@ -3326,17 +3334,29 @@ test "credential failure episodes deduplicate and clear on adoption" {
     _ = runtime.adoptCredential(alloc, &login);
 
     const failure = classifyCredentialFailure(.fx_login, error.InvalidGrant);
-    try std.testing.expect(runtime.recordCredentialFailure(failure));
-    try std.testing.expect(!runtime.recordCredentialFailure(failure));
+    try std.testing.expect(!runtime.recordCredentialFailure(failure, .{ .notify = false }));
+    try std.testing.expectEqual(failure, runtime.credentialFailure().?);
+    runtime.cancelPromptCredentialRefresh();
+    try std.testing.expect(runtime.recordCredentialFailure(failure, .{}));
+    try std.testing.expect(!runtime.recordCredentialFailure(failure, .{ .notify = false }));
+    try std.testing.expect(!runtime.recordCredentialFailure(failure, .{}));
     try std.testing.expectEqual(failure, runtime.credentialFailure().?);
     try std.testing.expectEqual(
         credentials.CatalogPublicOnlyReason.credential_refresh_failed,
         runtime.modelCatalogAccess().publicOnlyReason().?,
     );
 
+    const temporary = classifyCredentialFailure(.fx_login, error.OAuthRequestFailed);
+    try std.testing.expect(!runtime.recordCredentialFailure(temporary, .{ .notify = false }));
+    try std.testing.expectEqual(temporary, runtime.credentialFailure().?);
+    try std.testing.expect(runtime.recordCredentialFailure(temporary, .{}));
+    try std.testing.expect(!runtime.recordCredentialFailure(temporary, .{}));
+
     var refreshed = try makeTestCredential(alloc, "fresh-login-token", .fx_login, null, null);
     _ = runtime.adoptCredential(alloc, &refreshed);
     try std.testing.expect(runtime.credentialFailure() == null);
+    try std.testing.expect(runtime.recordCredentialFailure(temporary, .{}));
+    try std.testing.expect(!runtime.recordCredentialFailure(temporary, .{}));
 }
 
 test "auth runtime adopts credential ownership and prefers team id" {
@@ -3605,7 +3625,7 @@ test "startup status and inventory preserve selected and host-managed failure se
     defer credential.deinit(alloc);
     _ = runtime.adoptCredential(alloc, &credential);
     const failure = classifyCredentialFailure(.fx_login, error.OAuthRequestFailed);
-    _ = runtime.recordCredentialFailure(failure);
+    _ = runtime.recordCredentialFailure(failure, .{});
     runtime.recordStartupStatus(.not_attempted, .not_attempted, .{
         .source = .grok_subscription,
         .err = error.InvalidGrokAuthSession,

--- a/src/core/output/activity_status.zig
+++ b/src/core/output/activity_status.zig
@@ -2,6 +2,85 @@ const std = @import("std");
 const types = @import("../shared/types.zig");
 
 pub const StreamState = types.StreamState;
+const compaction_activity = @import("compaction_activity.zig");
+const ActivityProjection = @import("activity_runtime.zig").ActivityProjection;
+
+/// Selects the display clock without changing the underlying turn or its accounting.
+pub fn compactionClock(stream: StreamState, operation: compaction_activity.Operation) StreamState {
+    return if (operation.origin == .manual)
+        .{ .turn_started_ms = operation.started_at_ms }
+    else
+        stream;
+}
+
+/// Borrows either static feedback or the caller's label buffer.
+pub fn compactionProjection(
+    buf: []u8,
+    snapshot: compaction_activity.Snapshot,
+    stream: StreamState,
+    now_ms: i64,
+) ActivityProjection {
+    const op = snapshot.operation orelse return .none;
+    if (!op.visible(now_ms)) return .none;
+    const label: []const u8 = switch (op.phase) {
+        .preparing => "• Preparing compaction",
+        .running => |stage| if (stage == .preparation) "• Preparing compaction" else "• Compacting",
+        .stopping => "• Stopping compaction",
+        .terminal => |feedback| return .{ .turn_thinking = .{
+            .label = compactionFeedbackLabel(feedback),
+            .tone = switch (feedback.outcome) {
+                .failed => .danger,
+                .busy => .warning,
+                .succeeded, .no_op, .cancelled => .neutral,
+            },
+        } },
+    };
+    var out: std.Io.Writer = .fixed(buf);
+    out.writeAll(label) catch return .{ .turn_thinking = .{ .label = label } };
+    appendTurnElapsedSuffix(&out, compactionClock(stream, op), now_ms) catch {};
+    return .{ .turn_thinking = .{ .label = out.buffered() } };
+}
+
+fn compactionFeedbackLabel(feedback: compaction_activity.Feedback) []const u8 {
+    if (feedback.publication == .uncertain)
+        return "Compaction could not confirm saved context. Reopen the session before retrying.";
+    if (feedback.publication == .committed)
+        return "Compaction saved context, but could not finish. Reopen the session before retrying.";
+    if (feedback.outcome == .failed) {
+        if (feedback.err) |err| {
+            switch (err) {
+                error.CompactionAuthenticationRejected => return "Compaction was not started. Check authentication and try /compact again.",
+                error.ContextCapacityExceeded => return "Context is too large to compact. Choose a model with a larger context window.",
+                else => {},
+            }
+        }
+    }
+    return switch (feedback.outcome) {
+        .succeeded => "",
+        .no_op => "No context to compact.",
+        .busy => "Wait for the active work to finish before compacting context.",
+        .cancelled => "Compaction cancelled. Try /compact again when ready.",
+        .failed => if (feedback.stage == .preparation)
+            "Compaction was not started. Try /compact again."
+        else
+            "Compaction failed. Try /compact again.",
+    };
+}
+
+test "compaction feedback distinguishes authentication and capacity from other setup failures" {
+    try std.testing.expectEqualStrings(
+        "Compaction was not started. Check authentication and try /compact again.",
+        compactionFeedbackLabel(compaction_activity.failure(error.CompactionAuthenticationRejected, .preparation, false)),
+    );
+    try std.testing.expectEqualStrings(
+        "Context is too large to compact. Choose a model with a larger context window.",
+        compactionFeedbackLabel(compaction_activity.failure(error.ContextCapacityExceeded, .preparation, false)),
+    );
+    try std.testing.expectEqualStrings(
+        "Compaction was not started. Try /compact again.",
+        compactionFeedbackLabel(compaction_activity.failure(error.OutOfMemory, .preparation, false)),
+    );
+}
 
 const ActivityPart = struct {
     count: usize,
@@ -205,6 +284,52 @@ pub fn appendTokenProgressSuffix(writer: *std.Io.Writer, progress: types.TurnTok
 
 pub fn appendTurnTokenSuffix(writer: *std.Io.Writer, stream: StreamState) !void {
     try appendTokenProgressSuffix(writer, stream.token_progress);
+}
+
+test "compaction projection preserves turn accounting and selects the origin clock" {
+    var state: compaction_activity.State = .{};
+    const stream: StreamState = .{
+        .active = true,
+        .phase = .running,
+        .last_activity_kind = .read,
+        .turn_started_ms = 1_000,
+        .token_progress = .{ .input_tokens = 100, .output_tokens = 20 },
+    };
+    var buf: [256]u8 = undefined;
+    for ([_]compaction_activity.Origin{ .manual, .automatic, .provider_overflow }) |origin| {
+        const id = state.begin(origin, 1, 3_500);
+        state.running(id, .summary);
+        const projection = compactionProjection(&buf, state.snapshot, stream, 4_000);
+        try std.testing.expectEqualStrings(if (origin == .manual) "• Compacting (0s)" else "• Compacting (3s)", projection.turn_thinking.label);
+        try std.testing.expectEqual(@as(?bool, origin != .manual), activityBlinkVisible(compactionClock(stream, state.snapshot.operation.?), 4_000));
+        state.stopping(id);
+        try std.testing.expect(std.mem.startsWith(u8, compactionProjection(&buf, state.snapshot, stream, 4_000).turn_thinking.label, "• Stopping compaction"));
+        state.settle(id, .{ .outcome = .succeeded }, 4_000);
+        try std.testing.expect(compactionProjection(&buf, state.snapshot, stream, 4_000) == .none);
+    }
+    try std.testing.expectEqual(@as(u64, 100), stream.token_progress.input_tokens);
+    try std.testing.expectEqualStrings("• Running (3s) (↑100 ↓20)", buildTurnLabel(&buf, .{
+        .phase = stream.phase,
+        .turn_started_ms = stream.turn_started_ms,
+        .token_progress = stream.token_progress,
+    }, 4_000).?);
+}
+
+test "compaction terminal feedback is static scoped and publication honest" {
+    var state: compaction_activity.State = .{};
+    var buf: [256]u8 = undefined;
+    const id = state.begin(.manual, null, 1_000);
+    try std.testing.expectEqualStrings("• Preparing compaction (0s)", compactionProjection(&buf, state.snapshot, .{}, 1_000).turn_thinking.label);
+    state.settle(id, .{ .outcome = .failed, .stage = .publication, .publication = .uncertain }, 1_500);
+    const failed = compactionProjection(&buf, state.snapshot, .{}, 9_000).turn_thinking;
+    try std.testing.expectEqual(ActivityProjection.Tone.danger, failed.tone);
+    try std.testing.expectEqualStrings("Compaction could not confirm saved context. Reopen the session before retrying.", failed.label);
+    try std.testing.expect(state.dismiss(id, state.snapshot.revision));
+    try std.testing.expect(compactionProjection(&buf, state.snapshot, .{}, 9_000) == .none);
+    const next = state.begin(.manual, null, 10_000);
+    state.settle(next, .{ .outcome = .no_op }, 10_000);
+    try std.testing.expectEqual(ActivityProjection.Tone.neutral, compactionProjection(&buf, state.snapshot, .{}, 11_499).turn_thinking.tone);
+    try std.testing.expect(compactionProjection(&buf, state.snapshot, .{}, 11_500) == .none);
 }
 
 test "buildTurnLabel returns thinking when no tool activity" {

--- a/src/core/output/compaction_activity.zig
+++ b/src/core/output/compaction_activity.zig
@@ -1,0 +1,206 @@
+const std = @import("std");
+
+/// Process-local identity, distinct from a turn: one turn can compact repeatedly.
+pub const OperationId = enum(u64) { _ };
+pub const Origin = enum { manual, automatic, provider_overflow };
+pub const Stage = enum { preparation, summary, validation, publication };
+pub const Publication = enum { not_published, committed, uncertain };
+pub const Outcome = enum { succeeded, no_op, busy, cancelled, failed };
+
+pub const Feedback = struct {
+    outcome: Outcome,
+    stage: Stage = .preparation,
+    publication: Publication = .not_published,
+    /// Deliberately retains the original erased host/provider error, not text.
+    err: ?anyerror = null,
+};
+
+pub fn failure(err: anyerror, stage: Stage, cancelled: bool) Feedback {
+    return .{
+        .outcome = if (err == error.Cancelled or (cancelled and err == error.Aborted)) .cancelled else .failed,
+        .stage = stage,
+        .publication = if (err == error.SessionPersistenceUncertain) .uncertain else .not_published,
+        .err = err,
+    };
+}
+
+/// Carried only along the error return that actually escaped compaction.
+/// It is not inferred from a previous failed operation or from error text.
+pub const ErrorProvenance = struct {
+    operation_id: OperationId,
+    turn_id: ?u64,
+    err: anyerror,
+};
+
+pub const Phase = union(enum) {
+    preparing,
+    running: Stage,
+    stopping: Stage,
+    terminal: Feedback,
+};
+
+pub const Operation = struct {
+    id: OperationId,
+    turn_id: ?u64,
+    origin: Origin,
+    phase: Phase = .preparing,
+    /// Manual admission resets this when queued; automatic consumers use the turn clock.
+    started_at_ms: i64,
+    expires_at_ms: ?i64 = null,
+    dismissed: bool = false,
+
+    pub fn visible(self: Operation, now_ms: i64) bool {
+        if (self.dismissed) return false;
+        if (self.expires_at_ms) |expiry| if (now_ms >= expiry) return false;
+        return switch (self.phase) {
+            .terminal => |feedback| feedback.outcome != .succeeded,
+            .preparing, .running, .stopping => true,
+        };
+    }
+
+    pub fn active(self: Operation) bool {
+        return self.phase != .terminal;
+    }
+
+    pub fn stage(self: Operation) Stage {
+        return switch (self.phase) {
+            .preparing => .preparation,
+            .running, .stopping => |value| value,
+            .terminal => |feedback| feedback.stage,
+        };
+    }
+};
+
+/// Fixed-size, allocation-free copy. No borrowed mutable storage or permission snapshot.
+pub const Snapshot = struct {
+    revision: u64 = 0,
+    operation: ?Operation = null,
+};
+
+/// Owned exclusively by WorkerRuntime under worker_mutex. Clock inputs are explicit.
+pub const State = struct {
+    snapshot: Snapshot = .{},
+    next_id: u64 = 1,
+
+    pub fn begin(self: *State, origin: Origin, turn_id: ?u64, now_ms: i64) OperationId {
+        const id: OperationId = @enumFromInt(self.next_id);
+        // Neither counter is reused within a worker lifetime.
+        self.next_id += 1;
+        self.snapshot.operation = .{ .id = id, .turn_id = turn_id, .origin = origin, .started_at_ms = now_ms };
+        self.snapshot.revision += 1;
+        return id;
+    }
+
+    pub fn queued(self: *State, id: OperationId, turn_id: u64, now_ms: i64) void {
+        const op = self.match(id) orelse return;
+        if (!op.active()) return;
+        op.turn_id = turn_id;
+        op.started_at_ms = now_ms;
+        self.snapshot.revision += 1;
+    }
+
+    pub fn running(self: *State, id: OperationId, stage: Stage) void {
+        const op = self.match(id) orelse return;
+        if (!op.active()) return;
+        const next: Phase = if (op.phase == .stopping) .{ .stopping = stage } else .{ .running = stage };
+        if (std.meta.eql(op.phase, next)) return;
+        op.phase = next;
+        self.snapshot.revision += 1;
+    }
+
+    pub fn stopping(self: *State, id: OperationId) void {
+        const op = self.match(id) orelse return;
+        if (!op.active() or op.phase == .stopping) return;
+        op.phase = .{ .stopping = op.stage() };
+        self.snapshot.revision += 1;
+    }
+
+    pub fn settle(self: *State, id: OperationId, feedback: Feedback, now_ms: i64) void {
+        const op = self.match(id) orelse return;
+        if (!op.active()) return;
+        op.phase = .{ .terminal = feedback };
+        op.expires_at_ms = switch (feedback.outcome) {
+            .no_op, .busy => now_ms +| 1500,
+            .succeeded, .cancelled, .failed => null,
+        };
+        self.snapshot.revision += 1;
+    }
+
+    /// Dismisses only the terminal feedback observed by the caller, never newer work.
+    pub fn dismiss(self: *State, id: OperationId, revision: u64) bool {
+        if (revision != self.snapshot.revision) return false;
+        const op = self.match(id) orelse return false;
+        if (op.active() or op.dismissed) return false;
+        op.dismissed = true;
+        self.snapshot.revision += 1;
+        return true;
+    }
+
+    pub fn expire(self: *State, id: OperationId, revision: u64, now_ms: i64) bool {
+        const op = self.match(id) orelse return false;
+        const expiry = op.expires_at_ms orelse return false;
+        if (now_ms < expiry) return false;
+        return self.dismiss(id, revision);
+    }
+
+    fn match(self: *State, id: OperationId) ?*Operation {
+        const op = if (self.snapshot.operation) |*value| value else return null;
+        return if (op.id == id) op else null;
+    }
+};
+
+test "compaction activity is bounded and rejects stale updates and dismissals" {
+    try std.testing.expect(@sizeOf(State) <= 128);
+    var state: State = .{};
+    const manual = state.begin(.manual, null, 10);
+    state.queued(manual, 7, 20);
+    state.running(manual, .summary);
+    state.settle(manual, .{ .outcome = .succeeded, .publication = .committed }, 30);
+    const settled = state.snapshot;
+    state.settle(manual, failure(error.Cancelled, .summary, true), 40);
+    try std.testing.expectEqualDeep(settled, state.snapshot);
+    const auto = state.begin(.automatic, 7, 50);
+    const overflow = state.begin(.provider_overflow, 7, 60);
+    try std.testing.expect(manual != auto and auto != overflow);
+    try std.testing.expect(state.snapshot.revision > settled.revision);
+    state.settle(auto, failure(error.InvalidCompactionHandoff, .validation, false), 70);
+    try std.testing.expect(!state.dismiss(manual, settled.revision));
+    try std.testing.expectEqual(overflow, state.snapshot.operation.?.id);
+    state.stopping(overflow);
+    state.running(overflow, .publication);
+    try std.testing.expect(state.snapshot.operation.?.phase == .stopping);
+    state.settle(overflow, .{ .outcome = .succeeded, .publication = .committed }, 80);
+    try std.testing.expect(!state.snapshot.operation.?.visible(80));
+}
+
+test "compaction activity transient expiry and persistent feedback are identity scoped" {
+    var state: State = .{};
+    for ([_]Outcome{ .no_op, .busy }) |outcome| {
+        const id = state.begin(.manual, null, 0);
+        state.settle(id, .{ .outcome = outcome }, 100);
+        const revision = state.snapshot.revision;
+        try std.testing.expect(state.snapshot.operation.?.visible(1599));
+        try std.testing.expect(!state.expire(id, revision, 1599));
+        try std.testing.expect(state.expire(id, revision, 1600));
+        try std.testing.expect(!state.snapshot.operation.?.visible(1600));
+    }
+    for ([_]Outcome{ .failed, .cancelled }) |outcome| {
+        const id = state.begin(.manual, null, 0);
+        state.settle(id, .{ .outcome = outcome }, 1);
+        try std.testing.expect(state.snapshot.operation.?.visible(1_000_000));
+        try std.testing.expect(!state.expire(id, state.snapshot.revision, 1_000_000));
+        try std.testing.expect(state.dismiss(id, state.snapshot.revision));
+    }
+}
+
+test "compaction activity failure retains error and publication provenance" {
+    const uncertain = failure(error.SessionPersistenceUncertain, .publication, true);
+    try std.testing.expectEqual(Outcome.failed, uncertain.outcome);
+    try std.testing.expectEqual(Publication.uncertain, uncertain.publication);
+    try std.testing.expectEqual(error.SessionPersistenceUncertain, uncertain.err.?);
+    // A cooperative host can cancel transport before queued input sets the worker flag.
+    try std.testing.expectEqual(Outcome.cancelled, failure(error.Cancelled, .summary, false).outcome);
+    try std.testing.expectEqual(Outcome.cancelled, failure(error.Aborted, .publication, true).outcome);
+    try std.testing.expectEqual(Outcome.failed, failure(error.Aborted, .publication, false).outcome);
+    try std.testing.expectEqual(Outcome.failed, failure(error.ConnectionTimedOut, .summary, true).outcome);
+}

--- a/src/core/session/session_codec.zig
+++ b/src/core/session/session_codec.zig
@@ -584,6 +584,9 @@ pub fn writeHistoryTurn(writer: *std.Io.Writer, turn: session.HistoryTurn) !void
             try writer.writeByte(']');
             try writer.writeAll(",\"terminal_reason\":");
             try writeJsonString(writer, @tagName(entry.terminal_reason));
+            if (entry.cancellation_origin == .compaction) {
+                try writer.writeAll(",\"cancellation_origin\":\"compaction\"");
+            }
             if (hasDurableExecutionMemory(entry.execution)) {
                 try writer.writeAll(",\"execution\":");
                 try writeExecutionMemory(writer, entry.execution);
@@ -733,11 +736,13 @@ pub fn parseHistoryTurn(alloc: Allocator, value: std.json.Value) !session.Histor
         const has_execution = source.get("execution") != null;
         const has_presentation = source.get("cancelled_command") != null;
         const has_terminal_reason = source.get("terminal_reason") != null;
+        const has_cancellation_origin = source.get("cancellation_origin") != null;
         const object = try exactInterruptedHistoryObject(
             value,
             has_execution,
             has_presentation,
             has_terminal_reason,
+            has_cancellation_origin,
         );
         const user = try parseUserTurn(alloc, object.get("user") orelse return error.InvalidSessionFormat);
         errdefer session.freeUserTurn(alloc, user);
@@ -754,6 +759,11 @@ pub fn parseHistoryTurn(alloc: Allocator, value: std.json.Value) !session.Histor
             try parseInterruptedTerminalReason(object, "terminal_reason")
         else
             types.InterruptedTerminalReason.cancelled;
+        const cancellation_origin: types.CancellationOrigin = if (has_cancellation_origin)
+            std.meta.stringToEnum(types.CancellationOrigin, try requireString(object, "cancellation_origin")) orelse
+                return error.InvalidSessionFormat
+        else
+            .turn;
         const execution = if (has_execution)
             try parseExecutionMemory(alloc, object.get("execution") orelse return error.InvalidSessionFormat)
         else
@@ -784,6 +794,7 @@ pub fn parseHistoryTurn(alloc: Allocator, value: std.json.Value) !session.Histor
             .execution = execution,
             .cancelled_command = cancelled_command,
             .terminal_reason = terminal_reason,
+            .cancellation_origin = cancellation_origin,
         } };
     }
     return error.InvalidSessionFormat;
@@ -2828,8 +2839,9 @@ fn exactInterruptedHistoryObject(
     has_execution: bool,
     has_presentation: bool,
     has_terminal_reason: bool,
+    has_cancellation_origin: bool,
 ) !std.json.ObjectMap {
-    var keys: [8][]const u8 = undefined;
+    var keys: [9][]const u8 = undefined;
     keys[0] = "kind";
     keys[1] = "user";
     keys[2] = "assistant";
@@ -2846,6 +2858,10 @@ fn exactInterruptedHistoryObject(
     }
     if (has_terminal_reason) {
         keys[len] = "terminal_reason";
+        len += 1;
+    }
+    if (has_cancellation_origin) {
+        keys[len] = "cancellation_origin";
         len += 1;
     }
     return exactObject(value, keys[0..len]);
@@ -3723,6 +3739,78 @@ test "terminal action presentation codec preserves return and failure causes" {
             case,
             (try parseOptionalTerminalActionPresentation(parsed.value)).?,
         );
+    }
+}
+
+test "durable cancellation provenance defaults old records and preserves ordinary bytes" {
+    const alloc = std.testing.allocator;
+    const old = "{\"kind\":\"interrupted\",\"user\":{\"text\":\"request\",\"images\":[]},\"assistant\":\"partial\",\"tool_call\":null,\"completed_tool_names\":[]}";
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, old, .{});
+    defer parsed.deinit();
+    const turn = try parseHistoryTurn(alloc, parsed.value);
+    defer session.freeHistoryTurn(alloc, turn);
+    try std.testing.expectEqual(types.CancellationOrigin.turn, turn.interrupted.cancellation_origin);
+    try std.testing.expectEqual(types.InterruptedTerminalReason.cancelled, turn.interrupted.terminal_reason);
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    defer out.deinit();
+    try writeHistoryTurn(&out.writer, turn);
+    try std.testing.expectEqualStrings(old[0 .. old.len - 1] ++ ",\"terminal_reason\":\"cancelled\"}", out.written());
+}
+
+test "durable cancellation provenance roundtrips and cleans allocation failures" {
+    const Case = struct {
+        fn run(alloc: Allocator, origin: types.CancellationOrigin, reason: types.InterruptedTerminalReason) !void {
+            const turn: session.HistoryTurn = .{ .interrupted = .{
+                .user = .{ .text = @constCast("request") },
+                .assistant = @constCast("partial"),
+                .terminal_reason = reason,
+                .cancellation_origin = origin,
+            } };
+            const copy = try session.dupeHistoryTurn(alloc, turn);
+            defer session.freeHistoryTurn(alloc, copy);
+            var out: std.Io.Writer.Allocating = .init(alloc);
+            defer out.deinit();
+            // This in-memory writer reports injected allocation failure as WriteFailed.
+            writeHistoryTurn(&out.writer, copy) catch |err|
+                return if (err == error.WriteFailed) error.OutOfMemory else err;
+            try std.testing.expectEqual(origin == .compaction, std.mem.find(u8, out.written(), "\"cancellation_origin\"") != null);
+            var parsed = try std.json.parseFromSlice(std.json.Value, alloc, out.written(), .{});
+            defer parsed.deinit();
+            const decoded = try parseHistoryTurn(alloc, parsed.value);
+            defer session.freeHistoryTurn(alloc, decoded);
+            try std.testing.expectEqual(origin, decoded.interrupted.cancellation_origin);
+            try std.testing.expectEqual(reason, decoded.interrupted.terminal_reason);
+            try std.testing.expectEqualStrings("request", decoded.interrupted.user.text);
+            try std.testing.expectEqualStrings("partial", decoded.interrupted.assistant.?);
+            var again: std.Io.Writer.Allocating = .init(alloc);
+            defer again.deinit();
+            writeHistoryTurn(&again.writer, decoded) catch |err|
+                return if (err == error.WriteFailed) error.OutOfMemory else err;
+            try std.testing.expectEqualStrings(out.written(), again.written());
+        }
+    };
+    for (std.enums.values(types.CancellationOrigin)) |origin| {
+        for (std.enums.values(types.InterruptedTerminalReason)) |reason| {
+            try std.testing.checkAllAllocationFailures(std.testing.allocator, Case.run, .{ origin, reason });
+        }
+    }
+}
+
+test "durable cancellation provenance accepts explicit turn and rejects invalid or unknown fields" {
+    const alloc = std.testing.allocator;
+    const prefix = "{\"kind\":\"interrupted\",\"user\":{\"text\":\"request\",\"images\":[]},\"assistant\":\"partial\",\"tool_call\":null,\"completed_tool_names\":[\"read_file\"],\"cancellation_origin\":";
+    for ([_][]const u8{ "\"turn\"", "\"compaction\"", "\"unknown\"", "null", "0", "true", "{}", "[]", "\"compaction\",\"unknown_field\":true" }, 0..) |value, i| {
+        const bytes = try std.fmt.allocPrint(alloc, "{s}{s}}}", .{ prefix, value });
+        defer alloc.free(bytes);
+        var parsed = try std.json.parseFromSlice(std.json.Value, alloc, bytes, .{});
+        defer parsed.deinit();
+        if (i < 2) {
+            const turn = try parseHistoryTurn(alloc, parsed.value);
+            defer session.freeHistoryTurn(alloc, turn);
+            try std.testing.expectEqual(if (i == 0) types.CancellationOrigin.turn else .compaction, turn.interrupted.cancellation_origin);
+        } else {
+            try std.testing.expectError(error.InvalidSessionFormat, parseHistoryTurn(alloc, parsed.value));
+        }
     }
 }
 

--- a/src/core/session/session_event.zig
+++ b/src/core/session/session_event.zig
@@ -82,6 +82,60 @@ pub const ConversationInterruption = struct {
     command_artifact_ref: ?[]const u8 = null,
     files: []const types.FileEvidence = &.{},
     turn_summary: ?types.TurnSummary = null,
+    cancellation_origin: types.CancellationOrigin = .turn,
+
+    pub fn jsonParse(alloc: Allocator, source: anytype, options: std.json.ParseOptions) !ConversationInterruption {
+        const Wire = struct {
+            reason: session.InterruptedTerminalReason,
+            partial_text: ?[]const u8 = null,
+            command_replay_ref: ?[]const u8 = null,
+            command_replay_bytes: ?u64 = null,
+            command_artifact_ref: ?[]const u8 = null,
+            files: []const types.FileEvidence = &.{},
+            turn_summary: ?types.TurnSummary = null,
+            cancellation_origin: std.json.Value = .{ .string = "turn" },
+        };
+        const wire = try std.json.innerParse(Wire, alloc, source, options);
+        // The default enum decoder also accepts numeric tags, not just names.
+        if (wire.cancellation_origin != .string) return error.UnexpectedToken;
+        const origin = std.meta.stringToEnum(types.CancellationOrigin, wire.cancellation_origin.string) orelse
+            return error.InvalidEnumTag;
+        return .{
+            .reason = wire.reason,
+            .partial_text = wire.partial_text,
+            .command_replay_ref = wire.command_replay_ref,
+            .command_replay_bytes = wire.command_replay_bytes,
+            .command_artifact_ref = wire.command_artifact_ref,
+            .files = wire.files,
+            .turn_summary = wire.turn_summary,
+            .cancellation_origin = origin,
+        };
+    }
+
+    // Keep ordinary record bytes unchanged. Older strict readers reject the
+    // optional compaction origin; they cannot safely replay those records.
+    pub fn jsonStringify(self: ConversationInterruption, writer: *std.json.Stringify) !void {
+        try writer.beginObject();
+        try writer.objectField("reason");
+        try writer.write(self.reason);
+        try writer.objectField("partial_text");
+        try writer.write(self.partial_text);
+        try writer.objectField("command_replay_ref");
+        try writer.write(self.command_replay_ref);
+        try writer.objectField("command_replay_bytes");
+        try writer.write(self.command_replay_bytes);
+        try writer.objectField("command_artifact_ref");
+        try writer.write(self.command_artifact_ref);
+        try writer.objectField("files");
+        try writer.write(self.files);
+        try writer.objectField("turn_summary");
+        try writer.write(self.turn_summary);
+        if (self.cancellation_origin == .compaction) {
+            try writer.objectField("cancellation_origin");
+            try writer.write(self.cancellation_origin);
+        }
+        try writer.endObject();
+    }
 };
 
 pub const ConversationTurnCompleted = struct {
@@ -441,6 +495,7 @@ pub fn appendHistoryTurnConversationEvents(
             }
             try events.append(alloc, .{ .interrupted = .{
                 .reason = entry.terminal_reason,
+                .cancellation_origin = entry.cancellation_origin,
                 .partial_text = entry.assistant,
                 .command_replay_ref = interruptedCommandReplayRef(entry),
                 .command_replay_bytes = interruptedCommandReplayBytes(entry),
@@ -3268,6 +3323,146 @@ test "conversation transition validates sequence tool identity and checkpoint sa
         .timestamp_ms = 10,
         .event = .{ .assistant = .{ .text = "skipped sequence" } },
     }));
+}
+
+test "conversation cancellation provenance preserves ordinary frame bytes" {
+    const alloc = std.testing.allocator;
+    const encoded = try encodeConversationFrame(alloc, .{
+        .seq = 1,
+        .timestamp_ms = 1,
+        .event = .{ .interrupted = .{ .reason = .cancelled } },
+    });
+    defer alloc.free(encoded);
+    try std.testing.expectEqualStrings(
+        "{\"schema_version\":2,\"seq\":1,\"timestamp_ms\":1,\"event\":{\"interrupted\":{\"reason\":\"cancelled\",\"partial_text\":null,\"command_replay_ref\":null,\"command_replay_bytes\":null,\"command_artifact_ref\":null,\"files\":[],\"turn_summary\":null}}}\n",
+        encoded,
+    );
+    for ([_]u8{ 1, 2 }) |version| {
+        for (std.enums.values(session.InterruptedTerminalReason)) |reason| {
+            const old = try std.fmt.allocPrint(alloc, "{{\"schema_version\":{d},\"seq\":1,\"timestamp_ms\":1,\"event\":{{\"interrupted\":{{\"reason\":\"{s}\"}}}}}}\n", .{ version, @tagName(reason) });
+            defer alloc.free(old);
+            var decoded = try decodeConversationFrame(alloc, old);
+            defer decoded.deinit();
+            try std.testing.expectEqual(types.CancellationOrigin.turn, decoded.value.event.interrupted.cancellation_origin);
+            try std.testing.expectEqual(reason, decoded.value.event.interrupted.reason);
+            try validateConversationTransition(.{}, decoded.value);
+        }
+    }
+}
+
+test "conversation cancellation provenance roundtrips history projection with owned strings" {
+    const Case = struct {
+        fn run(alloc: Allocator, origin: types.CancellationOrigin) !void {
+            const turn: types.HistoryTurn = .{ .interrupted = .{
+                .user = .{ .text = @constCast("request") },
+                .assistant = @constCast("partial"),
+                .cancellation_origin = origin,
+            } };
+            const copy = try session.dupeHistoryTurn(alloc, turn);
+            defer session.freeHistoryTurn(alloc, copy);
+            var events: std.ArrayList(ConversationEvent) = .empty;
+            defer events.deinit(alloc);
+            try appendHistoryTurnConversationEvents(alloc, &events, copy);
+            try std.testing.expectEqual(@as(usize, 2), events.items.len);
+            try std.testing.expectEqual(origin, events.items[1].interrupted.cancellation_origin);
+            // This in-memory writer reports injected allocation failure as WriteFailed.
+            const encoded = encodeConversationFrame(alloc, .{ .seq = 2, .timestamp_ms = 1, .event = events.items[1] }) catch |err|
+                return if (err == error.WriteFailed) error.OutOfMemory else err;
+            defer alloc.free(encoded);
+            try std.testing.expectEqual(origin == .compaction, std.mem.find(u8, encoded, "\"cancellation_origin\"") != null);
+            var decoded = try decodeConversationFrame(alloc, encoded);
+            defer decoded.deinit();
+            try std.testing.expectEqual(origin, decoded.value.event.interrupted.cancellation_origin);
+            try std.testing.expectEqual(session.InterruptedTerminalReason.cancelled, decoded.value.event.interrupted.reason);
+            try std.testing.expectEqualStrings("partial", decoded.value.event.interrupted.partial_text.?);
+            try validateConversationTransition(.{ .last_seq = 1 }, decoded.value);
+            const again = encodeConversationFrame(alloc, decoded.value) catch |err|
+                return if (err == error.WriteFailed) error.OutOfMemory else err;
+            defer alloc.free(again);
+            try std.testing.expectEqualStrings(encoded, again);
+        }
+    };
+    for (std.enums.values(types.CancellationOrigin)) |origin| {
+        try std.testing.checkAllAllocationFailures(std.testing.allocator, Case.run, .{origin});
+    }
+}
+
+test "conversation cancellation provenance rejects invalid values and retains strict unknown fields" {
+    const alloc = std.testing.allocator;
+    for ([_][]const u8{ "\"turn\"", "\"compaction\"", "\"unknown\"", "null", "1", "true", "[]", "{}", "\"compaction\",\"future_field\":true" }, 0..) |origin, i| {
+        const bytes = try std.fmt.allocPrint(alloc, "{{\"schema_version\":2,\"seq\":1,\"timestamp_ms\":1,\"event\":{{\"interrupted\":{{\"reason\":\"cancelled\",\"partial_text\":\"partial\",\"cancellation_origin\":{s}}}}}}}\n", .{origin});
+        defer alloc.free(bytes);
+        if (i < 2) {
+            var decoded = try decodeConversationFrame(alloc, bytes);
+            defer decoded.deinit();
+            try std.testing.expectEqual(if (i == 0) types.CancellationOrigin.turn else .compaction, decoded.value.event.interrupted.cancellation_origin);
+        } else {
+            try std.testing.expectError(error.InvalidConversationFrame, decodeConversationFrame(alloc, bytes));
+        }
+    }
+}
+
+test "journal cancellation provenance survives reduction and durable checkpoint reload" {
+    const projection = @import("session_projection.zig");
+    const alloc = std.testing.allocator;
+    for (std.enums.values(types.CancellationOrigin)) |origin| {
+        var jsonl: std.Io.Writer.Allocating = .init(alloc);
+        defer jsonl.deinit();
+        const started = try encodeLegacyFixtureFrame(alloc, .{
+            .log_generation = identifier(1),
+            .seq = 1,
+            .event_id = identifier(2),
+            .timestamp_ms = 1,
+            .event = .{ .session_started = .{
+                .id = @constCast("provenance"),
+                .created_at_ms = 1,
+                .origin_workspace_root = @constCast("/tmp/workspace"),
+                .workspace_root = @constCast("/tmp/workspace"),
+                .conversation_language = .literal("en"),
+                .preferences = .{ .model = @constCast("test/model"), .effort = .auto, .fast_mode = false },
+            } },
+        });
+        defer alloc.free(started);
+        const committed = try encodeLegacyFixtureFrame(alloc, .{
+            .log_generation = identifier(1),
+            .seq = 2,
+            .event_id = identifier(3),
+            .timestamp_ms = 2,
+            .event = .{ .history_turn_committed = .{
+                .conversation_language = .literal("en"),
+                .total_input_tokens = 0,
+                .total_output_tokens = 0,
+                .turn = .{ .interrupted = .{
+                    .user = .{ .text = @constCast("request") },
+                    .assistant = @constCast("partial"),
+                    .cancellation_origin = origin,
+                } },
+            } },
+        });
+        defer alloc.free(committed);
+        try jsonl.writer.writeAll(started);
+        try jsonl.writer.writeAll(committed);
+        var source = std.Io.Reader.fixed(jsonl.written());
+        var reduced = try reduceJsonl(alloc, &source, null);
+        defer reduced.deinit(alloc);
+        try std.testing.expectEqual(origin, reduced.state.history[0].interrupted.cancellation_origin);
+        var duplicate = try reduced.state.dupe(alloc);
+        defer duplicate.deinit(alloc);
+        const checkpoint = try projection.encodeCheckpoint(alloc, .{
+            .session_id = duplicate.id,
+            .log_generation = identifier(1),
+            .through_seq = 2,
+            .through_event_id = identifier(3),
+            .through_event_log_bytes = jsonl.written().len,
+            .state = duplicate,
+        });
+        defer alloc.free(checkpoint);
+        var restored = try projection.decodeCheckpoint(alloc, checkpoint);
+        defer restored.deinit(alloc);
+        try std.testing.expectEqual(origin, restored.state.history[0].interrupted.cancellation_origin);
+        try std.testing.expectEqual(session.InterruptedTerminalReason.cancelled, restored.state.history[0].interrupted.terminal_reason);
+        try std.testing.expectEqualStrings("partial", restored.state.history[0].interrupted.assistant.?);
+    }
 }
 
 test "conversation frame round trips an external tool result reference" {

--- a/src/core/session/session_json.zig
+++ b/src/core/session/session_json.zig
@@ -114,6 +114,9 @@ fn writeHistoryTurnJson(writer: *std.Io.Writer, turn: session.HistoryTurn) !void
             try writeStringArrayJson(writer, entry.completed_tool_names);
             try writer.writeAll(",\"terminal_reason\":");
             try std.json.Stringify.value(@tagName(entry.terminal_reason), .{}, writer);
+            if (entry.cancellation_origin == .compaction) {
+                try writer.writeAll(",\"cancellation_origin\":\"compaction\"");
+            }
             if (!entry.execution.isEmpty()) {
                 try writer.writeAll(",\"execution\":");
                 try writeExecutionMemoryJson(writer, entry.execution);
@@ -704,6 +707,11 @@ fn parseLegacyHistoryTurn(alloc: Allocator, value: std.json.Value) !session.Hist
         const completed_tool_names = try parseOptionalStringArray(alloc, object.get("completed_tool_names"));
         errdefer session.freeCompletedToolNames(alloc, completed_tool_names);
         const terminal_reason = try parseLegacyInterruptedTerminalReason(object.get("terminal_reason"));
+        const cancellation_origin: types.CancellationOrigin = if (object.get("cancellation_origin")) |origin| blk: {
+            if (origin != .string) return error.InvalidSessionFormat;
+            break :blk std.meta.stringToEnum(types.CancellationOrigin, origin.string) orelse
+                return error.InvalidSessionFormat;
+        } else .turn;
         const execution = try parseOptionalExecutionMemory(alloc, object.get("execution"));
         return .{ .interrupted = .{
             .user = user,
@@ -712,6 +720,7 @@ fn parseLegacyHistoryTurn(alloc: Allocator, value: std.json.Value) !session.Hist
             .completed_tool_names = completed_tool_names,
             .execution = execution,
             .terminal_reason = terminal_reason,
+            .cancellation_origin = cancellation_origin,
         } };
     }
 
@@ -1789,6 +1798,52 @@ test "non-object legacy interrupted repair cleans every allocation failure" {
     , .{});
     defer parsed.deinit();
     try std.testing.checkAllAllocationFailures(alloc, checkNonObjectLegacyInterruptedAllocationFailures, .{parsed.value});
+}
+
+test "legacy cancellation provenance reads old sessions and roundtrips optional origin" {
+    const Case = struct {
+        fn run(alloc: Allocator, origin_field: []const u8, expected: types.CancellationOrigin) !void {
+            const json = try std.fmt.allocPrint(
+                alloc,
+                "{{\"schema_version\":1,\"id\":\"old\",\"created_at_ms\":1,\"updated_at_ms\":2," ++
+                    "\"workspace_root\":\"/tmp/workspace\",\"conversation_language\":\"en\",\"history_len\":1,\"history\":[" ++
+                    "{{\"kind\":\"interrupted\",\"user\":{{\"text\":\"request\",\"images\":[]}},\"assistant\":\"partial\"{s}}}]}}",
+                .{origin_field},
+            );
+            defer alloc.free(json);
+            var loaded = try parseStoredSession(TestStoredSession, alloc, json);
+            defer loaded.deinit(alloc);
+            try std.testing.expectEqual(expected, loaded.history[0].interrupted.cancellation_origin);
+            try std.testing.expectEqual(types.InterruptedTerminalReason.cancelled, loaded.history[0].interrupted.terminal_reason);
+            // This in-memory writer reports injected allocation failure as WriteFailed.
+            const encoded = renderSessionJson(alloc, loaded.id, loaded.created_at_ms, loaded.updated_at_ms, loaded.conversation_language, loaded.workspace_root.?, loaded.history, .{}) catch |err|
+                return if (err == error.WriteFailed) error.OutOfMemory else err;
+            defer alloc.free(encoded);
+            try std.testing.expectEqual(expected == .compaction, std.mem.find(u8, encoded, "\"cancellation_origin\"") != null);
+            var reloaded = try parseStoredSession(TestStoredSession, alloc, encoded);
+            defer reloaded.deinit(alloc);
+            try std.testing.expectEqual(expected, reloaded.history[0].interrupted.cancellation_origin);
+            try std.testing.expectEqualStrings("partial", reloaded.history[0].interrupted.assistant.?);
+        }
+    };
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, Case.run, .{ "", types.CancellationOrigin.turn });
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, Case.run, .{ ",\"cancellation_origin\":\"turn\"", types.CancellationOrigin.turn });
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, Case.run, .{ ",\"cancellation_origin\":\"compaction\"", types.CancellationOrigin.compaction });
+}
+
+test "legacy cancellation provenance rejects invalid values after owned fields" {
+    const alloc = std.testing.allocator;
+    for ([_][]const u8{ "\"unknown\"", "null", "1", "false", "[]", "{}" }) |origin| {
+        const json = try std.fmt.allocPrint(
+            alloc,
+            "{{\"kind\":\"interrupted\",\"user\":{{\"text\":\"request\",\"images\":[]}},\"assistant\":\"partial\",\"completed_tool_names\":[\"read_file\"],\"cancellation_origin\":{s}}}",
+            .{origin},
+        );
+        defer alloc.free(json);
+        var parsed = try std.json.parseFromSlice(std.json.Value, alloc, json, .{});
+        defer parsed.deinit();
+        try std.testing.expectError(error.InvalidSessionFormat, parseLegacyHistoryTurn(alloc, parsed.value));
+    }
 }
 
 test "old assistant session JSON without execution parses as empty memory" {

--- a/src/core/session/session_log.zig
+++ b/src/core/session/session_log.zig
@@ -1927,6 +1927,7 @@ const ConversationTurnBuilder = struct {
             .execution = execution,
             .cancelled_command = cancelled_command,
             .terminal_reason = value.reason,
+            .cancellation_origin = value.cancellation_origin,
         } };
     }
 
@@ -4878,6 +4879,64 @@ test "cache-free conversation session resumes from metadata and JSONL" {
     try std.testing.expectEqual(@as(usize, 1), resumed.history.len);
     try std.testing.expectEqualStrings("question", resumed.history[0].assistant.user.text);
     try std.testing.expectEqualStrings("answer", resumed.history[0].assistant.assistant);
+}
+
+test "conversation cancellation provenance survives checkpoint resume range and archive replay" {
+    const alloc = std.testing.allocator;
+    for (std.enums.values(types.CancellationOrigin)) |origin| {
+        for ([_]bool{ false, true }) |checkpoint| {
+            var temp = try TempRoot.init(alloc);
+            defer temp.deinit(alloc);
+            var initial = try testState(alloc, "cancellation-provenance", 10);
+            defer initial.deinit(alloc);
+            var steps = [_]types.ToolExecutionStep{.{ .assistant = @constCast("earlier reply") }};
+            const user: types.UserTurn = .{ .text = @constCast("request") };
+            {
+                var loaded = try temp.root.startConversationSession(alloc, initial, .{});
+                defer loaded.deinit(alloc);
+                if (checkpoint) {
+                    _ = try loaded.commitContextCompaction(alloc, .{
+                        .summary = @constCast("Earlier context."),
+                        .removed_turn_count = 0,
+                        .compaction_count = 1,
+                    }, .{
+                        .user = user,
+                        .assistant = @constCast(""),
+                        .execution = .{ .tool_steps = &steps },
+                    }, .{ .tool_steps = 1 }, 20);
+                }
+                _ = try loaded.appendEvent(alloc, .{ .history_turn_committed = .{
+                    .conversation_language = .literal("en"),
+                    .total_input_tokens = 1,
+                    .total_output_tokens = 1,
+                    .turn = .{ .interrupted = .{
+                        .user = user,
+                        .assistant = @constCast("partial reply"),
+                        .execution = .{ .tool_steps = if (checkpoint) &.{} else &steps },
+                        .cancellation_origin = origin,
+                    } },
+                } }, 30);
+            }
+            var resumed = try temp.root.resumeForWrite(alloc, initial.id, .{});
+            defer resumed.deinit(alloc);
+            try std.testing.expectEqual(@as(usize, if (checkpoint) 2 else 1), resumed.state.history.len);
+            const active = resumed.state.history[if (checkpoint) 1 else 0].interrupted;
+            try std.testing.expectEqual(origin, active.cancellation_origin);
+            try std.testing.expectEqual(types.InterruptedTerminalReason.cancelled, active.terminal_reason);
+            try std.testing.expectEqualStrings("partial reply", active.assistant.?);
+            const range = try loadConversationHistoryRange(alloc, &resumed.log.dir, 0, 1);
+            defer session.freeHistoryTurnSlice(alloc, range);
+            try std.testing.expectEqual(@as(usize, 1), range.len);
+            try std.testing.expectEqual(origin, range[0].interrupted.cancellation_origin);
+            try std.testing.expectEqualStrings("earlier reply", range[0].interrupted.execution.tool_steps[0].assistant.?);
+            const archive = try loadConversationArchive(alloc, &resumed.log.dir);
+            defer session.freeHistoryTurnSlice(alloc, archive);
+            try std.testing.expectEqual(origin, archive[archive.len - 1].interrupted.cancellation_origin);
+            var readonly = try temp.root.loadReadOnly(alloc, initial.id, .{});
+            defer readonly.deinit(alloc);
+            try std.testing.expectEqual(origin, readonly.history[readonly.history.len - 1].interrupted.cancellation_origin);
+        }
+    }
 }
 
 test "conversation preserves standalone replies across completion and interruption" {

--- a/src/core/shared/types.zig
+++ b/src/core/shared/types.zig
@@ -1865,6 +1865,11 @@ pub const InterruptedTerminalReason = enum {
     failed,
 };
 
+pub const CancellationOrigin = enum {
+    turn,
+    compaction,
+};
+
 pub const InterruptedHistoryTurn = struct {
     user: UserTurn,
     assistant: ?[]u8 = null,
@@ -1873,6 +1878,7 @@ pub const InterruptedHistoryTurn = struct {
     execution: ExecutionMemory = .{},
     cancelled_command: ?CancelledCommandPresentation = null,
     terminal_reason: InterruptedTerminalReason = .cancelled,
+    cancellation_origin: CancellationOrigin = .turn,
 };
 
 pub const context_handoff_open = "<context_handoff>";
@@ -2283,6 +2289,7 @@ pub fn dupeHistoryTurn(alloc: std.mem.Allocator, turn: HistoryTurn) !HistoryTurn
                 .execution = execution,
                 .cancelled_command = cancelled_command,
                 .terminal_reason = entry.terminal_reason,
+                .cancellation_origin = entry.cancellation_origin,
             } };
         },
     };

--- a/src/main.zig
+++ b/src/main.zig
@@ -1483,7 +1483,7 @@ const App = struct {
         try InputSubmitRuntime.request_context_compaction(self);
     }
 
-    pub fn enqueueContextCompaction(self: *App) !bool {
+    pub fn enqueueContextCompaction(self: *App, operation_id: @import("core/output/compaction_activity.zig").OperationId) !bool {
         if (self.worker.isProcessing() or self.worker.queuedPromptCount() > 0) return false;
         const selection = self.provider_selection.selection();
         const model = try std.heap.c_allocator.dupe(u8, selection.model);
@@ -1508,6 +1508,7 @@ const App = struct {
         errdefer types.freeHistoryTurnSlice(std.heap.c_allocator, history);
 
         try self.worker.enqueueContextCompaction(.{
+            .operation_id = operation_id,
             .model = model,
             .provider = selection.provider,
             .api_key = api_key,
@@ -2211,18 +2212,20 @@ const App = struct {
         }
     }
 
-    pub fn processQueuedWork(self: *App, work: WorkItem) !void {
+    pub fn processQueuedWork(self: *App, work: WorkItem, failure_provenance: *?@import("core/output/compaction_activity.zig").ErrorProvenance) !void {
         const result = switch (work) {
             .prompt => |job| AgentAppRuntime.processQueuedPrompt(
                 self,
                 job,
                 builtin_gateway.retry_count,
                 builtin_gateway.defaultChatUrl(),
+                failure_provenance,
             ),
             .compact_context => |task| AgentAppRuntime.processContextCompaction(
                 self,
                 task,
                 builtin_gateway.retry_count,
+                failure_provenance,
             ),
         };
         result catch |err| {
@@ -4165,6 +4168,10 @@ test {
     _ = @import("core/app/usage_dashboard_runtime.zig");
     _ = @import("core/app/app_process_runtime.zig");
     _ = @import("core/app/app_render_runtime.zig");
+    _ = @import("core/app/input_interrupt_runtime.zig");
+    _ = @import("ui/footer/render_input.zig");
+    _ = @import("ui/footer/surface_frame.zig");
+    _ = @import("ui/render_request.zig");
     _ = @import("core/app/app_runtime_setup.zig");
     _ = @import("core/app/app_session_runtime.zig");
     _ = @import("core/app/app_upgrade_runtime.zig");

--- a/src/ui/footer/render_input.zig
+++ b/src/ui/footer/render_input.zig
@@ -408,6 +408,7 @@ const max_static_status_activity_rows: u16 = 3;
 pub const RenderContext = struct {
     slash_registry: command_specs.SlashRegistry = .{},
     stream: StreamState,
+    compaction: @import("../../core/output/compaction_activity.zig").Snapshot = .{},
     pending_prompt_activity: bool = false,
     completed_assistant_presentation_tail: bool = false,
     // Pacer emitting visible text, including the post-finish tail drain.
@@ -699,7 +700,8 @@ pub fn frameOwnedActivityProjection(
     approval: ?approval_prompt.Projection,
 ) ActivityProjection {
     if (approval != null or ctx.question != null) return .none;
-    if (!ctx.stream.active and ctx.pending_prompt_activity) {
+    const compaction = activity_status.compactionProjection(buf, ctx.compaction, ctx.stream, ctx.now_ms);
+    if (compaction == .none and !ctx.stream.active and ctx.pending_prompt_activity) {
         return .{ .turn_thinking = .{ .label = "• Thinking" } };
     }
     switch (ctx.activity) {
@@ -709,7 +711,17 @@ pub fn frameOwnedActivityProjection(
         },
         .none => {},
     }
+    if (compaction != .none) return compaction;
     return turnActivityProjection(buf, shell, ctx);
+}
+
+pub fn frameActivityBlink(ctx: RenderContext) ?bool {
+    if (ctx.compaction.operation) |op| {
+        if (op.active() and op.visible(ctx.now_ms)) {
+            return activity_status.activityBlinkVisible(activity_status.compactionClock(ctx.stream, op), ctx.now_ms);
+        }
+    }
+    return activity_status.activityBlinkVisible(ctx.stream, ctx.now_ms);
 }
 
 fn turnActivityProjection(
@@ -930,6 +942,42 @@ test "frame-owned thinking activity projects the thinking label" {
         .turn_thinking => |thinking| try std.testing.expectEqualStrings("• Thinking", thinking.label),
         .none, .tool_slot => return error.TestUnexpectedResult,
     }
+}
+
+test "frame compaction overrides idle and tool activity but not blocking feedback or questions" {
+    var input = InputRuntime{};
+    defer input.deinit(std.testing.allocator);
+    var shell = TranscriptRuntime{};
+    defer shell.deinit(std.testing.allocator);
+    var state: @import("../../core/output/compaction_activity.zig").State = .{};
+    const id = state.begin(.manual, null, 1_000);
+    state.running(id, .summary);
+    var ctx: RenderContext = .{
+        .stream = .{},
+        .compaction = state.snapshot,
+        .now_ms = 2_500,
+        .has_api_key = true,
+        .model = "test",
+        .input = &input,
+    };
+    var buf: [256]u8 = undefined;
+    try std.testing.expectEqualStrings("• Compacting (1s)", frameOwnedActivityProjection(&buf, &shell, ctx, null).turn_thinking.label);
+    try std.testing.expectEqual(@as(?bool, false), frameActivityBlink(ctx));
+    try std.testing.expect(!ctx.stream.active);
+    ctx.activity = .{ .tool_slot = .{ .entry_id = 1, .fallback_label = "reading", .active = true, .kind = .read } };
+    try std.testing.expectEqualStrings("• Compacting (1s)", frameOwnedActivityProjection(&buf, &shell, ctx, null).turn_thinking.label);
+    ctx.activity = .{ .turn_thinking = .{ .label = "Blocking status", .tone = .danger } };
+    try std.testing.expectEqualStrings("Blocking status", frameOwnedActivityProjection(&buf, &shell, ctx, null).turn_thinking.label);
+    ctx.question = .{ .current_entry = null, .current_index = 0, .entry_count = 0 };
+    try std.testing.expect(frameOwnedActivityProjection(&buf, &shell, ctx, null) == .none);
+    ctx.question = null;
+    state.settle(id, .{ .outcome = .cancelled }, 2_500);
+    ctx.compaction = state.snapshot;
+    ctx.activity = .none;
+    try std.testing.expectEqual(ActivityProjection.Tone.neutral, frameOwnedActivityProjection(&buf, &shell, ctx, null).turn_thinking.tone);
+    try std.testing.expect(state.dismiss(id, state.snapshot.revision));
+    ctx.compaction = state.snapshot;
+    try std.testing.expect(frameOwnedActivityProjection(&buf, &shell, ctx, null) == .none);
 }
 
 test "pending prompt projects thinking before the worker stream starts" {

--- a/src/ui/footer/surface_frame.zig
+++ b/src/ui/footer/surface_frame.zig
@@ -812,10 +812,7 @@ fn assembleSurfaceFooterFrame(
         .activity_label = activity_label,
         .tool_activity_label = tool_activity_label,
         .shimmer_pos = assembly.planner_input.ctx.shimmer_pos,
-        .thinking_blink = activity_status.activityBlinkVisible(
-            assembly.planner_input.ctx.stream,
-            assembly.planner_input.ctx.now_ms,
-        ),
+        .thinking_blink = render_input.frameActivityBlink(assembly.planner_input.ctx),
         .trace_paint_frame = assembly.trace_paint_frame,
     };
 }
@@ -1481,6 +1478,30 @@ fn surfaceTestContext(input: *InputRuntime) RenderContext {
         .model = "gpt-5.1",
         .input = input,
     };
+}
+
+test "surface footer frame snapshots manual compaction blink with an inactive stream" {
+    const alloc = std.testing.allocator;
+    var input = InputRuntime{};
+    defer input.deinit(alloc);
+    var shell = surfaceTestShell(24, 80);
+    defer shell.deinit(alloc);
+    var metrics = Metrics{};
+    var force_redraw = false;
+    var ctx = surfaceTestContext(&input);
+    ctx.compaction = .{ .revision = 1, .operation = .{
+        .id = @enumFromInt(1),
+        .turn_id = 1,
+        .origin = .manual,
+        .phase = .{ .running = .summary },
+        .started_at_ms = 1_000,
+    } };
+    ctx.now_ms = 1_500;
+    var frame = try prepareSurfaceFooterFrameWithReservation(alloc, &shell, &metrics, &force_redraw, null, ctx, .{}, FrameInvalidationSet.empty());
+    defer frame.deinit(alloc);
+    try std.testing.expectEqual(@as(?bool, false), frame.thinking_blink);
+    try std.testing.expect(std.mem.find(u8, frame.activity_label.items, "Compacting (0s)") != null);
+    try std.testing.expect(!ctx.stream.active);
 }
 
 test "surface footer frame snapshots the thinking blink from the frame clock" {

--- a/src/ui/render_request.zig
+++ b/src/ui/render_request.zig
@@ -107,6 +107,13 @@ pub const RenderRequestState = struct {
     animation_candidate_in_flight: bool = false,
     next_animation_generation: u64 = 1,
     consecutive_input_pending_aborts: u8 = 0,
+    observed_compaction_revision: u64 = 0,
+
+    pub fn observeCompactionRevision(self: *RenderRequestState, revision: u64) void {
+        if (self.observed_compaction_revision == revision) return;
+        self.observed_compaction_revision = revision;
+        self.request(.footer);
+    }
 
     pub fn request(self: *RenderRequestState, reason: Reason) void {
         self.pending_reasons.insert(reason);
@@ -357,6 +364,19 @@ fn reasonsAffectApproval(reasons: ReasonSet) bool {
     relevant.remove(.animation);
     relevant.remove(.notification);
     return relevant.count() > 0;
+}
+
+test "compaction revisions request footer repaint without restarting animation" {
+    var state: RenderRequestState = .{};
+    state.observeCompactionRevision(1);
+    try std.testing.expect(state.hasReason(.footer));
+    state.clearReason(.footer);
+    state.observeCompactionRevision(1);
+    try std.testing.expect(!state.hasPending());
+    state.animation_next_deadline_ms = 100;
+    state.observeCompactionRevision(2);
+    try std.testing.expect(state.hasReason(.footer));
+    try std.testing.expectEqual(@as(i64, 100), state.animation_next_deadline_ms);
 }
 
 test "render request state exposes the transaction operations" {

--- a/tests/e2e/acp.test.ts
+++ b/tests/e2e/acp.test.ts
@@ -30,6 +30,7 @@ import {
   FAKE_GATEWAY_MODEL,
   fakeGatewayFinalText as finalText,
   heldFakeGatewayFinalText,
+  hasEmptyComposer,
   fakeGatewayPermissionDecision,
   fakeGatewaySerializedToolCall,
   fakeGatewaySse,
@@ -8921,16 +8922,31 @@ test.skipIf(!tmuxAvailable())(
         await tui.waitForText(answer!, TIMEOUT);
         await tui.waitForComposer(TIMEOUT);
       }
-      await tui.sendText("/compact");
-      await tui.waitForText("Context compacted.", TIMEOUT);
-      await tui.sendText("/quit");
-      expect(await tui.waitForSessionEnd(TIMEOUT)).toBe(true);
-      await tui.kill();
-      tui = null;
       const ids = readdirSync(join(root.home, ".fx", "sessions"), { withFileTypes: true })
         .filter((entry) => entry.isDirectory()).map((entry) => entry.name);
       expect(ids).toHaveLength(1);
       const eventsPath = join(root.home, ".fx", "sessions", ids[0]!, "events.jsonl");
+      const checkpointFrames = () => readFileSync(eventsPath, "utf8").trim().split("\n")
+        .map((line) => JSON.parse(line)).filter((frame) => frame.event?.context_checkpoint);
+      const beforeCompaction = readFileSync(eventsPath);
+      expect(checkpointFrames()).toHaveLength(0);
+      await tui.sendText("/compact");
+      // Success is silent: the committed checkpoint, not a transcript notice,
+      // establishes that compaction finished before testing ACP replay.
+      await waitForCondition("persisted compaction checkpoint", () => checkpointFrames().length === 1, TIMEOUT);
+      await tui.waitForPane((pane) => hasEmptyComposer(pane) && !/Compacting|Thinking|Preparing compaction/.test(pane), TIMEOUT);
+      expect(checkpointFrames()).toHaveLength(1);
+      expect(JSON.stringify(checkpointFrames())).toContain("ACP_INTERNAL_HANDOFF");
+      expect(readFileSync(eventsPath).subarray(0, beforeCompaction.length)).toEqual(beforeCompaction);
+      const inline = await tui.captureFullScrollbackEscapes();
+      expect(inline).toContain("ACP_EARLIER_VISIBLE_RESPONSE");
+      expect(inline).toContain("ACP_MIDDLE_VISIBLE_RESPONSE");
+      expect(inline).toContain("ACP_LATEST_VISIBLE_RESPONSE");
+      expect(inline).not.toMatch(/Context compacted|Compacting|ACP_INTERNAL_HANDOFF/);
+      await tui.sendText("/quit");
+      expect(await tui.waitForSessionEnd(TIMEOUT)).toBe(true);
+      await tui.kill();
+      tui = null;
       const savedEvents = readFileSync(eventsPath);
       expect(readFileSync(join(root.workspace, "replay-effects.txt"), "utf8")).toBe("ACP_SAVED_TOOL_OUTPUT\n");
       expect(gateway.requests).toHaveLength(5);

--- a/tests/e2e/ci-shard-weights.json
+++ b/tests/e2e/ci-shard-weights.json
@@ -25,6 +25,7 @@
   { "file": "tui-agent.test.ts", "weight": 1 },
   { "file": "tui-auth-source-selection.test.ts", "weight": 49 },
   { "file": "tui-command-permissions.test.ts", "weight": 153 },
+  { "file": "tui-compaction-activity.test.ts", "weight": 90 },
   { "file": "tui-composer-edit-contracts.test.ts", "weight": 168 },
   { "file": "tui-cost.test.ts", "weight": 16 },
   { "file": "tui-decision-prompts.test.ts", "weight": 174 },

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -70,6 +70,44 @@ function createFixtureRoot(label: string): FixtureRoot {
   return { root, home, workspace: realpathSync(workspace) };
 }
 
+const COMPACTION_ACTIVITY = /Compacting \((?:\d+h)?(?:\d+m)?\d+s\)/;
+
+function compactionIdle(pane: string): boolean {
+  return hasEmptyComposer(pane) && !COMPACTION_ACTIVITY.test(pane);
+}
+
+function compactionEventsPath(root: FixtureRoot): string {
+  const sessionsRoot = join(root.home, ".fx", "sessions");
+  const parents = readdirSync(sessionsRoot).filter((id) => {
+    const path = join(sessionsRoot, id, "session.json");
+    return existsSync(path) && !JSON.parse(readFileSync(path, "utf8")).subagent_child;
+  });
+  expect(parents).toHaveLength(1);
+  return join(sessionsRoot, parents[0]!, "events.jsonl");
+}
+
+function checkpointCount(events: string): number {
+  return events.split("\n").slice(0, -1)
+    .filter((line) => JSON.parse(line).event?.context_checkpoint).length;
+}
+
+async function compactAndWait(tui: TmuxSession, root: FixtureRoot, timeoutMs: number) {
+  const eventsPath = compactionEventsPath(root);
+  const before = readFileSync(eventsPath, "utf8");
+  const checkpoints = checkpointCount(before);
+  await tui.sendText("/compact");
+  const pane = await tui.waitForPane(
+    (text) => compactionIdle(text) &&
+      checkpointCount(readFileSync(eventsPath, "utf8")) === checkpoints + 1,
+    timeoutMs,
+  );
+  const after = readFileSync(eventsPath, "utf8");
+  expect(after.startsWith(before)).toBe(true);
+  expect(checkpointCount(after)).toBe(checkpoints + 1);
+  expect(pane).not.toContain("request failed:");
+  expect(pane).not.toContain("Compaction failed.");
+}
+
 function writeContextLimitFixture(root: FixtureRoot) {
   const skillDirectory = join(
     root.workspace,
@@ -5354,8 +5392,8 @@ printf '%s' ${JSON.stringify(trailingMarker)} > ${JSON.stringify(effectPath)}
       await tui.sendText("Remember the result and acknowledge this short follow-up.");
       await tui.waitForText("RECENT_TURN_DONE", 15_000);
       await tui.waitForComposer(15_000);
-      await tui.sendText("/compact");
-      await tui.waitForPane((text) => hasEmptyComposer(text) && summaries === 2 && (text.includes("Context compacted.") || text.includes("request failed:")), 20_000);
+      await compactAndWait(tui, root, 20_000);
+      expect(summaries).toBe(2);
       expect(readFileSync(tracePath, "utf8")).not.toContain("ContextCapacityExceeded");
       await tui.sendText("/quit");
       expect(await tui.waitForSessionEnd(15_000)).toBe(true);
@@ -5458,10 +5496,7 @@ printf '%s' ${JSON.stringify(trailingMarker)} > ${JSON.stringify(effectPath)}
           expect(pane).not.toContain("request failed:");
           expect(pane).toContain("RETRIEVAL_TURN_COMPLETE");
           if (trigger === "manual") {
-            await tui.sendText("/compact");
-            const compacted = await tui.waitForPane((text) => hasEmptyComposer(text) && (text.includes("Context compacted.") || text.includes("request failed:")), 20000);
-            expect(compacted).not.toContain("request failed:");
-            expect(compacted).toContain("Context compacted.");
+            await compactAndWait(tui, root, 20000);
           }
           expect(compactions).toBe(2);
           const summaryRequests = gateway.requests.filter((entry) => JSON.parse(entry.body).tools.length === 0);
@@ -5572,8 +5607,7 @@ printf '%s' ${JSON.stringify(trailingMarker)} > ${JSON.stringify(effectPath)}
           stderrPath: compactionStderrPath,
         });
         await tui.waitForComposer(15_000);
-        await tui.sendText("/compact");
-        await tui.waitForText("Context compacted.", 15_000);
+        await compactAndWait(tui, root, 15_000);
         await tui.sendText("/quit");
         await tui.waitForSessionEnd(15_000);
         tui = null;
@@ -5708,8 +5742,7 @@ printf '%s' ${JSON.stringify(trailingMarker)} > ${JSON.stringify(effectPath)}
         expect(resumedTranscript).toContain("compaction restart complete");
         expect(resumedTranscript).not.toContain("context_handoff");
         expect(resumedTranscript).not.toContain("Recent conversation turns are preserved verbatim");
-        await tui.sendText("/compact");
-        await tui.waitForText("Context compacted.", 15_000);
+        await compactAndWait(tui, root, 15_000);
         expect(await tui.captureFullScrollback()).not.toContain("context_handoff");
         await tui.sendText("/quit");
         await tui.waitForSessionEnd(15_000);
@@ -5825,10 +5858,7 @@ printf '%s' ${JSON.stringify(trailingMarker)} > ${JSON.stringify(effectPath)}
           expect(pane).not.toContain("request failed:");
           expect(pane).toContain("CANCEL_FOLLOWUP_COMPLETE");
           if (trigger === "manual") {
-            await tui.sendText("/compact");
-            const compacted = await tui.waitForPane((text) => hasEmptyComposer(text) && (text.includes("Context compacted.") || text.includes("request failed:")), 20000);
-            expect(compacted).not.toContain("request failed:");
-            expect(compacted).toContain("Context compacted.");
+            await compactAndWait(tui, root, 20000);
           }
           expect(compactions).toBe(1);
           expect(gateway.requests).toHaveLength(5);
@@ -5907,6 +5937,9 @@ printf '%s' ${JSON.stringify(trailingMarker)} > ${JSON.stringify(effectPath)}
           15_000,
         );
 
+        const eventsPath = compactionEventsPath(root);
+        const originalHistory = readFileSync(eventsPath, "utf8");
+        expect(checkpointCount(originalHistory)).toBe(0);
         await tui.sendText("/compact");
         const requestDeadline = Date.now() + 15_000;
         while (gateway.requests.length < 3) {
@@ -5919,11 +5952,18 @@ printf '%s' ${JSON.stringify(trailingMarker)} > ${JSON.stringify(effectPath)}
           if (Date.now() >= requestDeadline) throw new Error("compactor provider did not start");
           await Bun.sleep(10);
         }
+        await tui.waitForText(COMPACTION_ACTIVITY, Math.max(1, requestDeadline - Date.now()));
+        expect(gateway.requests).toHaveLength(3);
+        expect(JSON.parse(gateway.requests[2]!.body).tools).toEqual([]);
+        expect(JSON.parse(gateway.requests[2]!.body).toolChoice).toEqual({ type: "none" });
+        expect(readFileSync(eventsPath, "utf8")).toBe(originalHistory);
         tui.sendKeysImmediate(["Escape"]);
         await tui.waitForPane(
-          (pane) => pane.includes("Context compaction cancelled.") && hasEmptyComposer(pane),
+          (pane) => pane.includes("Compaction cancelled. Try /compact again when ready.") && compactionIdle(pane),
           5_000,
         );
+        expect(gateway.requests).toHaveLength(3);
+        expect(readFileSync(eventsPath, "utf8")).toBe(originalHistory);
 
         const latest = await runFx(["session", "last", "--json"], {
           cwd: root.workspace,
@@ -5949,17 +5989,25 @@ printf '%s' ${JSON.stringify(trailingMarker)} > ${JSON.stringify(effectPath)}
           15_000,
         );
         expect(gateway.requests).toHaveLength(4);
+        const followUpRequest = gateway.requests[3]!.body;
+        expect(followUpRequest).toContain("MANUAL_CANCEL_FIRST_READY");
+        expect(followUpRequest).toContain("MANUAL_CANCEL_SECOND_READY");
+        expect(followUpRequest).not.toContain("context_handoff");
+        const beforeFailure = readFileSync(eventsPath, "utf8");
+        expect(beforeFailure.startsWith(originalHistory)).toBe(true);
+        expect(checkpointCount(beforeFailure)).toBe(0);
         expect(readFileSync(tracePath, "utf8")).not.toContain(
           "[context_compaction] event=installed",
         );
         responses.push(fakeGatewayFinalText(""), fakeGatewayFinalText(""));
         await tui.sendText("/compact");
-        const failedSummary = await tui.waitForPane(
-          (pane) => pane.includes("context was kept") && hasEmptyComposer(pane),
+        await tui.waitForPane(
+          (pane) => pane.includes("Compaction failed. Try /compact again.") && compactionIdle(pane),
           15_000,
         );
-        expect(failedSummary.replace(/\s+/g, " ")).toContain("Try /compact again or send a follow-up");
         expect(gateway.requests).toHaveLength(6);
+        expect(gateway.requests[5]!.body).toBe(gateway.requests[4]!.body);
+        expect(readFileSync(eventsPath, "utf8")).toBe(beforeFailure);
         const afterFailure = await runFx(["session", "--id", sessionId, "--json"], {
           cwd: root.workspace, env: { HOME: root.home },
         });
@@ -6040,8 +6088,7 @@ printf '%s' ${JSON.stringify(trailingMarker)} > ${JSON.stringify(effectPath)}
             hasEmptyComposer(pane),
           20_000,
         );
-        await tui.sendText("/compact");
-        await tui.waitForText("Context compacted.", 15_000);
+        await compactAndWait(tui, root, 15_000);
         await tui.sendText("Read the explicit skill after compaction.");
         await tui.waitForPane(
           (pane) =>

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -6467,21 +6467,30 @@ tmuxTest(
     await Bun.sleep(Math.max(0, expiresAt - 60_000 + 100 - Date.now()));
     await session.sendText("/status");
     await session.waitForText("auth_expired=true", TIMEOUT);
+    const sessionIds = readdirSync(join(home, ".fx", "sessions")).filter((id) => existsSync(join(home!, ".fx", "sessions", id, "session.json")));
+    expect(sessionIds).toHaveLength(1);
+    const historyPath = join(home, ".fx", "sessions", sessionIds[0], "events.jsonl");
+    const before = readFileSync(historyPath, "utf8");
     await session.sendText("/compact");
     await waitForTrace(tracePath, "manual_compaction_auth_pending", TIMEOUT);
     expect(gateway.requests).toHaveLength(2);
     await session.sendText("/compact");
     await session.sendLiteral("PRESERVE_COMPACTION_DRAFT");
     await session.waitForText("PRESERVE_COMPACTION_DRAFT", 1_000);
-    await session.waitForText("Context compacted.", TIMEOUT);
-    expect(await session.captureFullScrollback()).toContain("PRESERVE_COMPACTION_DRAFT");
+    // Success is silent; wait for durable publication and the activity row to clear.
+    await session.waitForPane((pane) =>
+      pane.includes("PRESERVE_COMPACTION_DRAFT") &&
+      !/Preparing compaction|Compacting|Stopping compaction/.test(pane) &&
+      readFileSync(historyPath, "utf8").includes('"context_checkpoint"'),
+    TIMEOUT);
+    const scrollback = await session.captureFullScrollback();
+    expect(scrollback).toContain("PRESERVE_COMPACTION_DRAFT");
+    expect(scrollback).not.toContain("Context compacted.");
     expect(oauth.requests.filter((request) => request.grantType === "refresh_token")).toHaveLength(1);
     expect(gateway.requests).toHaveLength(3);
     expect(gateway.requests[2].headers.get("authorization")).toBe(`Bearer ${ACQUIRED_LOGIN_TOKEN}`);
     expect(JSON.parse(gateway.requests[2].body).tools ?? []).toHaveLength(0);
-    const sessionIds = readdirSync(join(home, ".fx", "sessions")).filter((id) => existsSync(join(home!, ".fx", "sessions", id, "session.json")));
-    expect(sessionIds).toHaveLength(1);
-    const historyPath = join(home, ".fx", "sessions", sessionIds[0], "events.jsonl");
+    expect(readFileSync(historyPath, "utf8").startsWith(before)).toBe(true);
     const records = readFileSync(historyPath, "utf8").trim().split("\n").map((line) => JSON.parse(line));
     expect(records.filter((record) => record.event.context_checkpoint)).toHaveLength(1);
     await session.sendKeys("C-u");
@@ -6536,9 +6545,9 @@ for (const outcome of ["failure", "cancel"] as const) {
     await session.waitForText("DRAFT_DURING_AUTH_BOUNDARY", 1_000);
     if (outcome === "cancel") {
       await session.sendKeys("C-c");
-      await session.waitForText("Context compaction cancelled.", 3_000);
+      await session.waitForText("Compaction cancelled. Try /compact again when ready.", 3_000);
     } else {
-      await session.waitForText("Your conversation is unchanged.", TIMEOUT);
+      await session.waitForText("Compaction was not started. Check authentication and try /compact again.", TIMEOUT);
       const scrollback = await session.captureFullScrollback();
       expect(scrollback).toContain("/compact again");
       expect(scrollback).not.toContain("Your prompt is saved.");

--- a/tests/e2e/tui-compaction-activity.test.ts
+++ b/tests/e2e/tui-compaction-activity.test.ts
@@ -1,0 +1,368 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+// The shared tmux helper imports eval helpers; do not load repository dotenv files.
+process.env.FX_E2E_DISABLE_DOTENV = "1";
+const {
+  FAKE_GATEWAY_MODEL, TmuxSession, fakeGatewayFinalText,
+  heldFakeGatewayFinalText, startDynamicFakeGateway, hasEmptyComposer,
+  tmuxAvailable,
+} = await import("./tmux-helpers");
+
+const binary = resolve(import.meta.dir, "../../zig-out/bin/fx");
+const HEAD = "HISTORY_HEAD_29b7";
+const TAIL = "HISTORY_TAIL_16d3";
+const HANDOFF = `INTERNAL_HANDOFF_4e12: preserve ${HEAD} and ${TAIL}; follow the latest user request.`;
+const FOLLOWUP = "FOLLOWUP_OK_732c";
+const REOPEN = "REOPEN_OK_492a";
+const ACTIVITY = /Compacting \((?:\d+h)?(?:\d+m)?\d+s\)/;
+const COMPACTION_OUTPUT = /Compacting|compaction|Context compacted|No context to compact|Your existing context was kept|Synthetic summary rejection|INTERNAL_HANDOFF_4e12/i;
+
+type Trigger = "manual" | "auto" | "overflow" | "ordinary";
+type Outcome = "success" | "cancel" | "empty" | "provider-error";
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function checkpoints(bytes: Buffer): number {
+  return bytes.toString().trim().split("\n").filter(Boolean)
+    .map((line) => JSON.parse(line)).filter((frame) => frame.event?.context_checkpoint).length;
+}
+
+async function until(predicate: () => boolean, label: string, timeout = 20_000) {
+  const deadline = Date.now() + timeout;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error(`timed out waiting for ${label}`);
+    await Bun.sleep(20);
+  }
+}
+
+async function fixture(trigger: Trigger, outcome: Outcome = "success", longResume = false) {
+  // Ctrl+O includes the recording path; keep it free of forbidden notice words.
+  const root = mkdtempSync(join(tmpdir(), "fx-activity-"));
+  const home = join(root, "home");
+  const workspace = join(root, "workspace");
+  mkdirSync(join(home, ".fx"), { recursive: true });
+  mkdirSync(workspace);
+  writeFileSync(join(home, ".fx/settings.json"), JSON.stringify({
+    model: FAKE_GATEWAY_MODEL, auto_upgrade: false, startup_scrollback: false,
+  }));
+  // Failure attempts need an older exchange outside the retained suffix, but
+  // must leave the next ordinary request below the automatic pressure threshold.
+  const seedTurns = trigger === "manual" && outcome !== "success" ? 3 : 1;
+  const lines = seedTurns > 1 ? 400 : trigger === "ordinary" ? 2 : trigger === "auto" || longResume ? 18_000 : 1600;
+  const seedReply = (turn: number) => `${turn === 1 ? HEAD : `HISTORY_MIDDLE_${turn}`}\n${"history alpha beta gamma delta sample line\n".repeat(lines)}SEED_DONE_${turn}${turn === seedTurns ? `\n${TAIL}` : ""}`;
+  const summaryHold = heldFakeGatewayFinalText();
+  const ordinaryHold = heldFakeGatewayFinalText();
+  let phase: "seed" | "attempt" | "followup" | "reopen" = "seed";
+  let summaries = 0;
+  let ordinary = 0;
+  let overflowSent = false;
+  let terminal: InstanceType<typeof TmuxSession> | undefined;
+  const requests: object[] = [];
+  const gateway = startDynamicFakeGateway((raw) => {
+    const request = JSON.parse(raw);
+    const summary = request.toolChoice?.type === "none" && request.tools?.length === 0;
+    requests.push({ phase, summary, at: Date.now(), bytes: raw.length,
+      head: raw.includes(HEAD), tail: raw.includes(TAIL), handoff: raw.includes("INTERNAL_HANDOFF_4e12"),
+      followup: raw.includes("Follow the latest request.") || raw.includes("Recover with another request."),
+      reopen: raw.includes("Continue after reopening.") || raw.includes("Check the reopened context."),
+    });
+    if (summary) {
+      summaries++;
+      if (phase === "attempt" && outcome === "provider-error") {
+        return Response.json({ error: { message: "Synthetic summary rejection" } }, { status: 400 });
+      }
+      if (phase === "attempt" && summaries === 1) return summaryHold.response;
+      // Each chunk/retry needs a fresh Response, not a consumed held body.
+      return fakeGatewayFinalText(phase === "attempt" && outcome === "empty" ? "" : HANDOFF);
+    }
+    ordinary++;
+    if (phase === "seed") return fakeGatewayFinalText(seedReply(ordinary));
+    if (phase === "attempt") {
+      if (trigger === "overflow" && !overflowSent) {
+        overflowSent = true;
+        return Response.json({ error: {
+          type: "invalid_request_error", code: "context_length_exceeded",
+          message: "This model's maximum context length is 128000 tokens. The request exceeds the context window.",
+        } }, { status: 400 });
+      }
+      return ordinaryHold.response;
+    }
+    return fakeGatewayFinalText(phase === "reopen" ? REOPEN : FOLLOWUP);
+  }, { models: [{ id: FAKE_GATEWAY_MODEL, type: "language", tags: ["tool-use"], context_window: 128000, max_tokens: 8192 }] });
+  const env = {
+    PATH: process.env.PATH ?? "/usr/bin:/bin", HOME: home, TMPDIR: root,
+    TERM: "xterm-256color", AI_GATEWAY_API_KEY: "synthetic-compaction-key",
+    FX_DISABLE_KEYCHAIN: "1", FX_E2E_DISABLE_DOTENV: "1", FX_SKIP_ONBOARDING: "1",
+    FX_SOUND: "0", FX_AUTO_UPGRADE: "0", FX_MODEL: FAKE_GATEWAY_MODEL,
+    FX_GATEWAY_BASE_URL: gateway.baseUrl, FX_GATEWAY_CHAT_URL: gateway.chatUrl,
+    FX_E2E_GATEWAY_CHAT_URL: gateway.chatUrl,
+    FX_E2E_GATEWAY_MODELS_URL: `${gateway.baseUrl}/coding-agent/v1/models`,
+  };
+  let sessionId = "";
+  let eventsPath = "";
+  let initial = Buffer.alloc(0);
+  let launchIndex = 0;
+  const stderrPaths: string[] = [];
+  const tapes: string[] = [];
+  async function cli(args: string[]) {
+    const child = Bun.spawn([binary, ...args], { cwd: workspace, env, stdin: "ignore", stdout: "pipe", stderr: "pipe" });
+    const timer = setTimeout(() => child.kill(), 30_000);
+    try {
+      const [code, stdout, stderr] = await Promise.all([child.exited, new Response(child.stdout).text(), new Response(child.stderr).text()]);
+      expect(code).toBe(0);
+      expect(stderr).toBe("");
+      return JSON.parse(stdout);
+    } finally { clearTimeout(timer); }
+  }
+  async function launch() {
+    const tape = join(root, `terminal-${++launchIndex}.fxtape`);
+    const stderr = join(root, `terminal-${launchIndex}.stderr`);
+    tapes.push(tape);
+    stderrPaths.push(stderr);
+    const terminalEnv = { ...env, FX_RECORD: tape, FX_DEBUG_RECORD_SILENT_BANNER: "1",
+      FX_TRACE_LOG: join(root, `terminal-${launchIndex}.trace`),
+      FX_TRACE_SCOPES: "input,worker,session,scroll,agent,gateway,compaction",
+    };
+    // Do not inherit provider overrides, credentials, shell startup or dotenv state.
+    const command = `/usr/bin/env -i ${Object.entries(terminalEnv).map(([key, value]) => shellQuote(`${key}=${value}`)).join(" ")} ${shellQuote(binary)} --resume ${shellQuote(sessionId)}`;
+    terminal = await TmuxSession.create({
+      cmd: command, cwd: workspace, env: { HOME: home, FX_SOUND: "0" }, isolated: true,
+      stderrPath: stderr, width: 90, height: 32, minimumHistoryLines: 25_000,
+      startupWaitMs: 0,
+    });
+    // A composer can be painted while resume history is still being restored.
+    // Wait for a stable frame, then acknowledge input without submitting a turn
+    // or retiring the retained resume transcript before the tested /compact.
+    await terminal.waitForStableComposer(20_000);
+    await terminal.sendLiteral("startup-input-handshake");
+    await terminal.waitForText("startup-input-handshake", 5000);
+    await terminal.sendKeys("C-u");
+    await terminal.waitForComposer(5000);
+    return terminal;
+  }
+  function durable() {
+    const bytes = readFileSync(eventsPath);
+    expect(bytes.subarray(0, initial.length).equals(initial)).toBe(true);
+    return checkpoints(bytes);
+  }
+  async function close() {
+    if (!terminal) return;
+    expect(terminal.paneStatus()).toEqual({ dead: false, status: null });
+    await terminal.sendText("/quit");
+    expect(await terminal.waitForSessionEnd(5000)).toBe(true);
+    await terminal.kill();
+    terminal = undefined;
+    for (const path of stderrPaths) expect(readFileSync(path, "utf8")).toBe("");
+  }
+  async function cleanup(passed: boolean) {
+    if (!passed) {
+      writeFileSync(join(root, "requests.json"), JSON.stringify({
+        trigger, outcome, phase, seedTurns, summaries, ordinary, overflowSent, requests,
+        paneStatus: terminal?.paneStatus(),
+      }, null, 2));
+      if (terminal) writeFileSync(join(root, "failure.scrollback.ansi"), await terminal.captureFullScrollbackEscapes());
+      console.error(`compaction evidence retained: ${root}; phase=${phase}, summaries=${summaries}, ordinary=${ordinary}`);
+    }
+    summaryHold.dispose();
+    ordinaryHold.dispose();
+    await terminal?.kill();
+    gateway.stop();
+    if (passed) rmSync(root, { recursive: true, force: true });
+  }
+  try {
+    for (let turn = 1; turn <= seedTurns; turn++) {
+      const reply = await cli(["ask", "--json", "--auto", ...(sessionId ? ["--resume", sessionId] : []), `Seed ordinary historical turn ${turn}.`]);
+      if (sessionId) expect(reply.session_id).toBe(sessionId);
+      else sessionId = reply.session_id;
+      expect(sessionId).toBeTruthy();
+      expect(ordinary).toBe(turn);
+      expect(summaries).toBe(0);
+    }
+    eventsPath = join(home, ".fx/sessions", sessionId, "events.jsonl");
+    initial = readFileSync(eventsPath);
+    expect(initial.toString()).toContain(HEAD);
+    expect(initial.toString()).toContain(TAIL);
+    expect(checkpoints(initial)).toBe(0);
+    expect(summaries).toBe(0);
+    expect(ordinary).toBe(seedTurns);
+    phase = "attempt";
+    return {
+      launch, close, cleanup, durable, cli, tapes, root, seedTurns, summaryHold, ordinaryHold,
+      counts: () => ({ summaries, ordinary, overflowSent }),
+      phase: (value: typeof phase) => { phase = value; },
+      lastRequest: () => gateway.requests.at(-1)!.body,
+    };
+  } catch (error) { await cleanup(false); throw error; }
+}
+
+async function assertSilent(terminal: InstanceType<typeof TmuxSession>, root: string, label: string) {
+  const inline = await terminal.captureFullScrollbackEscapes();
+  writeFileSync(join(root, `${label}.scrollback.ansi`), inline);
+  expect(inline.length).toBeGreaterThan(0);
+  expect(inline).not.toMatch(COMPACTION_OUTPUT);
+  await terminal.sendKeys("C-o");
+  await terminal.waitForText("Full detail", 5000);
+  await terminal.sendKeys("End");
+  const full = await terminal.waitForPane((pane) => pane.includes("Full detail"), 5000);
+  writeFileSync(join(root, `${label}.full-transcript.txt`), full);
+  expect(full).not.toMatch(COMPACTION_OUTPUT);
+  await terminal.sendKeys("C-o");
+  await terminal.waitForComposer(5000);
+}
+
+async function assertLive(terminal: InstanceType<typeof TmuxSession>) {
+  const first = await terminal.waitForText(ACTIVITY, 10_000);
+  const clock = first.match(ACTIVITY)![0];
+  const markers = new Set<boolean>();
+  const later = await terminal.waitForPane((pane) => {
+    const rows = pane.split("\n").filter((line) => ACTIVITY.test(line));
+    if (rows.length === 0) return false;
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).not.toMatch(/[↑↓]|tokens|chunk|%/i);
+    markers.add(rows[0].includes("•"));
+    return markers.size === 2 && !rows[0].includes(clock);
+  }, 5000);
+  expect(later.match(/Compacting/g)).toHaveLength(1);
+}
+
+describe.skipIf(!tmuxAvailable())("tui: compaction activity", () => {
+  for (const trigger of ["manual", "auto", "overflow"] as const) {
+    test(`${trigger}: held summary is transient, commits once released, and resumes ordinary work`, async () => {
+      const f = await fixture(trigger, "success", trigger === "manual");
+      let passed = false;
+      try {
+        const terminal = await f.launch();
+        // First interaction after a long resume; do not retire the resume source with a prompt.
+        await terminal.sendText(trigger === "manual" ? "/compact" : "Continue the current turn.");
+        await until(() => f.counts().summaries === 1, "first summary request");
+        await assertLive(terminal);
+        expect(f.durable()).toBe(0);
+        expect(f.counts().ordinary).toBe(f.seedTurns + (trigger === "overflow" ? 1 : 0));
+        if (trigger === "manual") {
+          await terminal.sendKeys("C-o");
+          await terminal.waitForText("Full detail", 5000);
+          expect(await terminal.capturePane()).not.toMatch(COMPACTION_OUTPUT);
+          await terminal.sendKeys("C-o");
+          await terminal.waitForText(ACTIVITY, 5000);
+          await terminal.resizeWindow(52, 24);
+          await terminal.waitForText(ACTIVITY, 5000);
+          await terminal.resizeWindow(90, 32);
+        }
+        f.summaryHold.release(HANDOFF);
+        await until(() => f.durable() > 0, "acknowledged checkpoint");
+        if (trigger === "manual") {
+          await terminal.waitForPane((pane) => !ACTIVITY.test(pane) && hasEmptyComposer(pane), 10_000);
+          expect(f.counts().ordinary).toBe(f.seedTurns);
+          expect(f.counts().summaries).toBeGreaterThan(1);
+        } else {
+          await until(() => f.counts().ordinary === f.seedTurns + (trigger === "overflow" ? 2 : 1), "ordinary request after compaction");
+          const pane = await terminal.waitForText(/Thinking \(/, 10_000);
+          expect(pane).not.toMatch(ACTIVITY);
+          expect(f.lastRequest()).toContain("INTERNAL_HANDOFF_4e12");
+          f.ordinaryHold.release("CURRENT_TURN_OK_f713");
+          await terminal.waitForPane((pane) => pane.includes("CURRENT_TURN_OK_f713") && hasEmptyComposer(pane), 10_000);
+        }
+        expect(f.counts().overflowSent).toBe(trigger === "overflow");
+        expect(f.durable()).toBe(1);
+        const before = f.counts();
+        f.phase("followup");
+        await terminal.sendText("Follow the latest request.");
+        await terminal.waitForPane((pane) => pane.includes(FOLLOWUP) && hasEmptyComposer(pane), 10_000);
+        expect(f.counts()).toEqual({ ...before, ordinary: before.ordinary + 1 });
+        expect(f.lastRequest()).toContain("INTERNAL_HANDOFF_4e12");
+        await assertSilent(terminal, f.root, "completed");
+        await f.close();
+        f.phase("reopen");
+        const reopened = await f.launch();
+        await reopened.sendText("Continue after reopening.");
+        await reopened.waitForPane((pane) => pane.includes(REOPEN) && hasEmptyComposer(pane), 10_000);
+        expect(f.counts()).toEqual({ ...before, ordinary: before.ordinary + 2 });
+        expect(f.durable()).toBe(1);
+        expect(f.lastRequest()).toContain("INTERNAL_HANDOFF_4e12");
+        await assertSilent(reopened, f.root, "reopened");
+        await f.close();
+        for (const tape of f.tapes) {
+          const replay = await f.cli(["replay", tape, "--json"]);
+          expect(replay.frame_count).toBeGreaterThan(0);
+          expect(replay.stdout_bytes).toBeGreaterThan(0);
+        }
+        passed = true;
+      } finally { await f.cleanup(passed); }
+    }, 120_000);
+  }
+
+  for (const outcome of ["cancel", "empty", "provider-error"] as const) {
+    test(`manual ${outcome}: scoped feedback preserves history and permits later input and reopen`, async () => {
+      const f = await fixture("manual", outcome);
+      let passed = false;
+      try {
+        const terminal = await f.launch();
+        await terminal.sendText("/compact");
+        await until(() => f.counts().summaries > 0, "summary boundary");
+        if (outcome !== "provider-error") {
+          await assertLive(terminal);
+          expect(f.durable()).toBe(0);
+          if (outcome === "cancel") await terminal.sendKeys("Escape");
+          else f.summaryHold.release("");
+        }
+        const feedback = outcome === "cancel"
+          ? "Compaction cancelled. Try /compact again when ready."
+          : "Compaction failed. Try /compact again.";
+        await terminal.waitForPane((pane) => !ACTIVITY.test(pane) && pane.includes(feedback) && hasEmptyComposer(pane), 15_000);
+        expect(f.durable()).toBe(0);
+        expect(f.counts().ordinary).toBe(f.seedTurns);
+        expect(f.counts().summaries).toBe(outcome === "empty" ? 2 : 1);
+        const afterFailure = f.counts();
+        if (outcome === "cancel") f.summaryHold.dispose();
+        await terminal.sendKeys("Escape");
+        await terminal.waitForPane((pane) => !/compact/i.test(pane) && hasEmptyComposer(pane), 5000);
+        await assertSilent(terminal, f.root, "failed");
+        f.phase("followup");
+        await terminal.sendText("Recover with another request.");
+        await terminal.waitForPane((pane) => pane.includes(FOLLOWUP) && hasEmptyComposer(pane), 10_000);
+        expect(f.counts()).toEqual({ ...afterFailure, ordinary: f.seedTurns + 1 });
+        expect(f.lastRequest()).toContain(HEAD);
+        expect(f.lastRequest()).toContain(TAIL);
+        expect(f.lastRequest()).not.toContain("INTERNAL_HANDOFF_4e12");
+        expect(f.durable()).toBe(0);
+        await f.close();
+        f.phase("reopen");
+        const reopened = await f.launch();
+        await reopened.sendText("Check the reopened context.");
+        await reopened.waitForPane((pane) => pane.includes(REOPEN) && hasEmptyComposer(pane), 10_000);
+        expect(f.counts()).toEqual({ ...afterFailure, ordinary: f.seedTurns + 2 });
+        expect(f.lastRequest()).toContain(HEAD);
+        expect(f.lastRequest()).toContain(TAIL);
+        expect(f.lastRequest()).not.toContain("INTERNAL_HANDOFF_4e12");
+        expect(f.durable()).toBe(0);
+        await assertSilent(reopened, f.root, "failed-reopen");
+        await f.close();
+        passed = true;
+      } finally { await f.cleanup(passed); }
+    }, 90_000);
+  }
+
+  test("ordinary held request remains Thinking without compaction or extra requests", async () => {
+    const f = await fixture("ordinary");
+    let passed = false;
+    try {
+      const terminal = await f.launch();
+      await terminal.sendText("Ordinary control request.");
+      await until(() => f.counts().ordinary === 2, "ordinary held request");
+      await terminal.waitForText(/Thinking \(/, 5000);
+      expect(f.counts().summaries).toBe(0);
+      expect(f.durable()).toBe(0);
+      f.ordinaryHold.release("ORDINARY_CONTROL_OK_727a");
+      await terminal.waitForPane((pane) => pane.includes("ORDINARY_CONTROL_OK_727a") && hasEmptyComposer(pane), 10_000);
+      expect(f.counts().ordinary).toBe(2);
+      await assertSilent(terminal, f.root, "control");
+      await f.close();
+      passed = true;
+    } finally { await f.cleanup(passed); }
+  }, 60_000);
+});

--- a/tests/e2e/tui-compaction-activity.test.ts
+++ b/tests/e2e/tui-compaction-activity.test.ts
@@ -119,15 +119,16 @@ async function fixture(trigger: Trigger, outcome: Outcome = "success", longResum
       return JSON.parse(stdout);
     } finally { clearTimeout(timer); }
   }
-  async function launch() {
+  async function launch(withoutCredential = false) {
     const tape = join(root, `terminal-${++launchIndex}.fxtape`);
     const stderr = join(root, `terminal-${launchIndex}.stderr`);
     tapes.push(tape);
     stderrPaths.push(stderr);
-    const terminalEnv = { ...env, FX_RECORD: tape, FX_DEBUG_RECORD_SILENT_BANNER: "1",
+    const terminalEnv: Record<string, string> = { ...env, FX_RECORD: tape, FX_DEBUG_RECORD_SILENT_BANNER: "1",
       FX_TRACE_LOG: join(root, `terminal-${launchIndex}.trace`),
       FX_TRACE_SCOPES: "input,worker,session,scroll,agent,gateway,compaction",
     };
+    if (withoutCredential) delete terminalEnv.AI_GATEWAY_API_KEY;
     // Do not inherit provider overrides, credentials, shell startup or dotenv state.
     const command = `/usr/bin/env -i ${Object.entries(terminalEnv).map(([key, value]) => shellQuote(`${key}=${value}`)).join(" ")} ${shellQuote(binary)} --resume ${shellQuote(sessionId)}`;
     terminal = await TmuxSession.create({
@@ -193,6 +194,7 @@ async function fixture(trigger: Trigger, outcome: Outcome = "success", longResum
     phase = "attempt";
     return {
       launch, close, cleanup, durable, cli, tapes, root, seedTurns, summaryHold, ordinaryHold,
+      savedEvents: () => readFileSync(eventsPath, "utf8"),
       counts: () => ({ summaries, ordinary, overflowSent }),
       phase: (value: typeof phase) => { phase = value; },
       lastRequest: () => gateway.requests.at(-1)!.body,
@@ -346,6 +348,77 @@ describe.skipIf(!tmuxAvailable())("tui: compaction activity", () => {
       } finally { await f.cleanup(passed); }
     }, 90_000);
   }
+
+  for (const trigger of ["auto", "ordinary"] as const) {
+    test(`${trigger}: cancellation provenance preserves the correct transcript after reopen`, async () => {
+      const f = await fixture(trigger);
+      let passed = false;
+      try {
+        const terminal = await f.launch();
+        await terminal.sendText("Cancel this held response.");
+        await until(() => trigger === "auto" ? f.counts().summaries === 1 : f.counts().ordinary === 2, "held cancellation boundary");
+        await terminal.waitForText(trigger === "auto" ? ACTIVITY : /Thinking \(/, 10_000);
+        await terminal.sendKeys("Escape");
+        if (trigger === "auto") {
+          await terminal.waitForText("Compaction cancelled.", 10_000);
+          await terminal.sendKeys("Escape");
+        } else {
+          await terminal.waitForText("Cancelled", 10_000);
+        }
+        await terminal.waitForComposer(5000);
+        expect(f.durable()).toBe(0);
+        await f.close();
+        expect(f.savedEvents().includes('"cancellation_origin":"compaction"')).toBe(trigger === "auto");
+
+        const reopened = await f.launch();
+        await reopened.sendKeys("C-o");
+        await reopened.waitForText("Full detail", 5000);
+        await reopened.sendKeys("End");
+        const full = await reopened.waitForPane((pane) => pane.includes("Cancel this held response."), 5000);
+        writeFileSync(join(f.root, "cancellation-reopened.txt"), full);
+        expect(full.includes("Cancelled")).toBe(trigger === "ordinary");
+        await reopened.sendKeys("C-o");
+        await reopened.waitForComposer(5000);
+        await f.close();
+        passed = true;
+      } finally { await f.cleanup(passed); }
+    }, 60_000);
+  }
+
+  test("missing credentials keep compaction feedback local without hiding ordinary auth errors", async () => {
+    const f = await fixture("manual");
+    let passed = false;
+    try {
+      const terminal = await f.launch(true);
+      const authMessage = "fx needs access to Vercel AI Gateway";
+      async function authNotices(label: string) {
+        await terminal.sendKeys("C-o");
+        await terminal.waitForText("Full detail", 5000);
+        await terminal.sendKeys("End");
+        const pane = await terminal.waitForPane((text) => text.includes("Full detail") && text.includes(authMessage), 5000);
+        writeFileSync(join(f.root, `${label}.txt`), pane);
+        await terminal.sendKeys("C-o");
+        await terminal.waitForComposer(5000);
+        return pane.split(authMessage).length - 1;
+      }
+      const initialNotices = await authNotices("auth-before");
+      expect(initialNotices).toBeGreaterThan(0);
+      await terminal.sendText("/compact");
+      await terminal.waitForText("Compaction was not started.", 5000);
+      expect(f.counts().summaries).toBe(0);
+      expect(f.counts().ordinary).toBe(f.seedTurns);
+      expect(f.durable()).toBe(0);
+      await terminal.sendKeys("Escape");
+      expect(await authNotices("auth-after-compaction")).toBe(initialNotices);
+
+      await terminal.sendText("Ordinary request without a credential.");
+      await terminal.waitForText(authMessage, 5000);
+      expect(await authNotices("auth-after-ordinary")).toBe(initialNotices + 1);
+      expect(f.counts().ordinary).toBe(f.seedTurns);
+      await f.close();
+      passed = true;
+    } finally { await f.cleanup(passed); }
+  }, 60_000);
 
   test("ordinary held request remains Thinking without compaction or extra requests", async () => {
     const f = await fixture("ordinary");

--- a/tests/e2e/tui-compaction-activity.test.ts
+++ b/tests/e2e/tui-compaction-activity.test.ts
@@ -146,6 +146,16 @@ async function fixture(trigger: Trigger, outcome: Outcome = "success", longResum
     await terminal.waitForComposer(5000);
     return terminal;
   }
+  async function waitForResumeHandoff() {
+    if (lines < 18_000) return;
+    const tracePath = join(root, `terminal-${launchIndex}.trace`);
+    // Wait only after submission: the composer accepts input during restoration,
+    // but replies need the immutable history source to hand off to the live one.
+    // 18k rows / 64 per frame needs about 282 frames. Debug observations reached
+    // 77 ms median / 134 ms max per frame; 60s bounds the drain, not the reply.
+    await until(() => readFileSync(tracePath, "utf8").includes("resume historical flow committed"),
+      `resume history-source handoff in ${tracePath}`, 60_000);
+  }
   function durable() {
     const bytes = readFileSync(eventsPath);
     expect(bytes.subarray(0, initial.length).equals(initial)).toBe(true);
@@ -193,7 +203,7 @@ async function fixture(trigger: Trigger, outcome: Outcome = "success", longResum
     expect(ordinary).toBe(seedTurns);
     phase = "attempt";
     return {
-      launch, close, cleanup, durable, cli, tapes, root, seedTurns, summaryHold, ordinaryHold,
+      launch, close, cleanup, durable, cli, tapes, root, seedTurns, summaryHold, ordinaryHold, waitForResumeHandoff,
       savedEvents: () => readFileSync(eventsPath, "utf8"),
       counts: () => ({ summaries, ordinary, overflowSent }),
       phase: (value: typeof phase) => { phase = value; },
@@ -267,6 +277,7 @@ describe.skipIf(!tmuxAvailable())("tui: compaction activity", () => {
           expect(pane).not.toMatch(ACTIVITY);
           expect(f.lastRequest()).toContain("INTERNAL_HANDOFF_4e12");
           f.ordinaryHold.release("CURRENT_TURN_OK_f713");
+          await f.waitForResumeHandoff();
           await terminal.waitForPane((pane) => pane.includes("CURRENT_TURN_OK_f713") && hasEmptyComposer(pane), 10_000);
         }
         expect(f.counts().overflowSent).toBe(trigger === "overflow");
@@ -282,6 +293,7 @@ describe.skipIf(!tmuxAvailable())("tui: compaction activity", () => {
         f.phase("reopen");
         const reopened = await f.launch();
         await reopened.sendText("Continue after reopening.");
+        await f.waitForResumeHandoff();
         await reopened.waitForPane((pane) => pane.includes(REOPEN) && hasEmptyComposer(pane), 10_000);
         expect(f.counts()).toEqual({ ...before, ordinary: before.ordinary + 2 });
         expect(f.durable()).toBe(1);

--- a/tests/e2e/tui-compaction-activity.test.ts
+++ b/tests/e2e/tui-compaction-activity.test.ts
@@ -361,14 +361,28 @@ describe.skipIf(!tmuxAvailable())("tui: compaction activity", () => {
         await terminal.sendKeys("Escape");
         if (trigger === "auto") {
           await terminal.waitForText("Compaction cancelled.", 10_000);
-          await terminal.sendKeys("Escape");
+          // An empty composer already exists while feedback is visible. Wait
+          // for Escape's visible acknowledgement, not a fixed sendKeys delay,
+          // so the slash in /quit cannot become part of a Meta key sequence.
+          terminal.sendKeysImmediate(["Escape"]);
         } else {
           await terminal.waitForText("Cancelled", 10_000);
         }
-        await terminal.waitForComposer(5000);
+        await terminal.waitForPane((pane) => hasEmptyComposer(pane) &&
+          !/Compaction cancelled|Compacting|Thinking/.test(pane), 5000);
+        const interruptions = () => f.savedEvents().trim().split("\n")
+          .map((line) => JSON.parse(line)).filter((frame) => frame.event?.interrupted);
+        await until(() => interruptions().length === 1, "durable cancellation", 5000);
+        expect(interruptions()[0].event.interrupted.reason).toBe("cancelled");
+        expect(interruptions()[0].event.interrupted.cancellation_origin === "compaction").toBe(trigger === "auto");
+        const cancelledCounts = { summaries: trigger === "auto" ? 1 : 0,
+          ordinary: f.seedTurns + (trigger === "ordinary" ? 1 : 0), overflowSent: false };
+        expect(f.counts()).toEqual(cancelledCounts);
         expect(f.durable()).toBe(0);
+        const cancelledEvents = f.savedEvents();
         await f.close();
-        expect(f.savedEvents().includes('"cancellation_origin":"compaction"')).toBe(trigger === "auto");
+        expect(f.counts()).toEqual(cancelledCounts);
+        expect(f.savedEvents()).toBe(cancelledEvents);
 
         const reopened = await f.launch();
         await reopened.sendKeys("C-o");
@@ -377,9 +391,19 @@ describe.skipIf(!tmuxAvailable())("tui: compaction activity", () => {
         const full = await reopened.waitForPane((pane) => pane.includes("Cancel this held response."), 5000);
         writeFileSync(join(f.root, "cancellation-reopened.txt"), full);
         expect(full.includes("Cancelled")).toBe(trigger === "ordinary");
+        expect(full).not.toMatch(COMPACTION_OUTPUT);
         await reopened.sendKeys("C-o");
         await reopened.waitForComposer(5000);
+        expect(await reopened.captureFullScrollbackEscapes()).not.toMatch(COMPACTION_OUTPUT);
         await f.close();
+        expect(f.counts()).toEqual(cancelledCounts);
+        expect(f.savedEvents()).toBe(cancelledEvents);
+        expect(f.durable()).toBe(0);
+        for (const tape of f.tapes) {
+          const replay = await f.cli(["replay", tape, "--json"]);
+          expect(replay.frame_count).toBeGreaterThan(0);
+          expect(replay.stdout_bytes).toBeGreaterThan(0);
+        }
         passed = true;
       } finally { await f.cleanup(passed); }
     }, 60_000);

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -6964,8 +6964,18 @@ test.skipIf(!tmuxAvailable())(
         await active.waitForComposer(TIMEOUT);
       }
       const sessionId = sessionIdFromHome(home);
+      const historyPath = join(home, ".fx", "sessions", sessionId, "events.jsonl");
+      const before = readFileSync(historyPath, "utf8");
       await active.sendText("/compact");
-      await active.waitForText("Context compacted.", TIMEOUT);
+      // Success is silent; publication, not a transcript notice, gates resume.
+      await waitForCondition(() => readFileSync(historyPath, "utf8").includes('"context_checkpoint"'), "durable context checkpoint");
+      await active.waitForPane((pane) => hasEmptyComposer(pane) && !/Preparing compaction|Compacting|Stopping compaction/.test(pane), TIMEOUT);
+      const compacted = readFileSync(historyPath, "utf8");
+      expect(compacted.startsWith(before)).toBe(true);
+      const records = compacted.trim().split("\n").map((line) => JSON.parse(line));
+      expect(records.filter((record) => record.event.context_checkpoint)).toHaveLength(1);
+      expect(await active.captureFullScrollback()).not.toContain("Context compacted.");
+      expect(gateway.requests).toHaveLength(4);
       const summaryRequest = JSON.parse(gateway.requests[3]!.body);
       expect(summaryRequest.prompt).toHaveLength(2);
       expect(summaryRequest.prompt[0].role).toBe("system");

--- a/tests/e2e/tui-slash-commands.test.ts
+++ b/tests/e2e/tui-slash-commands.test.ts
@@ -51,9 +51,10 @@ async function launchAndWait(): Promise<TmuxSession> {
   return s;
 }
 
-async function launchNoKeyAndWait(): Promise<{
+async function launchNoKeyAndWait(record = false): Promise<{
   terminal: TmuxSession;
   stderrPath: string;
+  root: string;
 }> {
   const root = mkdtempSync(join(tmpdir(), "fx-slash-commands-no-key-"));
   const home = join(root, "home");
@@ -65,8 +66,11 @@ async function launchNoKeyAndWait(): Promise<{
   const terminal = await TmuxSession.create({
     cwd: workspace,
     stderrPath,
+    isolated: true,
     env: {
       HOME: home,
+      FX_SOUND: "0",
+      ...(record ? { FX_RECORD: join(root, "terminal.fxtape"), FX_DEBUG_RECORD_SILENT_BANNER: "1" } : {}),
       AI_GATEWAY_API_KEY: undefined,
       FX_AUTO_UPGRADE: "0",
       FX_DISABLE_KEYCHAIN: "1",
@@ -75,11 +79,44 @@ async function launchNoKeyAndWait(): Promise<{
       VERCEL_OIDC_TOKEN: undefined,
     },
   });
-  await terminal.waitForComposer(10_000);
-  return { terminal, stderrPath };
+  await terminal.waitForText("Run /help for commands", 10_000);
+  await terminal.waitForStableComposer(10_000);
+  return { terminal, stderrPath, root };
 }
 
 describe.skipIf(TMUX_SKIP)("tui: no-key slash commands", () => {
+  test(
+    "/compact with no eligible context leaves no transcript notice",
+    async () => {
+      const launched = await launchNoKeyAndWait(true);
+      session = launched.terminal;
+      try {
+        await session.sendText("/compact");
+        await session.waitForText("No context to compact.", 5_000);
+        await session.waitForPane((pane) => !pane.includes("No context to compact."), 5_000);
+        await session.waitForComposer(5_000);
+        const scrollback = await session.captureFullScrollbackEscapes();
+        expect(scrollback).toContain("Run /help for commands");
+        expect(scrollback).not.toMatch(/No context to compact|Context:|Compacting/);
+        await session.sendKeys("C-o");
+        const transcript = await session.waitForText("Full detail", 5_000);
+        expect(transcript).not.toMatch(/No context to compact|Context:|Compacting/);
+        await session.sendKeys("C-o");
+        await session.waitForComposer(5_000);
+        await session.sendLiteral("composer-after-noop");
+        await session.waitForText("composer-after-noop", 5_000);
+        expect(session.paneStatus()).toEqual({ dead: false, status: null });
+        expect(readFileSync(launched.stderrPath, "utf8")).toBe("");
+      } catch (error) {
+        tempDirs.splice(tempDirs.indexOf(launched.root), 1);
+        writeFileSync(join(launched.root, "failure.scrollback.ansi"), await session.captureFullScrollbackEscapes());
+        console.error(`no-op evidence retained: ${launched.root}`);
+        throw error;
+      }
+    },
+    TIMEOUT,
+  );
+
   test(
     "/undo reports the exact empty state",
     async () => {
@@ -210,19 +247,6 @@ describe.skipIf(SKIP)("tui: slash commands", () => {
       await session.sendText("/model");
       const pane = await session.waitForText(/anthropic|model/i, 10_000);
       expect(pane.length).toBeGreaterThan(0);
-    },
-    TIMEOUT,
-  );
-
-  test(
-    "/compact reports when there is no eligible context",
-    async () => {
-      const launched = await launchNoKeyAndWait();
-      session = launched.terminal;
-      await session.sendText("/compact");
-      const pane = await session.waitForText("No context to compact.", 5_000);
-      expect(pane).toContain("No context to compact.");
-      expect(readFileSync(launched.stderrPath, "utf8")).toBe("");
     },
     TIMEOUT,
   );


### PR DESCRIPTION
## Summary

- Show manual and automatic compaction in the live activity row with elapsed time instead of turn token counters.
- Remove compaction progress and completion notices from the conversation and full transcript.
- Restore normal activity after automatic compaction and return manual compaction to an idle composer without sending a prompt.
- Keep compaction errors and cancellation feedback in the status area, with scoped dismissal and brief no-op or busy feedback.
- Keep browser terminal input and cancellation responsive while summary requests are pending.
- Clear stale compaction feedback when switching sessions without affecting newer work.
- Keep credential failures during `/compact` out of the transcript while preserving ordinary authentication errors and onboarding.
- Keep cancelled automatic compaction silent after reopening a session while preserving ordinary cancellation markers.
- Keep older saved sessions readable; sessions saved after cancelling automatic compaction require the same or a newer fx build.