### PR TITLE
Honor option sentinels before subcommand help

### DIFF
--- a/src/core/cli/cli_surface.zig
+++ b/src/core/cli/cli_surface.zig
@@ -593,6 +593,7 @@ fn topLevelHelpRequest(command_catalog: CommandCatalog, args: []const [:0]const 
     const kind = command_specs.topLevelKindFromToken(command_catalog, args[0]) orelse return null;
     if (kind == .help) return null;
     for (args[1..]) |arg| {
+        if (std.mem.eql(u8, arg, "--")) return null;
         if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) return kind;
     }
     return null;
@@ -4513,6 +4514,13 @@ test "top-level MCP trust persists project approval without interactive startup"
     defer choices.deinit(alloc);
     try std.testing.expectEqual(@as(usize, 1), choices.choices.approved.len);
     try std.testing.expectEqualStrings("fixture", choices.choices.approved[0]);
+}
+
+test "subcommand help detection stops at the option sentinel" {
+    const command_catalog = testCommandCatalog();
+    try std.testing.expectEqual(TopLevelKind.ask, topLevelHelpRequest(command_catalog, &.{ @constCast("ask"), @constCast("--help") }));
+    try std.testing.expectEqual(null, topLevelHelpRequest(command_catalog, &.{ @constCast("ask"), @constCast("--"), @constCast("--help") }));
+    try std.testing.expectEqual(null, topLevelHelpRequest(command_catalog, &.{ @constCast("ask"), @constCast("--"), @constCast("-h") }));
 }
 
 test "workspace launch modifiers preserve supported command help" {

--- a/src/core/cli/cli_surface.zig
+++ b/src/core/cli/cli_surface.zig
@@ -4516,11 +4516,18 @@ test "top-level MCP trust persists project approval without interactive startup"
     try std.testing.expectEqualStrings("fixture", choices.choices.approved[0]);
 }
 
-test "subcommand help detection stops at the option sentinel" {
+test "subcommand help detection stops at the option sentinel for every command" {
     const command_catalog = testCommandCatalog();
-    try std.testing.expectEqual(TopLevelKind.ask, topLevelHelpRequest(command_catalog, &.{ @constCast("ask"), @constCast("--help") }));
-    try std.testing.expectEqual(null, topLevelHelpRequest(command_catalog, &.{ @constCast("ask"), @constCast("--"), @constCast("--help") }));
-    try std.testing.expectEqual(null, topLevelHelpRequest(command_catalog, &.{ @constCast("ask"), @constCast("--"), @constCast("-h") }));
+    for (command_catalog.specs) |spec| {
+        if (spec.kind == .help) continue;
+        const token = try std.testing.allocator.dupeZ(u8, spec.token);
+        defer std.testing.allocator.free(token);
+
+        try std.testing.expectEqual(spec.kind, topLevelHelpRequest(command_catalog, &.{ token, @constCast("--help") }));
+        try std.testing.expectEqual(spec.kind, topLevelHelpRequest(command_catalog, &.{ token, @constCast("-h") }));
+        try std.testing.expectEqual(null, topLevelHelpRequest(command_catalog, &.{ token, @constCast("--"), @constCast("--help") }));
+        try std.testing.expectEqual(null, topLevelHelpRequest(command_catalog, &.{ token, @constCast("--"), @constCast("-h") }));
+    }
 }
 
 test "workspace launch modifiers preserve supported command help" {


### PR DESCRIPTION
## Summary

- stop shared subcommand-help detection at the option sentinel
- preserve arguments named `--help` or `-h` after `--` instead of intercepting them as help
- cover both help aliases across every registered top-level command

## Behavior

`fx <command> --help` and `fx <command> -h` still render command help. Once `--` is encountered, help detection leaves all remaining arguments to that command's parser. For `fx ask`, which supports the sentinel, this preserves literal prompt text such as `fx ask -- --help`.

## Verification

- `zig fmt --check src/`
- `git diff --check`
- `zig build test -- --test-filter 'subcommand help detection stops at the option sentinel for every command'`
- `zig build`
- exercised `./zig-out/bin/fx ask --no-save -- --help` against the local fake Gateway: the request contained the literal `--help` prompt, stdout was `PROMPT_RECEIVED`, stderr was empty, and the process exited 0
