### PR TITLE
Use native signing pages for macOS arm64

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -2,6 +2,11 @@ name: Benchmarks
 
 on:
   workflow_dispatch:
+    inputs:
+      signed_run:
+        description: Successful main Release validation run to compare (no signing credentials used)
+        type: string
+        default: ""
   push:
     branches: [main]
   pull_request:
@@ -15,6 +20,7 @@ permissions:
 
 jobs:
   bench:
+    if: inputs.signed_run == ''
     name: Startup Latency
     runs-on: ubuntu-latest
     steps:
@@ -41,7 +47,7 @@ jobs:
 
       - name: Run UI activity progress benchmark
         run: |
-          for run in 1 2 3; do
+          for _ in 1 2 3; do
             zig build run-bench-ui-activity -Doptimize=ReleaseSafe
           done
 
@@ -64,6 +70,7 @@ jobs:
           if-no-files-found: warn
 
   libfx-ttft:
+    if: inputs.signed_run == ''
     name: libfx Runtime
     runs-on: ubuntu-latest
     steps:
@@ -121,4 +128,72 @@ jobs:
         with:
           name: libfx-ttft-${{ github.sha }}
           path: benchmarks/results/libfx/*.json
+          if-no-files-found: error
+
+  signed-macos:
+    name: Signed macOS comparison
+    if: github.event_name == 'workflow_dispatch' && inputs.signed_run != ''
+    runs-on: macos-15
+    timeout-minutes: 20
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Download a successful main validation pair
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SIGNED_RUN: ${{ inputs.signed_run }}
+        run: |
+          [[ "$SIGNED_RUN" =~ ^[1-9][0-9]*$ ]]
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$SIGNED_RUN" > "$RUNNER_TEMP/signed-source.json"
+          jq -e --arg repo "$GITHUB_REPOSITORY" '
+            .conclusion == "success" and .head_branch == "main" and
+            .event == "workflow_dispatch" and .path == ".github/workflows/release.yml" and
+            .head_repository.full_name == $repo
+          ' "$RUNNER_TEMP/signed-source.json"
+          gh run download "$SIGNED_RUN" --repo "$GITHUB_REPOSITORY" \
+            --name fx-macos-aarch64 --name signing-control-macos-arm64 \
+            --dir "$RUNNER_TEMP/signed-input"
+          mkdir -p "$RUNNER_TEMP/signed-control" "$RUNNER_TEMP/signed-candidate"
+          tar -xzf "$RUNNER_TEMP/signed-input/signing-control-macos-arm64/fx-signing-control.tar.gz" -C "$RUNNER_TEMP/signed-control" fx
+          tar -xzf "$RUNNER_TEMP/signed-input/fx-macos-aarch64/fx-macos-aarch64.tar.gz" -C "$RUNNER_TEMP/signed-candidate" fx
+
+      - name: Install measurement tools
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+        run: |
+          command -v hyperfine >/dev/null || brew install hyperfine
+          xcrun clang -O2 benchmarks/signed_macos_resources.c -o "$RUNNER_TEMP/signed-resources"
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: "1.3.14"
+
+      - name: Compare signed startup
+        run: |
+          python3 -m scripts.compare_signed_macos \
+            --control "$RUNNER_TEMP/signed-control/fx" \
+            --candidate "$RUNNER_TEMP/signed-candidate/fx" \
+            --source-sha "$(jq -r .head_sha "$RUNNER_TEMP/signed-source.json")" \
+            --output "$RUNNER_TEMP/signed-comparison"
+
+      - name: Compare native image-flow memory
+        env:
+          FX_SIGNED_COMPARE_DIR: ${{ runner.temp }}/signed-comparison
+          FX_SIGNED_RESOURCE_PROBE: ${{ runner.temp }}/signed-resources
+        run: bun test benchmarks/signed_macos_memory.test.ts
+
+      - name: Retain paired measurements
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: signed-macos-comparison-${{ github.run_id }}
+          path: |
+            ${{ runner.temp }}/signed-comparison/manifest.json
+            ${{ runner.temp }}/signed-comparison/startup-*.json
+            ${{ runner.temp }}/signed-comparison/startup-*/logs/
+            ${{ runner.temp }}/signed-comparison/memory-*.json
+            ${{ runner.temp }}/signed-source.json
           if-no-files-found: error

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -51,7 +51,7 @@ jobs:
         run: ./scripts/check-public-surface.sh
 
       - name: Test signing and release routing
-        run: python3 -m unittest scripts.tests.test_macos_signing -q
+        run: python3 -m unittest scripts.tests.test_macos_signing scripts.tests.test_signed_macos -q
 
       - name: Build
         run: zig build -Doptimize=${{ matrix.optimize }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -453,6 +453,13 @@ workflow artifacts for matched signed-binary performance checks; notarization
 and smoke checks alone do not establish performance equivalence. Normal release
 runs keep the existing signing default.
 
+To compare the retained signatures on an isolated runner, run **Actions >
+Benchmarks** with `signed_run` set to the successful main validation run ID.
+This mode downloads already-notarized binaries and does not access Apple
+credentials. It records two alternating startup cohorts and a separate native
+image-flow memory screen. Review the retained measurements before changing
+release signing defaults; successful measurement is not performance approval.
+
 ## Benchmarks
 
 Startup latency benchmarks run automatically on every PR and push to `main` via `.github/workflows/bench.yml`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -456,9 +456,10 @@ runs keep the existing signing default.
 To compare the retained signatures on an isolated runner, run **Actions >
 Benchmarks** with `signed_run` set to the successful main validation run ID.
 This mode downloads already-notarized binaries and does not access Apple
-credentials. It records two alternating startup cohorts and a separate native
-image-flow memory screen. Review the retained measurements before changing
-release signing defaults; successful measurement is not performance approval.
+credentials. It records two alternating startup cohorts, an identical-control
+status calibration, and a separate native image-flow memory screen. Review the
+retained measurements before changing release signing defaults; successful
+measurement is not performance approval.
 
 ## Benchmarks
 

--- a/benchmarks/signed_macos_memory.test.ts
+++ b/benchmarks/signed_macos_memory.test.ts
@@ -13,13 +13,13 @@ test("signed macOS variants preserve the image flow and native resource accounti
   const rows: Array<Record<string, number | string>> = [];
   writeFileSync(join(root, "memory-manifest.json"), JSON.stringify({
     fixture_sha256: new Bun.CryptoHasher("sha256").update(readFileSync(fixture)).digest("hex"),
-    bun: Bun.version, model, samples_per_binary: 50, warmup_pairs: 3,
+    bun: Bun.version, model, samples_per_binary: 200, warmup_pairs: 3,
     boundary: "native fx PID after decoded image reaches provider, before final response",
     accounting: "proc_pid_rusage; excludes the Bun gateway and MCP helper",
     order: "alternating AB/BA with reversed equal-length lanes", timeout_ms: 20_000,
     claim_limit: "resource screen, not a heap-leak proof",
   }, null, 2));
-  for (let round = -3; round < 50; round++) {
+  for (let round = -3; round < 200; round++) {
     for (const label of round % 2 === 0 ? ["control", "candidate"] : ["candidate", "control"]) {
       const dir = mkdtempSync(join(tmpdir(), "fx-signed-memory-"));
       const cohort = Math.abs(Math.floor(round / 2)) % 2;
@@ -78,5 +78,5 @@ test("signed macOS variants preserve the image flow and native resource accounti
       } finally { gateway.stop(); rmSync(dir, { recursive: true, force: true }); }
     }
   }
-  expect(rows).toHaveLength(100);
+  expect(rows).toHaveLength(400);
 }, 180_000);

--- a/benchmarks/signed_macos_memory.test.ts
+++ b/benchmarks/signed_macos_memory.test.ts
@@ -1,0 +1,82 @@
+import { expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { fakeGatewayFinalText, fakeGatewayToolCall, startFakeGateway } from "../tests/e2e/tmux-helpers";
+
+test("signed macOS variants preserve the image flow and native resource accounting", async () => {
+  const root = process.env.FX_SIGNED_COMPARE_DIR;
+  const probe = process.env.FX_SIGNED_RESOURCE_PROBE;
+  if (!root || !probe) throw new Error("signed comparison paths are required");
+  const fixture = join(import.meta.dirname, "../tests/e2e/fixtures/mcp-modern-stdio.mjs");
+  const model = "fixture/vision";
+  const rows: Array<Record<string, number | string>> = [];
+  writeFileSync(join(root, "memory-manifest.json"), JSON.stringify({
+    fixture_sha256: new Bun.CryptoHasher("sha256").update(readFileSync(fixture)).digest("hex"),
+    bun: Bun.version, model, samples_per_binary: 50, warmup_pairs: 3,
+    boundary: "native fx PID after decoded image reaches provider, before final response",
+    accounting: "proc_pid_rusage; excludes the Bun gateway and MCP helper",
+    order: "alternating AB/BA with reversed equal-length lanes", timeout_ms: 20_000,
+    claim_limit: "resource screen, not a heap-leak proof",
+  }, null, 2));
+  for (let round = -3; round < 50; round++) {
+    for (const label of round % 2 === 0 ? ["control", "candidate"] : ["candidate", "control"]) {
+      const dir = mkdtempSync(join(tmpdir(), "fx-signed-memory-"));
+      const cohort = Math.abs(Math.floor(round / 2)) % 2;
+      const lane = (label === "candidate" ? 1 : 0) ^ cohort;
+      const binary = join(root, `cohort-${cohort}`, `lane-${lane}`, "fx");
+      const profile = join(dir, "profile"), workspace = join(dir, "workspace");
+      mkdirSync(join(profile, ".fx"), { recursive: true });
+      mkdirSync(workspace);
+      writeFileSync(join(profile, ".fx/settings.json"), "{}");
+      writeFileSync(join(profile, ".fx/mcp.json"), JSON.stringify({ mcp: { fixture: {
+        type: "local", command: [process.execPath, fixture], enabled: true,
+        environment: { FX_MCP_PROTOCOL_VERSION: "2026-07-28", FX_MCP_MODE: "image_result" },
+      } } }));
+      let childPid = 0;
+      let sample: Record<string, number> | null = null;
+      const gateway = startFakeGateway([
+        fakeGatewayToolCall("image_select", "mcp_select_tool", { name: "mcp_fixture_echo" }),
+        fakeGatewayToolCall("image_call", "mcp_fixture_echo", { text: "screenshot" }),
+        () => {
+          const measured = Bun.spawnSync([probe, String(childPid)], { stdout: "pipe", stderr: "pipe" });
+          expect(measured.exitCode, measured.stderr.toString()).toBe(0);
+          sample = JSON.parse(measured.stdout.toString());
+          return fakeGatewayFinalText("Image result observed.");
+        },
+      ], { models: [{ id: model, type: "language", tags: ["tool-use", "vision", "file-input"] }] });
+      try {
+        const child = Bun.spawn([binary, "ask", "--json", "--auto", "--no-save", "Get an image from the fixture"], {
+          cwd: workspace, stdin: "ignore", stdout: "pipe", stderr: "pipe",
+          env: { PATH: process.env.PATH ?? "", TMPDIR: dir, LANG: "en_US.UTF-8", TZ: "UTC",
+            HOME: profile, AI_GATEWAY_API_KEY: "fake-fixture-key", FX_AUTO_UPGRADE: "0", FX_SOUND: "0",
+            FX_DISABLE_KEYCHAIN: "1", FX_SKIP_ONBOARDING: "1", FX_PERMISSION_MODE: "auto", FX_MODEL: model,
+            FX_GATEWAY_BASE_URL: gateway.baseUrl, FX_GATEWAY_CHAT_URL: gateway.chatUrl,
+            FX_E2E_GATEWAY_CHAT_URL: gateway.chatUrl },
+        });
+        childPid = child.pid;
+        const timer = setTimeout(() => child.kill("SIGKILL"), 20_000);
+        let code: number, stdout: string, stderr: string;
+        try {
+          [code, stdout, stderr] = await Promise.all([child.exited, new Response(child.stdout).text(), new Response(child.stderr).text()]);
+        } finally {
+          clearTimeout(timer);
+          if (child.exitCode === null) {
+            child.kill("SIGKILL");
+            await child.exited;
+          }
+        }
+        expect(code!, stderr! || stdout!).toBe(0);
+        expect(stderr!.trim().split("\n")).toEqual(["Selecting MCP tool mcp_fixture_echo", "MCP: mcp_fixture_echo"]);
+        expect(JSON.parse(stdout!).output).toContain("Image result observed.");
+        const parts = JSON.parse(gateway.requests.at(-1)!.body).prompt.flatMap((message: any) => message.content ?? []);
+        const result = parts.find((part: any) => part.type === "tool-result" && part.toolCallId === "image_call");
+        expect(result.output.value.some((part: any) => part.type === "image-data" && part.mediaType === "image/png")).toBe(true);
+        expect(sample).not.toBeNull();
+        if (round >= 0) rows.push({ label, round, ...sample! });
+        writeFileSync(join(root, "memory-results.json"), JSON.stringify(rows, null, 2));
+      } finally { gateway.stop(); rmSync(dir, { recursive: true, force: true }); }
+    }
+  }
+  expect(rows).toHaveLength(100);
+}, 180_000);

--- a/benchmarks/signed_macos_resources.c
+++ b/benchmarks/signed_macos_resources.c
@@ -1,0 +1,24 @@
+#include <errno.h>
+#include <inttypes.h>
+#include <limits.h>
+#include <libproc.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char **argv) {
+    if (argc != 2) return 2;
+    char *end = NULL;
+    errno = 0;
+    long pid = strtol(argv[1], &end, 10);
+    if (errno || !end || *end || pid <= 0 || pid > INT_MAX) return 2;
+    struct rusage_info_v4 usage = {0};
+    if (proc_pid_rusage((int)pid, RUSAGE_INFO_V4, (rusage_info_t *)&usage)) {
+        perror("proc_pid_rusage");
+        return 1;
+    }
+    printf("{\"rss_bytes\":%" PRIu64 ",\"footprint_bytes\":%" PRIu64
+           ",\"max_footprint_bytes\":%" PRIu64 "}\n",
+           usage.ri_resident_size, usage.ri_phys_footprint,
+           usage.ri_lifetime_max_phys_footprint);
+    return 0;
+}

--- a/scripts/compare_signed_macos.py
+++ b/scripts/compare_signed_macos.py
@@ -97,6 +97,7 @@ def main() -> None:
     if not re.fullmatch(r"[0-9a-f]{40}", args.source_sha):
         parser.error("source SHA must be a full commit hash")
     repo = pathlib.Path(__file__).resolve().parents[1]
+    samples = 5_000
     binaries = {"control": args.control.resolve(), "candidate": args.candidate.resolve()}
     for label, path in binaries.items():
         if not path.is_file() or path.stat().st_size > 16 * 1024 * 1024:
@@ -115,25 +116,29 @@ def main() -> None:
         "platform": platform.platform(),
         "cpu": subprocess.check_output(["sysctl", "-n", "machdep.cpu.brand_string"], text=True).strip(),
         "hyperfine": subprocess.check_output(["hyperfine", "--version"], text=True).strip(),
-        "samples_per_binary_per_command_per_cohort": 1000, "cohorts": 2,
+        "samples_per_binary_per_command_per_cohort": samples, "cohorts": 2,
+        "calibration": {"cohort": 2, "commands": ["status"], "pair": "control versus identical control"},
         "order": "alternating rounds; equal-length paths; reversed lanes in cohort 1",
         "boundary": "warm process launch to exit; not first-use Gatekeeper assessment",
         "qualification": "measurement only; inspect latency and memory evidence before shipping",
     })
     (args.output / "manifest.json").write_text(json.dumps(manifest, indent=2) + "\n")
-    for label, path in binaries.items():
-        (args.output / label).mkdir()
-        shutil.copy2(path, args.output / label / "fx")
     hyperfine = pathlib.Path(shutil.which("hyperfine") or "hyperfine")
-    for cohort in (0, 1):
+    for cohort in (0, 1, 2):
         paths = {}
-        for label, lane in (("control", cohort), ("candidate", 1 - cohort)):
+        for label, lane in (("control", cohort % 2), ("candidate", 1 - cohort % 2)):
             directory = args.output / f"cohort-{cohort}" / f"lane-{lane}"
             directory.mkdir(parents=True)
             paths[label] = directory / "fx"
-            shutil.copy2(binaries[label], paths[label])
-        results = measure_startup(repo_root=repo, control_binary=paths["control"], candidate_binary=paths["candidate"], hyperfine_binary=hyperfine, output_dir=args.output / f"startup-{cohort}", samples=1000, timeout_s=30)
+            shutil.copy2(binaries["control" if cohort == 2 else label], paths[label])
+        results = measure_startup(
+            repo_root=repo, control_binary=paths["control"], candidate_binary=paths["candidate"],
+            hyperfine_binary=hyperfine, output_dir=args.output / f"startup-{cohort}",
+            samples=samples, timeout_s=30, command_names=("status",) if cohort == 2 else None,
+        )
         records = [measurement_record(result) for result in results]
+        for record in records:
+            record["pair"] = "control-versus-control" if cohort == 2 else "control-versus-candidate"
         (args.output / f"startup-{cohort}.json").write_text(json.dumps(records, indent=2) + "\n")
         for result in results:
             print(f"cohort {cohort} {result.name}: p50 {result.comparison.p50_change:+.3%}, p95 {result.comparison.p95_change:+.3%}", flush=True)

--- a/scripts/compare_signed_macos.py
+++ b/scripts/compare_signed_macos.py
@@ -1,0 +1,143 @@
+"""Measure two notarized copies of one macOS arm64 payload."""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import hashlib
+import json
+import pathlib
+import platform
+import re
+import shutil
+import struct
+import subprocess
+
+from scripts.pgso.qualify import MeasurementResult, measure_startup
+
+
+def measurement_record(result: MeasurementResult) -> dict:
+    record = dataclasses.asdict(result)
+    record.pop("passed")
+    if record["comparison"] is not None:
+        record["comparison"].pop("passed", None)
+    return record
+
+
+def signature_layout(data: bytes) -> tuple[int, int, int, list[tuple[int, int]]]:
+    if len(data) < 32:
+        raise ValueError("truncated Mach-O header")
+    magic, cpu, _, kind, count, size = struct.unpack_from("<6I", data)
+    if (magic, cpu, kind) != (0xFEEDFACF, 0x0100000C, 2):
+        raise ValueError("expected a thin arm64 Mach-O executable")
+    end = 32 + size
+    if end > len(data):
+        raise ValueError("truncated load commands")
+    command_offset = 32
+    fields: list[tuple[int, int]] = []
+    signature = None
+    for _ in range(count):
+        if command_offset + 8 > end:
+            raise ValueError("truncated load command")
+        command, length = struct.unpack_from("<2I", data, command_offset)
+        if length < 8 or command_offset + length > end:
+            raise ValueError("invalid load command length")
+        if command == 0x19:
+            if length < 72:
+                raise ValueError("truncated segment")
+            if data[command_offset + 8:command_offset + 24].rstrip(b"\0") == b"__LINKEDIT":
+                if fields:
+                    raise ValueError("ambiguous link-edit segment")
+                fields.extend(((command_offset + 32, 8), (command_offset + 48, 8)))
+        elif command == 0x1D:
+            if signature is not None or length != 16:
+                raise ValueError("ambiguous code signature")
+            signature = struct.unpack_from("<2I", data, command_offset + 8)
+            fields.append((command_offset + 12, 4))
+        command_offset += length
+    if command_offset != end or signature is None or len(fields) != 3:
+        raise ValueError("missing signature or link-edit segment")
+    offset, length = signature
+    if offset < end or offset + length > len(data):
+        raise ValueError("invalid code signature extent")
+    return end, offset, length, fields
+
+
+def compare_payloads(control: bytes, candidate: bytes) -> dict:
+    old_end, old_offset, old_size, old_fields = signature_layout(control)
+    new_end, new_offset, new_size, new_fields = signature_layout(candidate)
+    if (old_end, old_offset, old_fields) != (new_end, new_offset, new_fields):
+        raise ValueError("binary layouts differ")
+    old_header = bytearray(control[:old_end])
+    new_header = bytearray(candidate[:new_end])
+    for offset, length in old_fields:
+        old_header[offset:offset + length] = bytes(length)
+        new_header[offset:offset + length] = bytes(length)
+    if old_header != new_header or control[old_end:old_offset] != candidate[new_end:new_offset]:
+        raise ValueError("application header or payload changed")
+    if control[old_offset + old_size:] != candidate[new_offset + new_size:]:
+        raise ValueError("trailing data changed")
+    return {
+        "payload_range": [old_end, old_offset],
+        "payload_sha256": hashlib.sha256(control[old_end:old_offset]).hexdigest(),
+        "saving_bytes": len(control) - len(candidate),
+        "control_bytes": len(control), "candidate_bytes": len(candidate),
+        "control_sha256": hashlib.sha256(control).hexdigest(),
+        "candidate_sha256": hashlib.sha256(candidate).hexdigest(),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--control", type=pathlib.Path, required=True)
+    parser.add_argument("--candidate", type=pathlib.Path, required=True)
+    parser.add_argument("--output", type=pathlib.Path, required=True)
+    parser.add_argument("--source-sha", required=True)
+    args = parser.parse_args()
+    if not re.fullmatch(r"[0-9a-f]{40}", args.source_sha):
+        parser.error("source SHA must be a full commit hash")
+    repo = pathlib.Path(__file__).resolve().parents[1]
+    binaries = {"control": args.control.resolve(), "candidate": args.candidate.resolve()}
+    for label, path in binaries.items():
+        if not path.is_file() or path.stat().st_size > 16 * 1024 * 1024:
+            raise ValueError(f"invalid {label} binary")
+        subprocess.run(["codesign", "--verify", "--strict", "--check-notarization", "-R=notarized", str(path)], check=True, timeout=60)
+        details = subprocess.run(["codesign", "--display", "--verbose=4", str(path)], capture_output=True, text=True, check=True, timeout=30).stderr
+        page = 4096 if label == "control" else 16384
+        for required in ("Identifier=com.vercel.fx", "TeamIdentifier=JW6Y669B67", f"Page size={page}", "flags=0x10000(runtime)", "Timestamp="):
+            if required not in details:
+                raise ValueError(f"unexpected {label} signature: missing {required}")
+    manifest = compare_payloads(binaries["control"].read_bytes(), binaries["candidate"].read_bytes())
+    args.output.mkdir(parents=True, exist_ok=False)
+    manifest.update({
+        "artifact_source_sha": args.source_sha,
+        "driver_sha": subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo, text=True).strip(),
+        "platform": platform.platform(),
+        "cpu": subprocess.check_output(["sysctl", "-n", "machdep.cpu.brand_string"], text=True).strip(),
+        "hyperfine": subprocess.check_output(["hyperfine", "--version"], text=True).strip(),
+        "samples_per_binary_per_command_per_cohort": 1000, "cohorts": 2,
+        "order": "alternating rounds; equal-length paths; reversed lanes in cohort 1",
+        "boundary": "warm process launch to exit; not first-use Gatekeeper assessment",
+        "qualification": "measurement only; inspect latency and memory evidence before shipping",
+    })
+    (args.output / "manifest.json").write_text(json.dumps(manifest, indent=2) + "\n")
+    for label, path in binaries.items():
+        (args.output / label).mkdir()
+        shutil.copy2(path, args.output / label / "fx")
+    hyperfine = pathlib.Path(shutil.which("hyperfine") or "hyperfine")
+    for cohort in (0, 1):
+        paths = {}
+        for label, lane in (("control", cohort), ("candidate", 1 - cohort)):
+            directory = args.output / f"cohort-{cohort}" / f"lane-{lane}"
+            directory.mkdir(parents=True)
+            paths[label] = directory / "fx"
+            shutil.copy2(binaries[label], paths[label])
+        results = measure_startup(repo_root=repo, control_binary=paths["control"], candidate_binary=paths["candidate"], hyperfine_binary=hyperfine, output_dir=args.output / f"startup-{cohort}", samples=1000, timeout_s=30)
+        records = [measurement_record(result) for result in results]
+        (args.output / f"startup-{cohort}.json").write_text(json.dumps(records, indent=2) + "\n")
+        for result in results:
+            print(f"cohort {cohort} {result.name}: p50 {result.comparison.p50_change:+.3%}, p95 {result.comparison.p95_change:+.3%}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sign-and-notarize-macos.sh
+++ b/scripts/sign-and-notarize-macos.sh
@@ -21,15 +21,16 @@ if [[ $# -gt 2 || ( "${signing_page_size}" != 4096 && "${signing_page_size}" != 
     echo "Signature page size must be 4096 or 16384" >&2
     exit 1
 fi
-if [[ "${signing_page_size}" == 16384 ]]; then
-    if ! binary_archs="$("${xcrun_bin}" lipo -archs "${binary_path}")"; then
-        echo "Apple signing failed during architecture inspection" >&2
-        exit 1
-    fi
-    if [[ "${binary_archs}" != arm64 ]]; then
-        echo "16 KiB signature pages require a thin arm64 binary" >&2
-        exit 1
-    fi
+if ! binary_archs="$("${xcrun_bin}" lipo -archs "${binary_path}")"; then
+    echo "Apple signing failed during architecture inspection" >&2
+    exit 1
+fi
+if [[ $# -eq 1 && "${binary_archs}" == arm64 ]]; then
+    signing_page_size=16384
+fi
+if [[ "${signing_page_size}" == 16384 && "${binary_archs}" != arm64 ]]; then
+    echo "16 KiB signature pages require a thin arm64 binary" >&2
+    exit 1
 fi
 for required_name in \
     APPLE_DEVELOPER_ID_P12_BASE64 \

--- a/scripts/tests/test_macos_signing.py
+++ b/scripts/tests/test_macos_signing.py
@@ -233,11 +233,13 @@ else:
         )
         return result, binary, runner_temp, event_log
 
-    def test_explicit_page_size_preserves_the_production_default(self) -> None:
+    def test_selects_native_defaults_and_preserves_explicit_page_sizes(self) -> None:
         for arch, page_size, expected in (
-            ("arm64", None, "4096"),
+            ("arm64", None, "16384"),
             ("x86_64", None, "4096"),
             ("arm64 x86_64", None, "4096"),
+            ("x86_64 arm64", None, "4096"),
+            ("x86_64", "4096", "4096"),
             ("arm64", "4096", "4096"),
             ("arm64", "16384", "16384"),
         ):
@@ -351,6 +353,10 @@ else:
     def test_reports_failing_signing_stage_without_printing_secrets(self) -> None:
         self.assertTrue(SCRIPT_PATH.is_file(), "macOS signing helper is missing")
         cases = (
+            (
+                {"FX_SIGNING_TEST_XCRUN_FAIL_COMMAND": "-archs"},
+                "architecture inspection",
+            ),
             (
                 {"FX_SIGNING_TEST_SECURITY_FAIL_COMMAND": "import"},
                 "PKCS#12 import",

--- a/scripts/tests/test_signed_macos.py
+++ b/scripts/tests/test_signed_macos.py
@@ -1,7 +1,11 @@
+import json
+import pathlib
 import struct
+import tempfile
 import unittest
+from unittest import mock
 
-from scripts.compare_signed_macos import compare_payloads, measurement_record, signature_layout
+from scripts.compare_signed_macos import compare_payloads, main, measurement_record, signature_layout
 from scripts.pgso.qualify import MeasurementResult, compare_samples
 
 
@@ -17,6 +21,33 @@ def fixture(signature_size: int) -> bytes:
 
 
 class SignedMacosComparisonTests(unittest.TestCase):
+    def test_status_calibration_compares_identical_control_bytes(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            control, candidate, output = root / "control", root / "candidate", root / "output"
+            control.write_bytes(fixture(32))
+            candidate.write_bytes(fixture(16))
+            details = "Identifier=com.vercel.fx TeamIdentifier=JW6Y669B67 flags=0x10000(runtime) Timestamp=fixture Page size=4096 Page size=16384"
+            with mock.patch("sys.argv", ["compare_signed_macos", "--control", str(control), "--candidate", str(candidate), "--output", str(output), "--source-sha", "0" * 40]), \
+                 mock.patch("scripts.compare_signed_macos.subprocess.run", return_value=mock.Mock(stderr=details)), \
+                 mock.patch("scripts.compare_signed_macos.subprocess.check_output", return_value="fixture\n"), \
+                 mock.patch("scripts.compare_signed_macos.platform.platform", return_value="fixture"), \
+                 mock.patch("scripts.compare_signed_macos.measure_startup", return_value=()) as measure:
+                main()
+            self.assertEqual(3, measure.call_count)
+            for index, call in enumerate(measure.call_args_list):
+                args = call.kwargs
+                self.assertEqual(5000, args["samples"])
+                self.assertEqual(("status",) if index == 2 else None, args["command_names"])
+                self.assertEqual(control.read_bytes(), args["control_binary"].read_bytes())
+                expected = control if index == 2 else candidate
+                self.assertEqual(expected.read_bytes(), args["candidate_binary"].read_bytes())
+                self.assertEqual(len(str(args["control_binary"])), len(str(args["candidate_binary"])))
+            manifest = json.loads((output / "manifest.json").read_text())
+            self.assertEqual(2, manifest["calibration"]["cohort"])
+            self.assertFalse((output / "control").exists())
+            self.assertFalse((output / "candidate").exists())
+
     def test_measurement_does_not_inherit_pgso_regression_allowance(self):
         control = (1.0,) * 100
         candidate = (1.07,) * 100

--- a/scripts/tests/test_signed_macos.py
+++ b/scripts/tests/test_signed_macos.py
@@ -1,0 +1,74 @@
+import struct
+import unittest
+
+from scripts.compare_signed_macos import compare_payloads, measurement_record, signature_layout
+from scripts.pgso.qualify import MeasurementResult, compare_samples
+
+
+def fixture(signature_size: int) -> bytes:
+    payload = b"the same payload"
+    header = struct.pack("<8I", 0xFEEDFACF, 0x0100000C, 0, 2, 2, 88, 0, 0)
+    segment = struct.pack(
+        "<II16sQQQQiiII", 0x19, 72, b"__LINKEDIT", 0, 4096,
+        120, len(payload) + signature_size, 1, 1, 0, 0,
+    )
+    signature = struct.pack("<4I", 0x1D, 16, 120 + len(payload), signature_size)
+    return header + segment + signature + payload + bytes(signature_size)
+
+
+class SignedMacosComparisonTests(unittest.TestCase):
+    def test_measurement_does_not_inherit_pgso_regression_allowance(self):
+        control = (1.0,) * 100
+        candidate = (1.07,) * 100
+        comparison = compare_samples(control, candidate, minimum_samples=100)
+        self.assertTrue(comparison.passed)
+        result = MeasurementResult(
+            name="startup-help", argv=("help",), requested_samples=100,
+            control_samples=control, candidate_samples=candidate,
+            control_failures=0, candidate_failures=0, errors=(),
+            comparison=comparison, passed=True,
+        )
+        record = measurement_record(result)
+        self.assertNotIn("passed", record)
+        self.assertNotIn("passed", record["comparison"])
+        self.assertEqual(control, record["control_samples"])
+        self.assertEqual(candidate, record["candidate_samples"])
+        self.assertAlmostEqual(0.07, record["comparison"]["p95_change"])
+
+    def test_accepts_signature_only_size_changes(self):
+        result = compare_payloads(fixture(32), fixture(16))
+        self.assertEqual(16, result["saving_bytes"])
+        self.assertEqual([120, 136], result["payload_range"])
+
+    def test_rejects_changed_application_payload(self):
+        changed = bytearray(fixture(16))
+        changed[120] ^= 1
+        with self.assertRaisesRegex(ValueError, "payload changed"):
+            compare_payloads(fixture(32), changed)
+
+    def test_rejects_changed_non_signing_header(self):
+        changed = bytearray(fixture(16))
+        changed[24] ^= 1
+        with self.assertRaisesRegex(ValueError, "header or payload changed"):
+            compare_payloads(fixture(32), changed)
+
+    def test_rejects_truncated_header_commands_and_signature(self):
+        valid = fixture(32)
+        for length in (0, 31, 40, 119, len(valid) - 1):
+            with self.subTest(length=length):
+                with self.assertRaises(ValueError):
+                    signature_layout(valid[:length])
+
+    def test_rejects_other_architectures(self):
+        changed = bytearray(fixture(16))
+        struct.pack_into("<I", changed, 4, 0x01000007)
+        with self.assertRaisesRegex(ValueError, "thin arm64"):
+            signature_layout(changed)
+
+    def test_rejects_added_trailing_content(self):
+        with self.assertRaisesRegex(ValueError, "trailing data"):
+            compare_payloads(fixture(32), fixture(16) + b"extra")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/core/execution/command_runner.zig
+++ b/src/core/execution/command_runner.zig
@@ -3098,10 +3098,11 @@ test "foreground session owner loss kills the target and descendant before delay
     defer alloc.free(quoted_pids);
     const quoted_effect = try shellQuote(alloc, effect_path);
     defer alloc.free(quoted_effect);
+    // Keep a write window open, but publish readiness only after the PID record is complete.
     const target_script = try std.fmt.allocPrint(
         alloc,
-        "sleep 30 & child=$!; printf '%s %s' \"$$\" \"$child\" > {s}; sleep 3; printf FINISHED > {s}",
-        .{ quoted_pids, quoted_effect },
+        "sleep 30 & child=$!; (sleep 0.05; printf '%s %s' \"$$\" \"$child\") > {s}.pending && mv {s}.pending {s}; sleep 3; printf FINISHED > {s}",
+        .{ quoted_pids, quoted_pids, quoted_pids, quoted_effect },
     );
     defer alloc.free(target_script);
 
@@ -3111,6 +3112,11 @@ test "foreground session owner loss kills the target and descendant before delay
 
     const owner_write = child.stdin orelse return error.TestUnexpectedResult;
     child.stdin = null;
+    var owner_open = true;
+    errdefer if (owner_open) {
+        owner_write.close(io_mod.getIo());
+        _ = child.wait(io_mod.getIo()) catch {};
+    };
     try writeForegroundSessionFrameForTest(
         owner_write,
         foreground_session_release_byte,
@@ -3125,6 +3131,7 @@ test "foreground session owner loss kills the target and descendant before delay
     }
     const pids_text = try readAbsoluteFile(alloc, pids_path, 128);
     defer alloc.free(pids_text);
+    try std.testing.expectEqual(true, pids_text.len > 0);
     var pids = std.mem.tokenizeAny(u8, pids_text, " \r\n\t");
     const target_pid = try std.fmt.parseInt(std.posix.pid_t, pids.next() orelse return error.TestUnexpectedResult, 10);
     const descendant_pid = try std.fmt.parseInt(std.posix.pid_t, pids.next() orelse return error.TestUnexpectedResult, 10);
@@ -3133,6 +3140,7 @@ test "foreground session owner loss kills the target and descendant before delay
     defer signalProcess(descendant_pid, std.posix.SIG.KILL) catch {};
 
     owner_write.close(io_mod.getIo());
+    owner_open = false;
     _ = try child.wait(io_mod.getIo());
     try expectProcessGoneWithinForTest(target_pid, 2_000);
     try expectProcessGoneWithinForTest(descendant_pid, 2_000);


### PR DESCRIPTION
## Summary

- Use 16 KiB signature pages for thin macOS arm64 binaries to reduce signing metadata without changing application code or data.
- Keep 4 KiB signature pages for Intel and universal binaries, and retain the explicit control override.
- Preserve Developer ID signing, hardened runtime, secure timestamps and notarization checks.
- Compare already-notarized arm64 artifacts on an isolated runner without requesting signing credentials.
- Calibrate startup tails against identical binaries and record native image-flow memory measurements.
- Publish process IDs atomically in the cleanup test so readiness cannot precede the completed write.