### PR TITLE
Validate release artifacts without publishing

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Audit public surface
         run: ./scripts/check-public-surface.sh
 
+      - name: Test signing and release routing
+        run: python3 -m unittest scripts.tests.test_macos_signing -q
+
       - name: Build
         run: zig build -Doptimize=${{ matrix.optimize }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      validate_only:
+        description: Build all platforms and compare arm64 signing pages without publishing
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -14,9 +19,11 @@ concurrency:
 
 jobs:
   check-version:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     outputs:
       needed: ${{ steps.check.outputs.needed }}
+      publish: ${{ steps.check.outputs.publish }}
       version: ${{ steps.check.outputs.version }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
@@ -25,6 +32,8 @@ jobs:
 
       - name: Check if release needed
         id: check
+        env:
+          VALIDATE_ONLY: ${{ github.event_name == 'workflow_dispatch' && inputs.validate_only }}
         run: |
           VERSION=$(grep 'pub const version' src/main.zig | head -1 | sed 's/.*"\(.*\)".*/\1/')
           if ! [[ "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
@@ -33,11 +42,17 @@ jobs:
           fi
           TAG="v${VERSION}"
           echo "version=${TAG}" >> "$GITHUB_OUTPUT"
-          if git rev-parse "$TAG" >/dev/null 2>&1; then
+          if [[ "$VALIDATE_ONLY" == true ]]; then
+            echo "needed=true" >> "$GITHUB_OUTPUT"
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            echo "Validating release artifacts without publishing"
+          elif git rev-parse "$TAG" >/dev/null 2>&1; then
             echo "needed=false" >> "$GITHUB_OUTPUT"
+            echo "publish=false" >> "$GITHUB_OUTPUT"
             echo "Tag ${TAG} exists, no release needed"
           else
             echo "needed=true" >> "$GITHUB_OUTPUT"
+            echo "publish=true" >> "$GITHUB_OUTPUT"
             echo "Tag ${TAG} missing, release needed"
           fi
 
@@ -67,6 +82,7 @@ jobs:
 
       - name: Package
         run: |
+          python3 -c 'import pathlib; n = pathlib.Path("zig-out/bin/fx").stat().st_size; print(f"linux executable: {n:,} bytes ({n / 1048576:.6f} MiB)")' >> "$GITHUB_STEP_SUMMARY"
           package_dir="$RUNNER_TEMP/fx-package-${{ matrix.name }}"
           mkdir -p "$package_dir"
           cp zig-out/bin/fx LICENSE THIRD_PARTY_NOTICES.md "$package_dir/"
@@ -107,8 +123,16 @@ jobs:
           APPLE_NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
         run: scripts/sign-and-notarize-macos.sh zig-out/bin/fx
 
+      - name: Verify notarized Intel binary
+        if: github.event_name == 'workflow_dispatch' && inputs.validate_only
+        run: |
+          codesign --verify --strict --check-notarization -R=notarized ./zig-out/bin/fx
+          ./zig-out/bin/fx --version
+          ./zig-out/bin/fx help
+
       - name: Package
         run: |
+          python3 -c 'import pathlib; n = pathlib.Path("zig-out/bin/fx").stat().st_size; print(f"macOS Intel signed executable: {n:,} bytes ({n / 1048576:.6f} MiB)")' >> "$GITHUB_STEP_SUMMARY"
           package_dir="$RUNNER_TEMP/fx-package-macos-x86_64"
           mkdir -p "$package_dir"
           cp zig-out/bin/fx LICENSE THIRD_PARTY_NOTICES.md "$package_dir/"
@@ -161,12 +185,42 @@ jobs:
 
       - name: Sign and notarize stable release candidate
         env:
+          VALIDATE_ONLY: ${{ github.event_name == 'workflow_dispatch' && inputs.validate_only }}
           APPLE_DEVELOPER_ID_P12_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_P12_BASE64 }}
           APPLE_DEVELOPER_ID_P12_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_P12_PASSWORD }}
           APPLE_NOTARY_KEY_P8_BASE64: ${{ secrets.APPLE_NOTARY_KEY_P8_BASE64 }}
           APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
           APPLE_NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
-        run: scripts/sign-and-notarize-macos.sh "$RUNNER_TEMP/fx-pgso-aggregate/candidate/fx"
+        run: |
+          if [[ "$VALIDATE_ONLY" == true ]]; then
+            control_dir="$RUNNER_TEMP/fx-signing-control"
+            mkdir -p "$control_dir"
+            cp "$RUNNER_TEMP/fx-pgso-aggregate/candidate/fx" "$control_dir/fx"
+            scripts/sign-and-notarize-macos.sh "$control_dir/fx" 4096
+            scripts/sign-and-notarize-macos.sh "$RUNNER_TEMP/fx-pgso-aggregate/candidate/fx" 16384
+          else
+            scripts/sign-and-notarize-macos.sh "$RUNNER_TEMP/fx-pgso-aggregate/candidate/fx"
+          fi
+
+      - name: Verify notarized arm64 binaries
+        if: github.event_name == 'workflow_dispatch' && inputs.validate_only
+        run: |
+          for binary in "$RUNNER_TEMP/fx-signing-control/fx" "$RUNNER_TEMP/fx-pgso-aggregate/candidate/fx"; do
+            codesign --verify --strict --check-notarization -R=notarized "$binary"
+            "$binary" --version
+            "$binary" help
+            python3 -c 'import pathlib, sys; n = pathlib.Path(sys.argv[1]).stat().st_size; print(f"{sys.argv[1]}: {n:,} bytes ({n / 1048576:.6f} MiB)")' "$binary" >> "$GITHUB_STEP_SUMMARY"
+            shasum -a 256 "$binary" >> "$GITHUB_STEP_SUMMARY"
+          done
+          tar -czf "$RUNNER_TEMP/fx-signing-control.tar.gz" -C "$RUNNER_TEMP/fx-signing-control" fx
+
+      - name: Upload arm64 signing control
+        if: github.event_name == 'workflow_dispatch' && inputs.validate_only
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: signing-control-macos-arm64
+          path: ${{ runner.temp }}/fx-signing-control.tar.gz
+          if-no-files-found: error
 
       - name: Package stable release candidate
         run: |
@@ -189,6 +243,7 @@ jobs:
 
   release:
     needs: [check-version, build-linux, build-macos-x86_64, sign-macos-arm64]
+    if: needs.check-version.outputs.publish == 'true' && !(github.event_name == 'workflow_dispatch' && inputs.validate_only)
     runs-on: ubuntu-latest
     environment: release
     permissions:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -440,6 +440,19 @@ Release notes are public product copy. Describe user-visible behavior, always sp
 
 Do not create tags manually. The workflow owns tag creation.
 
+### Validate release artifacts without publishing
+
+Run **Actions > Release** on `main` with `validate_only` enabled. This builds
+all four release targets, runs macOS arm64 PGSO qualification, and uses the
+existing `apple-signing` approval to notarize both macOS targets. It does not
+create a tag, publish a GitHub Release, upload to the CDN, or change a channel.
+
+The arm64 validation retains both 4 KiB and 16 KiB signature variants of the
+same PGSO payload for comparison. Intel retains 4 KiB signatures. Download the
+workflow artifacts for matched signed-binary performance checks; notarization
+and smoke checks alone do not establish performance equivalence. Normal release
+runs keep the existing signing default.
+
 ## Benchmarks
 
 Startup latency benchmarks run automatically on every PR and push to `main` via `.github/workflows/bench.yml`.

--- a/scripts/sign-and-notarize-macos.sh
+++ b/scripts/sign-and-notarize-macos.sh
@@ -15,7 +15,22 @@ ditto_bin="${FX_SIGNING_DITTO_BIN:-/usr/bin/ditto}"
 xcrun_bin="${FX_SIGNING_XCRUN_BIN:-/usr/bin/xcrun}"
 jq_bin="${FX_SIGNING_JQ_BIN:-/usr/bin/jq}"
 
-binary_path="${1:?usage: sign-and-notarize-macos.sh <binary-path>}"
+binary_path="${1:?usage: sign-and-notarize-macos.sh <binary-path> [4096|16384]}"
+signing_page_size="${2-4096}"
+if [[ $# -gt 2 || ( "${signing_page_size}" != 4096 && "${signing_page_size}" != 16384 ) ]]; then
+    echo "Signature page size must be 4096 or 16384" >&2
+    exit 1
+fi
+if [[ "${signing_page_size}" == 16384 ]]; then
+    if ! binary_archs="$("${xcrun_bin}" lipo -archs "${binary_path}")"; then
+        echo "Apple signing failed during architecture inspection" >&2
+        exit 1
+    fi
+    if [[ "${binary_archs}" != arm64 ]]; then
+        echo "16 KiB signature pages require a thin arm64 binary" >&2
+        exit 1
+    fi
+fi
 for required_name in \
     APPLE_DEVELOPER_ID_P12_BASE64 \
     APPLE_DEVELOPER_ID_P12_PASSWORD \
@@ -95,6 +110,7 @@ if ! "${codesign_bin}" \
     --identifier "${signing_identifier}" \
     --options runtime \
     --timestamp \
+    --pagesize "${signing_page_size}" \
     "${binary_path}"; then
     fail_stage "code signing"
 fi

--- a/scripts/tests/test_macos_signing.py
+++ b/scripts/tests/test_macos_signing.py
@@ -163,7 +163,9 @@ with pathlib.Path(os.environ["FX_SIGNING_TEST_LOG"]).open("a") as log:
 if len(args) > 1 and args[1] == os.environ.get("FX_SIGNING_TEST_XCRUN_FAIL_COMMAND"):
     print("injected xcrun failure", file=sys.stderr)
     raise SystemExit(1)
-if args[:2] == ["notarytool", "submit"]:
+if args[:2] == ["lipo", "-archs"]:
+    print(os.environ.get("FX_SIGNING_TEST_ARCHS", "arm64"))
+elif args[:2] == ["notarytool", "submit"]:
     status = os.environ.get("FX_SIGNING_TEST_SUBMISSION_STATUS", "Accepted")
     print(json.dumps({{"id": "test-submission", "status": status}}))
 elif args[:2] == ["notarytool", "log"]:
@@ -192,6 +194,7 @@ else:
         self,
         root: pathlib.Path,
         extra_env: dict[str, str] | None = None,
+        page_size: str | None = None,
     ) -> tuple[subprocess.CompletedProcess[str], pathlib.Path, pathlib.Path, pathlib.Path]:
         runner_temp = root / "runner-temp"
         runner_temp.mkdir()
@@ -220,7 +223,8 @@ else:
         if extra_env:
             env.update(extra_env)
         result = subprocess.run(
-            [str(SCRIPT_PATH), str(binary)],
+            [str(SCRIPT_PATH), str(binary)]
+            + ([page_size] if page_size is not None else []),
             cwd=REPO_ROOT,
             env=env,
             capture_output=True,
@@ -228,6 +232,49 @@ else:
             check=False,
         )
         return result, binary, runner_temp, event_log
+
+    def test_explicit_page_size_preserves_the_production_default(self) -> None:
+        for arch, page_size, expected in (
+            ("arm64", None, "4096"),
+            ("x86_64", None, "4096"),
+            ("arm64 x86_64", None, "4096"),
+            ("arm64", "4096", "4096"),
+            ("arm64", "16384", "16384"),
+        ):
+            with self.subTest(arch=arch, page_size=page_size):
+                with tempfile.TemporaryDirectory(prefix="fx-signing-pages-") as tmp:
+                    result, _, runner_temp, event_log = self.run_script(
+                        pathlib.Path(tmp),
+                        {"FX_SIGNING_TEST_ARCHS": arch},
+                        page_size,
+                    )
+                    self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+                    self.assertIn(f"--pagesize {expected} ", event_log.read_text())
+                    self.assertEqual([], list(runner_temp.iterdir()))
+
+    def test_rejects_unsupported_page_sizes_before_importing_credentials(self) -> None:
+        for arch, page_size in (
+            ("arm64", "8192"),
+            ("arm64", "0"),
+            ("arm64", ""),
+            ("arm64", "--force"),
+            ("x86_64", "16384"),
+            ("arm64 x86_64", "16384"),
+            ("x86_64 arm64", "16384"),
+            ("", "16384"),
+        ):
+            with self.subTest(arch=arch, page_size=page_size):
+                with tempfile.TemporaryDirectory(prefix="fx-signing-pages-") as tmp:
+                    result, binary, runner_temp, event_log = self.run_script(
+                        pathlib.Path(tmp),
+                        {"FX_SIGNING_TEST_ARCHS": arch},
+                        page_size,
+                    )
+                    self.assertNotEqual(0, result.returncode)
+                    self.assertEqual(b"unsigned\n", binary.read_bytes())
+                    events = event_log.read_text() if event_log.exists() else ""
+                    self.assertNotIn("security import", events)
+                    self.assertEqual([], list(runner_temp.iterdir()))
 
     def test_signs_notarizes_and_cleans_credentials_without_printing_secrets(
         self,
@@ -460,6 +507,81 @@ else:
 
 
 class MacosSigningWorkflowTests(unittest.TestCase):
+    def test_validation_builds_existing_versions_without_publishing(self) -> None:
+        release = RELEASE_WORKFLOW_PATH.read_text(encoding="utf-8")
+        check_job = release.split("  check-version:\n", 1)[1].split(
+            "\n  build-linux:", 1
+        )[0]
+        check_script = textwrap.dedent(check_job.split("        run: |\n", 1)[1])
+        for validate, tag_exists, expected_needed, expected_publish in (
+            ("true", True, "true", "false"),
+            ("true", False, "true", "false"),
+            ("false", True, "false", "false"),
+            ("false", False, "true", "true"),
+        ):
+            with self.subTest(validate=validate, tag_exists=tag_exists):
+                with tempfile.TemporaryDirectory(prefix="fx-release-check-") as tmp:
+                    root = pathlib.Path(tmp)
+                    (root / "src").mkdir()
+                    (root / "src/main.zig").write_text(
+                        'pub const version = "0.0.8";\n'
+                    )
+                    git = root / "git"
+                    git.write_text(f"#!/bin/sh\nexit {0 if tag_exists else 1}\n")
+                    git.chmod(0o755)
+                    output = root / "outputs"
+                    env = dict(
+                        os.environ,
+                        PATH=f"{root}:{os.environ['PATH']}",
+                        GITHUB_OUTPUT=str(output),
+                        VALIDATE_ONLY=validate,
+                    )
+                    result = subprocess.run(
+                        ["bash", "-euo", "pipefail", "-c", check_script],
+                        cwd=root, env=env, capture_output=True, text=True,
+                    )
+                    self.assertEqual(0, result.returncode, result.stderr)
+                    self.assertIn(f"needed={expected_needed}\n", output.read_text())
+                    self.assertIn(f"publish={expected_publish}\n", output.read_text())
+                    self.assertIn("version=v0.0.8\n", output.read_text())
+
+    def test_validation_keeps_both_arm64_signatures(self) -> None:
+        release = RELEASE_WORKFLOW_PATH.read_text(encoding="utf-8")
+        step = release.split(
+            "      - name: Sign and notarize stable release candidate\n", 1
+        )[1].split("\n      - name:", 1)[0]
+        run = step.split("        run: ", 1)[1]
+        script = textwrap.dedent(run[2:]) if run.startswith("|\n") else run.strip()
+        for validate in ("true", "false"):
+            with self.subTest(validate=validate):
+                with tempfile.TemporaryDirectory(prefix="fx-signing-route-") as tmp:
+                    root = pathlib.Path(tmp)
+                    (root / "scripts").mkdir()
+                    signer = root / "scripts/sign-and-notarize-macos.sh"
+                    signer.write_text(
+                        "#!/bin/sh\nprintf '%s' \"${2-default}\" >> \"$1\"\n"
+                    )
+                    signer.chmod(0o755)
+                    candidate = root / "fx-pgso-aggregate/candidate/fx"
+                    candidate.parent.mkdir(parents=True)
+                    candidate.write_bytes(b"native:")
+                    result = subprocess.run(
+                        ["bash", "-euo", "pipefail", "-c", script],
+                        cwd=root,
+                        env=dict(
+                            os.environ, RUNNER_TEMP=str(root), VALIDATE_ONLY=validate,
+                        ),
+                        capture_output=True, text=True,
+                    )
+                    self.assertEqual(0, result.returncode, result.stderr)
+                    control = root / "fx-signing-control/fx"
+                    if validate == "true":
+                        self.assertEqual(b"native:16384", candidate.read_bytes())
+                        self.assertEqual(b"native:4096", control.read_bytes())
+                    else:
+                        self.assertEqual(b"native:default", candidate.read_bytes())
+                        self.assertFalse(control.exists())
+
     def test_every_privileged_publish_job_uses_an_environment_gate(self) -> None:
         release = RELEASE_WORKFLOW_PATH.read_text(encoding="utf-8")
         publish_libfx = PUBLISH_LIBFX_WORKFLOW_PATH.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- Add a manual release-validation mode that builds all four platforms without creating tags, publishing releases, or updating the CDN.
- Notarize both macOS targets through the existing protected signing environment.
- Retain 4 KiB and 16 KiB arm64 signatures for comparison while preserving Intel and normal release signing defaults.
- Report executable sizes and retain downloadable artifacts for signed-binary performance checks.
- Run the signing and release-routing tests on all four native Full CI platforms.
