### PR TITLE
Add model and effort overrides to subagent creation

### DIFF
--- a/src/builtins/tools.zig
+++ b/src/builtins/tools.zig
@@ -190,11 +190,13 @@ const ask_user_question_question_schema = model_tool_schema.ObjectSchema{
 };
 
 const subagent_description =
-    "Delegate work and receive one terminal child result. Use run for one temporary child and one task. Use message with a stable name to create or continue a persistent conversation in this parent session. Optional instructions replace only that child's system overlay; fx preserves its trusted base prompt. fx owns timing, worker identities, cancellation, permissions, persistence, and cleanup.";
+    "Delegate work and receive one terminal child result. Use run for one temporary child and one task. Use message with a stable name to create or continue a persistent conversation in this parent session. Optional instructions replace only that child's system overlay; fx preserves its trusted base prompt. Optional model and effort apply only when a child is created and are rejected for an existing child. fx owns timing, worker identities, cancellation, permissions, persistence, and cleanup.";
 
 const subagent_model_run_properties = [_]model_tool_schema.Property{
     .{ .name = "action", .json_type = .string, .shape = &.{ .enum_values = &.{"run"} } },
-    .{ .name = "task", .json_type = .string, .bounds = &.{ .min_length = 1, .max_length = subagent_domain.max_prompt_bytes }, .description = "One complete task for a temporary child. The child inherits the parent model and effort and accepts no follow-up." },
+    .{ .name = "task", .json_type = .string, .bounds = &.{ .min_length = 1, .max_length = subagent_domain.max_prompt_bytes }, .description = "One complete task for a temporary child. The child accepts no follow-up." },
+    .{ .name = "model", .json_type = .string, .bounds = &.{ .min_length = 1, .max_length = subagent_domain.max_model_bytes }, .description = "Optional model for this child. Inherits the parent's model when omitted." },
+    .{ .name = "effort", .json_type = .string, .bounds = &.{ .min_length = 1, .max_length = types.ReasoningEffort.max_name_bytes }, .description = "Optional reasoning effort for this child. Inherits the parent's effort when omitted." },
 };
 
 const subagent_model_message_properties = [_]model_tool_schema.Property{
@@ -202,6 +204,8 @@ const subagent_model_message_properties = [_]model_tool_schema.Property{
     .{ .name = "agent", .json_type = .string, .bounds = &.{ .min_length = 1, .max_length = subagent_domain.max_agent_name_bytes }, .description = "Stable lowercase name for one persistent conversation in this parent session. A new valid name creates it; later calls continue it." },
     .{ .name = "instructions", .json_type = .string, .bounds = &.{ .min_length = 1, .max_length = subagent_domain.max_instructions_bytes }, .description = "Optional persistent instructions for this child. When present, replaces its child-specific system overlay before this message; when omitted, preserves the existing overlay. Cannot replace fx's trusted base prompt or widen authority." },
     .{ .name = "message", .json_type = .string, .bounds = &.{ .min_length = 1, .max_length = subagent_domain.max_message_bytes }, .description = "Next message for that named agent. fx creates it on first use and continues it afterward." },
+    .{ .name = "model", .json_type = .string, .bounds = &.{ .min_length = 1, .max_length = subagent_domain.max_model_bytes }, .description = "Optional model applied when this message creates the child. Inherits the parent's model when omitted. Rejected when the named child already exists." },
+    .{ .name = "effort", .json_type = .string, .bounds = &.{ .min_length = 1, .max_length = types.ReasoningEffort.max_name_bytes }, .description = "Optional reasoning effort applied when this message creates the child. Inherits the parent's effort when omitted. Rejected when the named child already exists." },
 };
 
 const subagent_model_action_schemas = [_]model_tool_schema.ObjectSchema{
@@ -938,7 +942,7 @@ test "built-in model-facing tool contract stays byte exact" {
 
     const actual_hex = std.fmt.bytesToHex(hasher.finalResult(), .lower);
     try std.testing.expectEqualStrings(
-        "ccc1e489bf536f2f518a0b32c02ddc99a9f2af6fd3466c6456da3b22fbed23d4",
+        "ad41f2263f7497322e9eafa1d94d29176bd3eb33ae1c775e84f6c98549fd3f77",
         &actual_hex,
     );
 }
@@ -1403,6 +1407,11 @@ test "built-in subagent owns product metadata schema and callbacks" {
         try std.testing.expect(std.mem.find(u8, schema_json, action) != null);
     }
     try std.testing.expect(std.mem.find(u8, schema_json, "\"instructions\":") != null);
+    // Creation-time routing overrides are advertised on both actions.
+    try std.testing.expect(std.mem.find(u8, schema_json, "\"model\":") != null);
+    try std.testing.expect(std.mem.find(u8, schema_json, "\"effort\":") != null);
+    try std.testing.expect(std.mem.find(u8, schema_json, "Inherits the parent's model when omitted") != null);
+    try std.testing.expect(std.mem.find(u8, schema_json, "Rejected when the named child already exists") != null);
     for ([_][]const u8{
         "\"command\":",
         "\"relationship\":",
@@ -1412,8 +1421,7 @@ test "built-in subagent owns product metadata schema and callbacks" {
         "\"cursor\":",
         "\"generation\":",
         "\"reopen\"",
-        "\"model\"",
-        "\"effort\"",
+        "\"provider\"",
         "\"send\"",
         "\"wait\"",
         "\"stop\"",

--- a/src/core/subagent/agent_adapter.zig
+++ b/src/core/subagent/agent_adapter.zig
@@ -172,6 +172,16 @@ pub fn run(
     routed_config.tool_context.model = admission.model;
     routed_config.tool_context.provider = admission.provider;
     routed_config.tool_context.provider_capabilities = config.provider_set.select(admission.provider).capabilities;
+    debug_trace.logf(
+        "subagent",
+        "child turn routed child_id={s} provider={s} model={s} effort={s}",
+        .{
+            turn.child_id orelse "unknown",
+            @tagName(admission.provider),
+            admission.model,
+            admission.effort.label(),
+        },
+    );
     if (!routed_config.tool_context.provider_capabilities.fx_search) {
         routed_config.tool_context.web_search_backend = null;
         routed_config.tool_context.web_search_runtime_ready = false;

--- a/src/core/subagent/managed_owner.zig
+++ b/src/core/subagent/managed_owner.zig
@@ -322,6 +322,17 @@ fn runOne(slot: *Slot) OneOutcome {
         .work_id = work_id,
         .outcome = .cancelled,
     } else failedOutcome(work_id, "admission", err);
+    @import("../shared/debug_trace.zig").logf(
+        "subagent",
+        "child turn admitted child_id={s} work_id={s} provider={s} model={s} effort={s}",
+        .{
+            slot.child_id,
+            work_id,
+            @tagName(admission.provider),
+            admission.model,
+            admission.effort.label(),
+        },
+    );
     var owned_admission = admission;
     defer owned_admission.deinit(owner.alloc);
     const result = owner.services.run(

--- a/src/core/subagent/model_contract.zig
+++ b/src/core/subagent/model_contract.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const domain = @import("domain.zig");
+const types = @import("../shared/types.zig");
 
 const Allocator = std.mem.Allocator;
 
@@ -7,31 +8,58 @@ const max_error_code_bytes: usize = 64;
 
 pub const Action = enum { run, message };
 
-pub const RunInput = struct { task: []const u8 };
+pub const RunInput = struct {
+    task: []const u8,
+    model: ?[]const u8 = null,
+    effort: ?[]const u8 = null,
+};
 pub const MessageInput = struct {
     agent: []const u8,
     instructions: ?[]const u8 = null,
     message: []const u8,
+    model: ?[]const u8 = null,
+    effort: ?[]const u8 = null,
 };
 pub const RequestInput = union(Action) {
     run: RunInput,
     message: MessageInput,
 };
 
+/// Creation-time routing overrides carried by a request. Both default to the
+/// parent's values; overrides apply only when a child session is created.
+pub const Override = struct {
+    model: ?[]const u8 = null,
+    effort: ?types.ReasoningEffort = null,
+
+    pub fn present(self: Override) bool {
+        return self.model != null or self.effort != null;
+    }
+};
+
 pub const Request = union(Action) {
-    run: struct { task: []u8 },
+    run: struct {
+        task: []u8,
+        model: ?[]u8 = null,
+        effort: ?types.ReasoningEffort = null,
+    },
     message: struct {
         agent: []u8,
         instructions: ?[]u8 = null,
         message: []u8,
+        model: ?[]u8 = null,
+        effort: ?types.ReasoningEffort = null,
     },
     pub fn deinit(self: *Request, alloc: Allocator) void {
         switch (self.*) {
-            .run => |value| alloc.free(value.task),
+            .run => |value| {
+                alloc.free(value.task);
+                if (value.model) |model| alloc.free(model);
+            },
             .message => |value| {
                 alloc.free(value.agent);
                 if (value.instructions) |instructions| alloc.free(instructions);
                 alloc.free(value.message);
+                if (value.model) |model| alloc.free(model);
             },
         }
         self.* = undefined;
@@ -47,6 +75,14 @@ pub const Request = union(Action) {
             .run => null,
         };
     }
+
+    /// Borrows from the request; the request must outlive the returned value.
+    pub fn override(self: Request) Override {
+        return switch (self) {
+            .run => |value| .{ .model = value.model, .effort = value.effort },
+            .message => |value| .{ .model = value.model, .effort = value.effort },
+        };
+    }
 };
 
 pub const ValidationError = error{
@@ -55,6 +91,8 @@ pub const ValidationError = error{
     InvalidAgent,
     InvalidInstructions,
     InvalidMessage,
+    InvalidModel,
+    InvalidEffort,
 };
 
 pub fn validateRequest(
@@ -64,7 +102,14 @@ pub fn validateRequest(
     return switch (input) {
         .run => |value| blk: {
             try validateText(value.task, domain.max_prompt_bytes, error.InvalidTask);
-            break :blk .{ .run = .{ .task = try alloc.dupe(u8, value.task) } };
+            const effort = try validateOverrideText(value.model, value.effort);
+            const task = try alloc.dupe(u8, value.task);
+            errdefer alloc.free(task);
+            break :blk .{ .run = .{
+                .task = task,
+                .model = try dupeOptional(alloc, value.model),
+                .effort = effort,
+            } };
         },
         .message => |value| blk: {
             if (!domain.validAgentName(value.agent)) return error.InvalidAgent;
@@ -76,6 +121,7 @@ pub fn validateRequest(
                 }
             }
             try validateText(value.message, domain.max_message_bytes, error.InvalidMessage);
+            const effort = try validateOverrideText(value.model, value.effort);
             const agent = try alloc.dupe(u8, value.agent);
             errdefer alloc.free(agent);
             const instructions = if (value.instructions) |instructions|
@@ -83,13 +129,34 @@ pub fn validateRequest(
             else
                 null;
             errdefer if (instructions) |owned| alloc.free(owned);
+            const message = try alloc.dupe(u8, value.message);
+            errdefer alloc.free(message);
             break :blk .{ .message = .{
                 .agent = agent,
                 .instructions = instructions,
-                .message = try alloc.dupe(u8, value.message),
+                .message = message,
+                .model = try dupeOptional(alloc, value.model),
+                .effort = effort,
             } };
         },
     };
+}
+
+/// Validates override text without allocating. Returns the parsed effort.
+fn validateOverrideText(
+    model: ?[]const u8,
+    effort: ?[]const u8,
+) ValidationError!?types.ReasoningEffort {
+    if (model) |raw| try validateText(raw, domain.max_model_bytes, error.InvalidModel);
+    if (effort) |raw| {
+        return types.ReasoningEffort.parse(raw) orelse error.InvalidEffort;
+    }
+    return null;
+}
+
+/// Returns an owned copy the caller frees, or null. Never fails on null.
+fn dupeOptional(alloc: Allocator, value: ?[]const u8) ValidationError!?[]u8 {
+    return if (value) |raw| try alloc.dupe(u8, raw) else null;
 }
 
 fn validateText(
@@ -158,6 +225,28 @@ pub fn requestFingerprint(request: Request) [32]u8 {
             hash.update("\x00");
             hash.update(value.message);
         },
+    }
+    // Overrides extend the identity only when present so that override-less
+    // requests keep their pre-override fingerprints in persisted registries.
+    // The leading NUL is unambiguous: validated request text never contains
+    // NUL, so the override section cannot be confused with task or message
+    // content.
+    const override = request.override();
+    if (override.present()) {
+        hash.update("\x00\x01");
+        if (override.model) |model| {
+            hash.update("\x01");
+            hash.update(model);
+        } else {
+            hash.update("\x00");
+        }
+        hash.update("\x00");
+        if (override.effort) |effort| {
+            hash.update("\x01");
+            hash.update(effort.label());
+        } else {
+            hash.update("\x00");
+        }
     }
     return hash.finalResult();
 }
@@ -255,6 +344,54 @@ test "persistent instruction updates participate in operation identity" {
         &strict_fingerprint,
         &security_fingerprint,
     ));
+}
+
+test "creation overrides validate and participate in operation identity" {
+    const alloc = std.testing.allocator;
+    var plain = try validateRequest(alloc, .{ .run = .{ .task = "review this" } });
+    defer plain.deinit(alloc);
+    var routed = try validateRequest(alloc, .{ .run = .{
+        .task = "review this",
+        .model = "gpt-5.6-sol-fast",
+        .effort = "medium",
+    } });
+    defer routed.deinit(alloc);
+    try std.testing.expectEqualStrings("gpt-5.6-sol-fast", routed.run.model.?);
+    try std.testing.expectEqualStrings("medium", routed.run.effort.?.label());
+    try std.testing.expect(plain.override().present() == false);
+    try std.testing.expect(routed.override().present());
+    // Override-less requests keep their pre-override fingerprint.
+    const plain_digest = requestFingerprint(plain);
+    const expected_plain = comptime blk: {
+        @setEvalBranchQuota(100_000);
+        var hash = std.crypto.hash.sha2.Sha256.init(.{});
+        hash.update("fx.subagent.request.v1\x00");
+        hash.update("run");
+        hash.update("\x00");
+        hash.update("review this");
+        break :blk hash.finalResult();
+    };
+    try std.testing.expectEqual(expected_plain, plain_digest);
+    const routed_digest = requestFingerprint(routed);
+    try std.testing.expect(!std.mem.eql(u8, &plain_digest, &routed_digest));
+
+    var rerouted = try validateRequest(alloc, .{ .message = .{
+        .agent = "reviewer",
+        .message = "review this",
+        .effort = "high",
+    } });
+    defer rerouted.deinit(alloc);
+    try std.testing.expect(rerouted.message.model == null);
+    try std.testing.expectEqualStrings("high", rerouted.message.effort.?.label());
+
+    try std.testing.expectError(
+        error.InvalidModel,
+        validateRequest(alloc, .{ .run = .{ .task = "t", .model = "" } }),
+    );
+    try std.testing.expectError(
+        error.InvalidEffort,
+        validateRequest(alloc, .{ .run = .{ .task = "t", .effort = "not an effort!" } }),
+    );
 }
 
 test "persistent planning derives continue and busy" {

--- a/src/core/subagent/tool_host.zig
+++ b/src/core/subagent/tool_host.zig
@@ -306,6 +306,17 @@ pub const Runtime = struct {
         options: ExecuteOptions,
     ) !ManagedAdmission {
         const fingerprint = model_contract.requestFingerprint(request);
+        const defaults = effectiveDefaults(options.defaults, request.override());
+        debug_trace.logf(
+            "subagent",
+            "admission requested operation={s} action={s} agent={s} override={s}",
+            .{
+                operation_id,
+                @tagName(request.action()),
+                request.agentName() orelse "none",
+                if (request.override().present()) "yes" else "no",
+            },
+        );
         var lock = try self.managed.state_store.acquireLock(alloc);
         defer lock.release();
         var registry = try self.managed.state_store.load(alloc);
@@ -320,6 +331,11 @@ pub const Runtime = struct {
                 "operation_conflict",
             );
             if (!std.mem.eql(u8, &observed, &fingerprint)) {
+                debug_trace.logf(
+                    "subagent",
+                    "admission rejected operation={s} child_id={s} code=operation_conflict",
+                    .{ operation_id, existing.id },
+                );
                 return managedAdmissionRejected(
                     alloc,
                     existing.id,
@@ -330,7 +346,7 @@ pub const Runtime = struct {
                 alloc,
                 existing.id,
                 operation_id,
-                options.defaults,
+                defaults,
             );
             if (existing.last_work_id) |work_id| {
                 if (std.mem.eql(u8, work_id, operation_id)) return .{ .completed = .{
@@ -363,7 +379,7 @@ pub const Runtime = struct {
                     alloc,
                     child_id,
                     active.id,
-                    options.defaults,
+                    defaults,
                 );
                 return managedAdmissionReady(
                     alloc,
@@ -372,6 +388,18 @@ pub const Runtime = struct {
             },
             .message => |message| {
                 if (registry.findPersistent(message.agent)) |child| {
+                    if (request.override().present()) {
+                        debug_trace.logf(
+                            "subagent",
+                            "admission rejected operation={s} child_id={s} agent={s} code=override_after_create",
+                            .{ operation_id, child.id, message.agent },
+                        );
+                        return managedAdmissionRejected(
+                            alloc,
+                            child.id,
+                            "override_after_create",
+                        );
+                    }
                     switch (child.phase) {
                         .running, .awaiting_approval => return managedAdmissionRejected(
                             alloc,
@@ -408,7 +436,7 @@ pub const Runtime = struct {
                     alloc,
                     child_id,
                     active.id,
-                    options.defaults,
+                    defaults,
                 );
                 return managedAdmissionReady(
                     alloc,
@@ -437,6 +465,18 @@ pub const Runtime = struct {
             var writable = writable_value;
             writable.log.park();
             writable.deinit(alloc);
+            debug_trace.logf(
+                "subagent",
+                "child session created child_id={s} work_id={s} provider={s} model={s} effort={s} fast_mode={}",
+                .{
+                    child_id,
+                    work_id,
+                    @tagName(state.preferences.provider),
+                    state.preferences.model,
+                    state.preferences.effort.label(),
+                    state.preferences.fast_mode,
+                },
+            );
         } else |err| switch (err) {
             error.SessionAlreadyExists => {},
             else => return err,
@@ -543,6 +583,29 @@ test "internal operation identity is deterministic and invocation-bound" {
     try std.testing.expectEqualStrings(first, replay);
     try std.testing.expect(!std.mem.eql(u8, first, changed));
     try std.testing.expect(std.mem.startsWith(u8, first, "fxop:2:m:41:"));
+}
+
+test "creation defaults keep parent values unless the request overrides them" {
+    const parent = Defaults{
+        .provider = .gateway,
+        .model = "parent-model",
+        .effort = .auto,
+        .conversation_language = session.ConversationLanguage.default(),
+    };
+    const inherited = effectiveDefaults(parent, .{});
+    try std.testing.expectEqualStrings("parent-model", inherited.model);
+    try std.testing.expect(inherited.effort.isDefault());
+    const overridden = effectiveDefaults(parent, .{
+        .model = "gpt-5.6-sol-fast",
+        .effort = types.ReasoningEffort.parse("medium"),
+    });
+    try std.testing.expectEqualStrings("gpt-5.6-sol-fast", overridden.model);
+    try std.testing.expectEqualStrings("medium", overridden.effort.label());
+    try std.testing.expectEqual(parent.provider, overridden.provider);
+    // Model-only and effort-only overrides leave the other value inherited.
+    const model_only = effectiveDefaults(parent, .{ .model = "other-model" });
+    try std.testing.expectEqualStrings("other-model", model_only.model);
+    try std.testing.expect(model_only.effort.isDefault());
 }
 
 fn formatFailedResult(alloc: Allocator, failure: ?[]const u8, partial: ?[]const u8) ![]u8 {
@@ -703,6 +766,19 @@ fn assistantTextForWork(
         };
     }
     return null;
+}
+
+/// Resolves the defaults used to seed a new child session. The returned value
+/// borrows `override.model` from the request; both the request and the
+/// original defaults must outlive the result.
+fn effectiveDefaults(
+    defaults: Defaults,
+    override: model_contract.Override,
+) Defaults {
+    var resolved = defaults;
+    if (override.model) |model| resolved.model = model;
+    if (override.effort) |effort| resolved.effort = effort;
+    return resolved;
 }
 
 fn freshChildState(

--- a/src/tools/agent/subagent.zig
+++ b/src/tools/agent/subagent.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const model_contract = @import("../../core/subagent/model_contract.zig");
 const tool_provider = @import("../../core/subagent/tool_provider.zig");
 const tool_dispatch = @import("../../core/tooling/tool_dispatch.zig");
+const debug_trace = @import("../../core/shared/debug_trace.zig");
 
 const Allocator = std.mem.Allocator;
 
@@ -37,10 +38,12 @@ pub fn decode(
 
     const request_input = parseRoot(parsed.value) catch |err| {
         if (err == error.OutOfMemory) return error.OutOfMemory;
+        debug_trace.logf("subagent", "request decode rejected code={s}", .{decodeErrorCode(err)});
         return decodeFailure(ctx, decodeErrorCode(err)) catch return error.OutOfMemory;
     };
     const request = model_contract.validateRequest(ctx.allocator, request_input) catch |err| {
         if (err == error.OutOfMemory) return error.OutOfMemory;
+        debug_trace.logf("subagent", "request validation rejected code={s}", .{validationErrorCode(err)});
         return decodeFailure(ctx, validationErrorCode(err)) catch return error.OutOfMemory;
     };
     errdefer {
@@ -86,6 +89,8 @@ fn validationErrorCode(err: model_contract.ValidationError) []const u8 {
         error.InvalidAgent => "invalid_agent",
         error.InvalidInstructions => "invalid_instructions",
         error.InvalidMessage => "invalid_message",
+        error.InvalidModel => "invalid_model",
+        error.InvalidEffort => "invalid_effort",
     };
 }
 
@@ -98,17 +103,21 @@ fn parseRoot(value: std.json.Value) DecodeError!model_contract.RequestInput {
     const action = try requiredString(request, "action");
 
     if (std.mem.eql(u8, action, "run")) {
-        try rejectUnknown(request, &.{ "action", "task" });
+        try rejectUnknown(request, &.{ "action", "task", "model", "effort" });
         return .{ .run = .{
             .task = try requiredString(request, "task"),
+            .model = try optionalString(request, "model"),
+            .effort = try optionalString(request, "effort"),
         } };
     }
     if (std.mem.eql(u8, action, "message")) {
-        try rejectUnknown(request, &.{ "action", "agent", "instructions", "message" });
+        try rejectUnknown(request, &.{ "action", "agent", "instructions", "message", "model", "effort" });
         return .{ .message = .{
             .agent = try requiredString(request, "agent"),
             .instructions = try optionalString(request, "instructions"),
             .message = try requiredString(request, "message"),
+            .model = try optionalString(request, "model"),
+            .effort = try optionalString(request, "effort"),
         } };
     }
     return error.InvalidEnum;
@@ -168,9 +177,20 @@ pub fn call(
         }) catch return error.OutOfMemory;
         return .{ .failure = body };
     };
+    const request = &erased.as(Input).request;
+    debug_trace.logf(
+        "subagent",
+        "request accepted action={s} agent={s} model_override={s} effort_override={s}",
+        .{
+            @tagName(request.action()),
+            request.agentName() orelse "none",
+            request.override().model orelse "none",
+            if (request.override().effort) |effort| effort.label() else "none",
+        },
+    );
     const result = try provider.execute(
         ctx.allocator,
-        &erased.as(Input).request,
+        request,
         ctx.tool_call_id,
     );
     return switch (result.status) {
@@ -284,9 +304,19 @@ test "decode accepts only delegation intents" {
     try expectRequestTag("{\"request\":{\"action\":\"run\",\"task\":\"do it\"}}", .run);
     try expectRequestTag("{\"request\":{\"action\":\"message\",\"agent\":\"reviewer\",\"message\":\"next\"}}", .message);
     try expectRequestTag("{\"request\":{\"action\":\"message\",\"agent\":\"reviewer\",\"instructions\":\"Review strictly.\",\"message\":\"next\"}}", .message);
+    try expectRequestTag("{\"request\":{\"action\":\"run\",\"task\":\"do it\",\"model\":\"gpt-5.6-sol-fast\",\"effort\":\"medium\"}}", .run);
+    try expectRequestTag("{\"request\":{\"action\":\"message\",\"agent\":\"reviewer\",\"message\":\"next\",\"model\":\"gpt-5.6-sol-fast\"}}", .message);
+    try expectRequestTag("{\"request\":{\"action\":\"message\",\"agent\":\"reviewer\",\"message\":\"next\",\"effort\":\"high\"}}", .message);
     try expectDecodeFailure("{\"request\":{\"action\":\"wait\",\"child_id\":\"01J00000000000000000000000\"}}", "invalid_enum");
     try expectDecodeFailure("{\"request\":{\"action\":\"stop\",\"child_id\":\"01J00000000000000000000000\"}}", "invalid_enum");
     try expectDecodeFailure("{\"request\":{\"action\":\"cancel\",\"child_id\":\"01J00000000000000000000000\"}}", "invalid_enum");
+}
+
+test "decode rejects invalid creation overrides" {
+    try expectDecodeFailure("{\"request\":{\"action\":\"run\",\"task\":\"do it\",\"model\":\"\"}}", "invalid_model");
+    try expectDecodeFailure("{\"request\":{\"action\":\"run\",\"task\":\"do it\",\"effort\":\"not an effort!\"}}", "invalid_effort");
+    try expectDecodeFailure("{\"request\":{\"action\":\"message\",\"agent\":\"reviewer\",\"message\":\"next\",\"model\":7}}", "invalid_field_type");
+    try expectDecodeFailure("{\"request\":{\"action\":\"run\",\"task\":\"do it\",\"provider\":\"gateway\"}}", "unknown_field");
 }
 
 test "decode rejects manager input cross-action fields and unknown actions" {


### PR DESCRIPTION
**Summary**
---
- The subagent tool accepts optional model and effort fields on run and message; when set, the child session is created on that model and effort instead of the parent's.
- Overrides apply only at creation; sending model or effort to an existing persistent child fails with override_after_create.
- A child created with overrides keeps its model and effort on every later turn, even if the parent later changes model.
- Subagent pipeline stages (request admission, child session creation, per-turn admission, model routing) emit trace lines with the model and effort in effect.