### PR TITLE
Include recent renderer events in trace reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Interactive terminal tabs show `fx v<version> | <folder>` using the running bina
 
 Run `/feedback` to open the feedback form at `fx.sh/feedback`. It does not create a diagnostic or change the clipboard.
 
-Run `/trace` to create a private Markdown diagnostic with logs, session context, runtime state, permissions, and recent activity. On macOS, fx copies the `.md` file to the clipboard; on other platforms, it saves the file and prints its path. Review and redact the trace before sharing it.
+Run `/trace` to create a private Markdown diagnostic with logs, session context, runtime state, permissions, and recent activity. It includes the last 256 significant renderer events collected in memory without enabling `FX_TRACE`: source rewrites, viewport/history movement, scroll commits, redraws, and resets. Run it soon after a rendering problem, before quitting or changing sessions. These events describe fx's internal rendering state, not a readback of the terminal's scrollback. On macOS, fx copies the `.md` file to the clipboard; on other platforms, it saves the file and prints its path. Review and redact the trace before sharing it.
 
 fx automatically summarizes a long session into a fresh context window when the active model request reaches 80% of its usable input capacity, then continues the same turn. Run `/compact` to create the same durable handoff immediately and wait for your next prompt. Manual compaction refreshes the selected login when needed; Ctrl+C cancels preparation. If authentication fails, the chat stays open and unchanged so you can reconnect and retry `/compact`.
 

--- a/src/core/app/app_commands.zig
+++ b/src/core/app/app_commands.zig
@@ -2183,6 +2183,7 @@ fn buildTraceReport(app: anytype) ![]u8 {
     try writePermissionsSummary(&out.writer, app.permission_engine.grants.items);
     try writeRuntimeContextSummary(&out.writer, app, app.alloc);
     try writeRendererState(&out.writer, app, app.alloc);
+    try writeRendererEvents(&out.writer, app.alloc);
 
     if (app.shell.entries.items.len > 0) {
         try out.writer.writeAll("\n## Transcript Timeline\n");
@@ -2520,6 +2521,10 @@ fn writeRuntimeContextSummary(writer: *std.Io.Writer, app: anytype, alloc: std.m
     try writer.print("TERM: {s}\n", .{io_mod.getenv("TERM") orelse "(unset)"});
     try writer.print("TERM_PROGRAM: {s}\n", .{io_mod.getenv("TERM_PROGRAM") orelse "(unset)"});
     try writer.print("LANG: {s}\n", .{io_mod.getenv("LANG") orelse "(unset)"});
+    try writer.print("terminal_hosts: tmux={s} cmux={s}\n", .{
+        boolLabel(io_mod.getenv("TMUX") != null),
+        boolLabel(io_mod.getenv("CMUX_WORKSPACE_ID") != null),
+    });
 
     var mcp_lease = if (comptime @hasDecl(@TypeOf(app.*), "acquireMcpRuntime"))
         app.acquireMcpRuntime()
@@ -2587,6 +2592,10 @@ fn writeRendererState(writer: *std.Io.Writer, app: anytype, alloc: std.mem.Alloc
         },
     );
     try writer.print(
+        "projection: view={d} history={d} total_rows={d} source_bytes={d} recovery={s} catchup={s}\n",
+        .{ transcript_commit.visual_offset, transcript_commit.history_visual_offset, transcript_commit.total_visual_rows, transcript_commit.source_bytes, boolLabel(transcript_commit.normal_buffer_recovery_pending), boolLabel(transcript_commit.history_catchup_pending) },
+    );
+    try writer.print(
         "replaceable: active={s} row={d} start={d}\n",
         .{ boolLabel(app.shell.replaceable_last_line), app.shell.replaceable_row, app.shell.replaceable_start },
     );
@@ -2614,6 +2623,41 @@ fn writeRendererState(writer: *std.Io.Writer, app: anytype, alloc: std.mem.Alloc
         try writer.print("  {d:0>3}: {s}\n", .{ row, masked });
     }
     if (!emitted_any) try writer.writeAll("  (empty)\n");
+}
+
+fn writeRendererEvents(writer: *std.Io.Writer, alloc: std.mem.Allocator) !void {
+    var events: [diagnostics.render_ring_capacity]diagnostics.RenderEvent = undefined;
+    const count = diagnostics.snapshotRenderEvents(&events);
+    try writer.writeAll("\n## Recent Renderer Events\n");
+    try writer.writeAll("Internal rendering decisions, not terminal readback. Idle and same-row updates are omitted.\n");
+    if (count == 0) {
+        try writer.writeAll("(none recorded)\n");
+        return;
+    }
+    try writer.print("retained={d} capacity={d} overwritten_before={d}\n", .{
+        count, diagnostics.render_ring_capacity, events[0].sequence -| 1,
+    });
+    for (events[0..count]) |*event| {
+        try writeTraceTimestampUtc(writer, event.timestamp_ms);
+        try writer.print(" seq={d} kind={s} ", .{ event.sequence, @tagName(event.kind) });
+        try writeMaskedInline(writer, alloc, event.detail());
+        if (event.truncated) try writer.writeAll(" [truncated]");
+        try writer.writeByte('\n');
+    }
+}
+
+test "trace renderer events are available without opt-in file logging" {
+    diagnostics.resetForTest();
+    defer diagnostics.resetForTest();
+    debug_trace.shutdown();
+    diagnostics.recordRenderEvent(.transition, "release_past_finality history={d} releasable={d}", .{ 21, 20 });
+    var out: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer out.deinit();
+    try writeRendererEvents(&out.writer, std.testing.allocator);
+    try std.testing.expect(debug_trace.activeLogPath() == null);
+    try std.testing.expect(std.mem.find(u8, out.written(), "## Recent Renderer Events") != null);
+    try std.testing.expect(std.mem.find(u8, out.written(), "seq=1 kind=transition release_past_finality history=21 releasable=20") != null);
+    try std.testing.expect(std.mem.find(u8, out.written(), "overwritten_before=0") != null);
 }
 
 fn boolLabel(value: bool) []const u8 {

--- a/src/core/app/app_commands.zig
+++ b/src/core/app/app_commands.zig
@@ -2593,7 +2593,7 @@ fn writeRendererState(writer: *std.Io.Writer, app: anytype, alloc: std.mem.Alloc
     );
     try writer.print(
         "projection: view={d} history={d} total_rows={d} source_bytes={d} recovery={s} catchup={s}\n",
-        .{ transcript_commit.visual_offset, transcript_commit.history_visual_offset, transcript_commit.total_visual_rows, transcript_commit.source_bytes, boolLabel(transcript_commit.normal_buffer_recovery_pending), boolLabel(transcript_commit.history_catchup_pending) },
+        .{ transcript_commit.visual_offset, transcript_commit.history_visual_offset, transcript_commit.total_visual_rows, transcript_commit.source_bytes, boolLabel(app.shell.normalBufferRecoveryPending()), boolLabel(app.shell.historyCatchupPending()) },
     );
     try writer.print(
         "replaceable: active={s} row={d} start={d}\n",

--- a/src/core/workspace/diagnostics.zig
+++ b/src/core/workspace/diagnostics.zig
@@ -6,6 +6,7 @@
 
 const network_metrics = @import("network_metrics.zig");
 const tool_call_metrics = @import("tool_call_metrics.zig");
+const render_metrics = @import("render_metrics.zig");
 
 pub const NetworkCall = network_metrics.NetworkCall;
 pub const NetworkCallKind = network_metrics.NetworkCallKind;
@@ -14,6 +15,16 @@ pub const ToolCallRecord = tool_call_metrics.ToolCallRecord;
 pub const ToolCallOutcome = tool_call_metrics.ToolCallOutcome;
 pub const network_ring_capacity = network_metrics.ring_capacity;
 pub const tool_call_ring_capacity = tool_call_metrics.ring_capacity;
+pub const RenderEvent = render_metrics.Event;
+pub const render_ring_capacity = render_metrics.ring_capacity;
+
+pub fn recordRenderEvent(kind: render_metrics.Kind, comptime fmt: []const u8, args: anytype) void {
+    render_metrics.record(kind, fmt, args);
+}
+
+pub fn snapshotRenderEvents(out: []RenderEvent) usize {
+    return render_metrics.snapshot(out);
+}
 
 pub fn recordNetworkCall(call: NetworkCall) void {
     network_metrics.record(call);
@@ -38,6 +49,7 @@ pub fn snapshotToolCalls(out: []ToolCallMetric) usize {
 pub fn resetSession() void {
     network_metrics.reset();
     tool_call_metrics.reset();
+    render_metrics.reset();
 }
 
 pub fn resetForTest() void {

--- a/src/core/workspace/render_metrics.zig
+++ b/src/core/workspace/render_metrics.zig
@@ -1,0 +1,122 @@
+//! Bounded, always-on renderer breadcrumbs for the user-initiated /trace report.
+//! Callers supply internal state and counters, never transcript or input payloads.
+const std = @import("std");
+const io_mod = @import("../shared/io.zig");
+
+pub const ring_capacity = 256;
+const max_detail_bytes = 512;
+
+pub const Kind = enum {
+    source_rewrite,
+    source_invalidated,
+    history_projection,
+    transition,
+    commit,
+    reset,
+    redraw,
+    resize,
+};
+
+pub const Event = struct {
+    sequence: u64 = 0,
+    timestamp_ms: i64 = 0,
+    kind: Kind = .source_rewrite,
+    detail_len: u16 = 0,
+    truncated: bool = false,
+    detail_buf: [max_detail_bytes]u8 = [_]u8{0} ** max_detail_bytes,
+
+    pub fn detail(self: *const Event) []const u8 {
+        return self.detail_buf[0..self.detail_len];
+    }
+};
+
+const Ring = struct {
+    events: [ring_capacity]Event = std.mem.zeroes([ring_capacity]Event),
+    head: usize = 0,
+    stored: usize = 0,
+    total: u64 = 0,
+
+    fn append(self: *Ring, event: Event) void {
+        self.total +|= 1;
+        self.events[self.head] = event;
+        self.events[self.head].sequence = self.total;
+        self.head = (self.head + 1) % ring_capacity;
+        self.stored = @min(self.stored + 1, ring_capacity);
+    }
+
+    fn snapshot(self: *const Ring, out: []Event) usize {
+        const count = @min(self.stored, out.len);
+        for (out[0..count], 0..) |*event, index| {
+            event.* = self.events[(self.head + ring_capacity - count + index) % ring_capacity];
+        }
+        return count;
+    }
+};
+
+var mutex: std.Io.Mutex = .init;
+// Zero-initialized storage stays in .bss; unused slots are never read.
+var ring: Ring = std.mem.zeroes(Ring);
+
+pub fn record(kind: Kind, comptime fmt: []const u8, args: anytype) void {
+    var event: Event = .{ .kind = kind, .timestamp_ms = io_mod.milliTimestamp() };
+    var writer: std.Io.Writer = .fixed(&event.detail_buf);
+    writer.print(fmt, args) catch {
+        event.truncated = true;
+    };
+    event.detail_len = @intCast(writer.buffered().len);
+    const io = io_mod.getIo();
+    mutex.lockUncancelable(io);
+    defer mutex.unlock(io);
+    ring.append(event);
+}
+
+pub fn snapshot(out: []Event) usize {
+    const io = io_mod.getIo();
+    mutex.lockUncancelable(io);
+    defer mutex.unlock(io);
+    return ring.snapshot(out);
+}
+
+pub fn reset() void {
+    const io = io_mod.getIo();
+    mutex.lockUncancelable(io);
+    defer mutex.unlock(io);
+    ring.head = 0;
+    ring.stored = 0;
+    ring.total = 0;
+}
+
+test "render diagnostic ring retains the newest events in order" {
+    var local: Ring = .{};
+    for (0..ring_capacity + 3) |index| {
+        local.append(.{ .timestamp_ms = @intCast(index), .kind = .commit });
+    }
+    var events: [ring_capacity]Event = undefined;
+    try std.testing.expectEqual(ring_capacity, local.snapshot(&events));
+    try std.testing.expectEqual(@as(u64, 4), events[0].sequence);
+    try std.testing.expectEqual(@as(i64, 3), events[0].timestamp_ms);
+    try std.testing.expectEqual(@as(u64, ring_capacity + 3), events[ring_capacity - 1].sequence);
+    var tail: [2]Event = undefined;
+    try std.testing.expectEqual(@as(usize, 2), local.snapshot(&tail));
+    try std.testing.expectEqual(@as(u64, ring_capacity + 2), tail[0].sequence);
+    try std.testing.expectEqual(@as(usize, 0), local.snapshot(&.{}));
+}
+
+test "render diagnostics are bounded and reset without enabling file tracing" {
+    reset();
+    defer reset();
+    record(.source_rewrite, "view={d} history={d}", .{ 20, 17 });
+    const oversized = [_]u8{'x'} ** (max_detail_bytes + 10);
+    record(.transition, "{s}", .{oversized});
+    var events: [2]Event = undefined;
+    try std.testing.expectEqual(@as(usize, 2), snapshot(&events));
+    try std.testing.expectEqualStrings("view=20 history=17", events[0].detail());
+    try std.testing.expect(!events[0].truncated);
+    try std.testing.expect(events[1].truncated);
+    try std.testing.expect(events[1].detail_len <= max_detail_bytes);
+    reset();
+    try std.testing.expectEqual(@as(usize, 0), snapshot(&events));
+    record(.reset, "terminal_reset", .{});
+    try std.testing.expectEqual(@as(usize, 1), snapshot(&events));
+    try std.testing.expectEqual(@as(u64, 1), events[0].sequence);
+}

--- a/src/ui/resize_runtime.zig
+++ b/src/ui/resize_runtime.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const debug_trace = @import("../core/shared/debug_trace.zig");
+const diagnostics = @import("../core/workspace/diagnostics.zig");
 const io_mod = @import("../core/shared/io.zig");
 const record_tape = @import("../core/workspace/record_tape.zig");
 const types = @import("../core/shared/types.zig");
@@ -144,6 +145,11 @@ pub fn requestRedraw(
     metrics: *Metrics,
     mode: RedrawMode,
 ) !void {
+    diagnostics.recordRenderEvent(
+        .redraw,
+        "mode={s} terminal={d}x{d} owned_top={d} viewport_top={d} content_bottom={d} cursor={d},{d}",
+        .{ @tagName(mode), shell.layout.cols, shell.layout.rows, shell.owned_top_row, shell.viewport_top_row, shell.layout.content_bottom, shell.cursor_row, shell.cursor_col },
+    );
     debug_trace.logf("resize", "request_redraw mode={s} layout={d}x{d} viewport_top={d} content_bottom={d} cursor={d},{d}", .{ @tagName(mode), shell.layout.cols, shell.layout.rows, shell.viewport_top_row, shell.layout.content_bottom, shell.cursor_row, shell.cursor_col });
     switch (mode) {
         .resize_light, .replay_viewport => {
@@ -712,6 +718,11 @@ fn applyResizeWithLayoutResolved(
     });
 
     const mode = picked_mode orelse return;
+    diagnostics.recordRenderEvent(
+        .resize,
+        "old={d}x{d} new={d}x{d} settled={} mode={s} history_delta={any} pending_reflow={} invalid_dimensions={}",
+        .{ shell.layout.cols, shell.layout.rows, new_layout.cols, new_layout.rows, settled, @tagName(mode), history_row_delta, shell.render_requests.pending_settled_width_reflow, recovering_invalid_dimensions },
+    );
     const needs_owned_band_invalidation = size_changed or recovering_invalid_dimensions;
 
     if (!settled) {

--- a/src/ui/transcript/runtime.zig
+++ b/src/ui/transcript/runtime.zig
@@ -97,8 +97,6 @@ pub const TranscriptCommitDiagnostic = struct {
     history_visual_offset: u32 = 0,
     total_visual_rows: u32 = 0,
     source_bytes: usize = 0,
-    normal_buffer_recovery_pending: bool = false,
-    history_catchup_pending: bool = false,
     layout_id: u64 = 0,
     remaining_inline_rows: u32 = 0,
     remaining_unplanned_scroll_rows: u16 = 0,
@@ -4118,11 +4116,11 @@ test "render diagnostic commit skips unchanged same-row paints" {
         .shadow_state = .committed,
         .next_invalidation = .{},
     };
-    shell.recordRenderCommit(before, scroll_plan, result, false);
+    shell.recordRenderCommit(before, false, false, scroll_plan, result, false);
     var events: [2]diagnostics.RenderEvent = undefined;
     try std.testing.expectEqual(@as(usize, 0), diagnostics.snapshotRenderEvents(&events));
     result.full_repaint = true;
-    shell.recordRenderCommit(before, scroll_plan, result, false);
+    shell.recordRenderCommit(before, false, false, scroll_plan, result, false);
     try std.testing.expectEqual(@as(usize, 1), diagnostics.snapshotRenderEvents(&events));
     try std.testing.expectEqual(.commit, events[0].kind);
     try std.testing.expect(!events[0].truncated);
@@ -6632,8 +6630,6 @@ pub const TranscriptRuntime = struct {
                 .history_visual_offset = anchor.history_visual_offset,
                 .total_visual_rows = anchor.total_visual_rows,
                 .source_bytes = anchor.flow.len,
-                .normal_buffer_recovery_pending = anchor.normal_buffer_recovery_pending,
-                .history_catchup_pending = anchor.history_catchup_pending,
                 .layout_id = anchor.layout_id,
             },
             .recovering => |receipt| .{
@@ -6642,11 +6638,25 @@ pub const TranscriptRuntime = struct {
                 .history_visual_offset = receipt.accepted_history_visual_offset,
                 .total_visual_rows = receipt.attempt_total_visual_rows,
                 .source_bytes = receipt.flow.len,
-                .normal_buffer_recovery_pending = receipt.normal_buffer_recovery_pending,
                 .remaining_inline_rows = @as(u32, receipt.remaining_resize_reflow_rows) +
                     receipt.remaining_semantic_rows,
                 .remaining_unplanned_scroll_rows = receipt.remaining_unplanned_scroll_rows,
             },
+        };
+    }
+
+    pub fn normalBufferRecoveryPending(self: *const TranscriptRuntime) bool {
+        return switch (self.transcript_commit_state) {
+            .invalid => false,
+            .stable => |anchor| anchor.normal_buffer_recovery_pending,
+            .recovering => |receipt| receipt.normal_buffer_recovery_pending,
+        };
+    }
+
+    pub fn historyCatchupPending(self: *const TranscriptRuntime) bool {
+        return switch (self.transcript_commit_state) {
+            .invalid, .recovering => false,
+            .stable => |anchor| anchor.history_catchup_pending,
         };
     }
 
@@ -6735,7 +6745,7 @@ pub const TranscriptRuntime = struct {
             diagnostics.recordRenderEvent(
                 .source_invalidated,
                 "reason={s} state={s} view={d} history={d} rows={d} source_bytes={d} recovery={} catchup={}",
-                .{ reason, @tagName(diagnostic.state), diagnostic.visual_offset, diagnostic.history_visual_offset, diagnostic.total_visual_rows, diagnostic.source_bytes, diagnostic.normal_buffer_recovery_pending, diagnostic.history_catchup_pending },
+                .{ reason, @tagName(diagnostic.state), diagnostic.visual_offset, diagnostic.history_visual_offset, diagnostic.total_visual_rows, diagnostic.source_bytes, self.normalBufferRecoveryPending(), self.historyCatchupPending() },
             );
             debug_trace.logf(
                 "scroll",
@@ -8861,6 +8871,8 @@ pub const TranscriptRuntime = struct {
         transition: ?*TranscriptTransition,
     ) void {
         const before = self.transcriptCommitDiagnostic();
+        const before_recovery_pending = self.normalBufferRecoveryPending();
+        const before_history_catchup_pending = self.historyCatchupPending();
         const terminal_reset_commit =
             result.is_committed() and self.terminal_reset_pending;
         const resize_reset_commit =
@@ -8885,12 +8897,21 @@ pub const TranscriptRuntime = struct {
             if (committed_selection) |selection| selection.last_visible_row else 0,
             self.layout.content_bottom,
         );
-        self.recordRenderCommit(before, scroll_plan, result, terminal_reset_commit);
+        self.recordRenderCommit(
+            before,
+            before_recovery_pending,
+            before_history_catchup_pending,
+            scroll_plan,
+            result,
+            terminal_reset_commit,
+        );
     }
 
     fn recordRenderCommit(
         self: *const TranscriptRuntime,
         before: TranscriptCommitDiagnostic,
+        before_recovery_pending: bool,
+        before_history_catchup_pending: bool,
         scroll_plan: render_engine.frame_scroll_plan.FrameScrollPlan,
         result: render_engine.terminal_diff.FrameCommitResult,
         reset: bool,
@@ -8905,13 +8926,13 @@ pub const TranscriptRuntime = struct {
             before.history_visual_offset == after.history_visual_offset and
             before.total_visual_rows == after.total_visual_rows and
             before.layout_id == after.layout_id and
-            before.normal_buffer_recovery_pending == after.normal_buffer_recovery_pending and
-            before.history_catchup_pending == after.history_catchup_pending) return;
+            before_recovery_pending == self.normalBufferRecoveryPending() and
+            before_history_catchup_pending == self.historyCatchupPending()) return;
 
         diagnostics.recordRenderEvent(
             .commit,
             "state={s}->{s} result={s} view={d}->{d} history={d}->{d} rows={d}->{d} layout={x}->{x} terminal={d}x{d} cursor={d},{d} planned_scroll={d} accepted_scroll={d} bytes={d} repaint={} reset={} recovery={}->{} catchup={}->{}",
-            .{ @tagName(before.state), @tagName(after.state), @tagName(result.state()), before.visual_offset, after.visual_offset, before.history_visual_offset, after.history_visual_offset, before.total_visual_rows, after.total_visual_rows, before.layout_id, after.layout_id, self.layout.cols, self.layout.rows, result.committed_cursor_row, result.committed_cursor_col, scroll_plan.terminal_scroll_rows, result.terminal_scroll_rows_applied(), result.bytes_written, result.full_repaint, reset, before.normal_buffer_recovery_pending, after.normal_buffer_recovery_pending, before.history_catchup_pending, after.history_catchup_pending },
+            .{ @tagName(before.state), @tagName(after.state), @tagName(result.state()), before.visual_offset, after.visual_offset, before.history_visual_offset, after.history_visual_offset, before.total_visual_rows, after.total_visual_rows, before.layout_id, after.layout_id, self.layout.cols, self.layout.rows, result.committed_cursor_row, result.committed_cursor_col, scroll_plan.terminal_scroll_rows, result.terminal_scroll_rows_applied(), result.bytes_written, result.full_repaint, reset, before_recovery_pending, self.normalBufferRecoveryPending(), before_history_catchup_pending, self.historyCatchupPending() },
         );
     }
 

--- a/src/ui/transcript/runtime.zig
+++ b/src/ui/transcript/runtime.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const debug_trace = @import("../../core/shared/debug_trace.zig");
+const diagnostics = @import("../../core/workspace/diagnostics.zig");
 const managed_execution = @import("../../core/execution/managed_execution.zig");
 const display_width = @import("../../core/shared/display_width.zig");
 const input_action = @import("../../core/input/input_action.zig");
@@ -93,6 +94,11 @@ pub const TranscriptCommitDiagnostic = struct {
     state: TranscriptCommitDiagnosticState,
     stable_start_line: ?usize = null,
     visual_offset: u32 = 0,
+    history_visual_offset: u32 = 0,
+    total_visual_rows: u32 = 0,
+    source_bytes: usize = 0,
+    normal_buffer_recovery_pending: bool = false,
+    history_catchup_pending: bool = false,
     layout_id: u64 = 0,
     remaining_inline_rows: u32 = 0,
     remaining_unplanned_scroll_rows: u16 = 0,
@@ -4089,6 +4095,40 @@ const CompactTranscriptSourceCache = struct {
     }
 };
 
+test "render diagnostic commit skips unchanged same-row paints" {
+    diagnostics.resetForTest();
+    defer diagnostics.resetForTest();
+    const shell: TranscriptRuntime = .{ .layout = .{
+        .rows = 4,
+        .cols = 20,
+        .content_bottom = 1,
+        .divider_top_row = 2,
+        .input_row = 3,
+        .divider_bottom_row = 4,
+        .hint_row = 4,
+    } };
+    const before = shell.transcriptCommitDiagnostic();
+    const scroll_plan = render_engine.frame_scroll_plan.merge(4, 1, 0, 0);
+    var result: render_engine.terminal_diff.FrameCommitResult = .{
+        .bytes_written = 12,
+        .changed_cells = 1,
+        .full_repaint = false,
+        .committed_cursor_row = 3,
+        .committed_cursor_col = 1,
+        .shadow_state = .committed,
+        .next_invalidation = .{},
+    };
+    shell.recordRenderCommit(before, scroll_plan, result, false);
+    var events: [2]diagnostics.RenderEvent = undefined;
+    try std.testing.expectEqual(@as(usize, 0), diagnostics.snapshotRenderEvents(&events));
+    result.full_repaint = true;
+    shell.recordRenderCommit(before, scroll_plan, result, false);
+    try std.testing.expectEqual(@as(usize, 1), diagnostics.snapshotRenderEvents(&events));
+    try std.testing.expectEqual(.commit, events[0].kind);
+    try std.testing.expect(!events[0].truncated);
+    try std.testing.expect(std.mem.find(u8, events[0].detail(), "repaint=true") != null);
+}
+
 pub const TranscriptRuntime = struct {
     stdout_file: std.Io.File = std.Io.File.stdout(),
     sync_updates_enabled: bool = true,
@@ -6531,6 +6571,12 @@ pub const TranscriptRuntime = struct {
     }
 
     pub fn requestTerminalReset(self: *TranscriptRuntime, metrics: *Metrics) !void {
+        const before = self.transcriptCommitDiagnostic();
+        diagnostics.recordRenderEvent(
+            .reset,
+            "state={s} view={d} history={d} terminal={d}x{d} owned_top={d} cursor={d},{d}",
+            .{ @tagName(before.state), before.visual_offset, before.history_visual_offset, self.layout.cols, self.layout.rows, self.owned_top_row, self.cursor_row, self.cursor_col },
+        );
         const min_body_rows = self.min_visible_viewport_rows;
         self.reflow_clear_guard_rows = 0;
         self.resize_history_row_delta = null;
@@ -6583,11 +6629,20 @@ pub const TranscriptRuntime = struct {
                 .state = .stable,
                 .stable_start_line = anchor.selection.start_line,
                 .visual_offset = anchor.visual_offset,
+                .history_visual_offset = anchor.history_visual_offset,
+                .total_visual_rows = anchor.total_visual_rows,
+                .source_bytes = anchor.flow.len,
+                .normal_buffer_recovery_pending = anchor.normal_buffer_recovery_pending,
+                .history_catchup_pending = anchor.history_catchup_pending,
                 .layout_id = anchor.layout_id,
             },
             .recovering => |receipt| .{
                 .state = .recovering,
                 .visual_offset = receipt.accepted_visual_offset,
+                .history_visual_offset = receipt.accepted_history_visual_offset,
+                .total_visual_rows = receipt.attempt_total_visual_rows,
+                .source_bytes = receipt.flow.len,
+                .normal_buffer_recovery_pending = receipt.normal_buffer_recovery_pending,
                 .remaining_inline_rows = @as(u32, receipt.remaining_resize_reflow_rows) +
                     receipt.remaining_semantic_rows,
                 .remaining_unplanned_scroll_rows = receipt.remaining_unplanned_scroll_rows,
@@ -6677,6 +6732,11 @@ pub const TranscriptRuntime = struct {
     pub fn invalidateTranscriptAnchor(self: *TranscriptRuntime, reason: []const u8) void {
         const diagnostic = self.transcriptCommitDiagnostic();
         if (diagnostic.state != .invalid) {
+            diagnostics.recordRenderEvent(
+                .source_invalidated,
+                "reason={s} state={s} view={d} history={d} rows={d} source_bytes={d} recovery={} catchup={}",
+                .{ reason, @tagName(diagnostic.state), diagnostic.visual_offset, diagnostic.history_visual_offset, diagnostic.total_visual_rows, diagnostic.source_bytes, diagnostic.normal_buffer_recovery_pending, diagnostic.history_catchup_pending },
+            );
             debug_trace.logf(
                 "scroll",
                 "transcript_anchor_invalidate state={s} stable_start={d} visual_offset={d} reason={s}",
@@ -6738,6 +6798,11 @@ pub const TranscriptRuntime = struct {
                                     reason,
                                 },
                             );
+                            diagnostics.recordRenderEvent(
+                                .source_rewrite,
+                                "action=preserve reason={s} old_bytes={d} new_bytes={d} view={d} history={d} rows={d} start={d} layout={x} recovery={}->true catchup={}",
+                                .{ reason, anchor.flow.len, rendered_flow.len, anchor.visual_offset, anchor.history_visual_offset, anchor.total_visual_rows, anchor.selection.start_line, anchor.layout_id, anchor.normal_buffer_recovery_pending, anchor.history_catchup_pending },
+                            );
                             anchor.normal_buffer_recovery_pending = true;
                             return;
                         }
@@ -6769,6 +6834,11 @@ pub const TranscriptRuntime = struct {
                         if (receipt.document_append_committed) "true" else "false",
                         reason,
                     },
+                );
+                diagnostics.recordRenderEvent(
+                    .source_rewrite,
+                    "action=rebase_recovery reason={s} old_bytes={d} new_bytes={d} view={d} history={d} dropped_rows={d} append_committed={}",
+                    .{ reason, receipt.flow.len, rendered_flow.len, receipt.accepted_visual_offset, receipt.accepted_history_visual_offset, receipt.remaining_semantic_rows, receipt.document_append_committed },
                 );
                 receipt.remaining_semantic_rows = 0;
                 receipt.remaining_semantic_progress_rows = 0;
@@ -7241,6 +7311,13 @@ pub const TranscriptRuntime = struct {
             semantic_rows,
             semantic_rows,
         );
+        if (semantic_rows > releasable_advance) {
+            diagnostics.recordRenderEvent(
+                .transition,
+                "release_past_finality view={d}->{d} history={d} releasable={d} semantic={d} planned={d} compatible={} geometry={} recovery_rebase={} restore={} catchup={}",
+                .{ committed_projection_offset, target_offset, anchor.history_visual_offset, releasable_offset, semantic_rows, planned, source_compatible, geometry_rebase, recovery_rebase, anchor.normal_buffer_recovery_pending, anchor.history_catchup_pending },
+            );
+        }
         debug_trace.logf(
             "scroll",
             "transcript_transition_plan source_state=stable source_start={d} target_start={d} source_visual_offset={d} source_history_visual_offset={d} target_visual_offset={d} releasable_visual_offset={d} source_total_visual_rows={d} target_total_visual_rows={d} resize_reflow_candidate={d} resize_reflow_rows={d} semantic_rows={d} planned_rows={d} width_stable={s} source_compatible={s} footer_reservation_changed={s} replay_displaced_footer_history={s} geometry_rebase={s} recovery_rebase={s}",
@@ -7459,6 +7536,7 @@ pub const TranscriptRuntime = struct {
             target_area: render_engine.frame_layout.FrameRect,
         ) !void {
             const logical_visual_offset = self.visual_offset;
+            const previous_start_line = self.selection.start_line;
             try self.stagePreparedProjection(
                 alloc,
                 layout,
@@ -7468,6 +7546,11 @@ pub const TranscriptRuntime = struct {
             );
             self.visual_offset = logical_visual_offset;
             self.source_endpoint_visual_offset = self.history_visual_offset;
+            diagnostics.recordRenderEvent(
+                .history_projection,
+                "logical_view={d} history={d} start={d}->{d} endpoint={d} cursor={d},{d} terminal={d}x{d} area={d}..{d}",
+                .{ logical_visual_offset, self.history_visual_offset, previous_start_line, self.selection.start_line, self.source_endpoint_visual_offset, self.cursor_row, self.cursor_col, layout.cols, layout.rows, target_area.top, target_area.bottom },
+            );
         }
     };
 
@@ -7656,6 +7739,11 @@ pub const TranscriptRuntime = struct {
                     scroll_facts,
                     destructive_invalidation,
                 )) {
+                    diagnostics.recordRenderEvent(
+                        .transition,
+                        "rejected=rewind view={d}->{d} history={d}->{d} requested_view={d} compatible={} geometry={} restore={} catchup={}",
+                        .{ anchor.visual_offset, target.visual_offset, anchor.history_visual_offset, target.history_visual_offset, scroll_facts.target_visual_offset, scroll_facts.source_compatible, scroll_facts.geometry_rebase, target.normal_buffer_recovery_pending, target.history_catchup_pending },
+                    );
                     return error.InvalidTranscriptTransition;
                 }
                 if (semanticProgressNeedsStaging(
@@ -8692,6 +8780,16 @@ pub const TranscriptRuntime = struct {
             target_flow.len,
             target_layout.transcript_area,
         );
+        if (!scroll_facts.source_compatible or scroll_facts.geometry_rebase or
+            scroll_facts.recovery_rebase or scroll_plan.terminal_scroll_rows > 0 or plan.reset_terminal)
+        {
+            const before = self.transcriptCommitDiagnostic();
+            diagnostics.recordRenderEvent(
+                .transition,
+                "prepared view={d}->{d} history={d}->{d} start={d}->{d} rows={d}->{d} bytes={d}->{d} compatible={} geometry={} rebase={} hold={} restore={} catchup={} append={d}@{d},{d} scroll={d} reset={} body={d}..{d} footer={d}..{d}",
+                .{ before.visual_offset, target.visual_offset, before.history_visual_offset, target.history_visual_offset, before.stable_start_line orelse 0, target.selection.start_line, before.total_visual_rows, target.total_visual_rows, before.source_bytes, target_flow.len, scroll_facts.source_compatible, scroll_facts.geometry_rebase, scroll_facts.recovery_rebase, target.hold_staged, target.normal_buffer_recovery_pending, target.history_catchup_pending, document_append.bytes.len, document_append.start_row, document_append.start_col, scroll_plan.terminal_scroll_rows, plan.reset_terminal, target_layout.transcript_area.top, target_layout.transcript_area.bottom, target_layout.footer_area.top, target_layout.footer_area.bottom },
+            );
+        }
         return .{
             .scroll_plan = scroll_plan,
             .document_append = document_append,
@@ -8762,6 +8860,7 @@ pub const TranscriptRuntime = struct {
         result: render_engine.terminal_diff.FrameCommitResult,
         transition: ?*TranscriptTransition,
     ) void {
+        const before = self.transcriptCommitDiagnostic();
         const terminal_reset_commit =
             result.is_committed() and self.terminal_reset_pending;
         const resize_reset_commit =
@@ -8785,6 +8884,34 @@ pub const TranscriptRuntime = struct {
             if (committed_selection) |selection| selection.tail_kind else null,
             if (committed_selection) |selection| selection.last_visible_row else 0,
             self.layout.content_bottom,
+        );
+        self.recordRenderCommit(before, scroll_plan, result, terminal_reset_commit);
+    }
+
+    fn recordRenderCommit(
+        self: *const TranscriptRuntime,
+        before: TranscriptCommitDiagnostic,
+        scroll_plan: render_engine.frame_scroll_plan.FrameScrollPlan,
+        result: render_engine.terminal_diff.FrameCommitResult,
+        reset: bool,
+    ) void {
+        const after = self.transcriptCommitDiagnostic();
+        // Idle animation and same-row token paints must not evict the transitions
+        // that explain a jump before the user can request a trace.
+        if (result.is_committed() and !result.full_repaint and !reset and
+            scroll_plan.terminal_scroll_rows == 0 and
+            before.state == after.state and
+            before.visual_offset == after.visual_offset and
+            before.history_visual_offset == after.history_visual_offset and
+            before.total_visual_rows == after.total_visual_rows and
+            before.layout_id == after.layout_id and
+            before.normal_buffer_recovery_pending == after.normal_buffer_recovery_pending and
+            before.history_catchup_pending == after.history_catchup_pending) return;
+
+        diagnostics.recordRenderEvent(
+            .commit,
+            "state={s}->{s} result={s} view={d}->{d} history={d}->{d} rows={d}->{d} layout={x}->{x} terminal={d}x{d} cursor={d},{d} planned_scroll={d} accepted_scroll={d} bytes={d} repaint={} reset={} recovery={}->{} catchup={}->{}",
+            .{ @tagName(before.state), @tagName(after.state), @tagName(result.state()), before.visual_offset, after.visual_offset, before.history_visual_offset, after.history_visual_offset, before.total_visual_rows, after.total_visual_rows, before.layout_id, after.layout_id, self.layout.cols, self.layout.rows, result.committed_cursor_row, result.committed_cursor_col, scroll_plan.terminal_scroll_rows, result.terminal_scroll_rows_applied(), result.bytes_written, result.full_repaint, reset, before.normal_buffer_recovery_pending, after.normal_buffer_recovery_pending, before.history_catchup_pending, after.history_catchup_pending },
         );
     }
 

--- a/tests/e2e/tui-command-permissions.test.ts
+++ b/tests/e2e/tui-command-permissions.test.ts
@@ -1796,7 +1796,10 @@ describe("effect-aware command permissions", () => {
     "TUI creates a private Markdown trace without a feedback CTA",
     async () => {
       const root = createIsolatedRoot();
-      const gateway = startFakeGateway([]);
+      const gateway = startFakeGateway([finalText(
+        Array.from({ length: 80 }, (_, index) => `TRACE_RENDER_ROW_${index}\n`).join("") +
+          "TRACE_RENDER_DONE",
+      )]);
       const stderrPath = join(root.root, "trace-report-stderr.log");
       const clipboardPath = join(root.root, "trace-clipboard-path.txt");
       installClipboardFixture(
@@ -1812,12 +1815,20 @@ describe("effect-aware command permissions", () => {
           PATH: hostilePath(root),
           TMPDIR: root.root,
           FX_TRACE_CLIPBOARD_OUTPUT: clipboardPath,
+          FX_TRACE: "0",
+          FX_TRACE_LOG: undefined,
+          FX_TRACE_STDERR: "0",
         }),
         stderrPath,
         width: 120,
         height: 40,
       });
       await activeSession.waitForComposer(TIMEOUT);
+      await activeSession.sendText("Render the trace fixture.");
+      await activeSession.waitForText("TRACE_RENDER_DONE", TIMEOUT);
+      await activeSession.waitForStableComposer(TIMEOUT);
+      await activeSession.resizeWindow(100, 32);
+      await activeSession.waitForStableComposer(TIMEOUT);
       await activeSession.sendText("/trace");
       await activeSession.waitForText(
         process.platform === "darwin"
@@ -1836,6 +1847,16 @@ describe("effect-aware command permissions", () => {
       expect(report).toContain("# fx trace");
       expect(report).toContain("## Summary");
       expect(report).toContain(root.workspace);
+      expect(report).toContain("terminal_hosts: tmux=true");
+      expect(report).toContain("projection: view=");
+      const rendererEvents = report.split("## Recent Renderer Events\n")[1]?.split("## Transcript Timeline")[0];
+      expect(rendererEvents).toBeDefined();
+      expect(rendererEvents).toContain("kind=transition");
+      expect(rendererEvents).toContain("kind=commit");
+      expect(rendererEvents).toContain("kind=resize");
+      expect(rendererEvents).not.toContain("TRACE_RENDER_ROW_");
+      expect(rendererEvents).not.toContain("[truncated]");
+      expect(existsSync(join(root.home, ".fx", "logs", "trace.log"))).toBe(false);
       expect(statSync(reportPath).mode & 0o077).toBe(0);
       if (process.platform === "darwin") {
         expect(readFileSync(clipboardPath, "utf8")).toBe(reportPath);


### PR DESCRIPTION
## Summary

- Collect the latest 256 renderer events in memory without requiring debug flags or recording transcript content in those events.
- Include source rewrites, history movement, scroll commits, recovery, redraws, and resizes in `/trace` reports.
- Add current viewport/history positions and tmux/cmux detection to the report.
- Omit idle and unchanged same-row paint records so they do not displace useful transitions.
- Reset the renderer event buffer when the session diagnostics are reset.