### PR TITLE
Lowercase keyboard hints across the shell

### DIFF
--- a/sdk/node/test-term-compaction.mjs
+++ b/sdk/node/test-term-compaction.mjs
@@ -215,7 +215,7 @@ async function runScenario(name) {
   async function silentTranscript() {
     assert(!forbidden.test(grid(active.terminal)), "compaction output leaked into inline scrollback");
     active.runtime.write("\x0f");
-    await waitFor(() => active.terminal.buffer.active.type === "alternate" && grid(active.terminal).includes("Full detail"), "full transcript");
+    await waitFor(() => active.terminal.buffer.active.type === "alternate" && grid(active.terminal).includes("full detail"), "full transcript");
     assert(!forbidden.test(grid(active.terminal)), "compaction output leaked into Ctrl+O");
     active.runtime.write("\x0f");
     await waitFor(() => active.terminal.buffer.active.type === "normal" && emptyComposer(grid(active.terminal)), "inline restoration");
@@ -235,9 +235,9 @@ async function runScenario(name) {
     await start(["--resume", sessionId]);
     if (automatic) {
       active.runtime.write("/model\r");
-      await waitFor(() => grid(active.terminal).includes("128K context") && grid(active.terminal).includes("Tab Provider"), "model capabilities loaded");
+      await waitFor(() => grid(active.terminal).includes("128K context") && grid(active.terminal).includes("tab provider"), "model capabilities loaded");
       active.runtime.write("\x1b");
-      await waitFor(() => !grid(active.terminal).includes("Tab Provider") && emptyComposer(grid(active.terminal)), "model catalog closed");
+      await waitFor(() => !grid(active.terminal).includes("tab provider") && emptyComposer(grid(active.terminal)), "model catalog closed");
     }
     const beforeCommits = commits;
     const beforeBytes = [...records.values()][0].bytes.slice();
@@ -284,7 +284,7 @@ async function runScenario(name) {
       phase = "reopen";
       await start(["--resume", sessionId]);
       active.runtime.write("\x0f");
-      await waitFor(() => active.terminal.buffer.active.type === "alternate" && grid(active.terminal).includes("Full detail"), "reopened full transcript");
+      await waitFor(() => active.terminal.buffer.active.type === "alternate" && grid(active.terminal).includes("full detail"), "reopened full transcript");
       active.runtime.write("\x1b[F");
       await waitFor(() => grid(active.terminal).includes(cancelledPrompt), "replayed interrupted prompt");
       assert(!/cancelled|compaction|HOST_INTERNAL_HANDOFF_268a/i.test(grid(active.terminal)), "compaction cancellation must replay silently");

--- a/sdk/node/test-term-features.mjs
+++ b/sdk/node/test-term-features.mjs
@@ -103,7 +103,7 @@ for (const expected of ["first question", "first answer", "second question"]) {
 runtime.write("\x0f");
 await waitFor(() => terminal.buffer.active.type === "alternate", "full transcript alternate screen");
 runtime.write("\x1b[C");
-await waitFor(() => grid().includes("Full detail"), "full transcript detail");
+await waitFor(() => grid().includes("full detail"), "full transcript detail");
 runtime.write("\x0f");
 await waitFor(() => terminal.buffer.active.type === "normal", "full transcript close");
 
@@ -115,7 +115,7 @@ await command("/skills list", "Skills are unavailable in this host");
 runtime.write("/model\r");
 await waitFor(() => grid().includes("feature-model") && grid().includes("other-model"), "model catalog menu");
 runtime.write("\x1b");
-await waitFor(() => !grid().includes("Tab Provider"), "model catalog close");
+await waitFor(() => !grid().includes("tab provider"), "model catalog close");
 
 runtime.write("/exit\r");
 const code = await Promise.race([runtime.exited, new Promise((_, reject) => setTimeout(() => reject(new Error("exit timeout")), 5000))]);

--- a/src/core/app/app_auth_runtime.zig
+++ b/src/core/app/app_auth_runtime.zig
@@ -112,7 +112,7 @@ pub fn Runtime(comptime App: type) type {
                         try writeAuthNotice(app, .{
                             .topic = "auth",
                             .tone = .@"error",
-                            .body = "Could not load authentication settings. Check user settings, then press Enter to retry.",
+                            .body = "Could not load authentication settings. Check user settings, then press enter to retry.",
                         });
                         return false;
                     };
@@ -1115,7 +1115,7 @@ pub fn Runtime(comptime App: type) type {
             try app.writeDomainNotice(.{
                 .topic = "provider",
                 .tone = .neutral,
-                .body = "Provider preparation is still in progress. Ctrl+C cancels.",
+                .body = "Provider preparation is still in progress. ctrl+c cancels.",
             }, true);
             return true;
         }
@@ -1889,17 +1889,17 @@ pub fn Runtime(comptime App: type) type {
             return switch (failure.reason) {
                 .invalid_credential => std.fmt.allocPrint(
                     alloc,
-                    "{s} sign-in expired.\nPress Enter to sign in again. Your prompt is saved.",
+                    "{s} sign-in expired.\npress enter to sign in again. Your prompt is saved.",
                     .{source_label},
                 ),
                 .invalid_storage => std.fmt.allocPrint(
                     alloc,
-                    "{s}: Saved credential storage is unavailable.\nCheck credential storage, then press Enter to retry. Your prompt is saved.",
+                    "{s}: Saved credential storage is unavailable.\nCheck credential storage, then press enter to retry. Your prompt is saved.",
                     .{source_label},
                 ),
                 .persistence_uncertain => std.fmt.allocPrint(
                     alloc,
-                    "{s} refresh could not be saved.\nPress Enter to sign in again. Your prompt is saved.",
+                    "{s} refresh could not be saved.\npress enter to sign in again. Your prompt is saved.",
                     .{source_label},
                 ),
                 .authority_changed => std.fmt.allocPrint(
@@ -1909,7 +1909,7 @@ pub fn Runtime(comptime App: type) type {
                 ),
                 .temporary_unavailable => std.fmt.allocPrint(
                     alloc,
-                    "{s} credential refresh failed.\nPress Enter to retry. Your prompt is saved.",
+                    "{s} credential refresh failed.\npress enter to retry. Your prompt is saved.",
                     .{source_label},
                 ),
             };
@@ -3300,7 +3300,7 @@ test "prompt credential refresh failure is recoverable and detail-free" {
 
     try std.testing.expect(!try Runtime(TestApp).preparePromptCredential(&app));
     try std.testing.expect(std.mem.find(u8, app.transcript.items, "fx login credential refresh failed.") != null);
-    try std.testing.expect(std.mem.find(u8, app.transcript.items, "Press Enter to retry.") != null);
+    try std.testing.expect(std.mem.find(u8, app.transcript.items, "press enter to retry.") != null);
     try std.testing.expect(std.mem.find(u8, app.transcript.items, "Your prompt is saved.") != null);
     try std.testing.expect(std.mem.find(u8, app.transcript.items, "Choose another source") == null);
     try std.testing.expect(std.mem.find(u8, app.transcript.items, "OAuthRequestFailed") == null);
@@ -3354,7 +3354,7 @@ test "prompt credential admission rejects a credential that remains unavailable"
     try std.testing.expect(!try Runtime(TestApp).preparePromptCredential(&app));
     try std.testing.expectEqual(@as(usize, 2), app.auth.refresh_count);
     try std.testing.expect(std.mem.find(u8, app.transcript.items, "fx login sign-in expired.") != null);
-    try std.testing.expect(std.mem.find(u8, app.transcript.items, "Press Enter to sign in again.") != null);
+    try std.testing.expect(std.mem.find(u8, app.transcript.items, "press enter to sign in again.") != null);
     try std.testing.expect(std.mem.find(u8, app.transcript.items, "Your prompt is saved.") != null);
     try std.testing.expect(!app.auth.picker_opened);
 }
@@ -3463,7 +3463,7 @@ test "compaction credential failure preserves the first ordinary recovery notice
     try std.testing.expect(!try runtime.recoverCredentialFailure(&app, .fx_login, error.OAuthRequestFailed));
     try std.testing.expectEqual(@as(usize, 1), app.notice_write_count);
     try std.testing.expectEqualStrings(
-        "fx login credential refresh failed.\nPress Enter to retry. Your prompt is saved.",
+        "fx login credential refresh failed.\npress enter to retry. Your prompt is saved.",
         app.transcript.items,
     );
     try std.testing.expectEqualStrings("keep this ordinary prompt", app.submission.pending.?.draft.prompt);

--- a/src/core/app/app_bootstrap_runtime.zig
+++ b/src/core/app/app_bootstrap_runtime.zig
@@ -158,7 +158,7 @@ pub fn Runtime(comptime App: type) type {
 
         // Neutral one-line summary inline; the full detail stays behind Ctrl+O.
         fn writeCollapsedStartupNotice(app: *App, topic: []const u8, summary_lead: []const u8, detail: []const u8) !void {
-            const summary = try std.fmt.allocPrint(app.alloc, "{s} (ctrl o to view)", .{summary_lead});
+            const summary = try std.fmt.allocPrint(app.alloc, "{s} (ctrl+o to view)", .{summary_lead});
             defer app.alloc.free(summary);
             try app.writeDomainNotice(.{ .topic = topic, .tone = .neutral, .body = summary }, true);
             try app.writeDomainNotice(.{ .topic = topic, .tone = .neutral, .body = detail, .visibility = .full_only }, true);
@@ -1035,7 +1035,7 @@ test "app_bootstrap_runtime reports a bounded skill discovery warning" {
 
     try std.testing.expectEqual(@as(usize, 1), app.skills.diagnostics.len);
     try std.testing.expect(capture.early_notice_palette_initialized);
-    try std.testing.expect(std.mem.find(u8, app.transcript.items, "● Skills: 1 discovery issue; some skills may be missing (ctrl o to view)\n") != null);
+    try std.testing.expect(std.mem.find(u8, app.transcript.items, "● Skills: 1 discovery issue; some skills may be missing (ctrl+o to view)\n") != null);
     try std.testing.expect(std.mem.find(u8, app.transcript.items, "● Skills: skill discovery warning:") != null);
     try std.testing.expect(std.mem.find(u8, app.transcript.items, "hostile&#x0a;path/body-sentinel") != null);
     try std.testing.expect(std.mem.find(u8, app.transcript.items, "metadata is invalid (missing_name)") != null);
@@ -1051,6 +1051,6 @@ test "app_bootstrap_runtime collapses config diagnostics into one neutral summar
 
     try runBootstrapForTest(&app, &capture);
 
-    try std.testing.expect(std.mem.find(u8, app.transcript.items, "● Config: 2 configuration issues (ctrl o to view)\n") != null);
+    try std.testing.expect(std.mem.find(u8, app.transcript.items, "● Config: 2 configuration issues (ctrl+o to view)\n") != null);
     try std.testing.expect(std.mem.find(u8, app.transcript.items, "user: malformed_settings\nproject: settings_too_large [full-only]\n") != null);
 }

--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -616,10 +616,10 @@ pub fn Runtime(comptime App: type) type {
             const file_selection = if (file_view.receipt) |receipt| receipt.selected else null;
             const file_status: ?[]const u8 = switch (file_view.status) {
                 .unavailable => if (app.input_runtime.picker.file_completion.indexed)
-                    "Files unavailable. Tab to retry; Esc to dismiss."
+                    "Files unavailable. tab to retry; esc to dismiss."
                 else
-                    "Directory unavailable. Tab to retry; Esc to dismiss.",
-                .stale => "Selection unavailable. Navigate to choose; Tab to retry.",
+                    "Directory unavailable. tab to retry; esc to dismiss.",
+                .stale => "Selection unavailable. navigate to choose; tab to retry.",
                 .loading, .ready, .empty => null,
             };
             const inline_completion =
@@ -4552,7 +4552,7 @@ test "core.app_render_runtime active setup hub stays on the inline transcript su
     try std.testing.expect(try coordinatorGridContains(app.shell.shadow_vt.?.*, "Setup"));
     try std.testing.expect(try coordinatorGridContains(app.shell.shadow_vt.?.*, "Connections"));
     try std.testing.expect(try coordinatorGridContains(app.shell.shadow_vt.?.*, "Credential source"));
-    try std.testing.expect(try coordinatorGridContains(app.shell.shadow_vt.?.*, "Enter Open"));
+    try std.testing.expect(try coordinatorGridContains(app.shell.shadow_vt.?.*, "enter open"));
     try std.testing.expect(!(try coordinatorGridContains(app.shell.shadow_vt.?.*, "test-model")));
     try std.testing.expect(try coordinatorGridContains(app.shell.shadow_vt.?.*, "setup transcript stays behind"));
 

--- a/src/core/auth/grok_oauth.zig
+++ b/src/core/auth/grok_oauth.zig
@@ -409,7 +409,7 @@ pub fn runLogin(
     try writeStdout("Open this URL to sign in with Grok:\n");
     try writeStdout(authorization_url);
     try writeStdout("\n\nWaiting for browser authorization...\n");
-    try writeStdout("Paste the code shown by xAI and press Enter if the browser doesn't return.\n");
+    try writeStdout("Paste the code shown by xAI and press enter if the browser doesn't return.\n");
     if (io_mod.getenv("FX_NO_OPEN_BROWSER") == null) {
         _ = url_opener.open(alloc, authorization_url) catch false;
     }

--- a/src/core/auth/login_flow.zig
+++ b/src/core/auth/login_flow.zig
@@ -1045,7 +1045,7 @@ const BrowserOpenPrompt = struct {
 
     fn writeWaitingMessage(self: BrowserOpenPrompt) !void {
         if (self.enabled) {
-            try writeStdout("Waiting for authentication. Press Enter to open this in your browser, or use the URL manually.\n");
+            try writeStdout("Waiting for authentication. press enter to open this in your browser, or use the URL manually.\n");
         } else {
             try writeStdout("Waiting for authentication...\n");
         }

--- a/src/core/output/worker_status.zig
+++ b/src/core/output/worker_status.zig
@@ -167,7 +167,7 @@ fn format_status_label(
     else if (status.action == .waiting_for_connectivity)
         std.fmt.bufPrint(
             buf,
-            "{s} · Esc to try later",
+            "{s} · esc to try later",
             .{status.label(&base_buf)},
         ) catch status.label(buf)
     else if (status.action == .paused)
@@ -354,7 +354,7 @@ test "worker status route recovery labels expose required controls" {
     }, 0);
     switch (state.projection().?) {
         .turn_thinking => |projection| try std.testing.expectEqualStrings(
-            "⚠ Mac woke from sleep · waiting for connection · attempt 2/10 · Esc to try later",
+            "⚠ Mac woke from sleep · waiting for connection · attempt 2/10 · esc to try later",
             projection.label,
         ),
         .none, .tool_slot => return error.TestUnexpectedResult,

--- a/src/core/skills/skill_invocation.zig
+++ b/src/core/skills/skill_invocation.zig
@@ -269,7 +269,7 @@ pub fn buildExplicitPromptSection(
     const summary = if (failed == 0)
         try std.fmt.allocPrint(alloc, "{d} requested skill{s} loaded{s}", .{ loaded, if (loaded == 1) "" else "s", load_rows.written() })
     else
-        try std.fmt.allocPrint(alloc, "Requested skills · {d} loaded · {d} failed (ctrl o for details){s}", .{ loaded, failed, load_rows.written() });
+        try std.fmt.allocPrint(alloc, "Requested skills · {d} loaded · {d} failed (ctrl+o for details){s}", .{ loaded, failed, load_rows.written() });
     errdefer alloc.free(summary);
     const details = if (load_details.written().len > 0) try load_details.toOwnedSlice() else null;
     errdefer if (details) |value| alloc.free(value);
@@ -320,7 +320,7 @@ test "explicit skill requests report ambiguous names without selecting a source"
     try expectContains(section.load_notice.?.body, "ambiguous name");
     try expectNotContains(section.load_notice.?.body, "/workspace/review");
     try expectNotContains(section.load_notice.?.body, "/global/review");
-    try expectContains(section.load_notice.?.body, "ctrl o");
+    try expectContains(section.load_notice.?.body, "ctrl+o");
     try expectContains(section.load_details.?, "/workspace/review");
     try expectContains(section.load_details.?, "/global/review");
     try std.testing.expect(section.notice == null);

--- a/src/main.zig
+++ b/src/main.zig
@@ -1702,7 +1702,7 @@ const App = struct {
         var notice: std.Io.Writer.Allocating = .init(self.alloc);
         defer notice.deinit();
         try notice.writer.print(
-            "Project MCP server '{s}' is defined in .mcp.json.\n  [1] Approve  [2] Approve all  [3] Reject  [Esc] Dismiss remaining prompts\n",
+            "Project MCP server '{s}' is defined in .mcp.json.\n  [1] approve  [2] approve all  [3] reject  [esc] dismiss remaining prompts\n",
             .{name},
         );
         try self.writeTranscriptClassified(

--- a/src/ui/approval_screen.zig
+++ b/src/ui/approval_screen.zig
@@ -561,17 +561,17 @@ fn commandMaxScrollRows(command: []const u8, content_width: usize, row_count: u1
 // only cue that the review scrolls); the tail tiers reuse the shared approval
 // ladder so reworded copy cannot drift.
 const command_review_amendment_hints = [_][]const u8{
-    "1–3 Choose now    ↑↓ Options    Tab Amend    Wheel Scroll    Enter Confirm    Esc Cancel",
-    "1–3 Choose now    ↑↓ Options    Wheel Scroll    Enter Confirm    Esc Cancel",
-    "1–3 Choose    Wheel Scroll    Enter Confirm    Esc Cancel",
+    "1–3 choose now    ↑↓ options    tab amend    wheel scroll    enter confirm    esc cancel",
+    "1–3 choose now    ↑↓ options    wheel scroll    enter confirm    esc cancel",
+    "1–3 choose    wheel scroll    enter confirm    esc cancel",
     interaction_state.approval_hint_compact,
     interaction_state.approval_hint_minimal,
 };
 
 const command_review_navigation_hints = [_][]const u8{
-    "1–3 Choose now    ↑↓ or Tab Options    Wheel Scroll    Enter Confirm    Esc Cancel",
-    "1–3 Choose now    ↑↓ Options    Wheel Scroll    Enter Confirm    Esc Cancel",
-    "1–3 Choose    Wheel Scroll    Enter Confirm    Esc Cancel",
+    "1–3 choose now    ↑↓ or tab options    wheel scroll    enter confirm    esc cancel",
+    "1–3 choose now    ↑↓ options    wheel scroll    enter confirm    esc cancel",
+    "1–3 choose    wheel scroll    enter confirm    esc cancel",
     interaction_state.approval_hint_compact,
     interaction_state.approval_hint_minimal,
 };
@@ -1677,7 +1677,7 @@ test "command approval screen includes compact permission header" {
         row_text.clearRetainingCapacity();
         try grid.rowTextTrimmed(row, &row_text);
         if (std.mem.find(u8, row_text.items, "3. No") != null) choice_three_row = row;
-        if (std.mem.find(u8, row_text.items, "1–3 Choose") != null) hint_row = row;
+        if (std.mem.find(u8, row_text.items, "1–3 choose") != null) hint_row = row;
     }
 
     const choice_row = choice_three_row orelse return error.TestMissingChoice;
@@ -2191,7 +2191,7 @@ test "file approval top-aligns a fitting welcome document and clears below" {
 
     row.clearRetainingCapacity();
     try grid.rowTextTrimmed(16, &row);
-    try std.testing.expect(std.mem.indexOf(u8, row.items, "1–3 Choose") != null);
+    try std.testing.expect(std.mem.indexOf(u8, row.items, "1–3 choose") != null);
     row.clearRetainingCapacity();
     try grid.rowTextTrimmed(17, &row);
     try std.testing.expectEqualStrings("", row.items);
@@ -2453,30 +2453,30 @@ test "command review hint keeps enter and esc guidance at narrow widths" {
     var wide: std.Io.Writer.Allocating = .init(alloc);
     defer wide.deinit();
     try writeCommandReviewHint(&wide.writer, 5, 100, true);
-    try std.testing.expect(std.mem.find(u8, wide.written(), "Wheel Scroll") != null);
-    try std.testing.expect(std.mem.find(u8, wide.written(), "Tab Amend") != null);
-    try std.testing.expect(std.mem.find(u8, wide.written(), "Esc Cancel") != null);
+    try std.testing.expect(std.mem.find(u8, wide.written(), "wheel scroll") != null);
+    try std.testing.expect(std.mem.find(u8, wide.written(), "tab amend") != null);
+    try std.testing.expect(std.mem.find(u8, wide.written(), "esc cancel") != null);
 
     var navigation: std.Io.Writer.Allocating = .init(alloc);
     defer navigation.deinit();
     try writeCommandReviewHint(&navigation.writer, 5, 100, false);
-    try std.testing.expect(std.mem.find(u8, navigation.written(), "Tab Options") != null);
-    try std.testing.expect(std.mem.find(u8, navigation.written(), "Tab Amend") == null);
+    try std.testing.expect(std.mem.find(u8, navigation.written(), "tab options") != null);
+    try std.testing.expect(std.mem.find(u8, navigation.written(), "tab amend") == null);
 
     var narrow: std.Io.Writer.Allocating = .init(alloc);
     defer narrow.deinit();
     try writeCommandReviewHint(&narrow.writer, 5, 60, true);
-    try std.testing.expect(std.mem.find(u8, narrow.written(), "Wheel Scroll") != null);
-    try std.testing.expect(std.mem.find(u8, narrow.written(), "Enter Confirm") != null);
-    try std.testing.expect(std.mem.find(u8, narrow.written(), "Esc Cancel") != null);
+    try std.testing.expect(std.mem.find(u8, narrow.written(), "wheel scroll") != null);
+    try std.testing.expect(std.mem.find(u8, narrow.written(), "enter confirm") != null);
+    try std.testing.expect(std.mem.find(u8, narrow.written(), "esc cancel") != null);
     try std.testing.expect(std.mem.find(u8, narrow.written(), "Options") == null);
     try std.testing.expect(display_width.visibleWidthIgnoringAnsi(narrow.written()) <= 60);
 
     var minimal: std.Io.Writer.Allocating = .init(alloc);
     defer minimal.deinit();
     try writeCommandReviewHint(&minimal.writer, 5, 40, true);
-    try std.testing.expect(std.mem.find(u8, minimal.written(), "Enter Confirm") != null);
-    try std.testing.expect(std.mem.find(u8, minimal.written(), "Esc Cancel") != null);
-    try std.testing.expect(std.mem.find(u8, minimal.written(), "Wheel Scroll") == null);
+    try std.testing.expect(std.mem.find(u8, minimal.written(), "enter confirm") != null);
+    try std.testing.expect(std.mem.find(u8, minimal.written(), "esc cancel") != null);
+    try std.testing.expect(std.mem.find(u8, minimal.written(), "wheel scroll") == null);
     try std.testing.expect(display_width.visibleWidthIgnoringAnsi(minimal.written()) <= 40);
 }

--- a/src/ui/footer/approval_ui.zig
+++ b/src/ui/footer/approval_ui.zig
@@ -17,12 +17,12 @@ const TranscriptRuntime = transcript_runtime.TranscriptRuntime;
 const ApprovalPrompt = approval_prompt.ApprovalPrompt;
 const ApprovalProjection = approval_prompt.Projection;
 
-const file_approval_hint = "1–3 Choose now    ↑↓ Options    Tab Amend    Enter Confirm    Esc Cancel";
-const file_approval_navigation_hint = "1–3 Choose now    ↑↓ or Tab Options    Enter Confirm    Esc Cancel";
-const file_approval_screen_hint = "1–3 Choose now    ↑↓ Options    Tab Amend    Wheel Scroll    Enter Confirm    Esc Cancel";
-const file_approval_navigation_screen_hint = "1–3 Choose now    ↑↓ or Tab Options    Wheel Scroll    Enter Confirm    Esc Cancel";
-const file_approval_hint_compact = "1–3 Choose now    Enter Confirm    Esc Cancel";
-const file_approval_hint_minimal = "Enter Confirm    Esc Cancel";
+const file_approval_hint = "1–3 choose now    ↑↓ options    tab amend    enter confirm    esc cancel";
+const file_approval_navigation_hint = "1–3 choose now    ↑↓ or tab options    enter confirm    esc cancel";
+const file_approval_screen_hint = "1–3 choose now    ↑↓ options    tab amend    wheel scroll    enter confirm    esc cancel";
+const file_approval_navigation_screen_hint = "1–3 choose now    ↑↓ or tab options    wheel scroll    enter confirm    esc cancel";
+const file_approval_hint_compact = "1–3 choose now    enter confirm    esc cancel";
+const file_approval_hint_minimal = "enter confirm    esc cancel";
 // Ordered widest-first; every variant keeps the Enter/Esc controls so narrow
 // terminals never lose the submit and cancel instructions.
 const file_approval_hint_variants = [_][]const u8{ file_approval_hint, file_approval_hint_compact, file_approval_hint_minimal };
@@ -31,15 +31,15 @@ const file_approval_navigation_hint_variants = [_][]const u8{ file_approval_navi
 // is the only cue that the review document scrolls.
 const file_approval_screen_hint_variants = [_][]const u8{
     file_approval_screen_hint,
-    "1–3 Choose now    ↑↓ Options    Wheel Scroll    Enter Confirm    Esc Cancel",
-    "1–3 Choose    Wheel Scroll    Enter Confirm    Esc Cancel",
+    "1–3 choose now    ↑↓ options    wheel scroll    enter confirm    esc cancel",
+    "1–3 choose    wheel scroll    enter confirm    esc cancel",
     file_approval_hint_compact,
     file_approval_hint_minimal,
 };
 const file_approval_navigation_screen_hint_variants = [_][]const u8{
     file_approval_navigation_screen_hint,
-    "1–3 Choose now    ↑↓ Options    Wheel Scroll    Enter Confirm    Esc Cancel",
-    "1–3 Choose    Wheel Scroll    Enter Confirm    Esc Cancel",
+    "1–3 choose now    ↑↓ options    wheel scroll    enter confirm    esc cancel",
+    "1–3 choose    wheel scroll    enter confirm    esc cancel",
     file_approval_hint_compact,
     file_approval_hint_minimal,
 };
@@ -1739,8 +1739,8 @@ fn approvalChoicePrefix(choice: u8) []const u8 {
 fn approvalHint(approval: ApprovalProjection, width: u16) []const u8 {
     if (approval.request.confirmation_only) {
         const confirmation_variants = [_][]const u8{
-            "1–2 Choose    Enter Confirm    Esc Cancel",
-            "Enter Confirm    Esc Cancel",
+            "1–2 choose    enter confirm    esc cancel",
+            "enter confirm    esc cancel",
         };
         return display_width.widestFitting(&confirmation_variants, width);
     }
@@ -2273,15 +2273,15 @@ test "approval panel hint keeps enter and esc guidance at narrow widths" {
 
     var wide = try composeApprovalPanelRow(std.testing.allocator, prompt.projection().?, 120, 10, interaction_state.approval_panel_rows_spacious);
     defer wide.deinit(std.testing.allocator);
-    try std.testing.expect(std.mem.find(u8, wide.items, "1–3 Choose now") != null);
-    try std.testing.expect(std.mem.find(u8, wide.items, "Tab Amend") != null);
-    try std.testing.expect(std.mem.find(u8, wide.items, "Esc Cancel") != null);
+    try std.testing.expect(std.mem.find(u8, wide.items, "1–3 choose now") != null);
+    try std.testing.expect(std.mem.find(u8, wide.items, "tab amend") != null);
+    try std.testing.expect(std.mem.find(u8, wide.items, "esc cancel") != null);
 
     prompt.decision.choice_index = 1;
     var navigation = try composeApprovalPanelRow(std.testing.allocator, prompt.projection().?, 120, 10, interaction_state.approval_panel_rows_spacious);
     defer navigation.deinit(std.testing.allocator);
-    try std.testing.expect(std.mem.find(u8, navigation.items, "Tab Options") != null);
-    try std.testing.expect(std.mem.find(u8, navigation.items, "Tab Amend") == null);
+    try std.testing.expect(std.mem.find(u8, navigation.items, "tab options") != null);
+    try std.testing.expect(std.mem.find(u8, navigation.items, "tab amend") == null);
 
     _ = try prompt.decision.apply(
         std.testing.allocator,
@@ -2291,12 +2291,12 @@ test "approval panel hint keeps enter and esc guidance at narrow widths" {
     );
     var denial = try composeApprovalPanelRow(std.testing.allocator, prompt.projection().?, 120, 10, interaction_state.approval_panel_rows_spacious);
     defer denial.deinit(std.testing.allocator);
-    try std.testing.expect(std.mem.find(u8, denial.items, "Tab Amend") != null);
+    try std.testing.expect(std.mem.find(u8, denial.items, "tab amend") != null);
 
     var narrow = try composeApprovalPanelRow(std.testing.allocator, prompt.projection().?, 60, 10, interaction_state.approval_panel_rows_spacious);
     defer narrow.deinit(std.testing.allocator);
-    try std.testing.expect(std.mem.find(u8, narrow.items, "Enter Confirm") != null);
-    try std.testing.expect(std.mem.find(u8, narrow.items, "Esc Cancel") != null);
+    try std.testing.expect(std.mem.find(u8, narrow.items, "enter confirm") != null);
+    try std.testing.expect(std.mem.find(u8, narrow.items, "esc cancel") != null);
     try std.testing.expect(std.mem.find(u8, narrow.items, "Options") == null);
     try std.testing.expect(display_width.visibleWidthIgnoringAnsi(narrow.items) <= 60);
 }
@@ -2305,9 +2305,9 @@ test "file approval hint keeps Enter and Esc guidance at narrow widths" {
     const alloc = std.testing.allocator;
     var row = try composeFileApprovalHintRow(alloc, null, 40);
     defer row.deinit(alloc);
-    try std.testing.expect(std.mem.find(u8, row.items, "Enter Confirm") != null);
-    try std.testing.expect(std.mem.find(u8, row.items, "Esc Cancel") != null);
-    try std.testing.expect(std.mem.find(u8, row.items, "Tab Amend") == null);
+    try std.testing.expect(std.mem.find(u8, row.items, "enter confirm") != null);
+    try std.testing.expect(std.mem.find(u8, row.items, "esc cancel") != null);
+    try std.testing.expect(std.mem.find(u8, row.items, "tab amend") == null);
     try std.testing.expect(display_width.visibleWidthIgnoringAnsi(row.items) <= 40);
 }
 
@@ -2323,18 +2323,18 @@ test "file approval hints follow the selected amendment capability" {
     const projection = projectFileApproval(request, prompt.decision.choice_index, 120, fileApprovalDesiredRows(preview));
     var inline_hint = try composeFileApprovalRow(alloc, request, &projection, prompt.decision.choice_index, prompt.projection().?, 120, .hint);
     defer inline_hint.deinit(alloc);
-    try std.testing.expect(std.mem.find(u8, inline_hint.items, "Tab Options") != null);
-    try std.testing.expect(std.mem.find(u8, inline_hint.items, "Tab Amend") == null);
+    try std.testing.expect(std.mem.find(u8, inline_hint.items, "tab options") != null);
+    try std.testing.expect(std.mem.find(u8, inline_hint.items, "tab amend") == null);
 
     var screen = try composeFileApprovalScreenRow(alloc, request, .active_session, prompt.decision.choice_index, 120, .hint, true, true, prompt.projection().?);
     defer screen.text.deinit(alloc);
-    try std.testing.expect(std.mem.find(u8, screen.text.items, "Tab Options") != null);
-    try std.testing.expect(std.mem.find(u8, screen.text.items, "Wheel Scroll") != null);
+    try std.testing.expect(std.mem.find(u8, screen.text.items, "tab options") != null);
+    try std.testing.expect(std.mem.find(u8, screen.text.items, "wheel scroll") != null);
 
     prompt.decision.choice_index = 2;
     var denial = try composeFileApprovalScreenRow(alloc, request, .active_session, prompt.decision.choice_index, 120, .hint, true, true, prompt.projection().?);
     defer denial.text.deinit(alloc);
-    try std.testing.expect(std.mem.find(u8, denial.text.items, "Tab Amend") != null);
+    try std.testing.expect(std.mem.find(u8, denial.text.items, "tab amend") != null);
 }
 
 test "scrollable file approval hint keeps the wheel notice and Esc at 80 columns" {
@@ -2343,8 +2343,8 @@ test "scrollable file approval hint keeps the wheel notice and Esc at 80 columns
     const request: permission_request.FileApprovalRequest = .{ .kind = .edit, .intent = .mutation, .preview = preview, .scope = .workspace_files };
     var row = try composeFileApprovalScreenRow(alloc, request, .active_session, 0, 80, .hint, true, true, null);
     defer row.text.deinit(alloc);
-    try std.testing.expect(std.mem.find(u8, row.text.items, "Wheel Scroll") != null);
-    try std.testing.expect(std.mem.find(u8, row.text.items, "Esc Cancel") != null);
+    try std.testing.expect(std.mem.find(u8, row.text.items, "wheel scroll") != null);
+    try std.testing.expect(std.mem.find(u8, row.text.items, "esc cancel") != null);
     try std.testing.expect(display_width.visibleWidthIgnoringAnsi(row.text.items) <= 80);
 }
 
@@ -2429,8 +2429,8 @@ test "inline command panel wraps the complete target before its controls" {
     try std.testing.expect(std.mem.find(u8, panel.items, "INLINE_COMMAND_START") != null);
     try std.testing.expect(std.mem.find(u8, panel.items, "INLINE_COMMAND_END") != null);
     try std.testing.expect(std.mem.find(u8, panel.items, interaction_state.approval_once_label) != null);
-    try std.testing.expect(std.mem.find(u8, panel.items, "Enter Confirm") == null);
-    try std.testing.expect(std.mem.find(u8, panel.items, "Esc Cancel") == null);
+    try std.testing.expect(std.mem.find(u8, panel.items, "enter confirm") == null);
+    try std.testing.expect(std.mem.find(u8, panel.items, "esc cancel") == null);
 }
 
 test "inline command panel uses full command when label is bounded" {
@@ -2967,15 +2967,15 @@ test "permission hints use compact ask modal language" {
     try std.testing.expect(std.mem.find(
         u8,
         generic.items,
-        "1–3 Choose now",
+        "1–3 choose now",
     ) != null);
-    try std.testing.expect(std.mem.find(u8, generic.items, "Tab Amend") != null);
+    try std.testing.expect(std.mem.find(u8, generic.items, "tab amend") != null);
     try std.testing.expect(std.mem.find(
         u8,
         generic.items,
-        "Enter Confirm",
+        "enter confirm",
     ) != null);
-    try std.testing.expect(std.mem.find(u8, generic.items, "Esc Cancel") != null);
+    try std.testing.expect(std.mem.find(u8, generic.items, "esc cancel") != null);
 
     const preview = diff_mod.FileChangePreview{
         .path = "note.txt",
@@ -3005,8 +3005,8 @@ test "permission hints use compact ask modal language" {
     try std.testing.expect(std.mem.find(
         u8,
         file.text.items,
-        "1–3 Choose now",
+        "1–3 choose now",
     ) != null);
-    try std.testing.expect(std.mem.find(u8, file.text.items, "Wheel Scroll") != null);
-    try std.testing.expect(std.mem.find(u8, file.text.items, "Tab Amend") != null);
+    try std.testing.expect(std.mem.find(u8, file.text.items, "wheel scroll") != null);
+    try std.testing.expect(std.mem.find(u8, file.text.items, "tab amend") != null);
 }

--- a/src/ui/footer/compact_command_menu_presentation.zig
+++ b/src/ui/footer/compact_command_menu_presentation.zig
@@ -172,7 +172,7 @@ fn composeUsageRow(
         return composeStyledRow(
             alloc,
             if (projection.refresh_error != null)
-                "Usage unavailable · press R to retry"
+                "Usage unavailable · press r to retry"
             else
                 "Loading usage",
             width,
@@ -262,7 +262,7 @@ fn composeUsagePriorityRow(
     const snapshot = projection.snapshot orelse return composeStyledRow(
         alloc,
         if (projection.refresh_error != null)
-            "Usage unavailable · press R to retry"
+            "Usage unavailable · press r to retry"
         else
             "Loading usage",
         width,

--- a/src/ui/footer/input_presentation.zig
+++ b/src/ui/footer/input_presentation.zig
@@ -177,16 +177,16 @@ test "steering rows visibly escape terminal control bytes" {
 // Ordered widest-first; every fallback keeps the enter/esc controls so narrow
 // terminals never lose the submit and cancel instructions.
 const freeform_question_hints = [_][]const u8{
-    "↑↓ Cursor · Shift+↑↓ Options · Tab Questions · Enter Answer · Esc Cancel",
-    "Shift+↑↓ Options · Tab Questions · Enter Answer · Esc Cancel",
-    "Tab Questions · Enter Answer · Esc Cancel",
-    "Enter Answer · Esc Cancel",
+    "↑↓ cursor · shift+↑↓ options · tab questions · enter answer · esc cancel",
+    "shift+↑↓ options · tab questions · enter answer · esc cancel",
+    "tab questions · enter answer · esc cancel",
+    "enter answer · esc cancel",
 };
 
 const predefined_question_hints = [_][]const u8{
-    "↑↓ Options · Tab Questions · Enter Answer · Esc Cancel",
-    "Tab Questions · Enter Answer · Esc Cancel",
-    "Enter Answer · Esc Cancel",
+    "↑↓ options · tab questions · enter answer · esc cancel",
+    "tab questions · enter answer · esc cancel",
+    "enter answer · esc cancel",
 };
 
 fn questionInteractionHint(
@@ -203,11 +203,11 @@ fn questionInteractionHint(
     var out: std.Io.Writer = .fixed(out_buf);
     if (projection.isFreeformSelected()) {
         out.writeAll(
-            "Type answer    ↑↓←→ Cursor    Shift+↑↓ Options    Tab Questions    Enter Answer    Esc Cancel",
+            "type answer    ↑↓←→ cursor    shift+↑↓ options    tab questions    enter answer    esc cancel",
         ) catch return display_width.widestFitting(variants, width);
     } else {
         out.print(
-            "1–{d} Choose now    ↑↓ Options    Tab Questions    Enter Answer    Esc Cancel",
+            "1–{d} choose now    ↑↓ options    tab questions    enter answer    esc cancel",
             .{option_count},
         ) catch return display_width.widestFitting(variants, width);
     }
@@ -395,9 +395,9 @@ fn authPickerInteractionHint(view: auth_runtime.PickerView, width: u16) ?[]const
 
     if (view.stage == .api_key and view.api_key_inline) {
         const key_variants = [_][]const u8{
-            "Enter saves     Esc cancels     " ++ credentials.stored_key_backend_label,
-            "Enter saves  Esc cancels",
-            "Enter  Esc",
+            "enter saves     esc cancels     " ++ credentials.stored_key_backend_label,
+            "enter saves  esc cancels",
+            "enter  esc",
         };
         for (key_variants) |candidate| {
             if (display_width.visibleWidth(candidate) <= width) return candidate;
@@ -406,46 +406,46 @@ fn authPickerInteractionHint(view: auth_runtime.PickerView, width: u16) ?[]const
     }
 
     const root_variants = [_][]const u8{
-        "↑↓ Navigate     Enter Open     Esc Close",
-        "↑↓ Move  Enter Open  Esc",
-        "Enter Open  Esc Close",
-        "Enter Esc",
+        "↑↓ navigate     enter open     esc close",
+        "↑↓ move  enter open  esc",
+        "enter open  esc close",
+        "enter esc",
     };
     const connections_variants = [_][]const u8{
-        "↑↓ Navigate     Enter Open     Esc Back",
-        "↑↓ Move  Enter Open  Esc",
-        "Enter Open  Esc Back",
-        "Enter Esc",
+        "↑↓ navigate     enter open     esc back",
+        "↑↓ move  enter open  esc",
+        "enter open  esc back",
+        "enter esc",
     };
     const selection_variants = [_][]const u8{
-        "↑↓ Navigate     Enter Use     Esc Back",
-        "↑↓ Move  Enter Use  Esc",
-        "Enter Use  Esc Back",
-        "Enter Esc",
+        "↑↓ navigate     enter use     esc back",
+        "↑↓ move  enter use  esc",
+        "enter use  esc back",
+        "enter esc",
     };
     const team_variants = [_][]const u8{
-        "Type to search     ↑↓ Navigate     Enter Use     Esc Back",
-        "Type  ↑↓ Move  Enter  Esc",
-        "↑↓ Move  Enter  Esc",
-        "Enter Esc",
+        "type to search     ↑↓ navigate     enter use     esc back",
+        "type  ↑↓ move  enter  esc",
+        "↑↓ move  enter  esc",
+        "enter esc",
     };
     const codex_sign_in_variants = [_][]const u8{
-        "Enter reopens browser · Esc cancels",
-        "Enter reopens  Esc cancels",
-        "Enter  Esc",
-        "Enter Esc",
+        "enter reopens browser · esc cancels",
+        "enter reopens  esc cancels",
+        "enter  esc",
+        "enter esc",
     };
     const grok_browser_variants = [_][]const u8{
-        "Enter reopens browser · Tab enters code · Esc cancels",
-        "Enter reopens  Tab code  Esc cancels",
-        "Enter  Tab  Esc",
-        "Enter Tab Esc",
+        "enter reopens browser · tab enters code · esc cancels",
+        "enter reopens  tab code  esc cancels",
+        "enter  tab  esc",
+        "enter tab esc",
     };
     const grok_manual_variants = [_][]const u8{
-        "Enter submits code · Tab returns to browser · Esc cancels",
-        "Enter submits  Tab browser  Esc cancels",
-        "Enter  Tab  Esc",
-        "Enter Tab Esc",
+        "enter submits code · tab returns to browser · esc cancels",
+        "enter submits  tab browser  esc cancels",
+        "enter  tab  esc",
+        "enter tab esc",
     };
     const variants = switch (view.stage) {
         .root => root_variants,
@@ -598,53 +598,53 @@ pub fn composeMcpMenuHintRow(
     }
 
     const root_variants = [_][]const u8{
-        "↑↓ Move  Tab Section  Enter Inspect  A Add  R Reload  C Help  Esc Close",
-        "↑↓ Move  Tab Section  Enter  A Add  R Reload  C Help  Esc",
-        "Tab Enter A R C Esc",
+        "↑↓ move  tab section  enter inspect  a add  r reload  c help  esc close",
+        "↑↓ move  tab section  enter  a add  r reload  c help  esc",
+        "tab enter a r c esc",
     };
     const catalog_variants = [_][]const u8{
-        "↑↓ Navigate     Tab Section     Enter Open     / Filter     Esc Back",
-        "↑↓ Move  Tab Section  Enter  / Filter  Esc",
-        "Tab Enter / Esc",
+        "↑↓ navigate     tab section     enter open     / filter     esc back",
+        "↑↓ move  tab section  enter  / filter  esc",
+        "tab enter / esc",
     };
     const preview_variants = [_][]const u8{
-        "↑↓ Scroll     I Insert     Esc Back",
-        "↑↓ Scroll  I Insert  Esc",
-        "↑↓ I Esc",
+        "↑↓ scroll     i insert     esc back",
+        "↑↓ scroll  i insert  esc",
+        "↑↓ i esc",
     };
     const add_variants = [_][]const u8{
-        "Type field     Enter Next/Save     Tab Transport     Esc Cancel",
-        "Type  Enter Next/Save  Tab Transport  Esc",
-        "Enter Tab Esc",
+        "type field     enter next/save     tab transport     esc cancel",
+        "type  enter next/save  tab transport  esc",
+        "enter tab esc",
     };
     const argument_variants = [_][]const u8{
-        "Type value  Enter Next/Preview  Tab Complete  Esc Cancel",
-        "Type  Enter Next  Tab Complete  Esc",
-        "Enter Tab Esc",
+        "type value  enter next/preview  tab complete  esc cancel",
+        "type  enter next  tab complete  esc",
+        "enter tab esc",
     };
     var details: std.ArrayList(u8) = .empty;
     defer details.deinit(alloc);
     if (projection.selectedServer()) |server| {
         const labels = [_]struct { action: mcp_menu_state.Action, label: []const u8 }{
-            .{ .action = .authenticate, .label = "Enter Sign in  " },
-            .{ .action = .trust_approve, .label = "A Approve  " },
-            .{ .action = .trust_reject, .label = "X Reject  " },
-            .{ .action = .remove, .label = "D Remove  " },
-            .{ .action = .logout, .label = "L Logout  " },
+            .{ .action = .authenticate, .label = "enter sign in  " },
+            .{ .action = .trust_approve, .label = "a approve  " },
+            .{ .action = .trust_reject, .label = "x reject  " },
+            .{ .action = .remove, .label = "d remove  " },
+            .{ .action = .logout, .label = "l logout  " },
         };
         for (labels) |item| if (mcp_menu_state.serverActionAvailable(item.action, server)) try details.appendSlice(alloc, item.label);
     }
-    try details.appendSlice(alloc, "C Help  Esc Back");
-    const details_variants = [_][]const u8{ details.items, "C Help  Esc Back", "C Esc" };
+    try details.appendSlice(alloc, "c help  esc back");
+    const details_variants = [_][]const u8{ details.items, "c help  esc back", "c esc" };
     const confirm_variants = [_][]const u8{
-        "Enter Confirm     Esc Cancel",
-        "Enter Confirm  Esc",
-        "Enter Esc",
+        "enter confirm     esc cancel",
+        "enter confirm  esc",
+        "enter esc",
     };
     const info_variants = [_][]const u8{
-        "Esc Back",
-        "Esc",
-        "Esc",
+        "esc back",
+        "esc",
+        "esc",
     };
     const variants = switch (state.screen) {
         .browse => if (state.section == .servers) root_variants else catalog_variants,
@@ -682,11 +682,11 @@ pub fn composeHelpMenuHintRow(alloc: Allocator, width: u16, ctrl_c_pending: bool
     }
 
     const variants = [_][]const u8{
-        "↑↓ Navigate     Tab Category     Enter Open     Esc Close",
-        "↑↓ Navigate  Tab Category  Enter Open  Esc Close",
-        "↑↓ Move  Tab Category  Enter  Esc",
-        "Tab Category  Enter Open  Esc",
-        "Tab Enter Esc",
+        "↑↓ navigate     tab category     enter open     esc close",
+        "↑↓ navigate  tab category  enter open  esc close",
+        "↑↓ move  tab category  enter  esc",
+        "tab category  enter open  esc",
+        "tab enter esc",
     };
     var hint = variants[variants.len - 1];
     for (variants) |candidate| {
@@ -719,11 +719,11 @@ pub fn composeSettingsMenuHintRow(
     }
 
     const variants = [_][]const u8{
-        "↑↓ Navigate     Tab Category     ←→ Change     Esc Close",
-        "↑↓ Navigate  Tab Category  ←→ Change  Esc Close",
-        "↑↓ Move  Tab Category  ←→ Change  Esc",
-        "Tab Category  ←→ Change  Esc",
-        "Tab ←→ Esc",
+        "↑↓ navigate     tab category     ←→ change     esc close",
+        "↑↓ navigate  tab category  ←→ change  esc close",
+        "↑↓ move  tab category  ←→ change  esc",
+        "tab category  ←→ change  esc",
+        "tab ←→ esc",
     };
     var hint = variants[variants.len - 1];
     for (variants) |candidate| {
@@ -748,19 +748,19 @@ pub fn composeCompactCommandMenuHintRow(
 ) !std.ArrayList(u8) {
     const variants = switch (menu) {
         .statusline => [_][]const u8{
-            "↑↓ Navigate     ←→ Change     Esc Close",
-            "↑↓ Move  ←→ Change  Esc",
-            "←→ Esc",
+            "↑↓ navigate     ←→ change     esc close",
+            "↑↓ move  ←→ change  esc",
+            "←→ esc",
         },
         .usage => [_][]const u8{
-            "Tab Scope     ↑↓ Model     Enter Expand     R Refresh     Esc Close",
-            "Tab Scope  ↑↓ Model  Enter Expand  R Refresh  Esc",
-            "Tab ↑↓  Enter  R  Esc",
+            "tab scope     ↑↓ model     enter expand     r refresh     esc close",
+            "tab scope  ↑↓ model  enter expand  r refresh  esc",
+            "tab ↑↓  enter  r  esc",
         },
         .workspace => [_][]const u8{
-            "↑↓ Navigate     Enter Use     Esc Close",
-            "↑↓ Move  Enter Use  Esc",
-            "Enter Esc",
+            "↑↓ navigate     enter use     esc close",
+            "↑↓ move  enter use  esc",
+            "enter esc",
         },
     };
     var hint = variants[variants.len - 1];
@@ -796,25 +796,25 @@ fn composeCatalogMenuHintRow(alloc: Allocator, width: u16, ctrl_c_pending: bool,
     }
 
     const source_variants = [_][]const u8{
-        "↑↓ Navigate     Tab Source     Enter Use     Esc Close",
-        "↑↓ Navigate  Tab Source  Enter Use  Esc Close",
-        "↑↓ Move  Tab Source  Enter  Esc",
-        "Enter Use  Esc Close",
-        "Enter Esc",
+        "↑↓ navigate     tab source     enter use     esc close",
+        "↑↓ navigate  tab source  enter use  esc close",
+        "↑↓ move  tab source  enter  esc",
+        "enter use  esc close",
+        "enter esc",
     };
     const provider_variants = [_][]const u8{
-        "↑↓ Navigate     Tab Provider     Enter Use     Esc Close",
-        "↑↓ Navigate  Tab Provider  Enter Use  Esc Close",
-        "↑↓ Move  Tab Provider  Enter  Esc",
-        "Enter Use  Esc Close",
-        "Enter Esc",
+        "↑↓ navigate     tab provider     enter use     esc close",
+        "↑↓ navigate  tab provider  enter use  esc close",
+        "↑↓ move  tab provider  enter  esc",
+        "enter use  esc close",
+        "enter esc",
     };
     const scope_variants = [_][]const u8{
-        "↑↓ Navigate     Tab Scope     Enter Resume     Esc Close",
-        "↑↓ Navigate  Tab Scope  Enter Resume  Esc Close",
-        "↑↓ Move  Tab Scope  Enter  Esc",
-        "Enter Resume  Esc Close",
-        "Enter Esc",
+        "↑↓ navigate     tab scope     enter resume     esc close",
+        "↑↓ navigate  tab scope  enter resume  esc close",
+        "↑↓ move  tab scope  enter  esc",
+        "enter resume  esc close",
+        "enter esc",
     };
     const variants = switch (tab_kind) {
         .source => source_variants,
@@ -839,11 +839,11 @@ fn composeCatalogMenuHintRow(alloc: Allocator, width: u16, ctrl_c_pending: bool,
 
 pub fn composeSlashMenuHintRow(alloc: Allocator, width: u16) !std.ArrayList(u8) {
     const variants = [_][]const u8{
-        "↑↓ Navigate     Enter Use     Esc Close",
-        "↑↓ Navigate  Enter Use  Esc Close",
-        "↑↓ Move  Enter  Esc",
-        "Enter Use  Esc Close",
-        "Enter Esc",
+        "↑↓ navigate     enter use     esc close",
+        "↑↓ navigate  enter use  esc close",
+        "↑↓ move  enter  esc",
+        "enter use  esc close",
+        "enter esc",
     };
     var hint = variants[variants.len - 1];
     for (variants) |candidate| {
@@ -864,12 +864,12 @@ pub fn composeSlashMenuHintRow(alloc: Allocator, width: u16) !std.ArrayList(u8) 
 test "slash menu hint keeps navigation and selection controls width safe" {
     var wide = try composeSlashMenuHintRow(std.testing.allocator, 80);
     defer wide.deinit(std.testing.allocator);
-    try std.testing.expect(std.mem.find(u8, wide.items, "↑↓ Navigate     Enter Use     Esc Close") != null);
+    try std.testing.expect(std.mem.find(u8, wide.items, "↑↓ navigate     enter use     esc close") != null);
     try std.testing.expect(display_width.visibleWidthIgnoringAnsi(wide.items) <= 80);
 
     var narrow = try composeSlashMenuHintRow(std.testing.allocator, 12);
     defer narrow.deinit(std.testing.allocator);
-    try std.testing.expect(std.mem.find(u8, narrow.items, "Enter Esc") != null);
+    try std.testing.expect(std.mem.find(u8, narrow.items, "enter esc") != null);
     try std.testing.expect(display_width.visibleWidthIgnoringAnsi(narrow.items) <= 12);
 }
 
@@ -1592,16 +1592,16 @@ test "compose hint row replaces model status with setup navigation" {
 
     var root = try composeHintRow(std.testing.allocator, false, ctx, 96);
     defer root.deinit(std.testing.allocator);
-    try std.testing.expect(std.mem.find(u8, root.items, "↑↓ Navigate") != null);
-    try std.testing.expect(std.mem.find(u8, root.items, "Enter Open") != null);
-    try std.testing.expect(std.mem.find(u8, root.items, "Esc Close") != null);
+    try std.testing.expect(std.mem.find(u8, root.items, "↑↓ navigate") != null);
+    try std.testing.expect(std.mem.find(u8, root.items, "enter open") != null);
+    try std.testing.expect(std.mem.find(u8, root.items, "esc close") != null);
     try std.testing.expect(std.mem.find(u8, root.items, "gpt-5.1") == null);
 
     ctx.auth_picker.stage = .connections;
     ctx.auth_picker.selected_choice = .{ .action = .login };
     var child = try composeHintRow(std.testing.allocator, false, ctx, 96);
     defer child.deinit(std.testing.allocator);
-    try std.testing.expect(std.mem.find(u8, child.items, "Esc Back") != null);
+    try std.testing.expect(std.mem.find(u8, child.items, "esc back") != null);
 }
 
 test "compose hint row replaces model status with subscription sign-in controls" {
@@ -1614,17 +1614,17 @@ test "compose hint row replaces model status with subscription sign-in controls"
         .{
             .source = .chatgpt_subscription,
             .manual_code_visible = false,
-            .expected = "Enter reopens browser · Esc cancels",
+            .expected = "enter reopens browser · esc cancels",
         },
         .{
             .source = .grok_subscription,
             .manual_code_visible = false,
-            .expected = "Enter reopens browser · Tab enters code · Esc cancels",
+            .expected = "enter reopens browser · tab enters code · esc cancels",
         },
         .{
             .source = .grok_subscription,
             .manual_code_visible = true,
-            .expected = "Enter submits code · Tab returns to browser · Esc cancels",
+            .expected = "enter submits code · tab returns to browser · esc cancels",
         },
     };
 
@@ -1800,10 +1800,10 @@ test "question hint row excludes model and upgrade status at supported widths" {
         freeform: bool,
         hint: []const u8,
     }{
-        .{ .width = 120, .freeform = false, .hint = "1–4 Choose now    ↑↓ Options    Tab Questions    Enter Answer    Esc Cancel" },
-        .{ .width = 88, .freeform = false, .hint = "1–4 Choose now    ↑↓ Options    Tab Questions    Enter Answer    Esc Cancel" },
+        .{ .width = 120, .freeform = false, .hint = "1–4 choose now    ↑↓ options    tab questions    enter answer    esc cancel" },
+        .{ .width = 88, .freeform = false, .hint = "1–4 choose now    ↑↓ options    tab questions    enter answer    esc cancel" },
         .{ .width = 40, .freeform = false, .hint = predefined_question_hints[2] },
-        .{ .width = 120, .freeform = true, .hint = "Type answer    ↑↓←→ Cursor    Shift+↑↓ Options    Tab Questions    Enter Answer    Esc Cancel" },
+        .{ .width = 120, .freeform = true, .hint = "type answer    ↑↓←→ cursor    shift+↑↓ options    tab questions    enter answer    esc cancel" },
         .{ .width = 72, .freeform = true, .hint = freeform_question_hints[0] },
         .{ .width = 32, .freeform = true, .hint = freeform_question_hints[3] },
     };
@@ -1870,6 +1870,6 @@ test "question hint assigns tab to question pagination" {
     var row = try composeHintRow(std.testing.allocator, false, ctx, 120);
     defer row.deinit(std.testing.allocator);
 
-    try std.testing.expect(std.mem.find(u8, row.items, "Tab Questions") != null);
+    try std.testing.expect(std.mem.find(u8, row.items, "tab questions") != null);
     try std.testing.expect(std.mem.find(u8, row.items, "tab to choose") == null);
 }

--- a/src/ui/footer/interaction_state.zig
+++ b/src/ui/footer/interaction_state.zig
@@ -16,10 +16,10 @@ pub const approval_spacious_min_terminal_rows: u16 = 34;
 pub const approval_once_label = "1. Yes";
 pub const approval_always_file_label = "2. Yes, and don't ask again for this request";
 pub const approval_deny_label = "3. No";
-pub const approval_hint = "1–3 Choose now    ↑↓ or Tab Options    Enter Confirm    Esc Cancel";
-pub const approval_amendment_hint = "1–3 Choose now    ↑↓ Options    Tab Amend    Enter Confirm    Esc Cancel";
-pub const approval_hint_compact = "1–3 Choose now    Enter Confirm    Esc Cancel";
-pub const approval_hint_minimal = "Enter Confirm    Esc Cancel";
+pub const approval_hint = "1–3 choose now    ↑↓ or tab options    enter confirm    esc cancel";
+pub const approval_amendment_hint = "1–3 choose now    ↑↓ options    tab amend    enter confirm    esc cancel";
+pub const approval_hint_compact = "1–3 choose now    enter confirm    esc cancel";
+pub const approval_hint_minimal = "enter confirm    esc cancel";
 // Ordered widest-first; every variant keeps the enter/esc controls so narrow
 // terminals never lose the submit and cancel instructions.
 pub const approval_hint_variants = [_][]const u8{ approval_hint, approval_hint_compact, approval_hint_minimal };

--- a/src/ui/footer/mcp_menu_presentation.zig
+++ b/src/ui/footer/mcp_menu_presentation.zig
@@ -146,11 +146,11 @@ fn composeArgumentRow(
 
 fn confirmationText(action: ?mcp_menu_state.Action) []const u8 {
     return switch (action orelse return "Confirm this MCP action before continuing.") {
-        .remove => "Remove this profile MCP server? Press Enter to confirm.",
-        .logout => "Log out of this MCP server? Press Enter to confirm.",
-        .trust_reject => "Reject this project MCP server? Press Enter to confirm.",
-        .trust_approve_all => "Approve all pending project MCP servers? Press Enter to confirm.",
-        .trust_reset => "Reset all project MCP choices? Press Enter to confirm.",
+        .remove => "Remove this profile MCP server? press enter to confirm.",
+        .logout => "Log out of this MCP server? press enter to confirm.",
+        .trust_reject => "Reject this project MCP server? press enter to confirm.",
+        .trust_approve_all => "Approve all pending project MCP servers? press enter to confirm.",
+        .trust_reset => "Reset all project MCP choices? press enter to confirm.",
         else => "Confirm this MCP action before continuing.",
     };
 }
@@ -285,11 +285,11 @@ fn composeInfoRow(alloc: Allocator, row_index: u16, width: u16) !std.ArrayList(u
     return switch (row_index) {
         0 => composeFactRow(alloc, "Profile config", "~/.fx/mcp.json", width),
         1 => composeFactRow(alloc, "Project config", "<workspace>/.mcp.json", width),
-        2 => composeTextRow(alloc, "Servers: A Add · R Reload · Enter Inspect", width, ui_render.dim_style, 2),
-        3 => composeTextRow(alloc, "Project trust: P Approve all · Z Reset", width, ui_render.dim_style, 2),
-        4 => composeTextRow(alloc, "Details: Enter Sign in · L Logout · D Remove", width, ui_render.dim_style, 2),
-        5 => composeTextRow(alloc, "Project details: A Approve · X Reject", width, ui_render.dim_style, 2),
-        6 => composeTextRow(alloc, "Catalogs: / Filter · Enter Open · I Insert preview", width, ui_render.dim_style, 2),
+        2 => composeTextRow(alloc, "servers: a add · r reload · enter inspect", width, ui_render.dim_style, 2),
+        3 => composeTextRow(alloc, "project trust: p approve all · z reset", width, ui_render.dim_style, 2),
+        4 => composeTextRow(alloc, "details: enter sign in · l logout · d remove", width, ui_render.dim_style, 2),
+        5 => composeTextRow(alloc, "project details: a approve · x reject", width, ui_render.dim_style, 2),
+        6 => composeTextRow(alloc, "catalogs: / filter · enter open · i insert preview", width, ui_render.dim_style, 2),
         else => .empty,
     };
 }
@@ -987,6 +987,6 @@ test "MCP menu every screen and section renders through the VT" {
         projection,
         width,
         max_inline_rows,
-        &.{"Remove this profile MCP server? Press Enter to confirm."},
+        &.{"Remove this profile MCP server? press enter to confirm."},
     );
 }

--- a/src/ui/footer/paint_plan.zig
+++ b/src/ui/footer/paint_plan.zig
@@ -1011,7 +1011,7 @@ fn composeTranscriptViewerFooterFrame(
     errdefer frame.deinit(alloc);
     const width = shell.layout.cols;
     const navigation = switch (input.ctx.transcript_depth) {
-        .full => "Full detail · ctrl o close · PgUp/PgDn scroll · Esc close",
+        .full => "full detail · ctrl+o close · pgup/pgdn scroll · esc close",
         .inline_mode => unreachable,
     };
 
@@ -1331,7 +1331,7 @@ test "transcript viewer footer keeps navigation blank row and aligns main status
         &frame,
         frame_plan.paint.footer.top_divider,
         shell.layout.cols,
-        "┃ Full detail · ctrl o close · PgUp/PgDn scroll · Esc close",
+        "┃ full detail · ctrl+o close · pgup/pgdn scroll · esc close",
     );
     try expectFrameRowTextTrimmed(
         &frame,
@@ -1365,7 +1365,7 @@ test "transcript viewer footer keeps navigation blank row and aligns main status
         &full_frame,
         full_plan.paint.footer.top_divider,
         shell.layout.cols,
-        "┃ Full detail · ctrl o close · PgUp/PgDn scroll · Esc close",
+        "┃ full detail · ctrl+o close · pgup/pgdn scroll · esc close",
     );
 }
 
@@ -1853,7 +1853,7 @@ test "approval footer composition hides cursor while rendering command prompt" {
         if (std.mem.find(u8, row.text.items, "3. No") != null) {
             choice_three_row = row.row;
         }
-        if (std.mem.find(u8, row.text.items, "1–3 Choose") != null) {
+        if (std.mem.find(u8, row.text.items, "1–3 choose") != null) {
             controls_row = row.row;
             controls_count += 1;
             try std.testing.expect(std.mem.find(u8, row.text.items, "gpt-5.1") == null);

--- a/src/ui/footer/picker_presentation.zig
+++ b/src/ui/footer/picker_presentation.zig
@@ -414,7 +414,7 @@ fn composeOnboardingPickerRow(
         7 => "   Get started",
         12 => if (display_width.visibleWidthIgnoringAnsi(onboarding_note_link) <= width) onboarding_note_link else onboarding_note,
         13, 14 => "",
-        15 => "   Esc to set up later · Explore all commands with /help",
+        15 => "   esc to set up later · explore all commands with /help",
         16, 17 => "",
         else => "",
     };
@@ -505,7 +505,7 @@ fn composeSignInPickerRow(
             try row_text.appendClipped(
                 alloc,
                 &row,
-                "  Browser didn't return? Press Tab to enter a code",
+                "  Browser didn't return? press tab to enter a code",
                 width,
             );
         }
@@ -580,9 +580,9 @@ fn composeSignInPickerRow(
             .cancelled => "   Sign-in cancelled",
         },
         6 => if (accepts_manual_code)
-            "   Enter submits or reopens browser · Esc cancels"
+            "   enter submits or reopens browser · esc cancels"
         else
-            "   Enter reopens browser · Esc cancels",
+            "   enter reopens browser · esc cancels",
         else => "",
     };
     try row_text.appendClipped(alloc, &row, label, width);
@@ -615,7 +615,7 @@ fn composeApiKeyPickerRow(
                 for (0..@min(mask_count, width -| 5)) |_| try row.appendSlice(alloc, "•");
             }
         },
-        2 => try row_text.appendClipped(alloc, &row, "   Enter saves · Esc cancels", width),
+        2 => try row_text.appendClipped(alloc, &row, "   enter saves · esc cancels", width),
         3 => {
             var label_buf: [128]u8 = undefined;
             const label = std.fmt.bufPrint(
@@ -1209,7 +1209,7 @@ pub fn composeSlashMenuHeaderRow(
     const noun = if (layout.command_count == layout.result_count) "Commands" else "Results";
     var left_buf: [96]u8 = undefined;
     const left = if (std.mem.eql(u8, prefix, "/"))
-        std.fmt.bufPrint(&left_buf, "{s} {d} · Type to filter", .{ noun, layout.result_count }) catch noun
+        std.fmt.bufPrint(&left_buf, "{s} {d} · type to filter", .{ noun, layout.result_count }) catch noun
     else
         std.fmt.bufPrint(&left_buf, "{s} {d}", .{ noun, layout.result_count }) catch noun;
 
@@ -1584,7 +1584,7 @@ test "slash menu header reports command totals and visible range" {
     var row = try composeSlashMenuHeaderRow(std.testing.allocator, "/", layout, 80);
     defer row.deinit(std.testing.allocator);
 
-    try std.testing.expect(std.mem.find(u8, row.items, "Commands 7 · Type to filter") != null);
+    try std.testing.expect(std.mem.find(u8, row.items, "Commands 7 · type to filter") != null);
     try std.testing.expect(std.mem.find(u8, row.items, "1–6") != null);
     try std.testing.expect(display_width.visibleWidthIgnoringAnsi(row.items) <= 80);
 }
@@ -2157,7 +2157,7 @@ test "auth onboarding composes the welcome copy and setup choices" {
     try std.testing.expect(std.mem.find(u8, screen.items, "Learn more: https://") == null);
     try std.testing.expect(std.mem.find(u8, screen.items, "Sign in with Vercel") != null);
     try std.testing.expect(std.mem.find(u8, screen.items, "Add an API key") != null);
-    try std.testing.expect(std.mem.find(u8, screen.items, "Esc to set up later · Explore all commands with /help") != null);
+    try std.testing.expect(std.mem.find(u8, screen.items, "esc to set up later · explore all commands with /help") != null);
 
     var body_row = try composeAuthPickerRow(alloc, view, 2, authPickerRowCount(view), 100);
     defer body_row.deinit(alloc);
@@ -2259,8 +2259,8 @@ test "setup root fits the inline picker with status and controls" {
     try std.testing.expect(std.mem.find(u8, screen.items, "Model provider") != null);
     try std.testing.expect(std.mem.find(u8, screen.items, "Vercel team") != null);
     try std.testing.expect(std.mem.find(u8, screen.items, "Credential source") != null);
-    try std.testing.expect(std.mem.find(u8, screen.items, "Enter Open") == null);
-    try std.testing.expect(std.mem.find(u8, screen.items, "Esc Close") == null);
+    try std.testing.expect(std.mem.find(u8, screen.items, "enter open") == null);
+    try std.testing.expect(std.mem.find(u8, screen.items, "esc close") == null);
     try std.testing.expect(std.mem.find(u8, screen.items, "Routing") == null);
     try std.testing.expect(std.mem.find(u8, screen.items, "Vercel account") == null);
 
@@ -2481,7 +2481,7 @@ test "sign-in stage renders the complete device authorization screen" {
         "Open   https://vercel.test/verify",
         "Code   TEST-CODE",
         "Waiting for authorization",
-        "Enter reopens browser · Esc cancels",
+        "enter reopens browser · esc cancels",
     }) |expected| {
         try std.testing.expect(std.mem.find(u8, screen.items, expected) != null);
     }
@@ -2606,7 +2606,7 @@ test "Grok sign-in starts with the collapsed browser flow in the VT emulator" {
         "Sign in with Grok                                     Waiting for authorization…",
         "",
         "  Open   Authorize with Grok",
-        "  Browser didn't return? Press Tab to enter a code",
+        "  Browser didn't return? press tab to enter a code",
         "",
     };
     for (expected_rows, 1..) |expected, row_index| {
@@ -2719,8 +2719,8 @@ test "compact Grok sign-in keeps masked code entry without duplicate controls" {
     var row = try composeAuthPickerRow(alloc, view, 0, 1, 80);
     defer row.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, row.items, "•••") != null);
-    try std.testing.expect(std.mem.find(u8, row.items, "Enter submits") == null);
-    try std.testing.expect(std.mem.find(u8, row.items, "Esc cancels") == null);
+    try std.testing.expect(std.mem.find(u8, row.items, "enter submits") == null);
+    try std.testing.expect(std.mem.find(u8, row.items, "esc cancels") == null);
     try std.testing.expect(std.mem.find(u8, row.items, ui_render.selected_completion_style) != null);
 }
 

--- a/src/ui/footer/resume_menu_presentation.zig
+++ b/src/ui/footer/resume_menu_presentation.zig
@@ -461,8 +461,8 @@ fn composeSelectionFailureRow(
     if (indent_width > 0) try row.appendSlice(alloc, "  ");
     try row.appendSlice(alloc, ui_render.red_style);
     const message = switch (failure) {
-        .open_elsewhere => "This session is open in another fx. Close it there, then press Enter to retry.",
-        .being_updated => "This session is being updated. Wait a moment, then press Enter to retry.",
+        .open_elsewhere => "This session is open in another fx. Close it there, then press enter to retry.",
+        .being_updated => "This session is being updated. Wait a moment, then press enter to retry.",
         .unavailable => "Unable to resume this session.",
     };
     try row_text.appendSingleLineEllipsized(
@@ -617,11 +617,11 @@ test "resume menu explains retryable selected session contention" {
     }{
         .{
             .failure = .open_elsewhere,
-            .message = "This session is open in another fx. Close it there, then press Enter to retry.",
+            .message = "This session is open in another fx. Close it there, then press enter to retry.",
         },
         .{
             .failure = .being_updated,
-            .message = "This session is being updated. Wait a moment, then press Enter to retry.",
+            .message = "This session is being updated. Wait a moment, then press enter to retry.",
         },
         .{
             .failure = .unavailable,
@@ -673,7 +673,7 @@ test "resume menu keeps selected title and retry feedback in compact layouts" {
     try std.testing.expect(std.mem.find(u8, three_row_title.items, "Selected session") != null);
     var three_row_feedback = try composeSessionMenuRow(alloc, projection, 2, 100, 3);
     defer three_row_feedback.deinit(alloc);
-    try std.testing.expect(std.mem.find(u8, three_row_feedback.items, "press Enter to retry") != null);
+    try std.testing.expect(std.mem.find(u8, three_row_feedback.items, "press enter to retry") != null);
 
     var paged_projection = projection;
     paged_projection.has_more = true;
@@ -691,7 +691,7 @@ test "resume menu keeps selected title and retry feedback in compact layouts" {
         );
         defer paged_feedback.deinit(alloc);
         try std.testing.expect(
-            std.mem.find(u8, paged_feedback.items, "press Enter to retry") != null,
+            std.mem.find(u8, paged_feedback.items, "press enter to retry") != null,
         );
         var paged_title = try composeSessionMenuRow(
             alloc,

--- a/src/ui/resize_tests.zig
+++ b/src/ui/resize_tests.zig
@@ -1141,8 +1141,8 @@ test "MCP menu stays inline across the VT width matrix and restores the composer
         try expectGridContains(&h, "MCP 0");
         try expectGridContains(&h, "[Tools]");
         try expectGridContains(&h, "mcp_fixture_read_resource");
-        try expectGridContains(&h, "Tab");
-        try expectGridContains(&h, "Esc");
+        try expectGridContains(&h, "tab");
+        try expectGridContains(&h, "esc");
 
         ctx.mcp_menu = .{
             .state = .{
@@ -1158,7 +1158,7 @@ test "MCP menu stays inline across the VT width matrix and restores the composer
         try h.flush();
         try expectGridContains(&h, "untrusted content");
         try expectGridContains(&h, "RESOURCE_TEXT:");
-        try expectGridContains(&h, "I Insert");
+        try expectGridContains(&h, "i insert");
 
         ctx.mcp_menu = .{};
         h.frame_redraw = true;
@@ -1166,7 +1166,7 @@ test "MCP menu stays inline across the VT width matrix and restores the composer
         try h.flush();
         try expectGridContains(&h, "MCP menu transcript remains visible");
         try expectGridNotContains(&h, "[Resources]");
-        try expectGridNotContains(&h, "I Insert");
+        try expectGridNotContains(&h, "i insert");
     }
 }
 
@@ -4647,7 +4647,7 @@ test "runtime decomposition preserves command output state and replaceable paint
     try expectGridContains(&h, "Tests passed");
     try expectGridNotContains(&h, "│ visible");
     try expectGridNotContains(&h, "│ hidden");
-    try expectGridNotContains(&h, "ctrl o to view");
+    try expectGridNotContains(&h, "ctrl+o to view");
     try std.testing.expect(h.shell.replaceable_last_line);
     try std.testing.expectEqual(status_id, h.shell.replaceableEntryId().?);
 
@@ -4680,7 +4680,7 @@ test "runtime decomposition preserves command output state and replaceable paint
     try expectGridContains(&h, "Tests passed");
     try expectGridNotContains(&h, "│ visible");
     try expectGridNotContains(&h, "│ hidden");
-    try expectGridNotContains(&h, "ctrl o to view");
+    try expectGridNotContains(&h, "ctrl+o to view");
     try std.testing.expect(h.shell.replaceable_last_line);
     try std.testing.expectEqual(status_id, h.shell.replaceableEntryId().?);
     try std.testing.expect(h.shell.replaceable_start <= h.shell.transcript.items.len);
@@ -6229,11 +6229,11 @@ test "slash main page renders header categories selection range and contextual c
     try renderTestFooter(&h, &input, &approval, &h.frame_redraw);
     try h.flush();
 
-    try expectGridContains(&h, "Commands 35 · Type to filter");
+    try expectGridContains(&h, "Commands 35 · type to filter");
     try expectGridContains(&h, "1–6");
     try expectGridContains(&h, "/help");
     try expectGridContains(&h, "General");
-    try expectGridContains(&h, "↑↓ Navigate     Enter Use     Esc Close");
+    try expectGridContains(&h, "↑↓ navigate     enter use     esc close");
 
     input.picker.slash_completion_index = 6;
     h.frame_redraw = true;
@@ -6251,7 +6251,7 @@ test "slash main page renders header categories selection range and contextual c
     try expectGridContains(&h, "ask");
     try expectGridContains(&h, "test-model");
     try expectGridNotContains(&h, "Commands 35");
-    try expectGridNotContains(&h, "↑↓ Navigate");
+    try expectGridNotContains(&h, "↑↓ navigate");
 }
 
 test "slash main page drops categories and ellipsizes descriptions when narrow" {

--- a/src/ui/transcript/command_output_runtime.zig
+++ b/src/ui/transcript/command_output_runtime.zig
@@ -1931,8 +1931,8 @@ test "dimmed command rows frame physical lines independently" {
 fn foldedHint(alloc: Allocator, hidden_records: usize, cols: u16) ![]u8 {
     const noun = if (hidden_records == 1) "line" else "lines";
     const candidates = [_][]u8{
-        try std.fmt.allocPrint(alloc, "│ … {d} {s} more (ctrl o to view)", .{ hidden_records, noun }),
-        try std.fmt.allocPrint(alloc, "│ … {d} more (ctrl o)", .{hidden_records}),
+        try std.fmt.allocPrint(alloc, "│ … {d} {s} more (ctrl+o to view)", .{ hidden_records, noun }),
+        try std.fmt.allocPrint(alloc, "│ … {d} more (ctrl+o)", .{hidden_records}),
         try std.fmt.allocPrint(alloc, "│ … {d} more", .{hidden_records}),
     };
     defer for (candidates) |candidate| alloc.free(candidate);
@@ -2081,7 +2081,7 @@ test "compact command output caps physical rows" {
     try std.testing.expectEqual(@as(usize, 6), std.mem.count(u8, compact.bytes.items, "\n") + 1);
     try std.testing.expect(std.mem.find(u8, compact.bytes.items, "│ line-5") != null);
     try std.testing.expect(std.mem.find(u8, compact.bytes.items, "│ line-6") == null);
-    try std.testing.expect(std.mem.find(u8, compact.bytes.items, "│ … 2 lines more (ctrl o to view)") != null);
+    try std.testing.expect(std.mem.find(u8, compact.bytes.items, "│ … 2 lines more (ctrl+o to view)") != null);
 }
 
 test "compact command output stays bounded at one and two columns" {
@@ -2199,7 +2199,7 @@ test "compact incomplete retained record shows one hidden line" {
     defer compact.deinit(alloc);
 
     try std.testing.expectEqualStrings(
-        "│ retained prefix\n│ … 1 line more (ctrl o to view)",
+        "│ retained prefix\n│ … 1 line more (ctrl+o to view)",
         compact.bytes.items,
     );
 }
@@ -2233,7 +2233,7 @@ test "compact hint stays at the final owned source entry" {
 
     const first = projection.bytesForEntry(10).?;
     const final = projection.bytesForEntry(30).?;
-    try std.testing.expect(std.mem.find(u8, first, "ctrl o") == null);
+    try std.testing.expect(std.mem.find(u8, first, "ctrl+o") == null);
     try std.testing.expect(std.mem.find(u8, final, "│ … 2 more") != null);
 }
 

--- a/src/ui/transcript/runtime.zig
+++ b/src/ui/transcript/runtime.zig
@@ -2375,7 +2375,7 @@ test "nonzero streamed command reuses its active output block" {
     );
     try std.testing.expect(std.mem.find(u8, projection.bytes.items, "│ line-4") != null);
     try std.testing.expect(std.mem.find(u8, projection.bytes.items, "│ line-5") == null);
-    try std.testing.expect(std.mem.find(u8, projection.bytes.items, "│ … 2 lines more (ctrl o to view)") != null);
+    try std.testing.expect(std.mem.find(u8, projection.bytes.items, "│ … 2 lines more (ctrl+o to view)") != null);
     try std.testing.expectEqual(
         @as(usize, 1),
         std.mem.count(u8, projection.bytes.items, "│ exit code 7"),

--- a/src/ui/transcript/runtime_tests.zig
+++ b/src/ui/transcript/runtime_tests.zig
@@ -8925,7 +8925,7 @@ test "command output state keeps one authoritative folded hint" {
     try expectRawEntryBytes(
         &runtime,
         old_hint_entry_id,
-        "│ … 1 line more (ctrl o to view)",
+        "│ … 1 line more (ctrl+o to view)",
     );
 
     try runtime.writeCommandOutputChunk(
@@ -8943,7 +8943,7 @@ test "command output state keeps one authoritative folded hint" {
     try expectRawEntryBytes(
         &runtime,
         old_hint_entry_id,
-        "│ … 1 line more (ctrl o to view)",
+        "│ … 1 line more (ctrl+o to view)",
     );
     try expectRawEntryBytes(&runtime, newest_entry_id, "");
 
@@ -9055,7 +9055,7 @@ test "command output folding preserves rows between noncontiguous live rows" {
     try std.testing.expect(before_pos < intervening_pos);
     try std.testing.expect(intervening_pos < after_pos);
     try std.testing.expect(std.mem.indexOf(u8, source.bytes, "command-visible-1") == null);
-    try std.testing.expect(std.mem.indexOf(u8, source.bytes, "ctrl o to view") == null);
+    try std.testing.expect(std.mem.indexOf(u8, source.bytes, "ctrl+o to view") == null);
     try std.testing.expectEqual(@as(usize, 6), runtime.command_output_blocks.items[0].lines.items.len);
 }
 
@@ -9164,7 +9164,7 @@ test "production command pruning preserves deferred replay around a notice" {
     try std.testing.expect(compact_notice_pos < compact.bytes.len);
     try std.testing.expect(std.mem.find(u8, compact.bytes, "output-0") == null);
     try std.testing.expect(std.mem.find(u8, compact.bytes, "output-1") == null);
-    try std.testing.expect(std.mem.find(u8, compact.bytes, "ctrl o to view") == null);
+    try std.testing.expect(std.mem.find(u8, compact.bytes, "ctrl+o to view") == null);
 
     runtime.full_transcript.depth = .full;
     var projection = try runtime.buildFullTranscriptProjection(alloc, null);
@@ -9539,7 +9539,7 @@ test "command output display caps at five physical rows" {
     try std.testing.expectEqual(@as(usize, 5), std.mem.count(u8, projection.bytes.items, "│ line-"));
     try std.testing.expect(std.mem.find(u8, projection.bytes.items, "│ line-4") != null);
     try std.testing.expect(std.mem.find(u8, projection.bytes.items, "│ line-5") == null);
-    try std.testing.expect(std.mem.find(u8, projection.bytes.items, "│ … 21 lines more (ctrl o to view)") != null);
+    try std.testing.expect(std.mem.find(u8, projection.bytes.items, "│ … 21 lines more (ctrl+o to view)") != null);
 }
 
 test "structured retention prunes old raw transcript entries past cap" {
@@ -9680,7 +9680,7 @@ test "hidden command output becomes count-only at the hard cap" {
     try std.testing.expectEqual(@as(usize, 8), block.total_lines);
     const expected_summary = try std.fmt.allocPrint(
         alloc,
-        "│ … {d} lines more (ctrl o to view)",
+        "│ … {d} lines more (ctrl+o to view)",
         .{block.total_lines - @min(@as(usize, 5), block.lines.items.len)},
     );
     defer alloc.free(expected_summary);

--- a/tests/e2e/config-persistence.test.ts
+++ b/tests/e2e/config-persistence.test.ts
@@ -63,7 +63,7 @@ async function disablePromptHistory(
   settingsPath: string,
 ): Promise<void> {
   await session.sendText("/settings");
-  await session.waitForText("←→ Change", TIMEOUT);
+  await session.waitForText("←→ change", TIMEOUT);
   await session.sendLiteral("prompt history");
   await session.waitForPane(
     (pane) => pane.includes("Prompt history") && !pane.includes("Startup scrollback"),
@@ -82,7 +82,7 @@ async function disablePromptHistory(
   if (enabled !== false) throw new Error("Timed out disabling prompt history");
   await session.sendKeys("Escape");
   await session.waitForPane(
-    (pane) => hasEmptyComposer(pane) && !pane.includes("←→ Change"),
+    (pane) => hasEmptyComposer(pane) && !pane.includes("←→ change"),
     TIMEOUT,
   );
 }
@@ -288,14 +288,14 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
         expect(startup).not.toContain("adaptive");
         expect(startup).not.toContain("⚡︎ fast");
         await session.sendText("/settings");
-        const pane = await session.waitForText("←→ Change", TIMEOUT);
+        const pane = await session.waitForText("←→ change", TIMEOUT);
         expect(pane).toContain("anthropic/claude-opus-4.7");
         expect(pane).toContain("Startup scrollback");
         expect(pane).toContain("Prompt history");
         await session.sendKeys("Escape");
         await session.waitForPane(
           (current) =>
-            hasEmptyComposer(current) && !current.includes("←→ Change"),
+            hasEmptyComposer(current) && !current.includes("←→ change"),
           TIMEOUT,
         );
         await session.sendText("/statusline");
@@ -811,7 +811,7 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
         });
         await session.waitForText("Run /help", TIMEOUT);
         await session.sendText("/settings");
-        await session.waitForText("←→ Change", TIMEOUT);
+        await session.waitForText("←→ change", TIMEOUT);
         await session.sendLiteral("reason");
         const effortSetting = await session.waitForText("Reasoning effort", TIMEOUT);
         expect(effortSetting).toContain("low");

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -833,7 +833,7 @@ describe("gateway stream lifecycle", () => {
       expect(mixed).toContain("Could not load status-duplicate");
       expect(mixed).toContain("ambiguous");
       expect(mixed).toMatch(/^└ Could not load status-duplicate/m);
-      expect(mixed.replace(/\s+/g, " ")).toContain("ctrl o");
+      expect(mixed.replace(/\s+/g, " ")).toContain("ctrl+o");
       expect(mixed).not.toContain("duplicate-a");
       expect(mixed).not.toContain("duplicate-b");
       expect(mixed).not.toContain("Loaded skill status-duplicate");
@@ -1482,7 +1482,7 @@ describe("gateway stream lifecycle", () => {
         expect(full).not.toContain("[context]");
         const fullGrid = await tui.capturePaneGrid();
         const fullNavigationRow = fullGrid.findIndex((row) =>
-          row.includes("┃ Full detail · ctrl o close")
+          row.includes("┃ full detail · ctrl+o close")
         );
         expect(fullNavigationRow).toBeGreaterThan(0);
         expect(fullGrid[fullNavigationRow - 1]!.trim()).toBe("");

--- a/tests/e2e/mcp-auth.test.ts
+++ b/tests/e2e/mcp-auth.test.ts
@@ -2564,7 +2564,7 @@ describe("MCP remote authentication lifecycle", () => {
       expect(stored.credentials[0].access_token).toBe(ACCESS_INITIAL);
 
       await tui.sendKeys("Escape");
-      await tui.waitForText("Enter Inspect", 5_000);
+      await tui.waitForText("enter inspect", 5_000);
       await tui.sendKeys("Escape");
       await tui.waitForPane((pane) => !pane.includes("[Servers]"), 5_000);
       expect(await tui.captureFullScrollback()).toBe(beforeMenu);
@@ -3468,7 +3468,7 @@ describe("MCP remote authentication lifecycle", () => {
       await tui.waitForPane((pane) => /fixture\s+Disconnected/.test(pane), 5_000);
       expect(auth.authorizationRequests).toBe(0);
       await tui.sendKeys("Enter");
-      await tui.waitForText("Enter Sign in", 5_000);
+      await tui.waitForText("enter sign in", 5_000);
       expect(await tui.capturePane()).toMatch(/State\s+Disconnected/);
 
       await tui.sendKeys("Enter");

--- a/tests/e2e/mcp-stdio.test.ts
+++ b/tests/e2e/mcp-stdio.test.ts
@@ -1126,10 +1126,10 @@ exec "$FX_MCP_FIXTURE_RUNTIME" "$FX_MCP_FIXTURE_PATH"
         env,
       });
       await tui.waitForComposer(15_000);
-      await tui.waitForText("[Esc] Dismiss remaining prompts", 10_000);
+      await tui.waitForText("[esc] dismiss remaining prompts", 10_000);
       await tui.pasteText("2");
       await Bun.sleep(250);
-      expect((await tui.capturePane())).toContain("[2] Approve all");
+      expect((await tui.capturePane())).toContain("[2] approve all");
       expect(existsSync(root.launchLogPath)).toBe(false);
       expect(readFileSync(join(root.home, ".fx", "settings.json"), "utf8"))
         .not.toContain("enableAllProjectMcpServers");

--- a/tests/e2e/prompt-history.test.ts
+++ b/tests/e2e/prompt-history.test.ts
@@ -57,7 +57,7 @@ async function disablePromptHistory(
   settingsPath: string,
 ): Promise<void> {
   await session.sendText("/settings");
-  await session.waitForText("←→ Change", TIMEOUT);
+  await session.waitForText("←→ change", TIMEOUT);
   await session.sendLiteral("prompt history");
   await session.waitForPane(
     (pane) => pane.includes("Prompt history") && !pane.includes("Startup scrollback"),
@@ -76,7 +76,7 @@ async function disablePromptHistory(
   if (enabled !== false) throw new Error("Timed out disabling prompt history");
   await session.sendKeys("Escape");
   await session.waitForPane(
-    (pane) => hasEmptyComposer(pane) && !pane.includes("←→ Change"),
+    (pane) => hasEmptyComposer(pane) && !pane.includes("←→ change"),
     TIMEOUT,
   );
 }
@@ -119,7 +119,7 @@ describe.skipIf(!tmuxAvailable())("prompt history", () => {
         await session.sendText("/help");
         await session.waitForText("Commands 35", TIMEOUT);
         await session.sendKeys("Escape");
-        await session.waitForPane((pane) => !pane.includes("Enter Open"), TIMEOUT);
+        await session.waitForPane((pane) => !pane.includes("enter open"), TIMEOUT);
         await session.sendText("/quit");
         await session.waitForSessionEnd(TIMEOUT);
         session = null;

--- a/tests/e2e/render-lab/analyzer.ts
+++ b/tests/e2e/render-lab/analyzer.ts
@@ -1089,7 +1089,7 @@ function isFooterHintRow(line: string): boolean {
 function hasTranscriptViewerFooter(grid: string[]): boolean {
   for (let row = 0; row + 2 < grid.length; row += 1) {
     const navigation = semanticText(grid[row] ?? "").trim();
-    if (navigation !== "┃ Full detail · ctrl o close · PgUp/PgDn scroll · Esc close") {
+    if (navigation !== "┃ full detail · ctrl+o close · pgup/pgdn scroll · esc close") {
       continue;
     }
     if (isSemanticBlank(grid[row + 1] ?? "") && isFooterHintRow(grid[row + 2] ?? "")) {

--- a/tests/e2e/render-lab/index.ts
+++ b/tests/e2e/render-lab/index.ts
@@ -513,7 +513,7 @@ async function runActiveToolPlacement(
 
     await session.sendKeys("C-o");
     await session.waitForPane(
-      (pane) => pane.includes("┃ Full detail · ctrl o close"),
+      (pane) => pane.includes("┃ full detail · ctrl+o close"),
       10_000,
     );
     await captureMatching(
@@ -538,7 +538,7 @@ async function runActiveToolPlacement(
       session,
       "active-tool-command-output-expanded-shrink",
       (pane) =>
-        pane.includes("┃ Full detail · ctrl o close") &&
+        pane.includes("┃ full detail · ctrl+o close") &&
         commandMoreCount(pane) === null,
       ACTIVE_TOOL_RESIZE_CAPTURE_TIMEOUT_MS,
     );

--- a/tests/e2e/session-recovery.test.ts
+++ b/tests/e2e/session-recovery.test.ts
@@ -902,7 +902,7 @@ describe("session recovery", () => {
           await tui.waitForText(LEGACY_TITLE, TIMEOUT);
           await tui.waitForPane(() => readFileSync(trace, "utf8").includes("session catalog cache reused="), TIMEOUT);
           await tui.sendKeys("Escape");
-          await tui.waitForPane((pane) => !pane.includes("Esc Close"), TIMEOUT);
+          await tui.waitForPane((pane) => !pane.includes("esc close"), TIMEOUT);
           await tui.waitForComposer(TIMEOUT);
         }
         await tui.sendText("/quit");

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -2092,7 +2092,7 @@ tmuxTest(
         pane.includes("TEST-CODE") &&
         pane.includes("/verify") &&
         pane.includes("Waiting for authorization") &&
-        pane.includes("Enter reopens browser · Esc cancels"),
+        pane.includes("enter reopens browser · esc cancels"),
       TIMEOUT,
     );
     expect(signInScreen).not.toContain("Starting Vercel sign-in");
@@ -2138,12 +2138,12 @@ tmuxTest(
         pane.includes("Sign in with Codex") &&
         pane.includes("Authorize with Codex") &&
         pane.includes("Waiting for authorization") &&
-        pane.includes("Enter reopens browser · Esc cancels"),
+        pane.includes("enter reopens browser · esc cancels"),
       TIMEOUT,
     );
     expect(signInScreen).toMatch(/^Sign in with Codex\s+Waiting for authorization…$/m);
     expect(signInScreen).toMatch(/^  Open\s+Authorize with Codex$/m);
-    expect(signInScreen).toMatch(/^Enter reopens browser · Esc cancels$/m);
+    expect(signInScreen).toMatch(/^enter reopens browser · esc cancels$/m);
     expect(signInScreen).not.toContain("Code   ");
     expect(signInScreen).not.toContain(`${chatgptOauth.baseUrl}/oauth/authorize?`);
     const signInEscapes = await session.capturePaneEscapes();
@@ -2262,7 +2262,7 @@ for (const [provider, previousProvider] of [
           expect(grok.requests.filter((request) => request.path === "/v1/responses")).toHaveLength(0);
           expect(JSON.parse(readFileSync(settingsPath, "utf8"))).toEqual(preferences);
           await session.sendKeys("Escape");
-          await session.waitForPane((pane) => !pane.includes("Esc Close"), TIMEOUT);
+          await session.waitForPane((pane) => !pane.includes("esc close"), TIMEOUT);
           await session.sendKeys("C-u");
           await session.waitForComposer(TIMEOUT);
           await session.sendText("Continue the restored provider session.");
@@ -2442,7 +2442,7 @@ tmuxTest(
       expect(codexCatalog).not.toContain(vendor);
     }
     await session.sendKeys("Escape");
-    await session.waitForPane((pane) => !pane.includes("Esc Close"), TIMEOUT);
+    await session.waitForPane((pane) => !pane.includes("esc close"), TIMEOUT);
     await session.waitForComposer(TIMEOUT);
     const authorizeRequestsBeforeRoundTrip = chatgptOauth.requests.filter(
       (request) => request.path === "/oauth/authorize",
@@ -2628,7 +2628,7 @@ tmuxTest(
     await session.waitForPane(
       (pane) =>
         pane.includes("Codex subscription sign-in expired.") &&
-        pane.includes("Press Enter to sign in again."),
+        pane.includes("press enter to sign in again."),
       TIMEOUT,
     );
 
@@ -2672,7 +2672,7 @@ tmuxTest(
       await session.waitForPane(
         (pane) =>
           pane.includes("Grok subscription sign-in expired.") &&
-          pane.includes("Press Enter to sign in again."),
+          pane.includes("press enter to sign in again."),
         TIMEOUT,
       );
 
@@ -2822,7 +2822,7 @@ tmuxTest(
     await session.sendKeys("Down");
     await session.sendKeys("Right");
     const keyField = await session.waitForText("Paste or type a key", TIMEOUT);
-    expect(keyField).toContain("Enter saves");
+    expect(keyField).toContain("enter saves");
     await session.sendKeys("Escape");
     await session.waitForComposer(TIMEOUT);
 
@@ -4339,8 +4339,8 @@ tmuxTest(
       const collapsed = await session.waitForPane(
         (pane) =>
           pane.includes("Authorize with Grok") &&
-          pane.includes("Browser didn't return? Press Tab to enter a code") &&
-          pane.includes("Enter reopens browser · Tab enters code · Esc cancels"),
+          pane.includes("Browser didn't return? press tab to enter a code") &&
+          pane.includes("enter reopens browser · tab enters code · esc cancels"),
         TIMEOUT,
       );
       expect(collapsed).toMatch(/^Sign in with Grok\s+Waiting for authorization…$/m);
@@ -4418,10 +4418,10 @@ tmuxTest(
       await session.sendKeys("Down");
       await session.sendKeys("Down");
       await session.sendKeys("Enter");
-      await session.waitForText("Browser didn't return? Press Tab to enter a code", TIMEOUT);
+      await session.waitForText("Browser didn't return? press tab to enter a code", TIMEOUT);
       await session.pasteText("grok-code");
       await session.waitForPane(
-        (pane) => pane.includes("•••••••••") && pane.includes("Enter submits"),
+        (pane) => pane.includes("•••••••••") && pane.includes("enter submits"),
         TIMEOUT,
       );
       const expanded = await session.capturePane();
@@ -4430,17 +4430,17 @@ tmuxTest(
       const compactEntry = await session.waitForPane(
         (pane) =>
           pane.includes("•••••••••") &&
-          pane.includes("Enter submits") &&
-          pane.includes("Esc cancels"),
+          pane.includes("enter submits") &&
+          pane.includes("esc cancels"),
         TIMEOUT,
       );
       expect(compactEntry).not.toContain("Paste the code shown by xAI");
       await session.sendKeys("Tab");
-      const collapsedWithDraft = await session.waitForText("Tab enters code", TIMEOUT);
+      const collapsedWithDraft = await session.waitForText("tab enters code", TIMEOUT);
       expect(collapsedWithDraft).not.toContain("•••••••••");
       await session.sendKeys("Tab");
       await session.waitForPane(
-        (pane) => pane.includes("•••••••••") && pane.includes("Enter submits"),
+        (pane) => pane.includes("•••••••••") && pane.includes("enter submits"),
         TIMEOUT,
       );
       await session.sendKeys("Enter");
@@ -6391,7 +6391,7 @@ tmuxTest(
         pane.includes("Welcome to fx") &&
         pane.includes("Sign in with Vercel") &&
         pane.includes("Add an API key") &&
-        pane.includes("Esc to set up later"),
+        pane.includes("esc to set up later"),
       TIMEOUT,
     );
     expect(onboarding).not.toMatch(/^\s+fx login\s+/m);
@@ -6599,7 +6599,7 @@ tmuxTest(
     const failed = await session.waitForPane(
       (pane) =>
         pane.includes("fx login sign-in expired.") &&
-        pane.includes("Press Enter to sign in again.") &&
+        pane.includes("press enter to sign in again.") &&
         !pane.includes("Setup"),
       TIMEOUT,
     );
@@ -7015,7 +7015,7 @@ tmuxTest(
       (pane) =>
         pane.includes(FAKE_GATEWAY_MODEL) &&
         pane.includes("Vercel sign-in must refresh before team-private models can load.") &&
-        pane.includes("Esc Close"),
+        pane.includes("esc close"),
       TIMEOUT,
     );
 
@@ -7087,7 +7087,7 @@ tmuxTest(
 
     await session.sendKeys("Escape");
     await session.waitForPane(
-      (pane) => !pane.includes("Models ") && !pane.includes("Esc Close"),
+      (pane) => !pane.includes("Models ") && !pane.includes("esc close"),
       TIMEOUT,
     );
     await session.waitForComposer(TIMEOUT);
@@ -7097,7 +7097,7 @@ tmuxTest(
       (pane) =>
         pane.includes(blockedPrompt) &&
         pane.includes("fx login sign-in expired.") &&
-        pane.includes("Press Enter to sign in again.") &&
+        pane.includes("press enter to sign in again.") &&
         !pane.includes("Model provider"),
       TIMEOUT,
     );
@@ -7165,7 +7165,7 @@ tmuxTest(
       (pane) =>
         pane.includes(firstPrompt) &&
         pane.includes("fx login sign-in expired.") &&
-        pane.includes("Press Enter to sign in again.") &&
+        pane.includes("press enter to sign in again.") &&
         !pane.includes("Model provider"),
       TIMEOUT,
     );
@@ -7183,12 +7183,12 @@ tmuxTest(
     await session.waitForPane(
       (pane) =>
         pane.includes("Vercel sign-in refresh failed; using the public model catalog.") &&
-        pane.includes("Esc Close"),
+        pane.includes("esc close"),
       TIMEOUT,
     );
     expect(gateway.modelRequests).toHaveLength(1);
     await session.sendKeys("Escape");
-    await session.waitForPane((pane) => !pane.includes("Esc Close"), TIMEOUT);
+    await session.waitForPane((pane) => !pane.includes("esc close"), TIMEOUT);
     await session.waitForComposer(TIMEOUT);
     expect(gateway.requests).toHaveLength(0);
     expect(gateway.modelRequests).toHaveLength(1);
@@ -7317,7 +7317,7 @@ tmuxTest(
     const failed = await session.waitForPane(
       (pane) =>
         pane.includes("fx login sign-in expired.") &&
-        pane.includes("Press Enter to sign in again.") &&
+        pane.includes("press enter to sign in again.") &&
         pane.includes("/credits"),
       TIMEOUT,
     );

--- a/tests/e2e/tui-command-permissions.test.ts
+++ b/tests/e2e/tui-command-permissions.test.ts
@@ -1222,7 +1222,7 @@ describe("effect-aware command permissions", () => {
       expectNoOutputRows(completed);
 
       await activeSession.sendKeys("C-o");
-      await activeSession.waitForText("Full detail · ctrl o close", TIMEOUT);
+      await activeSession.waitForText("full detail · ctrl+o close", TIMEOUT);
       await activeSession.waitForText("FXC110_FAILED_STDERR", TIMEOUT);
       const full = await activeSession.capturePane();
       expect(full).toContain("FXC110_FAST_STDOUT");
@@ -1253,7 +1253,7 @@ describe("effect-aware command permissions", () => {
       expectNoOutputRows(await activeSession.captureFullScrollback());
 
       await activeSession.sendKeys("C-o");
-      await activeSession.waitForText("Full detail · ctrl o close", TIMEOUT);
+      await activeSession.waitForText("full detail · ctrl+o close", TIMEOUT);
       await activeSession.waitForText("FXC110_FAILED_STDERR", TIMEOUT);
       let resumedFull = await activeSession.capturePane();
       await activeSession.sendHexBytes(["1b", "5b", "35", "7e"]);
@@ -1407,14 +1407,14 @@ describe("effect-aware command permissions", () => {
       const losslessGrid = await activeSession.capturePaneGrid();
 
       await activeSession.sendKeys("C-o");
-      await activeSession.waitForText("Full detail · ctrl o close", TIMEOUT);
+      await activeSession.waitForText("full detail · ctrl+o close", TIMEOUT);
       await activeSession.waitForText(losslessRows[6]!, TIMEOUT);
       const losslessFull = await activeSession.capturePane();
       const losslessFullOutput = commandOutputText(losslessFull);
       for (const row of losslessRows) expect(losslessFullOutput).toContain(`│ ${row}`);
       expect(losslessFullOutput).not.toContain("<stdout>");
       expect(losslessFullOutput).not.toContain("</stdout>");
-      expect(losslessFullOutput).not.toContain("lines more (ctrl o");
+      expect(losslessFullOutput).not.toContain("lines more (ctrl+o");
       await activeSession.sendKeys("C-o");
       await activeSession.waitForText("DIRECT_LOSSLESS_DONE", TIMEOUT);
       expect(normalizeVolatileStatusRows(await activeSession.capturePaneGrid())).toEqual(
@@ -1436,7 +1436,7 @@ describe("effect-aware command permissions", () => {
       const lossyGrid = await activeSession.capturePaneGrid();
 
       await activeSession.sendKeys("C-o");
-      await activeSession.waitForText("Full detail · ctrl o close", TIMEOUT);
+      await activeSession.waitForText("full detail · ctrl+o close", TIMEOUT);
       await activeSession.sendHexBytes(["1b", "5b", "36", "7e"]);
       await activeSession.waitForText(lossyRows[7]!, TIMEOUT);
       const lossyFull = await activeSession.capturePane();
@@ -1506,7 +1506,7 @@ describe("effect-aware command permissions", () => {
       expect(resumedCompactOutput).toBe("");
       for (const row of lossyRows) expect(resumedCompact).not.toContain(`│ ${row}`);
       await activeSession.sendKeys("C-o");
-      await activeSession.waitForText("Full detail · ctrl o close", TIMEOUT);
+      await activeSession.waitForText("full detail · ctrl+o close", TIMEOUT);
       await activeSession.sendHexBytes(["1b", "5b", "36", "7e"]);
       await activeSession.waitForText(lossyRows[7]!, TIMEOUT);
       const resumedFull = await activeSession.capturePane();
@@ -1573,7 +1573,7 @@ describe("effect-aware command permissions", () => {
       for (const row of commandRows) expect(compact).not.toContain(`│ ${row}`);
 
       await activeSession.sendKeys("C-o");
-      await activeSession.waitForText("Full detail · ctrl o close", TIMEOUT);
+      await activeSession.waitForText("full detail · ctrl+o close", TIMEOUT);
       await activeSession.waitForText(commandRows.at(-1)!, TIMEOUT);
       const full = await activeSession.capturePane();
       for (const row of commandRows) expect(full).toContain(`│ ${row}`);
@@ -1588,10 +1588,10 @@ describe("effect-aware command permissions", () => {
       await activeSession.sendText("/sound on");
       await activeSession.waitForText("● Sound: on", TIMEOUT);
       await activeSession.sendText("/settings");
-      await activeSession.waitForText("←→ Change", TIMEOUT);
+      await activeSession.waitForText("←→ change", TIMEOUT);
       await activeSession.sendKeys("Escape");
       await activeSession.waitForPane(
-        (pane) => !pane.includes("←→ Change"),
+        (pane) => !pane.includes("←→ change"),
         TIMEOUT,
       );
       await activeSession.waitForText(responseRows.at(-1)!, TIMEOUT);
@@ -1969,7 +1969,7 @@ describe("effect-aware command permissions", () => {
       const compactGrid = await activeSession.capturePaneGrid();
 
       await activeSession.sendKeys("C-o");
-      await activeSession.waitForText("Full detail · ctrl o close", TIMEOUT);
+      await activeSession.waitForText("full detail · ctrl+o close", TIMEOUT);
       const fullTranscript = await activeSession.capturePane();
       expect(fullTranscript).not.toContain("Auto agent approved this request");
       expect(fullTranscript.indexOf("└ Ran")).toBeGreaterThanOrEqual(0);
@@ -2273,7 +2273,7 @@ describe("effect-aware command permissions", () => {
         expect(scrollback).not.toContain("FX_FOREGROUND_EXEC_FAILED");
 
         await activeSession.sendKeys("C-o");
-        await activeSession.waitForText("Full detail · ctrl o close", TIMEOUT);
+        await activeSession.waitForText("full detail · ctrl+o close", TIMEOUT);
         await activeSession.waitForText("TTY_SESSION_STDERR", TIMEOUT);
         const full = await activeSession.capturePane();
         expect(full).toContain("TTY_SESSION_STDOUT_BEGIN");

--- a/tests/e2e/tui-compaction-activity.test.ts
+++ b/tests/e2e/tui-compaction-activity.test.ts
@@ -218,9 +218,9 @@ async function assertSilent(terminal: InstanceType<typeof TmuxSession>, root: st
   expect(inline.length).toBeGreaterThan(0);
   expect(inline).not.toMatch(COMPACTION_OUTPUT);
   await terminal.sendKeys("C-o");
-  await terminal.waitForText("Full detail", 5000);
+  await terminal.waitForText("full detail", 5000);
   await terminal.sendKeys("End");
-  const full = await terminal.waitForPane((pane) => pane.includes("Full detail"), 5000);
+  const full = await terminal.waitForPane((pane) => pane.includes("full detail"), 5000);
   writeFileSync(join(root, `${label}.full-transcript.txt`), full);
   expect(full).not.toMatch(COMPACTION_OUTPUT);
   await terminal.sendKeys("C-o");
@@ -257,7 +257,7 @@ describe.skipIf(!tmuxAvailable())("tui: compaction activity", () => {
         expect(f.counts().ordinary).toBe(f.seedTurns + (trigger === "overflow" ? 1 : 0));
         if (trigger === "manual") {
           await terminal.sendKeys("C-o");
-          await terminal.waitForText("Full detail", 5000);
+          await terminal.waitForText("full detail", 5000);
           expect(await terminal.capturePane()).not.toMatch(COMPACTION_OUTPUT);
           await terminal.sendKeys("C-o");
           await terminal.waitForText(ACTIVITY, 5000);
@@ -398,7 +398,7 @@ describe.skipIf(!tmuxAvailable())("tui: compaction activity", () => {
 
         const reopened = await f.launch();
         await reopened.sendKeys("C-o");
-        await reopened.waitForText("Full detail", 5000);
+        await reopened.waitForText("full detail", 5000);
         await reopened.sendKeys("End");
         const full = await reopened.waitForPane((pane) => pane.includes("Cancel this held response."), 5000);
         writeFileSync(join(f.root, "cancellation-reopened.txt"), full);
@@ -429,9 +429,9 @@ describe.skipIf(!tmuxAvailable())("tui: compaction activity", () => {
       const authMessage = "fx needs access to Vercel AI Gateway";
       async function authNotices(label: string) {
         await terminal.sendKeys("C-o");
-        await terminal.waitForText("Full detail", 5000);
+        await terminal.waitForText("full detail", 5000);
         await terminal.sendKeys("End");
-        const pane = await terminal.waitForPane((text) => text.includes("Full detail") && text.includes(authMessage), 5000);
+        const pane = await terminal.waitForPane((text) => text.includes("full detail") && text.includes(authMessage), 5000);
         writeFileSync(join(f.root, `${label}.txt`), pane);
         await terminal.sendKeys("C-o");
         await terminal.waitForComposer(5000);

--- a/tests/e2e/tui-composer-edit-contracts.test.ts
+++ b/tests/e2e/tui-composer-edit-contracts.test.ts
@@ -264,7 +264,7 @@ async function selectReviewSkill(
   selectWorkspace = false,
 ): Promise<void> {
   await active.sendLiteralText("$review");
-  await active.waitForText("Enter Use", TIMEOUT);
+  await active.waitForText("enter use", TIMEOUT);
   if (selectWorkspace) await active.sendKeys("Down");
   await active.sendKeys("Enter");
 }

--- a/tests/e2e/tui-decision-prompts.test.ts
+++ b/tests/e2e/tui-decision-prompts.test.ts
@@ -1305,7 +1305,7 @@ describe.skipIf(SKIP)("tui: decision prompt input isolation", () => {
       expect(initialPane).toContain(`${COMMAND_SCROLL_LINE_PREFIX}001`);
       const initialRows = initialPane.split("\n");
       const initialChoiceThreeRow = initialRows.findIndex((row) => row.includes("3. No"));
-      const initialControlsRow = initialRows.findIndex((row) => row.includes("1–3 Choose"));
+      const initialControlsRow = initialRows.findIndex((row) => row.includes("1–3 choose"));
       expect(initialRows[initialChoiceThreeRow + 1]!.trim()).toBe("");
       expect(initialRows[initialChoiceThreeRow + 2]!.trim()).toMatch(/^─+$/);
       expect(initialControlsRow).toBe(initialChoiceThreeRow + 3);
@@ -1371,7 +1371,7 @@ describe.skipIf(SKIP)("tui: decision prompt input isolation", () => {
         ctx.session,
         "inline command approval footer",
         (value) =>
-          value.includes(APPROVAL_PROMPT) && value.includes("1–3 Choose"),
+          value.includes(APPROVAL_PROMPT) && value.includes("1–3 choose"),
         TIMEOUT,
       );
       const command = pane.replaceAll("\n    ", " ");
@@ -1380,7 +1380,7 @@ describe.skipIf(SKIP)("tui: decision prompt input isolation", () => {
       expectApprovalSelection(pane, 1, COMMAND_YES_CHOICE);
       const paneRows = pane.split("\n");
       const choiceThreeRow = paneRows.findIndex((row) => row.includes("3. No"));
-      const controlsRow = paneRows.findIndex((row) => row.includes("1–3 Choose"));
+      const controlsRow = paneRows.findIndex((row) => row.includes("1–3 choose"));
       expect(paneRows[choiceThreeRow + 1]!.trim()).toBe("");
       expect(paneRows[choiceThreeRow + 2]!.trim()).toMatch(/^─+$/);
       expect(controlsRow).toBe(choiceThreeRow + 3);
@@ -1676,12 +1676,12 @@ describe.skipIf(SKIP)("tui: decision prompt input isolation", () => {
         hasApprovalSelection(value, 2, COMMAND_ALWAYS_CHOICE),
       );
       expectApprovalSelection(pane, 2, COMMAND_ALWAYS_CHOICE);
-      expect(pane).toContain("Tab Options");
-      expect(pane).not.toContain("Tab Amend");
+      expect(pane).toContain("tab options");
+      expect(pane).not.toContain("tab amend");
 
       await ctx.session.sendKeys("Tab");
       pane = await waitForPaneState(ctx.session, "tab to denial", (value) =>
-        hasApprovalSelection(value, 3, COMMAND_NO_CHOICE) && value.includes("Tab Amend"),
+        hasApprovalSelection(value, 3, COMMAND_NO_CHOICE) && value.includes("tab amend"),
       );
       expectApprovalSelection(pane, 3, COMMAND_NO_CHOICE);
 
@@ -2725,10 +2725,10 @@ describe.skipIf(SKIP)("tui: decision prompt input isolation", () => {
       const pane = await waitForPaneState(
         ctx.session,
         "question freeform narrow hint",
-        (value) => value.includes("Shift+↑↓ Options"),
+        (value) => value.includes("shift+↑↓ options"),
       );
       expect(pane).toContain(
-        "↑↓ Cursor · Shift+↑↓ Options · Tab Questions · Enter Answer · Esc Cancel",
+        "↑↓ cursor · shift+↑↓ options · tab questions · enter answer · esc cancel",
       );
       expect(ctx.gateway.requests).toHaveLength(1);
 
@@ -2753,9 +2753,9 @@ describe.skipIf(SKIP)("tui: decision prompt input isolation", () => {
       const pane = await waitForPaneState(
         ctx.session,
         "approval narrow hint",
-        (value) => value.includes("Enter Confirm    Esc Cancel"),
+        (value) => value.includes("enter confirm    esc cancel"),
       );
-      expect(pane).toContain("1–3 Choose now    Enter Confirm    Esc Cancel");
+      expect(pane).toContain("1–3 choose now    enter confirm    esc cancel");
 
       await resolveApprovalWithDeny(ctx.session);
       await ctx.session.waitForText("approval narrow hint handled", TIMEOUT);

--- a/tests/e2e/tui-full-transcript-brutal.test.ts
+++ b/tests/e2e/tui-full-transcript-brutal.test.ts
@@ -32,7 +32,7 @@ import { stdoutFrames } from "./render-lab/tape";
 const TIMEOUT = 30_000;
 const INPUT_SANITY_BUDGET_MS = 5_000;
 const BURST_NAVIGATION_EVENTS = 2_048;
-const FULL_FOOTER = "Full detail · ctrl o close";
+const FULL_FOOTER = "full detail · ctrl+o close";
 const HISTORY_DONE = "CTRL_O_BRUTAL_HISTORY_DONE";
 const LIVE_START = "CTRL_O_BRUTAL_LIVE_0001";
 const LIVE_DONE = "CTRL_O_BRUTAL_LIVE_DONE";

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -5238,7 +5238,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
         expect(narrow).toContain("reviewer replied · Check replay again");
         await session.resizeWindow(110, 35);
         await session.sendKeys("C-o");
-        await session.waitForText("Full detail", TIMEOUT);
+        await session.waitForText("full detail", TIMEOUT);
         let details = await session.capturePane();
         for (let page = 0; page < 8 && !details.includes("CHILD_ROW_REPLY_0"); page += 1) {
           await session.sendKeys("PPage");

--- a/tests/e2e/tui-input-navigation.test.ts
+++ b/tests/e2e/tui-input-navigation.test.ts
@@ -325,7 +325,7 @@ tmuxTest(
     await active.waitForText("Commands 35", READY_TIMEOUT);
     await active.sendKeys("Escape");
     await active.waitForPane(
-      (pane) => hasEmptyComposer(pane) && !pane.includes("Enter Open"),
+      (pane) => hasEmptyComposer(pane) && !pane.includes("enter open"),
       READY_TIMEOUT,
     );
     expect(active.isAlive()).toBe(true);
@@ -355,7 +355,7 @@ tmuxTest(
 
     await active.sendKeys("Escape");
     await active.waitForPane(
-      (pane) => hasEmptyComposer(pane) && !pane.includes("Enter Open"),
+      (pane) => hasEmptyComposer(pane) && !pane.includes("enter open"),
       READY_TIMEOUT,
     );
     expect(active.isAlive()).toBe(true);
@@ -829,7 +829,7 @@ tmuxTest(
     await typeLiteral(active, draft);
     await waitForActiveFooter(active, (footer) => footer === `┃ ${draft}`);
 
-    const fullFooter = "Full detail · ctrl o close";
+    const fullFooter = "full detail · ctrl+o close";
     const response = "history prompt complete";
     const openRetainedTranscript = async () => {
       await active.sendKeys("C-o");
@@ -1754,7 +1754,7 @@ tmuxTest(
     await active.waitForPane((pane) => pane.includes("/he"), READY_TIMEOUT);
     await active.sendKeys("Enter");
     await active.waitForPane(
-      (pane) => hasEmptyComposer(pane) && pane.includes("Tab Ente"),
+      (pane) => hasEmptyComposer(pane) && pane.includes("tab ente"),
       READY_TIMEOUT,
     );
     await active.resizeWindow(80, 24, 300);

--- a/tests/e2e/tui-interrupt-recovery.test.ts
+++ b/tests/e2e/tui-interrupt-recovery.test.ts
@@ -255,7 +255,7 @@ describe.skipIf(SKIP)("tui: interrupt recovery", () => {
       expect(countOccurrences(readTrace(tracePath), "event=worker_begin")).toBe(2);
 
       await session.sendKeys("C-o");
-      await session.waitForText("Full detail", TIMEOUT);
+      await session.waitForText("full detail", TIMEOUT);
       await session.sendKeys("C-o");
       await session.waitForText("Thinking", TIMEOUT);
       await session.sendKeys("C-c");

--- a/tests/e2e/tui-performance.test.ts
+++ b/tests/e2e/tui-performance.test.ts
@@ -47,7 +47,7 @@ const LOCAL_MENU_ACTIONS = [
   { name: "mcpOpen", command: "/mcp", marker: "[Servers]" },
   { name: "usageOpen", command: "/usage", marker: "[30 days]" },
   { name: "statuslineOpen", command: "/statusline", marker: "Status line" },
-  { name: "workspaceOpen", command: "/workspace", marker: "Enter Use" },
+  { name: "workspaceOpen", command: "/workspace", marker: "enter use" },
 ] as const;
 
 const MEASURED_ACTION_NAMES = [
@@ -724,7 +724,7 @@ test.skipIf(!ENABLED || !tmuxAvailable())(
 
       // One correctness cycle also fences the inline prewarm before timing.
       session.sendKeysImmediate(["C-o"]);
-      await session.waitForText("Full detail · ctrl o close", TIMEOUT);
+      await session.waitForText("full detail · ctrl+o close", TIMEOUT);
       expect(await session.captureFullScrollback()).toContain("PERF_TRANSCRIPT_HEAD");
       session.sendKeysImmediate(["Escape"]);
       await session.waitForComposer(TIMEOUT);
@@ -742,15 +742,15 @@ test.skipIf(!ENABLED || !tmuxAvailable())(
         const open = await measureAction(
           fixture.tapePath,
           () => session!.sendKeysImmediate(["C-o"]),
-          () => session!.waitForText("Full detail · ctrl o close", TIMEOUT),
-          "Full detail",
+          () => session!.waitForText("full detail · ctrl+o close", TIMEOUT),
+          "full detail",
         );
         const beforeScroll = await session.capturePane();
         const scroll = await measureAction(
           fixture.tapePath,
           () => session!.sendKeysImmediate(["Up"]),
           () => session!.waitForPane(
-            (pane) => pane !== beforeScroll && pane.includes("Full detail"),
+            (pane) => pane !== beforeScroll && pane.includes("full detail"),
             TIMEOUT,
           ),
         );
@@ -763,14 +763,14 @@ test.skipIf(!ENABLED || !tmuxAvailable())(
       }
 
       session.sendKeysImmediate(["C-o"]);
-      await session.waitForText("Full detail · ctrl o close", TIMEOUT);
+      await session.waitForText("full detail · ctrl+o close", TIMEOUT);
       let beforePrime = await session.capturePane();
       // The first key moves one viewport into the three-viewport prepared
       // window. Each loop then moves to its edge before the measured key
       // crosses that edge and waits for the replacement window.
       session.sendKeysImmediate(["PageUp"]);
       await session.waitForPane(
-        (pane) => pane !== beforePrime && pane.includes("Full detail"),
+        (pane) => pane !== beforePrime && pane.includes("full detail"),
         TIMEOUT,
       );
       await waitForTapeQuiescence(fixture.tapePath);
@@ -779,7 +779,7 @@ test.skipIf(!ENABLED || !tmuxAvailable())(
         beforePrime = await session.capturePane();
         session.sendKeysImmediate([key]);
         await session.waitForPane(
-          (pane) => pane !== beforePrime && pane.includes("Full detail"),
+          (pane) => pane !== beforePrime && pane.includes("full detail"),
           TIMEOUT,
         );
         await waitForTapeQuiescence(fixture.tapePath);
@@ -788,7 +788,7 @@ test.skipIf(!ENABLED || !tmuxAvailable())(
           fixture.tapePath,
           () => session!.sendKeysImmediate([key]),
           () => session!.waitForPane(
-            (pane) => pane !== beforeMiss && pane.includes("Full detail"),
+            (pane) => pane !== beforeMiss && pane.includes("full detail"),
             TIMEOUT,
           ),
         );
@@ -1095,7 +1095,7 @@ test.skipIf(!LIVE_ENABLED || !tmuxAvailable())(
       await session.waitForText("LIVE_PERFORMANCE_DONE", TIMEOUT);
 
       session.sendKeysImmediate(["C-o"]);
-      await session.waitForText("Full detail · ctrl o close", TIMEOUT);
+      await session.waitForText("full detail · ctrl+o close", TIMEOUT);
       session.sendKeysImmediate(["Up"]);
       await Bun.sleep(25);
       session.sendKeysImmediate(["Escape"]);

--- a/tests/e2e/tui-permissions.test.ts
+++ b/tests/e2e/tui-permissions.test.ts
@@ -252,11 +252,11 @@ function expectApprovalControls(
   expect(choiceRows[0]).toBeLessThan(choiceRows[1]!);
   expect(choiceRows[1]).toBeLessThan(choiceRows[2]!);
   expect(block.match(/^\s*❯\s+[123]\s+/mg)).toHaveLength(1);
-  expect(block).toContain("1–3 Choose");
-  expect(block).toContain("Enter Confirm");
-  expect(block).toContain("Esc Cancel");
-  expect(block).toContain("↑↓ Options");
-  if (opts.scrollable) expect(block).toContain("Wheel Scroll");
+  expect(block).toContain("1–3 choose");
+  expect(block).toContain("enter confirm");
+  expect(block).toContain("esc cancel");
+  expect(block).toContain("↑↓ options");
+  if (opts.scrollable) expect(block).toContain("wheel scroll");
 
   expect(block).not.toMatch(/^\s*[123][YAN]\b/m);
   for (const oldCopy of [
@@ -831,14 +831,14 @@ describe.skipIf(!tmuxAvailable())("tui: file permissions", () => {
       expectApprovalControls(approval, {
         scope: "workspace file access for this session",
       });
-      expect(approval).not.toContain("Wheel Scroll");
+      expect(approval).not.toContain("wheel scroll");
       const grid = await session.capturePaneGrid();
       expect(grid[0]).toContain("Run /help for commands");
       const bottomDividerRow = grid.findLastIndex((row) =>
         /^─+$/.test(row.trim()),
       );
       expect(bottomDividerRow).toBeGreaterThanOrEqual(0);
-      expect(grid[bottomDividerRow + 1]).toContain("1–3 Choose");
+      expect(grid[bottomDividerRow + 1]).toContain("1–3 choose");
       const rows = approval.split("\n");
       const headerRow = rows.findIndex((row) =>
         row.includes("Permission needed · Review change"),
@@ -846,7 +846,7 @@ describe.skipIf(!tmuxAvailable())("tui: file permissions", () => {
       const questionRow = rows.findIndex((row) => row.includes(APPLY_QUESTION));
       const choiceOneRow = rows.findIndex((row) => row.includes("1  Apply once"));
       const choiceThreeRow = rows.findIndex((row) => row.includes("3  Don't apply"));
-      const hintRow = rows.findIndex((row) => row.includes("1–3 Choose"));
+      const hintRow = rows.findIndex((row) => row.includes("1–3 choose"));
       expect(rows[headerRow + 1]!.trim()).toBe("");
       expect(questionRow).toBe(headerRow + 2);
       expect(rows[questionRow + 1]!.trim()).toBe("");
@@ -1489,7 +1489,7 @@ describe.skipIf(!tmuxAvailable())("tui: file permissions", () => {
       expect(compactScrollback).not.toContain("CTRL_O_FIRST_060");
 
       await session.sendKeys("C-o");
-      await session.waitForText("Full detail · ctrl o close", TIMEOUT);
+      await session.waitForText("full detail · ctrl+o close", TIMEOUT);
       for (let page = 0; page < 20; page += 1) {
         await session.sendHexBytes(["1b", "5b", "36", "7e"]);
       }
@@ -1571,7 +1571,7 @@ describe.skipIf(!tmuxAvailable())("tui: file permissions", () => {
       expect(inline).not.toContain("NEW_WRAP_TAIL");
 
       await session.sendKeys("C-o");
-      await session.waitForText("Full detail · ctrl o close", TIMEOUT);
+      await session.waitForText("full detail · ctrl+o close", TIMEOUT);
       const full = await session.capturePane();
       expectDiffSentinelOnRail(full, "OLD_WRAP_TAIL");
       expectDiffSentinelOnRail(full, "NEW_WRAP_TAIL");

--- a/tests/e2e/tui-render-lab.test.ts
+++ b/tests/e2e/tui-render-lab.test.ts
@@ -334,12 +334,12 @@ test("render-lab analyzer enforces active-tool placement and uniqueness", () => 
     },
     {
       event: "active-tool-clipped",
-      grid: ["│ ACTIVE_TOOL_LINE_05", "│ … 27 lines more (ctrl o to view)", "", "● Running sleep 1; i=1", "", "▲ Thinking", "", "────────────────", "❯", "────────────────", "test"],
+      grid: ["│ ACTIVE_TOOL_LINE_05", "│ … 27 lines more (ctrl+o to view)", "", "● Running sleep 1; i=1", "", "▲ Thinking", "", "────────────────", "❯", "────────────────", "test"],
       rejected: false,
     },
     {
       event: "active-tool-clipped",
-      grid: ["│ ACTIVE_TOOL_LINE_05", "│ … 27 lines more (ctrl o to view)", "", "▲ Thinking", "", "────────────────", "❯", "────────────────", "test"],
+      grid: ["│ ACTIVE_TOOL_LINE_05", "│ … 27 lines more (ctrl+o to view)", "", "▲ Thinking", "", "────────────────", "❯", "────────────────", "test"],
       rejected: true,
     },
     {

--- a/tests/e2e/tui-render-replay.test.ts
+++ b/tests/e2e/tui-render-replay.test.ts
@@ -469,7 +469,7 @@ describe("tui: render record/replay", () => {
       expect(statSync(launched.tapePath).mode & 0o077).toBe(0);
 
       await session.sendKeys("C-o");
-      await session.waitForText("Full detail · ctrl o close", 5_000);
+      await session.waitForText("full detail · ctrl+o close", 5_000);
       await session.waitForText("visual terminal capture:", 5_000);
       await session.sendKeys("C-o");
       await session.waitForComposer(5_000);

--- a/tests/e2e/tui-render-stress.test.ts
+++ b/tests/e2e/tui-render-stress.test.ts
@@ -116,7 +116,7 @@ describe.skipIf(SKIP)("tui: render stress", () => {
         await session.sendText("/help");
         await session.waitForText("Commands 35", 5_000);
         await session.sendKeys("Escape");
-        await session.waitForPane((pane) => !pane.includes("Enter Open"), 5_000);
+        await session.waitForPane((pane) => !pane.includes("enter open"), 5_000);
         await session.sendText("/status");
         await session.waitForText("permission_mode", 5_000);
         const unknownCommand = `/unknown-render-stress-${run} local transcript notice`;

--- a/tests/e2e/tui-resize.test.ts
+++ b/tests/e2e/tui-resize.test.ts
@@ -1069,7 +1069,7 @@ function findInlineSkillsPicker(
   if (!isInputRow(grid[input]!)) return null;
   const bottomDivider = grid.findLastIndex((line) => isDividerRow(line));
   if (bottomDivider <= header || bottomDivider + 1 >= grid.length) return null;
-  if (!grid[bottomDivider + 1]!.includes("Esc Close")) return null;
+  if (!grid[bottomDivider + 1]!.includes("esc close")) return null;
   return {
     input,
     topDivider: header - 1,
@@ -1088,7 +1088,7 @@ function findInlineHelpPicker(
   if (!isInputRow(grid[input]!)) return null;
   const bottomDivider = grid.findLastIndex((line) => isDividerRow(line));
   if (bottomDivider <= header || bottomDivider + 1 >= grid.length) return null;
-  if (!grid[bottomDivider + 1]!.includes("Enter Open")) return null;
+  if (!grid[bottomDivider + 1]!.includes("enter open")) return null;
   return {
     input,
     topDivider: header - 1,
@@ -1235,7 +1235,7 @@ async function runLargeSkillResizeAttempt(attempt: number): Promise<string> {
       const grid = pane.split("\n");
       return (
         pane.includes("𝒇x") &&
-        !pane.includes("↑↓ Navigate") &&
+        !pane.includes("↑↓ navigate") &&
         findFooter(grid) !== null
       );
     }, 5_000);
@@ -1412,7 +1412,7 @@ async function runRapidSkillResizeAttempt(
       (pane) => {
         const grid = pane.replace(/\n$/, "").split("\n");
         return pane.includes("𝒇x") &&
-          !pane.includes("↑↓ Navigate") &&
+          !pane.includes("↑↓ navigate") &&
           findFooter(grid) !== null;
       },
       5_000,
@@ -2608,7 +2608,7 @@ describe.skipIf(SKIP)("tui: resize", () => {
       await session.waitForText("/help", 10_000);
       await waitForSelectedSlashLabel(session, "/help");
       const shrinkStage = await session.captureFullScrollback();
-      expect(shrinkStage).toContain("Commands 35 · Type to filter");
+      expect(shrinkStage).toContain("Commands 35 · type to filter");
       expect(shrinkStage).toContain("1–4");
       writeFileSync(join(root, "scrollback-after-shrink.txt"), shrinkStage);
 
@@ -2777,12 +2777,12 @@ describe.skipIf(SKIP)("tui: resize", () => {
       label: "help",
       width: 72,
       height: 16,
-      surfaceMarker: "Enter Open",
+      surfaceMarker: "enter open",
       editedInput: "x",
       async openSurface(active) {
         await active.resizeWindow(60, 12, 500);
         await active.sendText("/help");
-        await active.waitForText("Enter Open", TIMEOUT);
+        await active.waitForText("enter open", TIMEOUT);
       },
     },
     {
@@ -3267,11 +3267,11 @@ describe.skipIf(SKIP)("tui: resize", () => {
       }
 
       await session.resizeWindow(80, 17, 500);
-      pane = await session.waitForText("1–3 Choose", 5_000);
+      pane = await session.waitForText("1–3 choose", 5_000);
       expect(pane).toContain(FILE_APPROVAL_QUESTION);
       expect(pane).toContain("resize-approved.txt");
       expect(pane).toContain("+ preview-nine");
-      expect(pane).toContain("Wheel Scroll");
+      expect(pane).toContain("wheel scroll");
       expect(pane).not.toContain("omitted");
       fullBlock = findActiveFileApprovalBlock(await session.capturePaneGrid());
       expect(fullBlock).not.toBeNull();
@@ -3593,7 +3593,7 @@ describe.skipIf(SKIP)("tui: resize", () => {
       expect(findInlineHelpPicker(grid)).not.toBeNull();
 
       await session.sendKeys("Escape");
-      await session.waitForPane((pane) => !pane.includes("Enter Open"), 5_000);
+      await session.waitForPane((pane) => !pane.includes("enter open"), 5_000);
       await session.waitForStableComposer(5_000);
       await session.sendText("/quit");
       expect(await session.waitForSessionEnd(5_000)).toBe(true);
@@ -3627,7 +3627,7 @@ describe.skipIf(SKIP)("tui: resize", () => {
 
       await session.sendKeys("Escape");
       await session.waitForPane(
-        (pane) => hasEmptyComposer(pane) && !pane.includes("Enter Open"),
+        (pane) => hasEmptyComposer(pane) && !pane.includes("enter open"),
         5_000,
       );
       const restored = captureScrollback();
@@ -4174,7 +4174,7 @@ describe.skipIf(SKIP)("tui: resize", () => {
 
         await session.sendKeys("Escape");
         await session.waitForPane(
-          (pane) => hasEmptyComposer(pane) && !pane.includes("Enter Open"),
+          (pane) => hasEmptyComposer(pane) && !pane.includes("enter open"),
           5_000,
         );
         const scrollback = await session.captureFullScrollback();

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -847,7 +847,7 @@ test.skipIf(!tmuxAvailable())(
         expectInternal(resumed);
 
         await active.sendKeys("C-o");
-        await active.waitForText("┃ Full detail · ctrl o close", TIMEOUT);
+        await active.waitForText("┃ full detail · ctrl+o close", TIMEOUT);
         const full = await collectFullTranscriptPages(active, 40);
         expect(full).toContain("ARCHIVED_VISIBLE_REPLY");
         expect(full).toContain("VISIBLE_TOOL_RESULT");
@@ -948,7 +948,7 @@ test.skipIf(!tmuxAvailable())(
         await active.sendKeys("C-o");
         const full = await active.waitForPane(
           (pane) =>
-            pane.includes("Full detail · ctrl o close") &&
+            pane.includes("full detail · ctrl+o close") &&
             pane.includes("UTC · Usage") &&
             /\(↑\d+ ↓5\)/.test(pane),
           TIMEOUT,
@@ -1149,7 +1149,7 @@ printf '${trailingMarker}   '
       expect(compact).not.toContain("BOUNDARY_LEADING");
       expect(compact).not.toContain(splitMarker);
       expect(compact).not.toContain(trailingMarker);
-      expect(compact).not.toContain("lines more (ctrl o to view)");
+      expect(compact).not.toContain("lines more (ctrl+o to view)");
       expect(readFileSync(stderrPath, "utf8")).not.toContain("AnsiBandOverflow");
       expect(readFileSync(tracePath, "utf8")).toContain("route=approved_shell");
 
@@ -1178,7 +1178,7 @@ printf '${trailingMarker}   '
         .toBe(false);
 
       await active.sendKeys("C-o");
-      await active.waitForText("┃ Full detail · ctrl o close", TIMEOUT);
+      await active.waitForText("┃ full detail · ctrl+o close", TIMEOUT);
       await active.sendHexBytes(
         Array.from({ length: 80 }, () => ["1b", "5b", "36", "7e"]).flat(),
       );
@@ -1186,7 +1186,7 @@ printf '${trailingMarker}   '
       const fullTail = await active.capturePane();
       expect(fullTail).toContain(splitMarker);
       expect(fullTail).toContain(trailingMarker);
-      expect(fullTail).not.toContain("lines more (ctrl o");
+      expect(fullTail).not.toContain("lines more (ctrl+o");
       await active.sendHexBytes(
         Array.from({ length: 80 }, () => ["1b", "5b", "35", "7e"]).flat(),
       );
@@ -1240,7 +1240,7 @@ printf '${trailingMarker}   '
       });
       await active.waitForText(doneMarker, TIMEOUT);
       await active.sendKeys("C-o");
-      await active.waitForText("┃ Full detail · ctrl o close", TIMEOUT);
+      await active.waitForText("┃ full detail · ctrl+o close", TIMEOUT);
       await active.sendHexBytes(
         Array.from({ length: 80 }, () => ["1b", "5b", "36", "7e"]).flat(),
       );
@@ -1317,7 +1317,7 @@ test.skipIf(!tmuxAvailable())(
       await active.sendText("Run the prepared command.");
       const compact = await waitForScrollback(active, "FULL_CTRL_O_DONE");
       expect(compact).toContain("● 1 tool call · 1 command");
-      expect(compact).not.toContain("lines more (ctrl o to view)");
+      expect(compact).not.toContain("lines more (ctrl+o to view)");
       expect(compact).not.toContain(tailMarker);
       await active.waitForPane(
         (pane) => pane.includes("FULL_CTRL_O_DONE") && !pane.includes("Streaming ("),
@@ -1326,7 +1326,7 @@ test.skipIf(!tmuxAvailable())(
       const compactGrid = await active.capturePaneGrid();
 
       await active.sendKeys("C-o");
-      await active.waitForText("Full detail · ctrl o close · PgUp/PgDn scroll · Esc close", TIMEOUT);
+      await active.waitForText("full detail · ctrl+o close · pgup/pgdn scroll · esc close", TIMEOUT);
       const expandedAtTail = await active.waitForText(tailMarker, TIMEOUT);
       expect(expandedAtTail).toContain(tailMarker);
       expect(expandedAtTail).not.toContain("FULL_CTRL_O_LINE_0001");
@@ -1355,8 +1355,8 @@ test.skipIf(!tmuxAvailable())(
       await active.waitForText(tailMarker, TIMEOUT);
       const full = await active.capturePane();
       expect(full).toContain(tailMarker);
-      expect(full).not.toContain("lines more (ctrl o");
-      expect(full).toContain("Full detail · ctrl o close · PgUp/PgDn scroll · Esc close");
+      expect(full).not.toContain("lines more (ctrl+o");
+      expect(full).toContain("full detail · ctrl+o close · pgup/pgdn scroll · esc close");
 
       await active.sendHexBytes(["1b", "5b", "35", "7e"]);
       const afterPageUp = await active.waitForPane(
@@ -1388,7 +1388,7 @@ test.skipIf(!tmuxAvailable())(
       await active.waitForText("● 1 tool call · 1 command", TIMEOUT);
       const restored = await active.capturePane();
       const restoredScrollback = await active.captureFullScrollback();
-      expect(restored).not.toContain("lines more (ctrl o to view)");
+      expect(restored).not.toContain("lines more (ctrl+o to view)");
       expect(restored).not.toContain(tailMarker);
       expect(normalizeVolatileStatusRows(await active.capturePaneGrid())).toEqual(
         normalizeVolatileStatusRows(compactGrid),
@@ -1464,7 +1464,7 @@ test.skipIf(!tmuxAvailable())(
       await active.sendText("Run the prepared cap-crossing command.");
       const compact = await waitForScrollback(active, finalMarker, timeout);
       expect(compact).toContain("● 1 tool call · 1 command");
-      expect(compact).not.toContain("lines more (ctrl o to view)");
+      expect(compact).not.toContain("lines more (ctrl+o to view)");
       expect(compact).not.toContain(stdoutTail);
       expect(compact).not.toContain(stderrTail);
 
@@ -1610,7 +1610,7 @@ printf '${tailMarker}\\n'
         timeout,
       );
       const compactOutputRows = activeCompact.split("\n").filter((line) =>
-        line.trimStart().startsWith("│ ") && !line.includes("ctrl o to view")
+        line.trimStart().startsWith("│ ") && !line.includes("ctrl+o to view")
       );
       expect(compactOutputRows).toHaveLength(0);
       expect(activeCompact).not.toContain(tailMarker);
@@ -1668,7 +1668,7 @@ printf '${tailMarker}\\n'
       const terminalCompact = await active.capturePane();
       expect(terminalCompact).toContain("Ran ./active-overflow.sh");
       expect(terminalCompact).not.toContain(stableMarker);
-      expect(terminalCompact).not.toContain("lines more (ctrl o");
+      expect(terminalCompact).not.toContain("lines more (ctrl+o");
       expect(terminalCompact).not.toContain(tailMarker);
       expect(terminalCompact).not.toContain(futureMarker);
       const sessionId = sessionIdFromHome(home);
@@ -1834,7 +1834,7 @@ while :; do :; done
       expect(replayBytes.byteLength).toBeGreaterThan(1024 * 1024);
 
       await active.sendKeys("C-o");
-      await active.waitForText("┃ Full detail · ctrl o close", timeout);
+      await active.waitForText("┃ full detail · ctrl+o close", timeout);
       await active.waitForText(tailMarker, timeout);
       writeFileSync(ctrlOPath, await active.capturePane());
       await active.sendKeys("C-o");
@@ -2504,7 +2504,7 @@ test.skipIf(!tmuxAvailable())(
       const fullView = await active.capturePane();
       expect(fullView).toContain(firstDone);
       expect(fullView).not.toContain(fullViewDraft);
-      expect(fullView).toContain("┃ Full detail · ctrl o close");
+      expect(fullView).toContain("┃ full detail · ctrl+o close");
       await active.sendKeys("Escape");
       await active.waitForText(fullViewDraft, TIMEOUT);
       await active.sendKeys("Enter");
@@ -2578,7 +2578,7 @@ test.skipIf(!tmuxAvailable())(
       await active.waitForText(streamMarker, TIMEOUT);
 
       await active.sendKeys("C-o");
-      await active.waitForText("┃ Full detail · ctrl o close", TIMEOUT);
+      await active.waitForText("┃ full detail · ctrl+o close", TIMEOUT);
       const enterAlternate = Buffer.from("\x1b[?1049h");
       const leaveAlternate = Buffer.from("\x1b[?1049l");
       const tapeBeforeCancel = readFileSync(tapePath);
@@ -2733,18 +2733,18 @@ test.skipIf(!tmuxAvailable())(
       await active.sendHexBytes(stressBytes);
       await Bun.sleep(250);
       const inlineAfterWheel = (await active.capturePaneGrid()).join("\n");
-      expect(inlineAfterWheel).not.toContain("Full detail · ctrl o close");
+      expect(inlineAfterWheel).not.toContain("full detail · ctrl+o close");
       expect(readFileSync(tapePath)).not.toContain(Buffer.from("\x1b[?1000h\x1b[?1006h"));
       expect(readFileSync(tracePath, "utf8")).not.toContain(
         "depth_transition from=inline to=full",
       );
 
       await active.sendKeys("C-o");
-      await active.waitForText("┃ Full detail · ctrl o close", TIMEOUT);
+      await active.waitForText("┃ full detail · ctrl+o close", TIMEOUT);
       await active.sendKeys("Left");
-      await active.waitForText("┃ Full detail · ctrl o close", TIMEOUT);
+      await active.waitForText("┃ full detail · ctrl+o close", TIMEOUT);
       await active.sendKeys("Right");
-      await active.waitForText("┃ Full detail · ctrl o close", TIMEOUT);
+      await active.waitForText("┃ full detail · ctrl+o close", TIMEOUT);
       expect(readFileSync(tapePath)).not.toContain(Buffer.from("\x1b[?1000h\x1b[?1006h"));
       const alternateScrollTraceStart = statSync(tracePath).size;
       await active.sendHexBytes(["1b", "5b", "41"]);
@@ -2765,11 +2765,11 @@ test.skipIf(!tmuxAvailable())(
         "viewer page trace",
       );
       const readingBefore = await active.capturePaneGrid();
-      expect(readingBefore.join("\n")).toContain("Full detail · ctrl o close");
+      expect(readingBefore.join("\n")).toContain("full detail · ctrl+o close");
       expect(readingBefore.join("\n")).toMatch(
         new RegExp(`│ ${lineMarker} \\d{3}`),
       );
-      expect(readingBefore.join("\n")).not.toContain("ctrl o to view");
+      expect(readingBefore.join("\n")).not.toContain("ctrl+o to view");
 
       await waitForCondition(() => existsSync(phaseTwoComplete), "second output phase");
       await waitForCondition(() => gateway.requests.length >= 2, "post-command gateway request");
@@ -2796,13 +2796,13 @@ test.skipIf(!tmuxAvailable())(
 
       await active.sendKeys("Escape");
       await active.waitForPane(
-        (pane) => pane.includes(doneMarker) && !pane.includes("┃ Full detail · ctrl o close"),
+        (pane) => pane.includes(doneMarker) && !pane.includes("┃ full detail · ctrl+o close"),
         TIMEOUT,
       );
       const scrollback = await waitForScrollback(active, doneMarker);
       expect(scrollback).not.toContain(`│ ${lineMarker} 001`);
       expect(countOccurrences(scrollback, `│ ${lineMarker} 001`)).toBe(0);
-      expect(scrollback).not.toContain("lines more (ctrl o to view)");
+      expect(scrollback).not.toContain("lines more (ctrl+o to view)");
       expect(readFileSync(stderrPath, "utf8")).toBe("");
 
       await active.sendText("/quit");
@@ -2904,7 +2904,7 @@ test.skipIf(!tmuxAvailable())(
       expect(scrollback).not.toContain(
         `│ ${commandMarker} ${String(lineCount).padStart(5, "0")}`,
       );
-      expect(scrollback).not.toContain("lines more (ctrl o to view)");
+      expect(scrollback).not.toContain("lines more (ctrl+o to view)");
       expect(readFileSync(stderrPath, "utf8")).not.toContain("AnsiBandOverflow");
     } finally {
       if (active) {
@@ -3229,11 +3229,11 @@ test.skipIf(!tmuxAvailable())(
           const historyBefore = await active.captureFullScrollback();
 
           await active.sendKeys("C-o");
-          await active.waitForText("Full detail · ctrl o close", TIMEOUT);
+          await active.waitForText("full detail · ctrl+o close", TIMEOUT);
           if (width === 120) {
             await active.resizeWindow(88, 24, 500);
             await active.sendKeys("Escape C-o");
-            await active.waitForText("Full detail · ctrl o close", TIMEOUT);
+            await active.waitForText("full detail · ctrl+o close", TIMEOUT);
           }
           await active.sendKeys("Escape");
           const restored = await active.waitForStableGrid(
@@ -3321,7 +3321,7 @@ test.skipIf(!tmuxAvailable())(
       await active.sendKeys("C-o");
       await active.waitForText("READ_RESULT_MARKER", TIMEOUT);
       const full = await active.capturePane();
-      expect(full).toContain("Full detail · ctrl o close · PgUp/PgDn scroll · Esc close");
+      expect(full).toContain("full detail · ctrl+o close · pgup/pgdn scroll · esc close");
       expect(full).toContain("READ_RESULT_MARKER");
       expect(full).not.toContain("<path>");
       expect(full).not.toContain("<content>");
@@ -3385,7 +3385,7 @@ test.skipIf(!tmuxAvailable())(
       await active.waitForText("LIST_FULL_DETAIL_MARKER", TIMEOUT);
       const firstDetail = await active.capturePane();
       expect(firstDetail).toContain("LIST_FULL_DETAIL_MARKER");
-      expect(firstDetail).toContain("Full detail · ctrl o close · PgUp/PgDn scroll · Esc close");
+      expect(firstDetail).toContain("full detail · ctrl+o close · pgup/pgdn scroll · esc close");
       expect(firstDetail).not.toMatch(/^\s*input\s*$/m);
 
       await active.waitForText("READ_FULL_DETAIL_MARKER", TIMEOUT);
@@ -3484,7 +3484,7 @@ test.skipIf(!tmuxAvailable())(
       await active.sendKeys("1");
       await active.sendKeys("Enter");
       const beforeHandoff = await waitForScrollback(active, priorSummary);
-      expect(beforeHandoff).not.toContain("lines more (ctrl o to view)");
+      expect(beforeHandoff).not.toContain("lines more (ctrl+o to view)");
       expect(countOccurrences(beforeHandoff, priorSummary)).toBe(1);
       const compactOutputRows = beforeHandoff.match(/CTRL_O_FILE_FOLD_\d{4}/g) ?? [];
       expect(compactOutputRows).toHaveLength(0);
@@ -3730,7 +3730,7 @@ test.skipIf(!tmuxAvailable())(
 
       await active.sendKeys("C-o");
       await Bun.sleep(150);
-      await active.waitForText("┃ Full detail · ctrl o close", actionTimeout);
+      await active.waitForText("┃ full detail · ctrl+o close", actionTimeout);
       await active.sendHexBytes(
         Array.from({ length: 20 }, () => ["1b", "5b", "36", "7e"]).flat(),
       );
@@ -3811,8 +3811,8 @@ test.skipIf(!tmuxAvailable())(
     const streamGate = "CTRL_O_PRESSURE_STREAM_GATE";
     const activeDone = "CTRL_O_PRESSURE_ACTIVE_DONE";
     const questionMarker = "CTRL_O_PRESSURE_QUESTION";
-    const questionAnswerInstruction = "Enter Answer";
-    const questionCancelInstruction = "Esc Cancel";
+    const questionAnswerInstruction = "enter answer";
+    const questionCancelInstruction = "esc cancel";
     const composerProbe = "CTRL_O_PRESSURE_COMPOSER_READY";
     const setupCommand =
       "awk 'BEGIN { for (i = 1; i <= 72; i++) printf \"CTRL_O_PRESSURE_SETUP_OUTPUT_%03d: retained command history\\n\", i }'";
@@ -3928,7 +3928,7 @@ test.skipIf(!tmuxAvailable())(
       expect(setupScrollback).toContain(assistantTail);
       expect(setupScrollback).not.toContain(setupCompactLine);
       expect(setupScrollback).not.toContain(setupFullLine);
-      expect(setupScrollback).not.toContain("lines more (ctrl o to view)");
+      expect(setupScrollback).not.toContain("lines more (ctrl+o to view)");
 
       await active.sendText("Run the prepared streaming command and file review.");
       await active.waitForText("Would you like to run the following command?", TIMEOUT);
@@ -3947,7 +3947,7 @@ test.skipIf(!tmuxAvailable())(
         () => alternateDepthAt(tapeText()) === 1,
         "Ctrl-O to enter the alternate screen",
       );
-      await active.waitForText("┃ Full detail · ctrl o close", TIMEOUT);
+      await active.waitForText("┃ full detail · ctrl+o close", TIMEOUT);
       await active.sendHexBytes(["1b", "5b", "36", "7e"]);
       const tailViewport = await active.waitForText(streamGate, TIMEOUT);
       expect(tailViewport).toContain(streamGate);
@@ -3999,7 +3999,7 @@ test.skipIf(!tmuxAvailable())(
         () => alternateDepthAt(tapeText()) === 1,
         "the repeated Ctrl-O entry",
       );
-      await active.waitForText("┃ Full detail · ctrl o close", TIMEOUT);
+      await active.waitForText("┃ full detail · ctrl+o close", TIMEOUT);
       await active.sendKeys("C-o");
       await waitForCondition(
         () => alternateDepthAt(tapeText()) === 0,
@@ -4078,7 +4078,7 @@ test.skipIf(!tmuxAvailable())(
       expect(countOccurrences(finalScrollback, `│ ${activeStart}`)).toBe(0);
       expect(countOccurrences(finalScrollback, `│ ${streamGate}`)).toBe(0);
       expect(countOccurrences(finalScrollback, `│ ${activeDone}`)).toBe(0);
-      expect(finalScrollback).not.toContain("lines more (ctrl o to view)");
+      expect(finalScrollback).not.toContain("lines more (ctrl+o to view)");
       expect(finalPane).not.toContain("Apply this change?");
       expect(finalPane).not.toContain(questionAnswerInstruction);
       expect(finalPane).not.toContain(questionCancelInstruction);
@@ -4348,7 +4348,7 @@ test.skipIf(!tmuxAvailable())(
       await contender.sendKeys("Enter");
       await contender.waitForPane(
         (pane) => stripAnsi(pane).includes(
-          "This session is open in another fx. Close it there, then press Enter to retry.",
+          "This session is open in another fx. Close it there, then press enter to retry.",
         ),
         1_000,
       );
@@ -4357,7 +4357,7 @@ test.skipIf(!tmuxAvailable())(
       const contendedPicker = stripAnsi(await contender.capturePane());
       expect(contendedPicker).toContain(savedTitle);
       expect(contendedPicker).toContain(
-        "This session is open in another fx. Close it there, then press Enter to retry.",
+        "This session is open in another fx. Close it there, then press enter to retry.",
       );
       expect(contendedPicker).not.toContain("SessionBusy");
       const contendedEntries = visibleSessionPickerEntries(
@@ -4885,7 +4885,7 @@ test.skipIf(!tmuxAvailable())(
           TIMEOUT,
         ),
       );
-      expect(picker).toContain("Esc Close");
+      expect(picker).toContain("esc close");
 
       await active.sendKeys("Escape");
       await waitForSessionPickerClosed(active);
@@ -4964,7 +4964,7 @@ test.skipIf(!tmuxAvailable())(
         (pane) =>
           pane.includes("Sessions 1") &&
           pane.includes("Save a turn for resume.") &&
-          pane.includes("Enter Resume"),
+          pane.includes("enter resume"),
         TIMEOUT,
       );
       expect(picker).toContain("Save a turn for resume.");
@@ -5234,7 +5234,7 @@ test.skipIf(!tmuxAvailable())(
         expectNoRawToolReplay(resumedToolScrollback);
         if (index === 0) {
           await active.sendKeys("C-o");
-          await active.waitForText("┃ Full detail · ctrl o close", TIMEOUT);
+          await active.waitForText("┃ full detail · ctrl+o close", TIMEOUT);
           await active.waitForText(toolWorkspaceMarker, TIMEOUT);
           const full = await active.capturePane();
           expect(full).toContain("Ran pwd");
@@ -5672,7 +5672,7 @@ test.skipIf(!tmuxAvailable())(
       expect(resumed).not.toContain("RESUMED_SECOND_FILE_LINE_001");
 
       await active.sendKeys("C-o");
-      await active.waitForText("┃ Full detail · ctrl o close", TIMEOUT);
+      await active.waitForText("┃ full detail · ctrl+o close", TIMEOUT);
       await active.sendHexBytes(
         Array.from({ length: 10 }, () => ["1b", "5b", "36", "7e"]).flat(),
       );
@@ -5776,14 +5776,14 @@ printf '${stdoutTail2}\\n'
     function expectCompactCommandOutput(pane: string): void {
       expect(pane).toContain("● 1 tool call · 1 command");
       expect(pane).toContain("Ran ./resume-command-output.sh");
-      expect(pane).not.toContain("lines more (ctrl o to view)");
+      expect(pane).not.toContain("lines more (ctrl+o to view)");
       expect(pane).not.toContain(firstMarker);
       expect(pane).not.toContain("RESUME_COMMAND_TAIL");
     }
 
     async function expectRestoredViewerOutput(session: TmuxSession): Promise<void> {
       await session.sendKeys("C-o");
-      await session.waitForText("┃ Full detail · ctrl o close", TIMEOUT);
+      await session.waitForText("┃ full detail · ctrl+o close", TIMEOUT);
       const tail = await session.capturePane();
       expect(tail).toContain(stdoutTail2);
       expect(tail).not.toContain(firstMarker);
@@ -5997,7 +5997,7 @@ test.skipIf(!tmuxAvailable())(
       const allPicker = stripAnsi(await active.capturePane());
       expect(allPicker).toContain("Save the workspace A transcript.");
       expect(allPicker).toContain("Save the workspace B transcript.");
-      expect(allPicker).toContain("Tab Scope");
+      expect(allPicker).toContain("tab scope");
 
       await active.sendLiteralText("workspace B");
       await active.waitForPane((pane) => {
@@ -6215,7 +6215,7 @@ test.skipIf(!tmuxAvailable())(
       const atReversedSelection = (await active.capturePane()).split("\n");
       const headerRow = atReversedSelection.findIndex((line) => line.includes("Sessions 10"));
       const loadMoreRow = atReversedSelection.findIndex((line) => line.includes("↓ Load more"));
-      const hintRow = atReversedSelection.findIndex((line) => line.includes("Tab Scope"));
+      const hintRow = atReversedSelection.findIndex((line) => line.includes("tab scope"));
       expect(headerRow).toBeGreaterThanOrEqual(0);
       expect(loadMoreRow).toBeGreaterThan(headerRow);
       expect(hintRow).toBeGreaterThan(loadMoreRow);
@@ -6231,7 +6231,7 @@ test.skipIf(!tmuxAvailable())(
       const afterFurtherScroll = (await active.capturePane()).split("\n");
       expect(afterFurtherScroll.findIndex((line) => /Sessions 1[12]\b/.test(line))).toBe(headerRow);
       expect(afterFurtherScroll.findIndex((line) => line.includes("↓ Load more"))).toBe(-1);
-      expect(afterFurtherScroll.findIndex((line) => line.includes("Tab Scope"))).toBe(hintRow);
+      expect(afterFurtherScroll.findIndex((line) => line.includes("tab scope"))).toBe(hintRow);
       expect(visibleSessionPickerEntries(await active.capturePaneEscapes())[0]!.row).toBe(firstEntryRow);
 
       expect(active.isAlive()).toBe(true);
@@ -6998,7 +6998,7 @@ test.skipIf(!tmuxAvailable())(
       });
       await active.waitForComposer(TIMEOUT);
       await active.sendHexBytes(["0f"]);
-      await active.waitForText("Full detail · ctrl o close", TIMEOUT);
+      await active.waitForText("full detail · ctrl+o close", TIMEOUT);
       await active.sendKeys("Home");
       const pane = await active.waitForText("EARLIER_VISIBLE_RESPONSE", 5_000);
       expect(pane).toContain("Earlier visible request");
@@ -7045,7 +7045,7 @@ test.skipIf(!tmuxAvailable())(
       await active.waitForText(tail, TIMEOUT);
       await active.waitForComposer(TIMEOUT);
       await active.sendHexBytes(["0f"]);
-      await active.waitForPane((pane) => pane.includes("Full detail · ctrl o close") && pane.includes(tail), TIMEOUT);
+      await active.waitForPane((pane) => pane.includes("full detail · ctrl+o close") && pane.includes(tail), TIMEOUT);
       const resultsDir = join(home, ".fx", "sessions", sessionIdFromHome(home), "tool-results");
       const files = readdirSync(resultsDir).filter((name) => name.endsWith(".txt"));
       expect(files).toHaveLength(1);
@@ -7054,7 +7054,7 @@ test.skipIf(!tmuxAvailable())(
       const recovered = await active.waitForPane((pane) =>
         pane.includes("Full saved result unavailable.") && pane.includes(tail),
       TIMEOUT);
-      expect(recovered).toContain("Full detail · ctrl o close");
+      expect(recovered).toContain("full detail · ctrl+o close");
       expect(active.isPaneAlive()).toBe(true);
       expect(gateway.requests).toHaveLength(2);
       expect(readFileSync(stderrPath, "utf8")).toBe("");
@@ -7129,7 +7129,7 @@ for (const inspectDetails of [false, true]) {
         await assertHistory();
         if (inspectDetails) {
           await active.sendKeys("C-o");
-          await active.waitForText("Full detail", TIMEOUT);
+          await active.waitForText("full detail", TIMEOUT);
           await active.sendKeys("PPage");
           await active.resizeWindow(60, 18);
           await Bun.sleep(350);
@@ -7137,7 +7137,7 @@ for (const inspectDetails of [false, true]) {
           await active.resizeWindow(88, 24);
           await Bun.sleep(350);
           await active.sendKeys("Escape");
-          await active.waitForPane(pane => !pane.includes("Full detail"), TIMEOUT);
+          await active.waitForPane(pane => !pane.includes("full detail"), TIMEOUT);
           await Bun.sleep(150);
         }
         await prompt("In one sentence, confirm which file you created. Do not use tools.");
@@ -7251,7 +7251,7 @@ test.skipIf(!tmuxAvailable())("remembered continuation restores the selected con
     expect(readFileSync(join(root, "busy.stderr"), "utf8")).toContain("another fx process");
     await other.kill(); other = null;
     await active.sendText("/resume");
-    await active.waitForText("Enter Resume", TIMEOUT);
+    await active.waitForText("enter resume", TIMEOUT);
     await active.sendLiteralText("Remember conversation B.");
     await active.waitForText("Sessions 1", TIMEOUT);
     await active.sendKeys("Enter");

--- a/tests/e2e/tui-slash-commands.test.ts
+++ b/tests/e2e/tui-slash-commands.test.ts
@@ -99,7 +99,7 @@ describe.skipIf(TMUX_SKIP)("tui: no-key slash commands", () => {
         expect(scrollback).toContain("Run /help for commands");
         expect(scrollback).not.toMatch(/No context to compact|Context:|Compacting/);
         await session.sendKeys("C-o");
-        const transcript = await session.waitForText("Full detail", 5_000);
+        const transcript = await session.waitForText("full detail", 5_000);
         expect(transcript).not.toMatch(/No context to compact|Context:|Compacting/);
         await session.sendKeys("C-o");
         await session.waitForComposer(5_000);
@@ -232,9 +232,9 @@ describe.skipIf(SKIP)("tui: slash commands", () => {
     async () => {
       session = await launchAndWait();
       await session.sendText("/settings");
-      const pane = await session.waitForText("←→ Change", 5_000);
+      const pane = await session.waitForText("←→ change", 5_000);
       expect(pane).toContain("Settings");
-      expect(pane).toContain("↑↓ Navigate");
+      expect(pane).toContain("↑↓ navigate");
       expect(pane).not.toContain("[All]");
     },
     TIMEOUT,

--- a/tests/e2e/tui-slash-extra.test.ts
+++ b/tests/e2e/tui-slash-extra.test.ts
@@ -415,9 +415,9 @@ describe.skipIf(SKIP)("tui: extra slash commands", () => {
       );
       expect(pane).toContain("[30 days]");
       expect(pane).not.toMatch(/^● Usage/m);
-      expect(pane).toContain("Tab Scope");
-      expect(pane).toContain("R Refresh");
-      expect(pane).toContain("Esc Close");
+      expect(pane).toContain("tab scope");
+      expect(pane).toContain("r refresh");
+      expect(pane).toContain("esc close");
       await session.sendKeys("Escape");
       await session.waitForComposer(5_000);
       await session.sendText("/usage");
@@ -560,15 +560,15 @@ describe.skipIf(!tmuxAvailable())("tui: MCP commands", () => {
         const menu = await session.waitForText("MCP 0", 5_000);
         expect(menu).toContain("[Servers]");
         expect(menu).toContain("No MCP servers configured.");
-        expect(menu).toContain("A Add");
-        expect(menu).toContain("C Help");
+        expect(menu).toContain("a add");
+        expect(menu).toContain("c help");
         expect(menu).not.toContain("MCP: no servers configured");
 
         await session.sendKeys("C");
         const info = await session.waitForText("~/.fx/mcp.json", 5_000);
         expect(info).toContain("<workspace>/.mcp.json");
-        expect(info).toContain("P Approve all");
-        expect(info).toContain("Z Reset");
+        expect(info).toContain("p approve all");
+        expect(info).toContain("z reset");
         await session.sendKeys("Escape");
         await session.waitForText("No MCP servers configured.", 5_000);
 
@@ -848,7 +848,7 @@ describe.skipIf(!tmuxAvailable())("tui: MCP commands", () => {
         await session.sendKeys("Enter");
         await session.sendKeys("D");
         const confirmation = await session.waitForText("Remove this profile MCP server?", 5_000);
-        expect(confirmation).toContain("Enter Confirm");
+        expect(confirmation).toContain("enter confirm");
         await session.sendKeys("Enter");
         const removed = await session.waitForText("MCP 0", 15_000);
         expect(removed).toContain("No MCP servers configured.");

--- a/tests/e2e/tui-slash-menu.test.ts
+++ b/tests/e2e/tui-slash-menu.test.ts
@@ -155,7 +155,7 @@ async function waitForSettingsMenu(session: TmuxSession): Promise<string[]> {
     latest = await session.capturePaneGrid();
     const pane = latest.join("\n");
     if (
-      pane.includes("←→ Change") &&
+      pane.includes("←→ change") &&
       (pane.includes("Settings") || pane.includes("Status line context"))
     ) return latest;
     await Bun.sleep(100);
@@ -212,8 +212,8 @@ async function waitForStatuslineMenu(
     const pane = latest.join("\n");
     if (
       pane.includes("Status line") &&
-      pane.includes("↑↓ Navigate") &&
-      pane.includes("←→ Change") &&
+      pane.includes("↑↓ navigate") &&
+      pane.includes("←→ change") &&
       (expectedSelection === undefined || pane.includes(expectedSelection))
     ) return latest;
     await Bun.sleep(100);
@@ -229,7 +229,7 @@ async function waitForUsageMenu(session: TmuxSession): Promise<string[]> {
     const pane = latest.join("\n");
     if (
       pane.includes("[30 days]") &&
-      pane.includes("Esc Close") &&
+      pane.includes("esc close") &&
       !pane.includes("Loading usage")
     ) return latest;
     await Bun.sleep(100);
@@ -247,7 +247,7 @@ async function waitForWorkspaceMenu(session: TmuxSession): Promise<string[]> {
       pane.includes("Workspace") &&
       pane.includes("Additional directories") &&
       pane.includes("Add directory…") &&
-      pane.includes("Enter Use")
+      pane.includes("enter use")
     ) return latest;
     await Bun.sleep(100);
   }
@@ -602,7 +602,7 @@ function composerRow(grid: string[]): number {
 function footerStatusRow(grid: string[]): number {
   return lastRowMatching(
     grid,
-    (line) => line.includes("gpt-5") || line.includes("↑↓ Navigate"),
+    (line) => line.includes("gpt-5") || line.includes("↑↓ navigate"),
   );
 }
 
@@ -751,7 +751,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       });
 
       await session.waitForText(
-        "Skills: 1 discovery issue; some skills may be missing (ctrl o to view)",
+        "Skills: 1 discovery issue; some skills may be missing (ctrl+o to view)",
         10_000,
       );
       await session.waitForComposer(10_000);
@@ -1252,7 +1252,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       expect(mcpRow!.indexOf("Extensions")).toBe(metadataColumn);
       expect(mcpRow!.indexOf("Extensions") + "Extensions".length).toBe(99);
       expect(modelRow).toContain("Model");
-      expect(scrolledGrid.join("\n")).toContain("↑↓ Navigate     Enter Use     Esc Close");
+      expect(scrolledGrid.join("\n")).toContain("↑↓ navigate     enter use     esc close");
       expect(session.isAlive()).toBe(true);
 
       await session.sendKeys("C-u");
@@ -1298,7 +1298,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
 
       await session.sendKeys("Escape");
       await session.waitForPane(
-        (pane) => hasEmptyComposer(pane) && !pane.includes("←→ Change"),
+        (pane) => hasEmptyComposer(pane) && !pane.includes("←→ change"),
         5_000,
       );
       await session.sendLiteralText("/m");
@@ -1451,12 +1451,12 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       await Bun.sleep(100);
       let pane = await session.capturePane();
       expect(composerContains(pane, "/hezzzzz")).toBe(true);
-      expect(pane).not.toContain("Enter Use");
+      expect(pane).not.toContain("enter use");
       expect(pane).not.toContain("no matching slash commands");
 
       for (let index = 0; index < 5; index++) await session.sendKeys("BSpace");
       await session.waitForPane(
-        (current) => composerContains(current, "/he") && current.includes("Enter Use"),
+        (current) => composerContains(current, "/he") && current.includes("enter use"),
         5_000,
       );
 
@@ -1470,7 +1470,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       await Bun.sleep(100);
       pane = await session.capturePane();
       expect(pane).not.toContain("no matching slash commands");
-      expect(pane).not.toContain("Enter Use");
+      expect(pane).not.toContain("enter use");
 
       await session.sendKeys("C-u");
       await session.sendLiteralText("/name");
@@ -1488,7 +1488,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       await session.sendKeys("Enter");
       pane = await session.waitForText("Commands", 5_000);
       expect(pane).toContain("/help");
-      expect(pane).toContain("Enter Open");
+      expect(pane).toContain("enter open");
 
       await session.sendKeys("Escape");
       await session.waitForPane(
@@ -1500,7 +1500,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
         (current) =>
           composerContains(current, "/resume") &&
           !current.includes("resume-helper") &&
-          !current.includes("Enter Use"),
+          !current.includes("enter use"),
         5_000,
       );
       expect(pane).not.toContain("no matching slash commands");
@@ -1532,12 +1532,12 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       await session.sendKeys("C-u");
       await session.pasteText("\n   ");
       await session.sendLiteralText("/resume-helper");
-      await session.waitForText("Enter Use", 5_000);
+      await session.waitForText("enter use", 5_000);
       await session.sendKeys("Enter");
       pane = await session.waitForPane(
         (current) =>
           current.includes("resume-helper") &&
-          !current.includes("Enter Use") &&
+          !current.includes("enter use") &&
           !current.includes("fx needs access to Vercel AI Gateway"),
         5_000,
       );
@@ -1584,9 +1584,9 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       expect(pane).toContain("/help");
       expect(pane).not.toContain("● /help");
       expect(pane).toContain("show available slash commands");
-      expect(pane).toContain("↑↓ Navigate");
-      expect(pane).toContain("Tab Category");
-      expect(pane).toContain("Enter Open");
+      expect(pane).toContain("↑↓ navigate");
+      expect(pane).toContain("tab category");
+      expect(pane).toContain("enter open");
 
       await session.sendKeys("Tab");
       grid = await waitForHelpMenu(session, 5);
@@ -1638,7 +1638,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       await session.waitForText("No commands found.", 5_000);
       await session.sendKeys("Escape");
       await session.waitForPane(
-        (current) => hasEmptyComposer(current) && current.includes("𝒇x") && !current.includes("Enter Open"),
+        (current) => hasEmptyComposer(current) && current.includes("𝒇x") && !current.includes("enter open"),
         5_000,
       );
 
@@ -1687,10 +1687,10 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       expect(pane).toContain("Settings");
       expect(pane).toContain("Interface");
       expect(pane).toContain("[All]");
-      expect(pane).toContain("↑↓ Navigate");
-      expect(pane).toContain("Tab Category");
-      expect(pane).toContain("←→ Change");
-      expect(pane).toContain("Esc Close");
+      expect(pane).toContain("↑↓ navigate");
+      expect(pane).toContain("tab category");
+      expect(pane).toContain("←→ change");
+      expect(pane).toContain("esc close");
       expect(pane).not.toContain("Enter Change");
 
       expect(pane).not.toContain("Input appearance");
@@ -1712,7 +1712,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
           hasEmptyComposer(current) &&
           current.includes("𝒇x") &&
           current.includes("workspace-statusline-visible") &&
-          !current.includes("←→ Change"),
+          !current.includes("←→ change"),
         5_000,
       );
       expect(capturePaneHistory(session, -1000)).not.toContain("● Settings:");
@@ -1765,7 +1765,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       expect(pane).toContain("Status line context");
       await session.sendKeys("Escape");
       await session.waitForPane(
-        (current) => hasEmptyComposer(current) && !current.includes("←→ Change"),
+        (current) => hasEmptyComposer(current) && !current.includes("←→ change"),
         5_000,
       );
 
@@ -1815,8 +1815,8 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       expect(pane).toContain("off  on");
       expect(pane).not.toContain("❯");
       expect(pane).not.toContain("Choose what appears");
-      expect(pane).toContain("↑↓ Navigate");
-      expect(pane).toContain("←→ Change");
+      expect(pane).toContain("↑↓ navigate");
+      expect(pane).toContain("←→ change");
 
       await session.sendKeys("Right");
       grid = await waitForStatuslineMenu(session, "off  on");
@@ -1844,7 +1844,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
           hasEmptyComposer(current) &&
           current.includes("𝒇x") &&
           current.includes("compact-statusline-workspace") &&
-          !current.includes("←→ Change"),
+          !current.includes("←→ change"),
         5_000,
       );
       expect(session.isAlive()).toBe(true);
@@ -2058,7 +2058,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       await session.waitForComposer(10_000);
       await session.sendText("/usage");
       await session.waitForText(
-        "Usage unavailable · press R to retry",
+        "Usage unavailable · press r to retry",
         TIMEOUT,
       );
 
@@ -2136,17 +2136,17 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       await session.waitForComposer(10_000);
       await session.sendText("/usage");
       let pane = await session.waitForText(
-        "Usage unavailable · press R to retry",
+        "Usage unavailable · press r to retry",
         TIMEOUT,
       );
       expect(pane).toContain("[30 days]");
 
       await session.sendKeys("Left");
       pane = await session.waitForText("[7 days]", TIMEOUT);
-      expect(pane).toContain("Usage unavailable · press R to retry");
+      expect(pane).toContain("Usage unavailable · press r to retry");
       await session.sendKeys("Left");
       pane = await session.waitForText("[24 hours]", TIMEOUT);
-      expect(pane).toContain("Usage unavailable · press R to retry");
+      expect(pane).toContain("Usage unavailable · press r to retry");
       await session.sendKeys("Left");
       pane = await session.waitForText("[Session]", TIMEOUT);
       expect(pane).toMatch(/0 tokens/);
@@ -2370,7 +2370,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       await session.waitForPane(
         (current) =>
           composerContains(current, "/workspace add") &&
-          !current.includes("Enter Use"),
+          !current.includes("enter use"),
         5_000,
       );
 
@@ -2382,7 +2382,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       pane = await session.waitForPane(
         (current) =>
           composerContains(current, `/workspace remove ${sharedRoot}`) &&
-          !current.includes("Enter Use"),
+          !current.includes("enter use"),
         5_000,
       );
       expect(composerContains(pane, `/workspace remove ${sharedRoot}`)).toBe(true);
@@ -2442,8 +2442,8 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       expect(pane).toContain("fx · Global");
       expect(pane).toContain("workspace-menu");
       expect(pane).toContain("fx · Workspace");
-      expect(pane).toContain("↑↓ Navigate");
-      expect(pane).toContain("Enter Use");
+      expect(pane).toContain("↑↓ navigate");
+      expect(pane).toContain("enter use");
 
       const deep_history = capturePaneHistory(session, -1000);
       const tail_history = capturePaneHistory(session, -80);
@@ -2466,7 +2466,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
         (current) =>
           hasEmptyComposer(current) &&
           current.includes("𝒇x") &&
-          !current.includes("↑↓ Navigate"),
+          !current.includes("↑↓ navigate"),
         5_000,
       );
 
@@ -2484,7 +2484,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
         (current) =>
           composerContains(current, "$work") &&
           current.includes("𝒇x") &&
-          !current.includes("↑↓ Navigate"),
+          !current.includes("↑↓ navigate"),
         5_000,
       );
       expect(alternateCount("\x1b[?1049h")).toBe(entersBeforeDollar);
@@ -2537,7 +2537,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
           composerContains(current, "explain $manzzzzzz") &&
           !current.includes("Skills ") &&
           !current.includes("No skills found.") &&
-          !current.includes("Enter Use"),
+          !current.includes("enter use"),
         5_000,
       );
 
@@ -2639,7 +2639,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       grid = await session.capturePaneGrid();
       expect(composerContains(grid.join("\n"), "workspace-menu")).toBe(true);
       expect(grid.join("\n")).toContain("𝒇x");
-      expect(grid.join("\n")).not.toContain("↑↓ Navigate");
+      expect(grid.join("\n")).not.toContain("↑↓ navigate");
       expect(capturePaneHistory(session, -1000)).not.toContain("Unknown command");
       expect(session.isAlive()).toBe(true);
 
@@ -2657,7 +2657,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       expect(codexPane).toContain("Codex · Global");
 
       await session.sendKeys("C-[");
-      await session.waitForPane((current) => !current.includes("↑↓ Navigate"), 5_000);
+      await session.waitForPane((current) => !current.includes("↑↓ navigate"), 5_000);
       expect(alternateCount("\x1b[?1049h")).toBe(entersBeforeSkills);
       expect(alternateCount("\x1b[?1049l")).toBe(leavesBeforeSkills);
 
@@ -2668,7 +2668,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       expect(alternateCount("\x1b[?1049l")).toBe(leavesBeforeSkills);
       await session.sendKeys("Escape");
       await session.waitForPane(
-        (current) => hasEmptyComposer(current) && !current.includes("Enter Open"),
+        (current) => hasEmptyComposer(current) && !current.includes("enter open"),
         5_000,
       );
 
@@ -2679,7 +2679,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       expect(alternateCount("\x1b[?1049l")).toBe(leavesBeforeSkills);
       await session.sendKeys("Escape");
       await session.waitForPane(
-        (current) => hasEmptyComposer(current) && !current.includes("←→ Change"),
+        (current) => hasEmptyComposer(current) && !current.includes("←→ change"),
         5_000,
       );
 
@@ -2691,7 +2691,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       expect(alternateCount("\x1b[?1049l")).toBe(leavesBeforeSkills);
       await session.sendKeys("Escape");
       await session.waitForPane(
-        (current) => hasEmptyComposer(current) && !current.includes("Enter Resume"),
+        (current) => hasEmptyComposer(current) && !current.includes("enter resume"),
         5_000,
       );
 
@@ -2765,7 +2765,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       expect(capturePaneHistory(session, -1000)).not.toContain("Unknown command");
 
       await session.sendKeys("C-[");
-      await session.waitForPane((current) => !current.includes("↑↓ Navigate"), 5_000);
+      await session.waitForPane((current) => !current.includes("↑↓ navigate"), 5_000);
       await session.sendKeys("C-u");
       await session.sendText("/quit");
       expect(await session.waitForSessionEnd(TIMEOUT)).toBe(true);
@@ -2848,7 +2848,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       expect(await session.captureFullScrollback()).not.toContain(`● Model: ${currentModel}`);
       await session.sendKeys("Escape");
       await session.waitForPane(
-        (current) => hasEmptyComposer(current) && !current.includes("Tab Provider"),
+        (current) => hasEmptyComposer(current) && !current.includes("tab provider"),
         5_000,
       );
 
@@ -2858,7 +2858,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
         (current) =>
           composerContains(current, "/model") &&
           current.includes(currentModel) &&
-          !current.includes("Tab Provider"),
+          !current.includes("tab provider"),
         5_000,
       );
       expect(stagedPane).not.toContain("Models 4");
@@ -2902,8 +2902,8 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       expect(pane).not.toContain("Authenticated model catalog loaded.");
       expect(pane).not.toContain("Current");
       expect(pane).not.toContain("Reasoning");
-      expect(pane).toContain("↑↓ Navigate");
-      expect(pane).toContain("Tab Provider");
+      expect(pane).toContain("↑↓ navigate");
+      expect(pane).toContain("tab provider");
 
       await session.sendKeys("Tab");
       grid = await waitForModelsMenu(session, 1);
@@ -2924,7 +2924,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
 
       await session.sendKeys("C-[");
       await session.waitForPane(
-        (current) => hasEmptyComposer(current) && current.includes("𝒇x") && !current.includes("Tab Provider"),
+        (current) => hasEmptyComposer(current) && current.includes("𝒇x") && !current.includes("tab provider"),
         5_000,
       );
 
@@ -3193,11 +3193,11 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       await session.sendKeys("C-x");
 
       const grid = await waitForSkillsMenu(session, 4);
-      expect(grid.join("\n")).toContain("↑↓ Navigate");
+      expect(grid.join("\n")).toContain("↑↓ navigate");
       expect(session.isAlive()).toBe(true);
 
       await session.sendKeys("C-[");
-      await session.waitForPane((current) => !current.includes("↑↓ Navigate"), 5_000);
+      await session.waitForPane((current) => !current.includes("↑↓ navigate"), 5_000);
       await session.sendText("/skills");
       await waitForSkillsMenu(session, 4);
       await session.sendHexBytes(["1b", "18"]);
@@ -3240,7 +3240,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
 
       await session.sendKeys("C-[");
       await session.waitForPane(
-        (pane) => pane.includes("Generating") && !pane.includes("↑↓ Navigate"),
+        (pane) => pane.includes("Generating") && !pane.includes("↑↓ navigate"),
         5_000,
       );
       expect(stream.cancelled).toBe(false);
@@ -3285,14 +3285,14 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       await waitForHeldSkillStream(stream);
       await session.waitForText("Generating", 10_000);
       await session.sendLiteralText("/he");
-      await session.waitForText("Esc Close", 10_000);
+      await session.waitForText("esc close", 10_000);
 
       await session.sendKeys("Escape");
       await session.waitForPane(
         (pane) =>
           pane.includes("Generating") &&
           pane.includes("/he") &&
-          !pane.includes("Esc Close"),
+          !pane.includes("esc close"),
         5_000,
       );
       expect(stream.cancelled).toBe(false);
@@ -3352,7 +3352,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
 
       releaseApproval();
       await session.waitForText("catalog-approval.txt", 10_000);
-      expect(await session.capturePane()).not.toContain("↑↓ Navigate");
+      expect(await session.capturePane()).not.toContain("↑↓ navigate");
 
       await session.sendKeys("3");
       let grid = await waitForSkillsMenu(session, 4);
@@ -3556,7 +3556,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       });
 
       const diagnosticSummary =
-        "Skills: 1 discovery issue; some skills may be missing (ctrl o to view)";
+        "Skills: 1 discovery issue; some skills may be missing (ctrl+o to view)";
       await session.waitForText(diagnosticSummary, 10_000);
       await session.waitForComposer(10_000);
       expect(await session.captureFullScrollback()).not.toContain(

--- a/tests/e2e/tui-startup.test.ts
+++ b/tests/e2e/tui-startup.test.ts
@@ -42,8 +42,8 @@ describe.skipIf(SKIP)("tui: startup and exit", () => {
       await session.sendText("/help");
       const pane = await session.waitForText("Commands 35", 5_000);
       expect(pane).toContain("[All]");
-      expect(pane).toContain("Tab Category");
-      expect(pane).toContain("Enter Open");
+      expect(pane).toContain("tab category");
+      expect(pane).toContain("enter open");
       expect(pane).toContain("Run /help for commands");
     },
     TIMEOUT,
@@ -437,7 +437,7 @@ describe.skipIf(SKIP_TMUX)("tui: credential onboarding", () => {
       const initial = await session.waitForText("Welcome to fx", TIMEOUT);
       expect(initial).toContain("Sign in with Vercel");
       expect(initial).toContain("Add an API key");
-      expect(initial).toContain("Esc to set up later");
+      expect(initial).toContain("esc to set up later");
       expect(initial).not.toContain("Change team");
       expect(initial).not.toContain("Switch credential");
       expect(initial).not.toContain("Skip for now");

--- a/tests/e2e/yolo-permission-mode.test.ts
+++ b/tests/e2e/yolo-permission-mode.test.ts
@@ -326,11 +326,11 @@ describe.skipIf(!tmuxAvailable())("yolo interactive mode", () => {
       expect(warningPane).toContain("full access ·");
 
       await session.sendText("/settings");
-      const settingsPane = await session.waitForText("←→ Change", TIMEOUT);
+      const settingsPane = await session.waitForText("←→ change", TIMEOUT);
       expect(settingsPane).toContain("Permission mode");
       expect(settingsPane).not.toContain("Command sandbox");
       await Bun.sleep(4_300);
-      expect(await session.capturePane()).toContain("←→ Change");
+      expect(await session.capturePane()).toContain("←→ change");
 
       await session.sendKeys("Escape");
       const resumedWarning = await session.waitForText(WARNING, TIMEOUT);


### PR DESCRIPTION
## Summary

- Show all keyboard hint rows in lowercase (ctrl+o close, enter confirm, esc cancel, tab category) across menus, approval prompts, question prompts, and the full-transcript footer.
- Write the full-transcript shortcut as ctrl+o in fold notices and startup summaries, matching the existing ctrl+c and ctrl+g style.
- Lowercase key names in auth, resume, file-picker, and MCP trust prompts, such as press enter to retry and [esc] dismiss remaining prompts.