### PR TITLE
Replay structured tool calls in ACP session history

### DIFF
--- a/src/acp/prompt.zig
+++ b/src/acp/prompt.zig
@@ -1922,21 +1922,7 @@ fn recordToolCallRejected(
 }
 
 fn toolUpdateContentText(result: ToolExecutionResult) []const u8 {
-    if (!text_utils.isModelSafeText(result.model_output)) {
-        debug_trace.logf(
-            "acp",
-            "tool update omitted binary or non-utf8 output bytes={d}",
-            .{result.model_output.len},
-        );
-        return "binary or non-utf8 tool output omitted";
-    }
-    if (result.status == .failure and
-        (tool_result_errors.isToolPermissionDeniedOutput(result.model_output) or
-            tool_result_errors.isToolReviewHeldOutput(result.model_output)))
-    {
-        return result.model_output;
-    }
-    return text_utils.utf8PrefixByBytes(result.model_output, 200);
+    return tool_call_presentation.toolUpdateContentText(result.status == .failure, result.model_output);
 }
 
 fn propagateHistoryTurn(raw_ctx: *anyopaque, turn: HistoryTurn) !void {

--- a/src/acp/prompt.zig
+++ b/src/acp/prompt.zig
@@ -57,6 +57,7 @@ const tool_specs = @import("../core/tooling/tool_specs.zig");
 const tool_set_contract = @import("../core/tooling/tool_set.zig");
 const tool_mcp_runtime = @import("../core/tooling/tool_mcp_runtime.zig");
 const tool_presentation = @import("../core/tooling/tool_presentation.zig");
+const tool_call_presentation = @import("tool_call_presentation.zig");
 const tool_result_errors = @import("../core/tooling/tool_result_errors.zig");
 const tool_runtime = @import("../core/tooling/tool_runtime.zig");
 const command_output_content = @import("../core/tooling/command_output_content.zig");
@@ -428,9 +429,7 @@ const AcpContext = struct {
 };
 
 fn activeToolSet(state: *const server.ServerState) tool_set_contract.ToolSet {
-    if (state.host_tools.tools.len > 0) return state.host_tools.toolSet();
-    if (comptime host_target.is_wasm) return tool_set_contract.empty;
-    return if (state.cfg.allow_native_tools) builtin_tools.advertisement_set else tool_set_contract.empty;
+    return tool_call_presentation.activeToolSet(state);
 }
 
 fn hostToolProvider(state: *server.ServerState) ?tool_dispatch.HostToolProvider {
@@ -2679,26 +2678,11 @@ fn activeMcp(ctx: *AcpContext) ?*mcp_runtime.McpRuntime {
     return session.mcp;
 }
 
-pub fn mapToolKind(tool_name: []const u8) acp_types.ToolCallKind {
-    if (tool_presentation.isProviderSearchAlias(tool_name)) return .search;
-    if (std.mem.eql(u8, tool_name, "glob_files")) return .read;
-    if (std.mem.eql(u8, tool_name, "grep_files")) return .search;
-    if (std.mem.eql(u8, tool_name, "read_file")) return .read;
-    if (std.mem.eql(u8, tool_name, "web_fetch")) return .fetch;
-    if (std.mem.eql(u8, tool_name, "web_search")) return .search;
-    if (std.mem.eql(u8, tool_name, "write_file")) return .edit;
-    if (std.mem.eql(u8, tool_name, "edit_file")) return .edit;
-    if (std.mem.eql(u8, tool_name, "shell")) return .execute;
-    if (std.mem.eql(u8, tool_name, "terminal")) return .execute;
-    if (std.mem.eql(u8, tool_name, "run_command")) return .execute;
-    if (std.mem.eql(u8, tool_name, "skill")) return .other;
-    if (std.mem.eql(u8, tool_name, "install_skill")) return .other;
-    return .other;
-}
+pub const mapToolKind = tool_call_presentation.mapToolKind;
 
-fn acpToolName(tool_name: []const u8) []const u8 {
-    return if (tool_presentation.isProviderSearchAlias(tool_name)) "web_search" else tool_name;
-}
+const acpToolName = tool_call_presentation.acpToolName;
+
+const describeToolTitle = tool_call_presentation.describeToolTitle;
 
 fn providerTerminalStatus(outcome: types.ToolOutcomeKind) ?acp_types.ToolCallStatus {
     return switch (outcome) {
@@ -2706,22 +2690,6 @@ fn providerTerminalStatus(outcome: types.ToolOutcomeKind) ?acp_types.ToolCallSta
         .denied, .cancelled, .failed => .failed,
         .deferred => null,
     };
-}
-
-fn describeToolTitle(registry: tool_dispatch.Registry, arena: Allocator, call: ToolCall) ![]const u8 {
-    if (registry.lookup(call.name) != null) {
-        if (try tool_presentation.formatSubagentPlainAction(arena, call, .identity)) |title| return title;
-    }
-    if (tool_presentation.isProviderSearchAlias(call.name)) {
-        return tool_presentation.formatPlainAction(arena, .{
-            .tool_registry = registry,
-            .call = call,
-        });
-    }
-    if (tool_dispatch.toolCallPresentation(arena, registry, call)) |presentation| {
-        return std.fmt.allocPrint(arena, "{s}", .{presentation.action_label});
-    }
-    return std.fmt.allocPrint(arena, "{s}", .{call.name});
 }
 
 test "ACP subagent titles and terminal descriptions share request projection" {

--- a/src/acp/sessions.zig
+++ b/src/acp/sessions.zig
@@ -12,6 +12,9 @@ const session_store = @import("../core/session/session_store.zig");
 const legacy_background_migration = @import("../core/session/legacy_background_migration.zig");
 const js_host_session_store = @import("../core/session/js_host_session_store.zig");
 const session_runtime = @import("../core/session/session.zig");
+const agent_execution_memory = @import("../core/agent/execution_memory.zig");
+const tool_dispatch = @import("../core/tooling/tool_dispatch.zig");
+const tool_call_presentation = @import("tool_call_presentation.zig");
 const mcp_runtime = @import("../core/mcp/mcp_runtime.zig");
 const mcp_contract = @import("../core/mcp/mcp_contract.zig");
 const project_config = @import("../core/mcp/project_config.zig");
@@ -1291,9 +1294,144 @@ fn sendExecutionHistory(
     session_id: []const u8,
     execution: types.ExecutionMemory,
 ) !void {
-    const text = try session_runtime.formatExecutionReplayContext(alloc, execution) orelse return;
-    defer alloc.free(text);
-    try sendAgentHistoryChunk(state, alloc, session_id, text);
+    if (execution.isEmpty()) return;
+    var arena_state = std.heap.ArenaAllocator.init(alloc);
+    defer arena_state.deinit();
+    const frames = try planExecutionReplay(
+        arena_state.allocator(),
+        tool_call_presentation.activeToolRegistry(state),
+        execution,
+    );
+    for (frames) |frame| {
+        switch (frame) {
+            .assistant_text => |text| try sendAgentHistoryChunk(state, alloc, session_id, text),
+            .tool_call => |call| try sendHistoryToolCall(state, alloc, session_id, call),
+        }
+    }
+}
+
+const ReplayToolCall = struct {
+    id: []const u8,
+    name: []const u8,
+    title: []const u8,
+    kind: acp_types.ToolCallKind,
+    status: acp_types.ToolCallStatus,
+    raw_input: ?std.json.Value,
+    content_text: ?[]const u8,
+};
+
+const ReplayFrame = union(enum) {
+    assistant_text: []const u8,
+    tool_call: ReplayToolCall,
+};
+
+fn replayStatus(result: ?types.PersistedToolResult) acp_types.ToolCallStatus {
+    const r = result orelse return .pending;
+    return switch (r.status) {
+        .success => .completed,
+        .failure => .failed,
+    };
+}
+
+fn findToolResultIndex(results: []const types.PersistedToolResult, call_id: []const u8) ?usize {
+    for (results, 0..) |result, i| {
+        if (std.mem.eql(u8, result.tool_call_id, call_id)) return i;
+    }
+    return null;
+}
+
+fn planToolCallFrame(
+    arena: Allocator,
+    registry: tool_dispatch.Registry,
+    call: types.ToolCall,
+    result: ?types.PersistedToolResult,
+) !ReplayToolCall {
+    const name = tool_call_presentation.acpToolName(call.name);
+    const title = tool_call_presentation.describeToolTitle(registry, arena, call) catch "Tool call";
+    const masked_arguments = try agent_execution_memory.redactToolArgumentsJson(arena, call.name, call.arguments_json);
+    // Parsed with the arena and returned in the frame; no deinit, the caller's
+    // arena frees it in bulk.
+    const parsed: ?std.json.Parsed(std.json.Value) = std.json.parseFromSlice(
+        std.json.Value,
+        arena,
+        masked_arguments,
+        .{},
+    ) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => null,
+    };
+    return .{
+        .id = call.id,
+        .name = name,
+        .title = title,
+        .kind = tool_call_presentation.mapToolKind(name),
+        .status = replayStatus(result),
+        .raw_input = if (parsed) |p| p.value else null,
+        .content_text = if (result) |r| if (r.output.len > 0) r.output else null else null,
+    };
+}
+
+/// Maps a persisted execution memory onto the same session/update frame
+/// sequence the live prompt path emits: interleaved assistant text plus one
+/// tool_call announcement (and final tool_call_update) per tool call.
+/// The returned frames borrow from `execution` and `arena`; the caller owns
+/// the slice and must free it with the arena.
+fn planExecutionReplay(
+    arena: Allocator,
+    registry: tool_dispatch.Registry,
+    execution: types.ExecutionMemory,
+) ![]ReplayFrame {
+    var frames: std.ArrayList(ReplayFrame) = .empty;
+    for (execution.tool_steps) |step| {
+        if (step.assistant) |assistant| {
+            if (assistant.len > 0) try frames.append(arena, .{ .assistant_text = assistant });
+        }
+        const matched = try arena.alloc(bool, step.tool_results.len);
+        @memset(matched, false);
+        for (step.tool_calls) |call| {
+            const result: ?types.PersistedToolResult = if (findToolResultIndex(step.tool_results, call.id)) |i| blk: {
+                matched[i] = true;
+                break :blk step.tool_results[i];
+            } else null;
+            try frames.append(arena, .{ .tool_call = try planToolCallFrame(arena, registry, call, result) });
+        }
+        // Results without a surviving call record (e.g. trimmed history) still
+        // replay as completed frames so the transcript stays faithful.
+        for (step.tool_results, 0..) |result, i| {
+            if (matched[i]) continue;
+            const call: types.ToolCall = .{
+                .id = result.tool_call_id,
+                .name = result.tool_name,
+                .arguments_json = "{}",
+            };
+            try frames.append(arena, .{ .tool_call = try planToolCallFrame(arena, registry, call, result) });
+        }
+    }
+    return frames.toOwnedSlice(arena);
+}
+
+fn sendHistoryToolCall(
+    state: *server.ServerState,
+    alloc: Allocator,
+    session_id: []const u8,
+    call: ReplayToolCall,
+) !void {
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    defer out.deinit();
+    try out.writer.writeAll("{\"sessionId\":");
+    try writeJsonStr(session_id, &out.writer);
+    try out.writer.writeAll(",\"update\":");
+    try acp_types.writeToolCall(&out.writer, call.id, call.name, call.title, call.kind, .pending, call.raw_input);
+    try out.writer.writeAll("}");
+    try state.writer.writeNotification(alloc, "session/update", out.writer.buffered());
+    if (call.status == .pending) return;
+    out.clearRetainingCapacity();
+    try out.writer.writeAll("{\"sessionId\":");
+    try writeJsonStr(session_id, &out.writer);
+    try out.writer.writeAll(",\"update\":");
+    try acp_types.writeToolCallUpdate(&out.writer, call.id, call.status, call.content_text);
+    try out.writer.writeAll("}");
+    try state.writer.writeNotification(alloc, "session/update", out.writer.buffered());
 }
 
 fn sendAgentHistoryChunk(state: *server.ServerState, alloc: Allocator, session_id: []const u8, text: []const u8) !void {
@@ -1650,6 +1788,199 @@ test "ACP interrupted history replay hides model-only abort context" {
     try std.testing.expect(std.mem.find(u8, captured, "cancelled") != null);
     try std.testing.expect(std.mem.find(u8, captured, "Interrupted by user after completing") == null);
     try std.testing.expect(std.mem.find(u8, captured, "<turn_aborted>") == null);
+}
+
+fn readCaptured(capture_file: *std.Io.File, alloc: Allocator) ![]u8 {
+    try capture_file.sync(io_mod.getIo());
+    return io_mod.readFileToEnd(alloc, capture_file, 1024 * 1024);
+}
+
+test "ACP history replay emits structured tool call frames" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var arena_state = std.heap.ArenaAllocator.init(alloc);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const workspace = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(workspace);
+    var capture = try tmp.dir.createFile(io_mod.getIo(), "history.jsonl", .{ .read = true });
+    defer capture.close(io_mod.getIo());
+    var state = try initAcpSessionTestState(arena, workspace, capture);
+    defer state.deinit();
+
+    var calls = [_]types.ToolCall{
+        .{ .id = "call_read_1", .name = "read_file", .arguments_json = "{\"path\":\"README.md\"}" },
+        .{ .id = "call_write_1", .name = "write_file", .arguments_json = "{\"path\":\"out.txt\",\"content\":\"done\"}" },
+    };
+    var results = [_]types.PersistedToolResult{
+        .{
+            .tool_call_id = @constCast("call_read_1"),
+            .tool_name = @constCast("read_file"),
+            .status = .success,
+            .output = @constCast("<content>readme text</content>"),
+            .output_bytes = 27,
+            .stored_output_bytes = 27,
+        },
+        .{
+            .tool_call_id = @constCast("call_write_1"),
+            .tool_name = @constCast("write_file"),
+            .status = .failure,
+            .output = @constCast("permission denied"),
+            .output_bytes = 17,
+            .stored_output_bytes = 17,
+        },
+    };
+    var steps = [_]types.ToolExecutionStep{.{
+        .assistant = @constCast("Let me inspect those files."),
+        .tool_calls = calls[0..],
+        .tool_results = results[0..],
+    }};
+    try sendHistoryTurnAsUpdates(&state, arena, "session-1", .{ .assistant = .{
+        .user = .{ .text = @constCast("read and write") },
+        .assistant = @constCast("All done."),
+        .execution = .{ .tool_steps = steps[0..] },
+    } });
+
+    const captured = try readCaptured(&capture, alloc);
+    defer alloc.free(captured);
+
+    try std.testing.expect(std.mem.find(u8, captured, "Previous tool execution") == null);
+    try std.testing.expect(std.mem.find(u8, captured, "Let me inspect those files.") != null);
+    try std.testing.expect(std.mem.find(u8, captured, "All done.") != null);
+
+    const announce_read = std.mem.find(u8, captured, "\"sessionUpdate\":\"tool_call\",\"toolCallId\":\"call_read_1\"").?;
+    const announce_write = std.mem.find(u8, captured, "\"sessionUpdate\":\"tool_call\",\"toolCallId\":\"call_write_1\"").?;
+    const finish_read = std.mem.find(u8, captured, "\"sessionUpdate\":\"tool_call_update\",\"toolCallId\":\"call_read_1\"").?;
+    const finish_write = std.mem.find(u8, captured, "\"sessionUpdate\":\"tool_call_update\",\"toolCallId\":\"call_write_1\"").?;
+    try std.testing.expect(announce_read < finish_read);
+    try std.testing.expect(announce_write < finish_write);
+    try std.testing.expect(announce_read < announce_write);
+
+    try std.testing.expect(std.mem.find(u8, captured, "\"name\":\"read_file\"") != null);
+    try std.testing.expect(std.mem.find(u8, captured, "\"kind\":\"read\"") != null);
+    try std.testing.expect(std.mem.find(u8, captured, "\"rawInput\":{\"path\":\"README.md\"}") != null);
+    try std.testing.expect(std.mem.find(u8, captured, "\"status\":\"completed\"") != null);
+    try std.testing.expect(std.mem.find(u8, captured, "\"status\":\"failed\"") != null);
+    try std.testing.expect(std.mem.find(u8, captured, "readme text") != null);
+    try std.testing.expect(std.mem.find(u8, captured, "permission denied") != null);
+}
+
+test "ACP history replay leaves resultless tool calls pending" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var arena_state = std.heap.ArenaAllocator.init(alloc);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const workspace = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(workspace);
+    var capture = try tmp.dir.createFile(io_mod.getIo(), "history.jsonl", .{ .read = true });
+    defer capture.close(io_mod.getIo());
+    var state = try initAcpSessionTestState(arena, workspace, capture);
+    defer state.deinit();
+
+    var calls = [_]types.ToolCall{
+        .{ .id = "call_orphan", .name = "read_file", .arguments_json = "{\"path\":\"a.txt\"}" },
+    };
+    var steps = [_]types.ToolExecutionStep{.{ .tool_calls = calls[0..] }};
+    try sendHistoryTurnAsUpdates(&state, arena, "session-1", .{ .interrupted = .{
+        .user = .{ .text = @constCast("inspect") },
+        .execution = .{ .tool_steps = steps[0..] },
+    } });
+
+    const captured = try readCaptured(&capture, alloc);
+    defer alloc.free(captured);
+    try std.testing.expect(std.mem.find(u8, captured, "\"sessionUpdate\":\"tool_call\",\"toolCallId\":\"call_orphan\"") != null);
+    try std.testing.expect(std.mem.find(u8, captured, "\"sessionUpdate\":\"tool_call_update\"") == null);
+    try std.testing.expect(std.mem.find(u8, captured, "Previous tool execution") == null);
+}
+
+test "ACP history replay redacts sensitive tool arguments" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var arena_state = std.heap.ArenaAllocator.init(alloc);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const workspace = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(workspace);
+    var capture = try tmp.dir.createFile(io_mod.getIo(), "history.jsonl", .{ .read = true });
+    defer capture.close(io_mod.getIo());
+    var state = try initAcpSessionTestState(arena, workspace, capture);
+    defer state.deinit();
+
+    var calls = [_]types.ToolCall{
+        .{ .id = "call_secret", .name = "run_command", .arguments_json = "{\"command\":\"echo ok\",\"api_key\":\"sk-live-secret\"}" },
+    };
+    var results = [_]types.PersistedToolResult{.{
+        .tool_call_id = @constCast("call_secret"),
+        .tool_name = @constCast("run_command"),
+        .status = .success,
+        .output = @constCast("ok"),
+        .output_bytes = 2,
+        .stored_output_bytes = 2,
+    }};
+    var steps = [_]types.ToolExecutionStep{.{ .tool_calls = calls[0..], .tool_results = results[0..] }};
+    try sendHistoryTurnAsUpdates(&state, arena, "session-1", .{ .assistant = .{
+        .user = .{ .text = @constCast("run it") },
+        .assistant = @constCast("done"),
+        .execution = .{ .tool_steps = steps[0..] },
+    } });
+
+    const captured = try readCaptured(&capture, alloc);
+    defer alloc.free(captured);
+    try std.testing.expect(std.mem.find(u8, captured, "sk-live-secret") == null);
+    try std.testing.expect(std.mem.find(u8, captured, "[REDACTED]") != null);
+}
+
+test "execution replay plan interleaves assistant text and orphan results" {
+    const alloc = std.testing.allocator;
+    var arena_state = std.heap.ArenaAllocator.init(alloc);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    var calls = [_]types.ToolCall{
+        .{ .id = "call_a", .name = "read_file", .arguments_json = "{\"path\":\"a.txt\"}" },
+    };
+    var results = [_]types.PersistedToolResult{
+        .{
+            .tool_call_id = @constCast("call_a"),
+            .tool_name = @constCast("read_file"),
+            .status = .success,
+            .output = @constCast("alpha"),
+            .output_bytes = 5,
+            .stored_output_bytes = 5,
+        },
+        .{
+            .tool_call_id = @constCast("call_orphaned"),
+            .tool_name = @constCast("write_file"),
+            .status = .failure,
+            .output = @constCast("denied"),
+            .output_bytes = 6,
+            .stored_output_bytes = 6,
+        },
+    };
+    var steps = [_]types.ToolExecutionStep{.{
+        .assistant = @constCast("working"),
+        .tool_calls = calls[0..],
+        .tool_results = results[0..],
+    }};
+
+    const frames = try planExecutionReplay(
+        arena,
+        @import("../builtins/tools.zig").registry,
+        .{ .tool_steps = steps[0..] },
+    );
+    try std.testing.expectEqual(@as(usize, 3), frames.len);
+    try std.testing.expectEqualStrings("working", frames[0].assistant_text);
+    try std.testing.expectEqualStrings("call_a", frames[1].tool_call.id);
+    try std.testing.expectEqual(acp_types.ToolCallStatus.completed, frames[1].tool_call.status);
+    try std.testing.expectEqual(acp_types.ToolCallKind.read, frames[1].tool_call.kind);
+    try std.testing.expectEqualStrings("alpha", frames[1].tool_call.content_text.?);
+    try std.testing.expectEqualStrings("call_orphaned", frames[2].tool_call.id);
+    try std.testing.expectEqual(acp_types.ToolCallStatus.failed, frames[2].tool_call.status);
+    try std.testing.expect(frames[2].tool_call.raw_input != null);
 }
 
 test "ACP load maps one-off child denial to invalid params" {

--- a/src/acp/sessions.zig
+++ b/src/acp/sessions.zig
@@ -1367,7 +1367,10 @@ fn planToolCallFrame(
         .kind = tool_call_presentation.mapToolKind(name),
         .status = replayStatus(result),
         .raw_input = if (parsed) |p| p.value else null,
-        .content_text = if (result) |r| if (r.output.len > 0) r.output else null else null,
+        .content_text = if (result) |r| if (r.output.len > 0)
+            tool_call_presentation.toolUpdateContentText(r.status == .failure, r.output)
+        else
+            null else null,
     };
 }
 

--- a/src/acp/tool_call_presentation.zig
+++ b/src/acp/tool_call_presentation.zig
@@ -3,7 +3,10 @@ const acp_types = @import("types.zig");
 const server = @import("server.zig");
 const tool_dispatch = @import("../core/tooling/tool_dispatch.zig");
 const tool_presentation = @import("../core/tooling/tool_presentation.zig");
+const tool_result_errors = @import("../core/tooling/tool_result_errors.zig");
 const tool_set_contract = @import("../core/tooling/tool_set.zig");
+const text_utils = @import("../core/shared/text_utils.zig");
+const debug_trace = @import("../core/shared/debug_trace.zig");
 const builtin_tools = @import("../builtins/tools.zig");
 const host_target = @import("../core/hosts/target.zig");
 const types = @import("../core/shared/types.zig");
@@ -57,4 +60,38 @@ pub fn activeToolSet(state: *const server.ServerState) tool_set_contract.ToolSet
 
 pub fn activeToolRegistry(state: *const server.ServerState) tool_dispatch.Registry {
     return activeToolSet(state).registry;
+}
+
+/// Applies the live path's tool_call_update content contract: unsafe bytes are
+/// replaced with a notice, permission-denied and review-held failures keep
+/// their full text, and everything else is clipped to the 200-byte preview.
+pub fn toolUpdateContentText(is_failure: bool, output: []const u8) []const u8 {
+    if (!text_utils.isModelSafeText(output)) {
+        debug_trace.logf(
+            "acp",
+            "tool update omitted binary or non-utf8 output bytes={d}",
+            .{output.len},
+        );
+        return "binary or non-utf8 tool output omitted";
+    }
+    if (is_failure and
+        (tool_result_errors.isToolPermissionDeniedOutput(output) or
+            tool_result_errors.isToolReviewHeldOutput(output)))
+    {
+        return output;
+    }
+    return text_utils.utf8PrefixByBytes(output, 200);
+}
+
+test "toolUpdateContentText clips long output and guards unsafe bytes" {
+    const long = "x" ** 500;
+    const clipped = toolUpdateContentText(false, long);
+    try std.testing.expectEqual(@as(usize, 200), clipped.len);
+
+    const unsafe = toolUpdateContentText(false, "ok\xFF\xFEbinary");
+    try std.testing.expectEqualStrings("binary or non-utf8 tool output omitted", unsafe);
+
+    const denied_json = "{\"error\":{\"type\":\"tool_permission_denied\",\"tool_name\":\"run_command\",\"message\":\"Permission denied by user\",\"reason\":\"user_denied\"}}";
+    const denied = toolUpdateContentText(true, denied_json);
+    try std.testing.expectEqualStrings(denied_json, denied);
 }

--- a/src/acp/tool_call_presentation.zig
+++ b/src/acp/tool_call_presentation.zig
@@ -1,0 +1,60 @@
+const std = @import("std");
+const acp_types = @import("types.zig");
+const server = @import("server.zig");
+const tool_dispatch = @import("../core/tooling/tool_dispatch.zig");
+const tool_presentation = @import("../core/tooling/tool_presentation.zig");
+const tool_set_contract = @import("../core/tooling/tool_set.zig");
+const builtin_tools = @import("../builtins/tools.zig");
+const host_target = @import("../core/hosts/target.zig");
+const types = @import("../core/shared/types.zig");
+
+const Allocator = std.mem.Allocator;
+const ToolCall = types.ToolCall;
+
+/// Maps an internal tool name to the public ACP-facing name.
+pub fn acpToolName(tool_name: []const u8) []const u8 {
+    return if (tool_presentation.isProviderSearchAlias(tool_name)) "web_search" else tool_name;
+}
+
+pub fn mapToolKind(tool_name: []const u8) acp_types.ToolCallKind {
+    if (tool_presentation.isProviderSearchAlias(tool_name)) return .search;
+    if (std.mem.eql(u8, tool_name, "glob_files")) return .read;
+    if (std.mem.eql(u8, tool_name, "grep_files")) return .search;
+    if (std.mem.eql(u8, tool_name, "read_file")) return .read;
+    if (std.mem.eql(u8, tool_name, "web_fetch")) return .fetch;
+    if (std.mem.eql(u8, tool_name, "web_search")) return .search;
+    if (std.mem.eql(u8, tool_name, "write_file")) return .edit;
+    if (std.mem.eql(u8, tool_name, "edit_file")) return .edit;
+    if (std.mem.eql(u8, tool_name, "shell")) return .execute;
+    if (std.mem.eql(u8, tool_name, "terminal")) return .execute;
+    if (std.mem.eql(u8, tool_name, "run_command")) return .execute;
+    if (std.mem.eql(u8, tool_name, "skill")) return .other;
+    if (std.mem.eql(u8, tool_name, "install_skill")) return .other;
+    return .other;
+}
+
+pub fn describeToolTitle(registry: tool_dispatch.Registry, arena: Allocator, call: ToolCall) ![]const u8 {
+    if (registry.lookup(call.name) != null) {
+        if (try tool_presentation.formatSubagentPlainAction(arena, call, .identity)) |title| return title;
+    }
+    if (tool_presentation.isProviderSearchAlias(call.name)) {
+        return tool_presentation.formatPlainAction(arena, .{
+            .tool_registry = registry,
+            .call = call,
+        });
+    }
+    if (tool_dispatch.toolCallPresentation(arena, registry, call)) |presentation| {
+        return std.fmt.allocPrint(arena, "{s}", .{presentation.action_label});
+    }
+    return std.fmt.allocPrint(arena, "{s}", .{call.name});
+}
+
+pub fn activeToolSet(state: *const server.ServerState) tool_set_contract.ToolSet {
+    if (state.host_tools.tools.len > 0) return state.host_tools.toolSet();
+    if (comptime host_target.is_wasm) return tool_set_contract.empty;
+    return if (state.cfg.allow_native_tools) builtin_tools.advertisement_set else tool_set_contract.empty;
+}
+
+pub fn activeToolRegistry(state: *const server.ServerState) tool_dispatch.Registry {
+    return activeToolSet(state).registry;
+}

--- a/src/core/agent/execution_memory.zig
+++ b/src/core/agent/execution_memory.zig
@@ -852,9 +852,8 @@ test "execution memory redacts secret values from arguments results and provider
     try std.testing.expect(std.mem.find(u8, parsed.value.object.get("command").?.string, "[redacted]") != null);
 }
 
-test "execution memory removes token-shaped call ids from JSON and replay" {
+test "execution memory removes token-shaped call ids from JSON" {
     const runtime_execution_memory = @import("runtime/execution_memory.zig");
-    const session_runtime = @import("../session/session.zig");
     const testing_session_json = @import("../session/session_json.zig");
     const ChatMessage = types.ChatMessage;
     const alloc = std.testing.allocator;
@@ -897,13 +896,6 @@ test "execution memory removes token-shaped call ids from JSON and replay" {
         memory,
     );
     try std.testing.expect(std.mem.find(u8, json.written(), secret_id) == null);
-
-    const replay = (try session_runtime.formatExecutionReplayContext(
-        alloc,
-        memory,
-    )).?;
-    defer alloc.free(replay);
-    try std.testing.expect(std.mem.find(u8, replay, secret_id) == null);
 }
 
 test "durable execution memory masks token-shaped values" {

--- a/src/core/session/session.zig
+++ b/src/core/session/session.zig
@@ -3273,61 +3273,6 @@ pub fn formatExecutionFileContext(alloc: Allocator, files: []const core_types.Fi
     return out.toOwnedSlice() catch return error.OutOfMemory;
 }
 
-pub fn formatExecutionReplayContext(
-    alloc: Allocator,
-    execution: core_types.ExecutionMemory,
-) !?[]u8 {
-    if (execution.isEmpty()) return null;
-
-    var out: std.Io.Writer.Allocating = .init(alloc);
-    errdefer out.deinit();
-    out.writer.writeAll("Previous tool execution:") catch return error.OutOfMemory;
-
-    for (execution.tool_steps) |step| {
-        if (step.assistant) |assistant| {
-            if (assistant.len > 0) {
-                out.writer.print("\n\nAssistant:\n{s}", .{assistant}) catch return error.OutOfMemory;
-            }
-        }
-        for (step.tool_results) |result| {
-            out.writer.print(
-                "\n\nTool {s} ({s}):\n{s}",
-                .{ result.tool_name, @tagName(result.status), result.output },
-            ) catch return error.OutOfMemory;
-            for (result.permission_feedback) |feedback| {
-                out.writer.print(
-                    "\n\nUser permission feedback:\n{s}",
-                    .{feedback},
-                ) catch return error.OutOfMemory;
-            }
-        }
-    }
-    if (execution.files.len > 0) {
-        const files = try formatExecutionFileContext(alloc, execution.files);
-        defer alloc.free(files);
-        out.writer.print("\n\n{s}", .{files}) catch return error.OutOfMemory;
-    }
-
-    return out.toOwnedSlice() catch return error.OutOfMemory;
-}
-
-test "turn summary alone does not create model execution replay context" {
-    const execution = ExecutionMemory{ .turn_summary = .{
-        .started_at_ms = 100,
-        .completed_at_ms = 250,
-        .thinking_duration_ms = 40,
-        .turn_duration_ms = 150,
-        .token_progress = .{ .input_tokens = 12, .output_tokens = 34 },
-    } };
-
-    const context = try formatExecutionReplayContext(
-        std.testing.allocator,
-        execution,
-    );
-    defer if (context) |value| std.testing.allocator.free(value);
-    try std.testing.expect(context == null);
-}
-
 pub fn formatInterruptedHistoryContext(alloc: Allocator, entry: InterruptedHistoryTurn) ![]u8 {
     _ = entry;
     return alloc.dupe(u8, interrupted_turn_context);
@@ -4053,8 +3998,7 @@ test "resume projections group two tool results before their feedback" {
     try std.testing.expectEqual(core_types.ChatRole.user, chat_messages.items[5].role);
 }
 
-test "execution replay context and token estimate include permission feedback" {
-    const alloc = std.testing.allocator;
+test "execution token estimate includes permission feedback" {
     var feedback = [_][]u8{@constCast("read it after writing")};
     var with_feedback_results = [_]PersistedToolResult{.{
         .tool_call_id = @constCast("call_feedback"),
@@ -4078,10 +4022,6 @@ test "execution replay context and token estimate include permission feedback" {
     const with_feedback = ExecutionMemory{ .tool_steps = with_feedback_steps[0..] };
     const without_feedback = ExecutionMemory{ .tool_steps = without_feedback_steps[0..] };
 
-    const context = (try formatExecutionReplayContext(alloc, with_feedback)).?;
-    defer alloc.free(context);
-    try std.testing.expect(std.mem.find(u8, context, "wrote note.txt") != null);
-    try std.testing.expect(std.mem.find(u8, context, "read it after writing") != null);
     try std.testing.expect(estimateExecutionTokens(with_feedback) > estimateExecutionTokens(without_feedback));
 }
 

--- a/tests/e2e/acp.test.ts
+++ b/tests/e2e/acp.test.ts
@@ -1787,6 +1787,80 @@ describe("acp: model-independent", () => {
   );
 
   test(
+    "ACP session/load replays structured tool call frames",
+    async () => {
+      const root = createIsolatedRoot("fx-acp-load-tool-replay-");
+      writeFileSync(join(root.workspace, "replay-note.txt"), "ACP_LOAD_REPLAY_CONTENT\n");
+      const gateway = startFakeGateway([
+        fakeGatewayToolCall("replay_call_1", "read_file", { path: "replay-note.txt" }),
+        finalText("ACP_LOAD_REPLAY_ANSWER"),
+      ]);
+      let client: AcpClient | undefined;
+      try {
+        client = await AcpClient.create({
+          cwd: root.workspace,
+          env: fakeGatewayEnv(root, gateway),
+        });
+        const sessionId = await startCodeSession(client);
+        const prompt = await runPrompt(client, "Read replay-note.txt for me.", TIMEOUT);
+        expect(prompt.promptResult.result.stopReason).toBe("end_turn");
+        await client.close();
+
+        client = await AcpClient.create({
+          cwd: root.workspace,
+          env: fakeGatewayEnv(root, gateway),
+        });
+        await client.request("initialize", { protocolVersion: 1 }, 10);
+        client.send({
+          jsonrpc: "2.0",
+          id: 91,
+          method: "session/load",
+          params: { sessionId, cwd: root.workspace, mcpServers: [] },
+        });
+        const replay: any[] = [];
+        while (true) {
+          const message = await client.readLine() as any;
+          if (message.id === 91) break;
+          replay.push(message);
+        }
+        const updates = replay
+          .filter((message) => message.method === "session/update")
+          .map((message) => message.params.update);
+
+        const announce = updates.find((update) =>
+          update.sessionUpdate === "tool_call" && update.toolCallId === "replay_call_1"
+        );
+        expect(announce).toBeDefined();
+        expect(announce.name).toBe("read_file");
+        expect(announce.kind).toBe("read");
+        expect(announce.rawInput).toEqual({ path: "replay-note.txt" });
+
+        const finish = updates.find((update) =>
+          update.sessionUpdate === "tool_call_update" && update.toolCallId === "replay_call_1"
+        );
+        expect(finish?.status).toBe("completed");
+        expect(JSON.stringify(finish?.content)).toContain("ACP_LOAD_REPLAY_CONTENT");
+
+        expect(updates.some((update) =>
+          update.sessionUpdate === "user_message_chunk" &&
+          JSON.stringify(update).includes("Read replay-note.txt")
+        )).toBe(true);
+        expect(updates.some((update) =>
+          update.sessionUpdate === "agent_message_chunk" &&
+          JSON.stringify(update).includes("ACP_LOAD_REPLAY_ANSWER")
+        )).toBe(true);
+        expect(JSON.stringify(replay)).not.toContain("Previous tool execution");
+        expect(client.stderr).toBe("");
+      } finally {
+        await client?.close();
+        gateway.stop();
+        rmSync(root.root, { recursive: true, force: true });
+      }
+    },
+    TIMEOUT,
+  );
+
+  test(
     "ACP reload replays pending execution once and clears recovery after completion",
     async () => {
       const root = createIsolatedRoot("fx-acp-reload-model-recovery-");
@@ -1844,8 +1918,9 @@ describe("acp: model-independent", () => {
         expect(loadUpdates).toContain(
           "Preserve this ACP prompt across a process restart.",
         );
-        expect(loadUpdates).toContain("Previous tool execution:");
-        expect(loadUpdates).toContain("Tool read_file (success):");
+        expect(loadUpdates).toContain("\"sessionUpdate\":\"tool_call\"");
+        expect(loadUpdates).toContain("\"sessionUpdate\":\"tool_call_update\"");
+        expect(loadUpdates).toContain("recovery_read_1");
         expect(occurrenceCount(loadUpdates, toolEvidence)).toBe(1);
         expect(occurrenceCount(loadUpdates, partialText)).toBe(1);
 
@@ -7086,6 +7161,30 @@ describe("acp: model-independent", () => {
         }
 
         expect(loadResponse.error).toBeUndefined();
+        const replayedToolCalls = loadMessages
+          .filter((message) =>
+            message.method === "session/update" &&
+            message.params?.update?.sessionUpdate === "tool_call"
+          )
+          .map((message) => message.params.update);
+        const replayedToolUpdates = loadMessages
+          .filter((message) =>
+            message.method === "session/update" &&
+            message.params?.update?.sessionUpdate === "tool_call_update"
+          )
+          .map((message) => message.params.update);
+        expect(replayedToolCalls).toHaveLength(1);
+        expect(replayedToolCalls[0]).toMatchObject({
+          toolCallId: "history_read_1",
+          name: "read_file",
+          kind: "read",
+          status: "pending",
+          rawInput: { path: "fixture.txt" },
+        });
+        expect(replayedToolUpdates).toHaveLength(1);
+        expect(replayedToolUpdates[0].toolCallId).toBe("history_read_1");
+        expect(replayedToolUpdates[0].status).toBe("completed");
+        expect(JSON.stringify(replayedToolUpdates[0].content)).toContain("ACP_HISTORY_EVIDENCE");
         const replayedText = loadMessages
           .filter((message) =>
             message.method === "session/update" &&
@@ -7093,11 +7192,9 @@ describe("acp: model-independent", () => {
           )
           .map((message) => message.params.update.content.text);
         expect(replayedText).toEqual([
-          expect.stringContaining("Previous tool execution:"),
           "ACP load replay complete.",
         ]);
-        expect(replayedText[0]).toContain("Tool read_file (success):");
-        expect(replayedText[0]).toContain("ACP_HISTORY_EVIDENCE");
+        expect(JSON.stringify(loadMessages)).not.toContain("Previous tool execution:");
         expect(client.stderr).toBe("");
       } finally {
         await client?.close();


### PR DESCRIPTION
## Summary

- `session/load` replays each historical tool call as a structured `tool_call` frame (name, title, kind, input) followed by a final `tool_call_update` (status, output), matching the live turn shape instead of one flattened summary message.
- Replayed tool output follows the live content contract: binary or non-UTF-8 output is replaced with a notice and everything else is clipped to the 200-byte preview.
- Assistant text produced between tool steps replays in its original position rather than inside the summary block.
- Tool calls without a recorded result (interrupted or crashed turns) replay as pending without a final update.
- The "Previous tool execution" summary message is no longer sent during history replay. Its permission feedback lines and file evidence list are dropped from the client replay with it; neither ever appeared in the live ACP turn stream, and both still reach the model through the resume context.

Fixes #624.