### PR TITLE
Match lowercased approval hints in subagent search e2e

### DIFF
--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -7362,7 +7362,7 @@ printf '%s' ${JSON.stringify(trailingMarker)} > ${JSON.stringify(effectPath)}
       });
       await session.waitForStableComposer(15_000);
       await session.sendText("Delegate the prepared search.");
-      await session.waitForPane(pane => pane.includes("APPROVAL_SEARCH") && pane.includes("Esc Cancel"), 15_000);
+      await session.waitForPane(pane => pane.includes("APPROVAL_SEARCH") && pane.includes("esc cancel"), 15_000);
       expect(existsSync(join(target, "match.txt"))).toBe(true);
       renameSync(target, join(root.workspace, "moved-target"));
       await session.sendKeys("Enter");


### PR DESCRIPTION
## Summary

- Fix the approval-pane wait in the subagent search e2e test to match the lowercased keyboard hints, restoring Full CI on shard 3 for every branch based on current main.