### PR TITLE
Remove dead model catalog fetch wrappers from builtins/gateway

### DIFF
--- a/src/builtins/gateway.zig
+++ b/src/builtins/gateway.zig
@@ -2357,41 +2357,6 @@ pub fn fetchModelIdsCancellable(
     return fetchModelIdsForView(alloc, access, path, cancel_flag, .full);
 }
 
-pub fn fetchPickerModelIdsCancellable(
-    alloc: std.mem.Allocator,
-    access: credentials.CatalogAccess,
-    path: []const u8,
-    cancel_flag: *std.atomic.Value(bool),
-) !std.ArrayList([]u8) {
-    return fetchModelIdsForView(alloc, access, path, cancel_flag, .picker);
-}
-
-pub fn fetchModelCatalog(alloc: std.mem.Allocator, access: credentials.CatalogAccess, path: []const u8) !std.ArrayList(ModelCatalogEntry) {
-    return fetchModelCatalogForView(alloc, access, path, null, .full);
-}
-
-pub fn fetchModelCatalogCancellable(
-    alloc: std.mem.Allocator,
-    access: credentials.CatalogAccess,
-    path: []const u8,
-    cancel_flag: *std.atomic.Value(bool),
-) !std.ArrayList(ModelCatalogEntry) {
-    return fetchModelCatalogForView(alloc, access, path, cancel_flag, .full);
-}
-
-pub fn fetchPickerModelCatalog(alloc: std.mem.Allocator, access: credentials.CatalogAccess, path: []const u8) !std.ArrayList(ModelCatalogEntry) {
-    return fetchModelCatalogForView(alloc, access, path, null, .picker);
-}
-
-pub fn fetchPickerModelCatalogCancellable(
-    alloc: std.mem.Allocator,
-    access: credentials.CatalogAccess,
-    path: []const u8,
-    cancel_flag: *std.atomic.Value(bool),
-) !std.ArrayList(ModelCatalogEntry) {
-    return fetchModelCatalogForView(alloc, access, path, cancel_flag, .picker);
-}
-
 pub const model_catalog_provider = model_catalog.Provider{
     .fetch_fn = fetchCatalogForProvider,
 };
@@ -2823,10 +2788,6 @@ fn parseSortedModelCatalog(alloc: std.mem.Allocator, json_text: []const u8) !std
 
 fn parsePickerModelIds(alloc: std.mem.Allocator, json_text: []const u8) !std.ArrayList([]u8) {
     return parseModelIdsForView(alloc, json_text, .picker);
-}
-
-fn parsePickerModelCatalog(alloc: std.mem.Allocator, json_text: []const u8) !std.ArrayList(ModelCatalogEntry) {
-    return parseModelCatalogForView(alloc, json_text, .picker);
 }
 
 fn parseModelCatalogEntry(alloc: std.mem.Allocator, entry: std.json.Value) !?ModelCatalogEntry {


### PR DESCRIPTION
## Summary

- Remove five unreferenced catalog fetch wrappers (`fetchPickerModelIdsCancellable`, `fetchModelCatalog`, `fetchModelCatalogCancellable`, `fetchPickerModelCatalog`, `fetchPickerModelCatalogCancellable`) and the unreferenced `parsePickerModelCatalog` helper from the built-in gateway provider. No user-facing behavior change: every production catalog fetch goes through the injected `model_catalog.Provider` contract, and nothing referenced the removed declarations in production, tests, build roots, or docs.