### PR TITLE
Route Gateway chat requests to the v4 language-model endpoint

### DIFF
--- a/examples/browser-agent/api/gateway.js
+++ b/examples/browser-agent/api/gateway.js
@@ -4,7 +4,7 @@ export default {
   async fetch(request) {
     try {
       const path = new URL(request.url).searchParams.get('path')
-      const paths = ['/coding-agent/v1/models', '/v3/ai/language-model']
+      const paths = ['/coding-agent/v1/models', '/v4/ai/language-model']
       if (!paths.includes(path)) return new Response('Not found', { status: 404 })
       const upstream = await gatewayFetch(new Request(`https://ai-gateway.vercel.sh${path}`, request))
       return new Response(upstream.body, {

--- a/examples/browser-agent/main.test.mjs
+++ b/examples/browser-agent/main.test.mjs
@@ -39,7 +39,7 @@ async function page({ key = '', fail = false, stopReason = 'stop', duringFetch }
           return {
             result: Promise.resolve({ stopReason }),
             async *[Symbol.asyncIterator]() {
-              await options.fetch('https://ai-gateway.vercel.sh/v3/ai/language-model', {
+              await options.fetch('https://ai-gateway.vercel.sh/v4/ai/language-model', {
                 method: 'POST', headers: { authorization: `Bearer ${options.apiKey}` },
               })
               yield { type: 'text_delta', delta: 'hello' }
@@ -66,7 +66,7 @@ test('a blank key keeps the free proxy and reuses the conversation', async () =>
   await app.submit()
   assert.equal(app.agents.length, 1)
   assert.equal(app.agents[0].options.apiKey, 'demo')
-  assert.equal(app.calls[0].url, '/api/gateway?path=%2Fv3%2Fai%2Flanguage-model')
+  assert.equal(app.calls[0].url, '/api/gateway?path=%2Fv4%2Fai%2Flanguage-model')
   assert.equal(app.elements['#reply'].value, 'hello')
 })
 
@@ -75,7 +75,7 @@ test('an entered key goes directly to Gateway without touching the proxy', async
   await app.submit()
   assert.equal(app.agents[0].options.apiKey, 'test-user-key')
   assert.equal(app.calls.length, 1)
-  assert.equal(app.calls[0].url, 'https://ai-gateway.vercel.sh/v3/ai/language-model')
+  assert.equal(app.calls[0].url, 'https://ai-gateway.vercel.sh/v4/ai/language-model')
   assert.equal(app.calls[0].init.headers.authorization, 'Bearer test-user-key')
 })
 
@@ -90,15 +90,15 @@ test('changing or clearing a key closes the old conversation and changes the rou
   assert.equal(app.agents[0].closed, true)
   assert.equal(app.agents[1].closed, true)
   assert.equal(app.agents[2].closed, false)
-  assert.equal(app.calls[1].url, 'https://ai-gateway.vercel.sh/v3/ai/language-model')
-  assert.equal(app.calls[2].url, '/api/gateway?path=%2Fv3%2Fai%2Flanguage-model')
+  assert.equal(app.calls[1].url, 'https://ai-gateway.vercel.sh/v4/ai/language-model')
+  assert.equal(app.calls[2].url, '/api/gateway?path=%2Fv4%2Fai%2Flanguage-model')
 })
 
 test('a rejected personal key never falls back to the free proxy', async () => {
   const app = await page({ key: 'invalid-key', fail: true })
   await app.submit()
   assert.equal(app.calls.length, 1)
-  assert.equal(app.calls[0].url, 'https://ai-gateway.vercel.sh/v3/ai/language-model')
+  assert.equal(app.calls[0].url, 'https://ai-gateway.vercel.sh/v4/ai/language-model')
   assert.equal(app.elements['#status'].textContent, 'Invalid key')
   assert.equal(app.elements.button.disabled, false)
   assert.equal(app.elements['#api-key'].disabled, false)

--- a/examples/shared/gateway.mjs
+++ b/examples/shared/gateway.mjs
@@ -45,7 +45,7 @@ export async function gatewayFetch(input, init) {
   const request = new Request(input, init)
   const url = new URL(request.url)
   const catalog = url.pathname === '/coding-agent/v1/models' && request.method === 'GET'
-  const generation = url.pathname === '/v3/ai/language-model' && request.method === 'POST'
+  const generation = url.pathname === '/v4/ai/language-model' && request.method === 'POST'
   if (url.origin !== 'https://ai-gateway.vercel.sh' || url.search || (!catalog && !generation)) {
     fail(404, 'Unknown model endpoint.')
   }

--- a/examples/shared/gateway.test.mjs
+++ b/examples/shared/gateway.test.mjs
@@ -51,7 +51,7 @@ test('gateway fixes the model and output limit without forwarding caller credent
     return new Response('stream')
   })
   const prompt = [{ role: 'user', content: [{ type: 'text', text: 'Hi' }] }]
-  const response = await gatewayFetch('https://ai-gateway.vercel.sh/v3/ai/language-model', {
+  const response = await gatewayFetch('https://ai-gateway.vercel.sh/v4/ai/language-model', {
     method: 'POST',
     headers: { authorization: 'Bearer caller-key', 'ai-language-model-id': 'expensive', cookie: 'private', 'ai-language-model-streaming': 'true', 'ai-language-model-specification-version': '4' },
     body: JSON.stringify({ prompt, maxOutputTokens: 50000, providerOptions: { tools: ['search'] } }),
@@ -70,7 +70,7 @@ test('gateway refuses unknown destinations and non-text model inputs before tran
   for (const url of ['https://example.test/', 'https://ai-gateway.vercel.sh/v1/credits']) {
     await assert.rejects(gatewayFetch(url), { status: 404 })
   }
-  await assert.rejects(gatewayFetch('https://ai-gateway.vercel.sh/v3/ai/language-model', {
+  await assert.rejects(gatewayFetch('https://ai-gateway.vercel.sh/v4/ai/language-model', {
     method: 'POST', body: JSON.stringify({ prompt: [{ role: 'user', content: [{ type: 'image', image: 'https://example.test/image' }] }] }),
   }), { status: 400 })
 })

--- a/sdk/fx-sdk.js
+++ b/sdk/fx-sdk.js
@@ -36,6 +36,7 @@ function validateGatewayChatUrl(value) {
   if (url.username || url.password || url.hash) {
     throw new TypeError("gatewayChatUrl must not contain credentials or a fragment");
   }
+  if (url.href === "https://ai-gateway.vercel.sh/v4/ai/language-model") return;
   if (url.href === "https://ai-gateway.vercel.sh/v3/ai/language-model") return;
   const loopback = url.hostname === "127.0.0.1" || url.hostname === "[::1]" || url.hostname === "localhost";
   if (url.protocol !== "http:" || !loopback || !url.port) {

--- a/sdk/tests/test-agent-request-context.mjs
+++ b/sdk/tests/test-agent-request-context.mjs
@@ -118,7 +118,7 @@ try {
   for (const event of transportStarts) {
     assert.equal(event.endpoint, event.method === "GET"
       ? "https://ai-gateway.vercel.sh/coding-agent/v1/models"
-      : "https://ai-gateway.vercel.sh/v3/ai/language-model");
+      : "https://ai-gateway.vercel.sh/v4/ai/language-model");
     assert.equal(event.model, "request-context/model");
   }
   for (const event of transportResponses) {

--- a/sdk/tests/test-term-login.mjs
+++ b/sdk/tests/test-term-login.mjs
@@ -97,7 +97,7 @@ const stubFetch = async (input, init = {}) => {
       data: [{ id: "stub/login-model", type: "language", released: 1, tags: ["tool-use"] }],
     });
   }
-  if (url.href === "https://ai-gateway.vercel.sh/v3/ai/language-model") {
+  if (url.href === "https://ai-gateway.vercel.sh/v4/ai/language-model") {
     gatewayRequests.push({ authorization: headers.get("authorization") });
     return sseResponse(`LOGIN_GATEWAY_OK_${gatewayRequests.length}`);
   }

--- a/src/builtins/gateway.zig
+++ b/src/builtins/gateway.zig
@@ -42,7 +42,7 @@ const Response = web_search_contract.ProviderResponse;
 const ProgressFn = web_search_contract.ProgressFn;
 
 pub const default_model = "moonshotai/kimi-k3";
-pub const default_chat_url = "https://ai-gateway.vercel.sh/v3/ai/language-model";
+pub const default_chat_url = "https://ai-gateway.vercel.sh/v4/ai/language-model";
 pub const models_path = "/coding-agent/v1/models";
 const credits_path = "/coding-agent/v1/credits";
 pub const retry_count: usize = 3;
@@ -1633,7 +1633,7 @@ fn expectGatewayWorkerAdapterExecutes(backend: web_search_contract.SearchBackend
         .team = "team_123",
         .model = "provider/model",
         .retry_count = 1,
-        .chat_url = "https://ai-gateway.vercel.sh/v3/ai/language-model",
+        .chat_url = "https://ai-gateway.vercel.sh/v4/ai/language-model",
         .usage = &usage,
         .usage_allocator = alloc,
         .stream_ctx = @ptrCast(&fake),
@@ -1863,7 +1863,7 @@ test "cancelled gateway worker performs zero stream requests" {
         .api_key = "key",
         .model = "provider/model",
         .retry_count = 1,
-        .chat_url = "https://ai-gateway.vercel.sh/v3/ai/language-model",
+        .chat_url = "https://ai-gateway.vercel.sh/v4/ai/language-model",
         .stream_ctx = @ptrCast(&fake),
         .stream_fn = FakeStream.execute,
     }, .{
@@ -1979,7 +1979,7 @@ test "pre-send web search failure stays unbilled" {
         .api_key = "key",
         .model = "provider/model",
         .retry_count = 1,
-        .chat_url = "https://ai-gateway.vercel.sh/v3/ai/language-model",
+        .chat_url = "https://ai-gateway.vercel.sh/v4/ai/language-model",
         .usage = &usage,
         .usage_allocator = alloc,
         .stream_ctx = @ptrCast(&fake),
@@ -2008,7 +2008,7 @@ test "possibly sent web search failure marks billing incomplete" {
         .api_key = "key",
         .model = "provider/model",
         .retry_count = 1,
-        .chat_url = "https://ai-gateway.vercel.sh/v3/ai/language-model",
+        .chat_url = "https://ai-gateway.vercel.sh/v4/ai/language-model",
         .usage = &usage,
         .usage_allocator = alloc,
         .stream_ctx = @ptrCast(&fake),
@@ -2028,7 +2028,7 @@ test "possibly sent web search failure marks billing incomplete" {
 
 test "built-in gateway defaults preserve active provider policy" {
     try std.testing.expectEqualStrings("moonshotai/kimi-k3", default_model);
-    try std.testing.expectEqualStrings("https://ai-gateway.vercel.sh/v3/ai/language-model", default_chat_url);
+    try std.testing.expectEqualStrings("https://ai-gateway.vercel.sh/v4/ai/language-model", default_chat_url);
     try std.testing.expectEqualStrings("/coding-agent/v1/models", models_path);
     try std.testing.expectEqual(@as(usize, 3), retry_count);
     try std.testing.expectEqualStrings("FX_GATEWAY_CHAT_URL", chat_url_env);
@@ -2312,7 +2312,7 @@ test "built-in gateway chat url honors loopback override before fallback" {
 }
 
 test "built-in gateway chat url ignores untrusted overrides and falls back" {
-    const fallback = "https://ai-gateway.vercel.sh/v3/ai/language-model";
+    const fallback = "https://ai-gateway.vercel.sh/v4/ai/language-model";
     for ([_][]const u8{
         "https://evil.example/chat",
         "http://evil.example/chat",

--- a/src/core/tooling/web_search_runtime.zig
+++ b/src/core/tooling/web_search_runtime.zig
@@ -39,7 +39,7 @@ pub const Config = struct {
     gateway_team: ?[]const u8 = null,
     worker_model: []const u8 = "",
     gateway_retry_count: usize = 3,
-    gateway_chat_url: []const u8 = "https://ai-gateway.vercel.sh/v3/ai/language-model",
+    gateway_chat_url: []const u8 = "https://ai-gateway.vercel.sh/v4/ai/language-model",
     usage: ?*session_usage.Usage = null,
     usage_allocator: Allocator = std.heap.c_allocator,
 };

--- a/src/gateway/client.zig
+++ b/src/gateway/client.zig
@@ -4550,12 +4550,12 @@ test "consumeSseStream keyless tracing handles oversized CRLF payloads" {
 
 test "E2E gateway URL override accepts loopback HTTP only" {
     try std.testing.expectEqualStrings(
-        "https://ai-gateway.vercel.sh/v3/ai/language-model",
-        try selectE2eGatewayUrl(null, "https://ai-gateway.vercel.sh/v3/ai/language-model"),
+        "https://ai-gateway.vercel.sh/v4/ai/language-model",
+        try selectE2eGatewayUrl(null, "https://ai-gateway.vercel.sh/v4/ai/language-model"),
     );
     try std.testing.expectEqualStrings(
-        "http://127.0.0.1:43123/v3/ai/language-model",
-        try selectE2eGatewayUrl("http://127.0.0.1:43123/v3/ai/language-model", "https://ai-gateway.vercel.sh/v3/ai/language-model"),
+        "http://127.0.0.1:43123/v4/ai/language-model",
+        try selectE2eGatewayUrl("http://127.0.0.1:43123/v4/ai/language-model", "https://ai-gateway.vercel.sh/v4/ai/language-model"),
     );
     try std.testing.expectEqualStrings(
         "http://[::1]:43123/v1/models",
@@ -4563,11 +4563,11 @@ test "E2E gateway URL override accepts loopback HTTP only" {
     );
     try std.testing.expectError(
         error.InvalidE2EGatewayUrl,
-        selectE2eGatewayUrl("https://ai-gateway.vercel.sh/v3/ai/language-model", "https://ai-gateway.vercel.sh/v3/ai/language-model"),
+        selectE2eGatewayUrl("https://ai-gateway.vercel.sh/v4/ai/language-model", "https://ai-gateway.vercel.sh/v4/ai/language-model"),
     );
     try std.testing.expectError(
         error.InvalidE2EGatewayUrl,
-        selectE2eGatewayUrl("http://127.0.0.1:43123@ai-gateway.vercel.sh/v3/ai/language-model", "https://ai-gateway.vercel.sh/v3/ai/language-model"),
+        selectE2eGatewayUrl("http://127.0.0.1:43123@ai-gateway.vercel.sh/v4/ai/language-model", "https://ai-gateway.vercel.sh/v4/ai/language-model"),
     );
 }
 

--- a/src/gateway/vercel_protocol.zig
+++ b/src/gateway/vercel_protocol.zig
@@ -314,6 +314,14 @@ pub const BuildBudget = struct {
     }
 };
 
+/// The language-model route validates reasoning effort against its own tier
+/// names and rejects "max", which the model catalog still advertises for some
+/// models. Map it to the highest accepted tier.
+fn reasoningWireValue(label: []const u8) []const u8 {
+    if (std.mem.eql(u8, label, "max")) return "xhigh";
+    return label;
+}
+
 fn buildGatewayRequestBodyValidated(
     alloc: std.mem.Allocator,
     tools_json: []const u8,
@@ -384,7 +392,7 @@ fn buildGatewayRequestBodyValidated(
 
     if (options.reasoning) |*reasoning| {
         try out.writer.writeAll(",\"reasoning\":");
-        try std.json.Stringify.value(reasoning.label(), .{}, &out.writer);
+        try std.json.Stringify.value(reasoningWireValue(reasoning.label()), .{}, &out.writer);
     }
     try writeProviderOptions(&out.writer, options);
 
@@ -1453,6 +1461,21 @@ test "buildGatewayRequestBodyWithOptions keeps Anthropic default silent and name
     defer named_parsed.deinit();
     try std.testing.expectEqualStrings("future-tier", named_parsed.value.object.get("reasoning").?.string);
     try std.testing.expect(named_parsed.value.object.get("providerOptions") == null);
+}
+
+test "buildGatewayRequestBodyWithOptions maps max effort to the highest accepted tier" {
+    const alloc = std.testing.allocator;
+    const messages = [_]ChatMessage{
+        .{ .role = .user, .content = "question" },
+    };
+
+    const body = try buildGatewayRequestBodyWithOptions(alloc, "[]", &messages, .{
+        .reasoning = types.ReasoningEffort.literal("max"),
+    }, .auto);
+    defer alloc.free(body);
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, body, .{});
+    defer parsed.deinit();
+    try std.testing.expectEqualStrings("xhigh", parsed.value.object.get("reasoning").?.string);
 }
 
 test "required gateway request serializes required tool choice and max output" {

--- a/tests/e2e/config-persistence.test.ts
+++ b/tests/e2e/config-persistence.test.ts
@@ -1117,7 +1117,7 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
           "Bearer fake-capability-key",
         );
         expect(JSON.parse(gateway.requests[1]!.body)).toMatchObject({
-          reasoning: "max",
+          reasoning: "xhigh",
           providerOptions: { gateway: { speed: "fast" } },
         });
         expect(JSON.parse(gateway.requests[1]!.body)).not.toHaveProperty("fast");

--- a/tests/e2e/file-tool-paths.test.ts
+++ b/tests/e2e/file-tool-paths.test.ts
@@ -196,7 +196,7 @@ function startFakeGateway(
 
   return {
     baseUrl: `http://127.0.0.1:${server.port}`,
-    chatUrl: `http://127.0.0.1:${server.port}/v3/ai/language-model`,
+    chatUrl: `http://127.0.0.1:${server.port}/v4/ai/language-model`,
     requests,
     classifierRequests,
     remainingResponseCount() {

--- a/tests/e2e/render-lab/index.ts
+++ b/tests/e2e/render-lab/index.ts
@@ -131,7 +131,7 @@ const OBSERVABILITY_FINAL_MARKER = "OBSERVABILITY_FINAL_RESPONSE";
 const OBSERVABILITY_PERMISSION_PROMPT = "Would you like to run the following command?";
 const OBSERVABILITY_PERMISSION_REVIEW = "Permission needed";
 const OBSERVABILITY_TOOL_COMMAND = "touch render-lab-observability-approved.txt";
-const LOCAL_GATEWAY_CHAT_PATH = "/v3/ai/language-model";
+const LOCAL_GATEWAY_CHAT_PATH = "/v4/ai/language-model";
 const LOCAL_GATEWAY_MODELS_PATH = "/coding-agent/v1/models";
 const DEFAULT_BENCH_SIZES: RenderLabTerminalSize[] = [
   { cols: 80, rows: 24 },

--- a/tests/e2e/tmux-helpers.ts
+++ b/tests/e2e/tmux-helpers.ts
@@ -381,7 +381,7 @@ function serveFakeGateway(
   });
   return {
     baseUrl: `http://127.0.0.1:${server.port}`,
-    chatUrl: `http://127.0.0.1:${server.port}/v3/ai/language-model`,
+    chatUrl: `http://127.0.0.1:${server.port}/v4/ai/language-model`,
     requests,
     classifierRequests,
     generationRequests,

--- a/tests/e2e/tui-command-permissions.test.ts
+++ b/tests/e2e/tui-command-permissions.test.ts
@@ -403,7 +403,7 @@ function startFakeGateway(
   });
   const gateway = {
     baseUrl: `http://127.0.0.1:${server.port}`,
-    chatUrl: `http://127.0.0.1:${server.port}/v3/ai/language-model`,
+    chatUrl: `http://127.0.0.1:${server.port}/v4/ai/language-model`,
     requests,
     classifierRequests,
     stop() {

--- a/tests/e2e/tui-decision-prompts.test.ts
+++ b/tests/e2e/tui-decision-prompts.test.ts
@@ -391,7 +391,7 @@ function startFakeGateway(
   });
 
   return {
-    chatUrl: `http://127.0.0.1:${server.port}/v3/ai/language-model`,
+    chatUrl: `http://127.0.0.1:${server.port}/v4/ai/language-model`,
     baseUrl: `http://127.0.0.1:${server.port}`,
     requests,
     classifierRequests,

--- a/tests/e2e/tui-render-lab.test.ts
+++ b/tests/e2e/tui-render-lab.test.ts
@@ -714,7 +714,7 @@ describe.skipIf(SKIP)("tui: render lab", () => {
       expect(readQuiescence(artifacts.manifest)).toHaveLength(1);
       expect(artifacts.gatewayRequests).toEqual([
         "GET /coding-agent/v1/models",
-        "POST /v3/ai/language-model",
+        "POST /v4/ai/language-model",
       ]);
       expect(artifacts.stderr).toBe("");
     },
@@ -734,7 +734,7 @@ describe.skipIf(SKIP)("tui: render lab", () => {
       expect(artifacts.finalFrame.grid.some((row) => /^┃\s*$/.test(row))).toBe(true);
       expect(artifacts.finalFrame.grid.some((row) => row.includes("HTTP 401"))).toBe(false);
       expect(artifacts.finalFrame.grid.some((row) => row.includes("RENDER_LAB_LOCAL_GATEWAY_OK"))).toBe(false);
-      expect(artifacts.gatewayRequests).toEqual(["GET /coding-agent/v1/models", "POST /v3/ai/language-model"]);
+      expect(artifacts.gatewayRequests).toEqual(["GET /coding-agent/v1/models", "POST /v4/ai/language-model"]);
       expect(artifacts.stderr).toBe("");
     },
     TIMEOUT,
@@ -754,7 +754,7 @@ describe.skipIf(SKIP)("tui: render lab", () => {
       expect(artifacts.finalFrame.grid.some((row) => /^┃\s*$/.test(row))).toBe(true);
       expect(artifacts.finalFrame.grid.some((row) => row.includes("HTTP 401"))).toBe(false);
       expect(artifacts.finalFrame.grid.some((row) => row.includes("RENDER_LAB_LOCAL_GATEWAY_OK"))).toBe(false);
-      expect(artifacts.gatewayRequests).toEqual(["GET /coding-agent/v1/models", "POST /v3/ai/language-model"]);
+      expect(artifacts.gatewayRequests).toEqual(["GET /coding-agent/v1/models", "POST /v4/ai/language-model"]);
       expect(artifacts.stderr).toBe("");
     },
     TIMEOUT,

--- a/tests/e2e/vision-route-fake-gateway.test.ts
+++ b/tests/e2e/vision-route-fake-gateway.test.ts
@@ -245,7 +245,7 @@ function startImageGateway(
 
   return {
     baseUrl: `http://127.0.0.1:${server.port}`,
-    chatUrl: `http://127.0.0.1:${server.port}/v3/ai/language-model`,
+    chatUrl: `http://127.0.0.1:${server.port}/v4/ai/language-model`,
     chatRequests,
     get catalogRequests() {
       return catalogRequests;

--- a/tests/e2e/web-fetch-fake-network.test.ts
+++ b/tests/e2e/web-fetch-fake-network.test.ts
@@ -95,7 +95,7 @@ function startFakeGateway(
   });
 
   return {
-    chatUrl: `http://127.0.0.1:${server.port}/v3/ai/language-model`,
+    chatUrl: `http://127.0.0.1:${server.port}/v4/ai/language-model`,
     baseUrl: `http://127.0.0.1:${server.port}`,
     model,
     requests,

--- a/tests/e2e/web-fetch-live.test.ts
+++ b/tests/e2e/web-fetch-live.test.ts
@@ -103,7 +103,7 @@ async function startFakeGateway(responses: Response[]) {
   });
 
   return {
-    chatUrl: `http://127.0.0.1:${server.port}/v3/ai/language-model`,
+    chatUrl: `http://127.0.0.1:${server.port}/v4/ai/language-model`,
     baseUrl: `http://127.0.0.1:${server.port}`,
     requests,
     stop() {

--- a/tests/e2e/web-search-fake-gateway.test.ts
+++ b/tests/e2e/web-search-fake-gateway.test.ts
@@ -269,7 +269,7 @@ function startFakeGateway(
   });
 
   return {
-    chatUrl: `http://127.0.0.1:${server.port}/v3/ai/language-model`,
+    chatUrl: `http://127.0.0.1:${server.port}/v4/ai/language-model`,
     baseUrl: `http://127.0.0.1:${server.port}`,
     requests,
     stop() {

--- a/tests/evals/auto-permission-reliability.test.ts
+++ b/tests/evals/auto-permission-reliability.test.ts
@@ -17,7 +17,7 @@ import { HAS_API_KEY, runFx } from "./eval-helpers";
 const TIMEOUT = 180_000;
 const MODEL = "openai/gpt-5";
 const REAL_GATEWAY_CHAT_URL =
-  "https://ai-gateway.vercel.sh/v3/ai/language-model";
+  "https://ai-gateway.vercel.sh/v4/ai/language-model";
 const EXPECTED_REVIEWER_MODEL = "openai/gpt-5.6-luna";
 const BROAD_DESTRUCTIVE_REASON =
   /\b(?:destruct\w*|recurs\w*|broad[_ -]delet\w*|source tree|critical files|irreversib\w*)\b/i;
@@ -292,7 +292,7 @@ function startClassifierProxy(prepared: PreparedScenario) {
   });
   const gateway = {
     baseUrl: `http://127.0.0.1:${server.port}`,
-    chatUrl: `http://127.0.0.1:${server.port}/v3/ai/language-model`,
+    chatUrl: `http://127.0.0.1:${server.port}/v4/ai/language-model`,
     classifierRequests,
     reviewerObservations,
     outerRequests,


### PR DESCRIPTION
## Summary

- Send chat requests to the v4 AI Gateway language-model endpoint so reasoning effort settings are applied instead of dropped by the v3 route.
- Send an effort of "max" as "xhigh", the highest tier the v4 endpoint accepts, so models whose catalogs advertise "max" no longer fail with HTTP 400.