### PR TITLE
Rename steering wait presentation fields to boundary

### DIFF
--- a/src/core/agent/worker_runtime.zig
+++ b/src/core/agent/worker_runtime.zig
@@ -310,7 +310,7 @@ pub const CommandOutputChunk = struct {
 pub const SteeringPresentationSnapshot = struct {
     messages: [][]u8 = &.{},
     pending_feedback: [][]u8 = &.{},
-    waits_for_tool: bool = false,
+    waits_for_boundary: bool = false,
 
     pub fn deinit(self: *SteeringPresentationSnapshot, alloc: std.mem.Allocator) void {
         for (self.messages) |message| alloc.free(message);
@@ -1626,7 +1626,7 @@ pub const WorkerRuntime = struct {
             if (prompt.delivery.isSteering()) steering_count += 1;
         }
         var snapshot: SteeringPresentationSnapshot = .{
-            .waits_for_tool = steering_count > 0 and self.hasSteeringWaitBoundaryLocked(),
+            .waits_for_boundary = steering_count > 0 and self.hasSteeringWaitBoundaryLocked(),
         };
         errdefer snapshot.deinit(alloc);
         snapshot.pending_feedback = pending: {
@@ -4329,7 +4329,7 @@ test "interactive prompt during running manual compaction waits without cancelli
     try std.testing.expectEqual(@as(?u64, null), runtime.steering_cancel_turn_id);
     var snapshot = try runtime.snapshotSteeringPresentation(alloc);
     defer snapshot.deinit(alloc);
-    try std.testing.expect(snapshot.waits_for_tool);
+    try std.testing.expect(snapshot.waits_for_boundary);
 
     // A compaction work item never takes a steering boundary; finishing it
     // promotes the waiting prompt to a continuation that runs next.
@@ -4648,7 +4648,7 @@ test "tool handoff phase holds steering only through its model step" {
     try std.testing.expectEqual(@as(usize, 1), runtime.queuedPromptCount());
     var snapshot = try runtime.snapshotSteeringPresentation(alloc);
     defer snapshot.deinit(alloc);
-    try std.testing.expect(snapshot.waits_for_tool);
+    try std.testing.expect(snapshot.waits_for_boundary);
 
     const guidance = try expectContinuedSteering(
         try runtime.takeSteeringBoundary(alloc, 41, .model),
@@ -4754,7 +4754,7 @@ test "queued steer waiting at a tool boundary pops back for editing" {
     defer snapshot.deinit(alloc);
     try std.testing.expectEqual(@as(usize, 1), snapshot.messages.len);
     try std.testing.expectEqualStrings("first steer", snapshot.messages[0]);
-    try std.testing.expect(snapshot.waits_for_tool);
+    try std.testing.expect(snapshot.waits_for_boundary);
 
     const guidance = try expectContinuedSteering(
         try runtime.takeSteeringBoundary(alloc, 41, .model),
@@ -4875,7 +4875,7 @@ test "immediate steering is visible while the provider cutoff settles" {
     try std.testing.expectEqual(@as(usize, 2), snapshot.messages.len);
     try std.testing.expectEqualStrings("first", snapshot.messages[0]);
     try std.testing.expectEqualStrings("second", snapshot.messages[1]);
-    try std.testing.expect(!snapshot.waits_for_tool);
+    try std.testing.expect(!snapshot.waits_for_boundary);
 }
 
 test "steering presentation survives queue to feedback transfer without duplicate input" {
@@ -4954,7 +4954,7 @@ test "tool-blocked steering snapshot owns visible messages in admission order" {
     try std.testing.expectEqual(@as(usize, 2), snapshot.messages.len);
     try std.testing.expectEqualStrings("first", snapshot.messages[0]);
     try std.testing.expectEqualStrings("second", snapshot.messages[1]);
-    try std.testing.expect(snapshot.waits_for_tool);
+    try std.testing.expect(snapshot.waits_for_boundary);
 }
 
 test "late steering keeps admission order when demoted on finish" {

--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -137,7 +137,7 @@ const RenderReconciliation = union(enum) {
 const SteeringProjection = struct {
     messages: [][]u8 = &.{},
     pending_feedback: [][]u8 = &.{},
-    waits_for_tool: bool = false,
+    waits_for_boundary: bool = false,
 
     fn deinit(self: *SteeringProjection, alloc: std.mem.Allocator) void {
         for (self.messages) |message| alloc.free(message);
@@ -296,7 +296,7 @@ fn buildPendingSteeringCardProjection(
     steering: SteeringProjection,
     checkpoint: ?*build_checkpoint.BuildCheckpoint,
 ) !?PendingCardProjection {
-    const queued_count = if (steering.waits_for_tool) 0 else steering.messages.len;
+    const queued_count = if (steering.waits_for_boundary) 0 else steering.messages.len;
     var index = steering.pending_feedback.len + queued_count;
     if (index == 0) return null;
 
@@ -399,7 +399,7 @@ fn buildSteeringProjection(comptime App: type, app: *App) !SteeringProjection {
     if (comptime @hasDecl(@TypeOf(app.worker), "snapshotSteeringPresentation")) {
         var snapshot = try app.worker.snapshotSteeringPresentation(app.alloc);
         defer snapshot.deinit(app.alloc);
-        projection.waits_for_tool = snapshot.waits_for_tool;
+        projection.waits_for_boundary = snapshot.waits_for_boundary;
         projection.messages = snapshot.messages;
         snapshot.messages = &.{};
         projection.pending_feedback = snapshot.pending_feedback;
@@ -697,7 +697,7 @@ pub fn Runtime(comptime App: type) type {
                 else
                     .ask,
                 .steering_messages = steering.messages,
-                .steering_waits_for_tool = steering.waits_for_tool,
+                .steering_waits_for_boundary = steering.waits_for_boundary,
                 .fast_indicator_active = fast_indicator_active,
                 .effort = visible_effort,
                 .model_supports_effort = model_supports_effort,
@@ -2569,7 +2569,7 @@ test "pending steering cards preserve feedback order and tool waiting placement"
     try std.testing.expectEqual(@as(usize, 2), std.mem.count(u8, card.bytes, "┃"));
     try std.testing.expect(std.mem.find(u8, card.bytes, "┋") == null);
 
-    steering.waits_for_tool = true;
+    steering.waits_for_boundary = true;
     var waiting = (try buildPendingSteeringCardProjection(alloc, &shell, steering, null)).?;
     defer waiting.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, waiting.bytes, "accepted earlier") != null);
@@ -2577,7 +2577,7 @@ test "pending steering cards preserve feedback order and tool waiting placement"
     steering.pending_feedback = &.{};
     try std.testing.expect((try buildPendingSteeringCardProjection(alloc, &shell, steering, null)) == null);
 
-    steering.waits_for_tool = false;
+    steering.waits_for_boundary = false;
     shell.layout.content_bottom = 1;
     var clipped = (try buildPendingSteeringCardProjection(alloc, &shell, steering, null)).?;
     defer clipped.deinit(alloc);

--- a/src/core/app/input_completion_runtime.zig
+++ b/src/core/app/input_completion_runtime.zig
@@ -285,7 +285,7 @@ pub fn CompletionRuntime(comptime App: type) type {
             }
         }
 
-        /// Pulls the newest queued steering prompt that still waits for a tool
+        /// Pulls the newest queued steering prompt that still waits for a
         /// boundary back into the empty composer for editing. Returns false when
         /// no steer is retractable, leaving history navigation to run unchanged.
         /// An active history episode keeps its stashed draft untouched.
@@ -540,7 +540,7 @@ pub fn CompletionRuntime(comptime App: type) type {
             defer steering.deinit(app.alloc);
             const requested_banner_rows = render_input.steeringBannerRowsForMessages(
                 steering.messages,
-                steering.waits_for_tool,
+                steering.waits_for_boundary,
                 app.shell.layout.cols,
             );
             return .{

--- a/src/ui/footer/input_presentation.zig
+++ b/src/ui/footer/input_presentation.zig
@@ -60,11 +60,11 @@ pub fn composeSteeringMessageRows(
     message: []const u8,
     width: u16,
     row_limit: u16,
-    waits_for_tool: bool,
+    waits_for_boundary: bool,
 ) !ComposedInputRows {
     var composed: ComposedInputRows = .{};
     errdefer composed.deinit(alloc);
-    const layout = render_input.steering_message_layout(message, width, waits_for_tool, row_limit);
+    const layout = render_input.steering_message_layout(message, width, waits_for_boundary, row_limit);
     for (layout.rows[0..layout.row_count], 0..) |content, index| {
         const normalized = try alloc.dupe(u8, content);
         defer alloc.free(normalized);
@@ -76,8 +76,8 @@ pub fn composeSteeringMessageRows(
 
         var row: std.ArrayList(u8) = .empty;
         errdefer row.deinit(alloc);
-        try row.appendSlice(alloc, if (waits_for_tool) ui_render.dim_style else ui_render.hint_style);
-        if (waits_for_tool) try row_text.appendClipped(alloc, &row, "┋ ", width);
+        try row.appendSlice(alloc, if (waits_for_boundary) ui_render.dim_style else ui_render.hint_style);
+        if (waits_for_boundary) try row_text.appendClipped(alloc, &row, "┋ ", width);
         const ellipsis = layout.truncated and index + 1 == layout.row_count and layout.content_width > 0;
         try row_text.appendClipped(alloc, &row, safe.bytes, layout.content_width - @as(u16, @intFromBool(ellipsis)));
         if (ellipsis) {

--- a/src/ui/footer/paint_plan.zig
+++ b/src/ui/footer/paint_plan.zig
@@ -592,7 +592,7 @@ fn pushSteeringRows(
         const candidate_rows = render_input.steering_message_layout(
             ctx.steering_messages[candidate],
             width,
-            ctx.steering_waits_for_tool,
+            ctx.steering_waits_for_boundary,
             render_input.max_steering_message_rows,
         ).row_count;
         visible_start = candidate;
@@ -613,7 +613,7 @@ fn pushSteeringRows(
             message,
             width,
             row_limit,
-            ctx.steering_waits_for_tool,
+            ctx.steering_waits_for_boundary,
         );
         defer rows.deinit(alloc);
         for (rows.rows.items) |*row| {
@@ -1471,7 +1471,7 @@ test "steering banner keeps two clean lines and a composer gap in both delivery 
         const messages = [_][]const u8{"FIRST_LINE\nSECOND_LINE\nHIDDEN_END"};
         var ctx = testContext(&input);
         ctx.steering_messages = &messages;
-        ctx.steering_waits_for_tool = waiting;
+        ctx.steering_waits_for_boundary = waiting;
         const planner_input: FooterPlannerInput = .{
             .active_label = null,
             .ctx = ctx,

--- a/src/ui/footer/render_input.zig
+++ b/src/ui/footer/render_input.zig
@@ -419,7 +419,7 @@ pub const RenderContext = struct {
     composer_visible: bool = true,
     permission_mode: types.PermissionMode = .ask,
     steering_messages: []const []const u8 = &.{},
-    steering_waits_for_tool: bool = false,
+    steering_waits_for_boundary: bool = false,
     fast_indicator_active: bool = false,
     effort: types.ReasoningEffort = .auto,
     model_supports_effort: bool = false,
@@ -518,11 +518,11 @@ fn steering_unit_width(raw: []const u8) usize {
 pub fn steering_message_layout(
     message: []const u8,
     width: u16,
-    waits_for_tool: bool,
+    waits_for_boundary: bool,
     row_limit: u16,
 ) SteeringMessageLayout {
     var layout: SteeringMessageLayout = .{
-        .content_width = if (waits_for_tool) width -| 2 else width,
+        .content_width = if (waits_for_boundary) width -| 2 else width,
     };
     const limit = @min(row_limit, max_steering_message_rows);
     var offset: usize = 0;
@@ -578,13 +578,13 @@ pub fn steering_message_layout(
 
 pub fn steeringBannerRowsForMessages(
     messages: []const []const u8,
-    waits_for_tool: bool,
+    waits_for_boundary: bool,
     width: u16,
 ) u16 {
-    if (messages.len == 0 or !waits_for_tool) return 0;
+    if (messages.len == 0 or !waits_for_boundary) return 0;
     var rows: u16 = 0;
     for (messages) |message| {
-        rows +|= steering_message_layout(message, width, waits_for_tool, max_steering_message_rows).row_count;
+        rows +|= steering_message_layout(message, width, waits_for_boundary, max_steering_message_rows).row_count;
     }
     return rows +| steering_composer_gap_rows;
 }
@@ -592,7 +592,7 @@ pub fn steeringBannerRowsForMessages(
 pub fn steeringBannerRows(ctx: RenderContext, width: u16) u16 {
     return steeringBannerRowsForMessages(
         ctx.steering_messages,
-        ctx.steering_waits_for_tool,
+        ctx.steering_waits_for_boundary,
         width,
     );
 }

--- a/src/ui/resize_tests.zig
+++ b/src/ui/resize_tests.zig
@@ -2668,7 +2668,7 @@ test "entry-bound shimmer is suppressed when footer banner covers its row" {
     try expectGridNotContains(&h, "Overlay should fit");
 
     ctx.steering_messages = &.{"pending steering"};
-    ctx.steering_waits_for_tool = true;
+    ctx.steering_waits_for_boundary = true;
     h.frame_redraw = true;
     try renderTestFooterWithContext(&h, &approval, &h.frame_redraw, ctx);
     try h.flush();
@@ -2694,7 +2694,7 @@ test "footer banner keeps a gap after entry-bound activity" {
     var ctx = defaultFooterContext(&input);
     setToolActivity(&ctx, status_id, "Overlay should be hidden by banner");
     ctx.steering_messages = &.{"pending steering"};
-    ctx.steering_waits_for_tool = true;
+    ctx.steering_waits_for_boundary = true;
     h.frame_redraw = true;
     try renderTestFooterWithContext(&h, &approval, &h.frame_redraw, ctx);
     try h.flush();
@@ -2733,7 +2733,7 @@ test "footer banner reserves blank row after bottom entry-bound activity" {
     var ctx = defaultFooterContext(&input);
     setToolActivity(&ctx, status_id, "Creating project");
     ctx.steering_messages = &.{"pending steering"};
-    ctx.steering_waits_for_tool = true;
+    ctx.steering_waits_for_boundary = true;
     h.frame_redraw = true;
     try renderTestFooterWithContext(&h, &approval, &h.frame_redraw, ctx);
     try h.flush();
@@ -2782,7 +2782,7 @@ test "banner-suppressed overlay restore keeps reserved footer gap" {
     try std.testing.expect(!h.shell.shimmer_active);
 
     ctx.steering_messages = &.{"pending steering"};
-    ctx.steering_waits_for_tool = true;
+    ctx.steering_waits_for_boundary = true;
     h.frame_redraw = true;
     try renderTestFooterWithContext(&h, &approval, &h.frame_redraw, ctx);
     try h.flush();
@@ -4595,7 +4595,7 @@ test "render engine preserves transcript footer activity behavior" {
     try std.testing.expectEqual(status_row, try findRowContaining(&h, "Writing render-engine-plan"));
 
     ctx.steering_messages = &.{"pending steering"};
-    ctx.steering_waits_for_tool = true;
+    ctx.steering_waits_for_boundary = true;
     setToolActivity(&ctx, status_id, "Overlay hidden by banner");
     h.frame_redraw = true;
     try renderTestFooterWithContext(&h, &approval, &h.frame_redraw, ctx);


### PR DESCRIPTION
## Summary

- Rename the internal steering-wait presentation fields from `waits_for_tool` and `steering_waits_for_tool` to `waits_for_boundary` and `steering_waits_for_boundary`, matching the admission predicate that computes them now that steering waits on compaction as well as tools.
- No behavior change; the waiting treatment and its tests are untouched apart from the identifier.

Stacked on #795.