### PR TITLE
Preserve subagent attribution in trace tool summaries

### DIFF
--- a/src/core/tooling/tool_runtime.zig
+++ b/src/core/tooling/tool_runtime.zig
@@ -439,6 +439,7 @@ pub fn executeToolCallAuthorized(
             .model_output = "",
             .outcome = classifyToolExecutionError(err),
             .started_at_ms = started_at_ms,
+            .subagent_id = execution_ctx.lifecycle_scope.subagent_id orelse 0,
         });
         return if (err == error.CancelledBeforeExecution) error.Cancelled else err;
     };
@@ -451,6 +452,7 @@ pub fn executeToolCallAuthorized(
             result,
         ),
         .started_at_ms = started_at_ms,
+        .subagent_id = execution_ctx.lifecycle_scope.subagent_id orelse 0,
     });
     if (request.command_replay_capture) |continued| {
         replay_continuation_transferred = result.command_replay_capture == continued;
@@ -2469,8 +2471,12 @@ fn terminalExecCallForTest(arena: Allocator, call: ToolCall) !ToolCall {
 }
 
 test "registered terminal exec preserves invalid execution authority error" {
+    diagnostics.resetForTest();
+    defer diagnostics.resetForTest();
     var rt = TestRuntime{};
     defer rt.deinit(std.testing.allocator);
+    var ctx = rt.context();
+    ctx.lifecycle_scope = .{ .kind = .subagent, .workspace_root = rt.workspace_root, .subagent_id = 8 };
 
     var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_state.deinit();
@@ -2483,7 +2489,7 @@ test "registered terminal exec preserves invalid execution authority error" {
 
     try std.testing.expectError(
         error.InvalidRunCommandExecutionAuthority,
-        executeToolCallAuthorized(rt.context(), .{
+        executeToolCallAuthorized(ctx, .{
             .call_allocator = arena,
             .result_allocator = arena,
             .call = call,
@@ -2493,6 +2499,10 @@ test "registered terminal exec preserves invalid execution authority error" {
             .max_tool_result_bytes = rt.max_tool_result_bytes,
         }),
     );
+    var metrics: [1]diagnostics.ToolCallMetric = undefined;
+    try std.testing.expectEqual(@as(usize, 1), diagnostics.snapshotToolCalls(&metrics));
+    try std.testing.expectEqual(@as(u64, 8), metrics[0].subagent_id);
+    try std.testing.expectEqual(diagnostics.ToolCallOutcome.runtime_failed, metrics[0].outcome);
 }
 
 test "captured command compatibility bypasses compound commands" {
@@ -3580,6 +3590,38 @@ test "parent web_fetch tool-call metric omits URL and fetched result content" {
     try std.testing.expectEqual(@as(u32, 0), buf[0].args_total_bytes);
     try std.testing.expectEqual(@as(u32, 0), buf[0].result_total_bytes);
     try expectNotContains(buf[0].result(), "FETCHED_PAGE_SECRET_RAW");
+}
+
+test "tool-call metrics retain caller identity across returned results" {
+    const alloc = std.testing.allocator;
+    diagnostics.resetForTest();
+    defer diagnostics.resetForTest();
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeTestFile(tmp.dir, "note.txt", "caller attribution");
+    const root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(root);
+    var rt = TestRuntime{ .workspace_root = root };
+    defer rt.deinit(alloc);
+    var arena = std.heap.ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    const callers = [_]?u64{ null, 3, 7, null };
+    for (callers, 0..) |caller, index| {
+        var ctx = rt.context();
+        ctx.lifecycle_scope = .{ .kind = if (caller == null) .interactive else .subagent, .workspace_root = root, .subagent_id = caller };
+        const result = try executeToolCall(ctx, arena.allocator(), .{
+            .id = "attribution",
+            .name = if (index == 2) "unknown_tool" else "read_file",
+            .arguments_json = "{\"path\":\"note.txt\"}",
+        });
+        try std.testing.expectEqual(if (index == 2) tool_contracts.ToolExecutionStatus.failure else .success, result.status);
+    }
+    var metrics: [4]diagnostics.ToolCallMetric = undefined;
+    try std.testing.expectEqual(@as(usize, 4), diagnostics.snapshotToolCalls(&metrics));
+    for (metrics, callers, 0..) |metric, caller, index| {
+        try std.testing.expectEqual(caller orelse 0, metric.subagent_id);
+        try std.testing.expectEqual(if (index == 2) diagnostics.ToolCallOutcome.tool_failed else .succeeded, metric.outcome);
+    }
 }
 
 test "non-web_fetch tool-call metrics retain bounded args and result" {

--- a/tests/e2e/tui-command-permissions.test.ts
+++ b/tests/e2e/tui-command-permissions.test.ts
@@ -1675,6 +1675,11 @@ describe("effect-aware command permissions", () => {
       writeFileSync(stderrPath, "");
       installClipboardFixture(root, "#!/bin/sh\nexit 1\n");
       const gateway = startFakeGateway([
+        gatewayToolCall("subagent", {
+          request: { action: "run", task: "Run the prepared child diagnostic command." },
+        }, "trace_child"),
+        toolCall("printf child-trace-output", {}, "trace_child_command"),
+        finalText("child diagnostic complete"),
         gatewayToolCall("edit_file", {
           path: "duplicate.txt",
           old_string: "same",
@@ -1691,6 +1696,9 @@ describe("effect-aware command permissions", () => {
           PATH: hostilePath(root),
           TMPDIR: root.root,
           FX_PERMISSION_MODE: "yolo",
+          FX_TRACE: "0",
+          FX_TRACE_LOG: undefined,
+          FX_TRACE_STDERR: "0",
         }),
         stderrPath,
         width: 120,
@@ -1710,10 +1718,16 @@ describe("effect-aware command permissions", () => {
       );
       const report = readFileSync(latestTraceReportPath(root), "utf8");
 
-      expect(gateway.requests).toHaveLength(3);
+      expect(gateway.requests).toHaveLength(6);
       expect(report).toContain(
-        "last=2 succeeded=0 rejected=1 command_failed=1 tool_failed=0 runtime_failed=0",
+        "last=4 succeeded=2 rejected=1 command_failed=1 tool_failed=0 runtime_failed=0",
       );
+      const localCalls = report.split("## Tool Calls\n### Local\n")[1]?.split("### Web Search")[0];
+      expect(localCalls).toBeDefined();
+      expect(localCalls).toMatch(/name=shell outcome=succeeded duration=\d+ms source=subagent#1\n/);
+      expect(localCalls).toMatch(/name=subagent outcome=succeeded duration=\d+ms source=parent\n/);
+      expect(localCalls).toMatch(/name=shell outcome=command_failed duration=\d+ms source=parent\n/);
+      expect(localCalls).toMatch(/name=edit_file outcome=rejected duration=\d+ms source=parent\n/);
       expect(report).toContain("name=edit_file outcome=rejected");
       expect(report).toContain("name=shell outcome=command_failed");
       expect(report).not.toContain("name=edit_file outcome=runtime_failed");


### PR DESCRIPTION
## Summary

- Attribute subagent tool results and errors to the child in trace summaries instead of labeling them as parent calls.
