### PR TITLE
Expose reasoning effort as an ACP config option

### DIFF
--- a/src/acp/server.zig
+++ b/src/acp/server.zig
@@ -2207,6 +2207,33 @@ fn handleSetConfigOption(state: *ServerState, alloc: Allocator, msg: *jsonrpc.Me
             defer state.subagent_authority_mutex.unlock(io_mod.getIo());
             applySessionMode(state.cfg.mode_registry, session, value);
         }
+    } else if (std.mem.eql(u8, config_id, "effort")) {
+        const session = if (state.active_session) |*active| active else return state.writer.writeError(alloc, msg.id, .{
+            .code = ErrorCode.invalid_request,
+            .message = "No active session",
+        });
+        const effort = types.ReasoningEffort.parse(value) orelse
+            return state.writer.writeError(alloc, msg.id, .{
+                .code = ErrorCode.invalid_params,
+                .message = "Invalid reasoning effort",
+            });
+        const config = sessions.effortConfigState(state) orelse
+            return state.writer.writeError(alloc, msg.id, .{
+                .code = ErrorCode.invalid_params,
+                .message = "Reasoning effort is unavailable for the active model",
+            });
+        if (!sessions.effortSupportedBy(config.efforts, effort)) {
+            return state.writer.writeError(alloc, msg.id, .{
+                .code = ErrorCode.invalid_params,
+                .message = "Reasoning effort is not available for the active model",
+            });
+        }
+        commitActiveSessionEffort(alloc, session, effort) catch {
+            return state.writer.writeError(alloc, msg.id, .{
+                .code = ErrorCode.internal_error,
+                .message = "Failed to persist session effort",
+            });
+        };
     }
 
     try refreshModelCatalogForOptions(state);
@@ -2230,6 +2257,10 @@ fn handleSetConfigOption(state: *ServerState, alloc: Allocator, msg: *jsonrpc.Me
     );
     try out.writer.writeAll(",");
     try sessions.writeModeConfigOption(&out.writer, state.cfg.mode_registry, current_mode);
+    if (sessions.effortConfigState(state)) |config| {
+        try out.writer.writeAll(",");
+        try sessions.writeEffortConfigOption(&out.writer, config.efforts, config.current);
+    }
     try out.writer.writeAll("]}");
     try state.writer.writeResponse(alloc, msg.id, out.writer.buffered());
 }
@@ -2318,6 +2349,34 @@ fn commitSessionModel(
     );
     alloc.free(active_model.*);
     active_model.* = staged_model;
+}
+
+fn commitActiveSessionEffort(
+    alloc: Allocator,
+    session: *ActiveSessionState,
+    effort: types.ReasoningEffort,
+) !void {
+    if (host_target.is_wasm and session.writable == null) {
+        const previous = session.effort;
+        session.effort = effort;
+        sessions.commitWasmSession(alloc, session) catch |err| {
+            session.effort = previous;
+            return err;
+        };
+        return;
+    }
+    session.session_write_mutex.lockUncancelable(io_mod.getIo());
+    defer session.session_write_mutex.unlock(io_mod.getIo());
+    const writable = if (session.writable) |*active|
+        active
+    else
+        return error.SessionPersistenceUnavailable;
+    _ = try writable.appendEvent(
+        alloc,
+        .{ .preferences_changed = .{ .effort = effort } },
+        io_mod.milliTimestamp(),
+    );
+    session.effort = effort;
 }
 
 fn handleSetMode(state: *ServerState, alloc: Allocator, msg: *jsonrpc.Message) !void {

--- a/src/acp/sessions.zig
+++ b/src/acp/sessions.zig
@@ -21,6 +21,7 @@ const project_config = @import("../core/mcp/project_config.zig");
 const workspace_config = @import("../core/mcp/workspace_config.zig");
 const config_runtime = @import("../core/config/config_runtime.zig");
 const model_catalog = @import("../core/gateway/model_catalog.zig");
+const model_capabilities = @import("../core/config/model_capabilities.zig");
 const provider_set = @import("../core/gateway/provider_set.zig");
 const host = @import("../core/hosts/host.zig");
 const host_target = @import("../core/hosts/target.zig");
@@ -326,6 +327,10 @@ fn writeNewSessionResponse(
         state.cfg.mode_registry,
         state.cfg.mode_registry.default_mode_id,
     );
+    if (effortConfigState(state)) |config| {
+        try out.writer.writeAll(",");
+        try writeEffortConfigOption(&out.writer, config.efforts, config.current);
+    }
     try out.writer.writeAll("],\"modes\":{\"currentModeId\":");
     try writeJsonStr(state.cfg.mode_registry.default_mode_id, &out.writer);
     try out.writer.writeAll(",\"availableModes\":");
@@ -863,6 +868,10 @@ fn writeLoadSessionResponse(
         state.cfg.mode_registry,
         state.cfg.mode_registry.default_mode_id,
     );
+    if (effortConfigState(state)) |config| {
+        try out.writer.writeAll(",");
+        try writeEffortConfigOption(&out.writer, config.efforts, config.current);
+    }
     try out.writer.writeAll("],\"modes\":{\"currentModeId\":");
     try writeJsonStr(state.cfg.mode_registry.default_mode_id, &out.writer);
     try out.writer.writeAll(",\"availableModes\":");
@@ -1618,6 +1627,82 @@ fn writeModesArray(w: *std.Io.Writer, registry: mode_registry.Registry) !void {
         try w.writeAll("}");
     }
     try w.writeAll("]");
+}
+
+pub const EffortConfigState = struct {
+    efforts: model_capabilities.ReasoningEffortOptions,
+    current: types.ReasoningEffort,
+};
+
+/// Reasoning-effort selector state for the active session, or null when the
+/// active model advertises no effort options (matching the TUI, which hides
+/// the effort picker for those models).
+pub fn effortConfigState(state: *server.ServerState) ?EffortConfigState {
+    const active = if (state.active_session) |*session| session else return null;
+    const bundle = state.cfg.provider_set.select(active.provider);
+    const capabilities = state.capability_resolver.available(
+        active.model,
+        bundle.fallbackModelCapabilities(active.model),
+    );
+    if (capabilities.reasoning_efforts.len == 0) return null;
+    return .{ .efforts = capabilities.reasoning_efforts, .current = active.effort };
+}
+
+pub fn effortSupportedBy(efforts: model_capabilities.ReasoningEffortOptions, effort: types.ReasoningEffort) bool {
+    if (effort == .auto) return true;
+    for (efforts.slice()) |option| {
+        if (option.eql(effort)) return true;
+    }
+    return false;
+}
+
+pub fn writeEffortConfigOption(
+    w: *std.Io.Writer,
+    efforts: model_capabilities.ReasoningEffortOptions,
+    current: types.ReasoningEffort,
+) !void {
+    try w.writeAll("{\"id\":\"effort\",\"name\":\"Reasoning Effort\",\"description\":\"Controls how much the model thinks before responding\",\"category\":\"thought_level\",\"type\":\"select\",\"currentValue\":");
+    try writeJsonStr(current.label(), w);
+    try w.writeAll(",\"options\":[{\"value\":\"auto\",\"name\":\"default\"}");
+    for (efforts.slice()) |effort| {
+        try w.writeAll(",{\"value\":");
+        try writeJsonStr(effort.label(), w);
+        try w.writeAll(",\"name\":");
+        try writeJsonStr(effort.displayLabel(), w);
+        try w.writeAll("}");
+    }
+    try w.writeAll("]}");
+}
+
+test "writeEffortConfigOption produces thought_level select with auto first" {
+    const alloc = std.testing.allocator;
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    defer out.deinit();
+    const efforts = model_capabilities.ReasoningEffortOptions.fromSlice(&.{
+        types.ReasoningEffort.literal("low"),
+        types.ReasoningEffort.literal("high"),
+    });
+    try writeEffortConfigOption(&out.writer, efforts, .literal("high"));
+    const items = out.writer.buffered();
+    try std.testing.expect(std.mem.find(u8, items, "\"id\":\"effort\"") != null);
+    try std.testing.expect(std.mem.find(u8, items, "\"category\":\"thought_level\"") != null);
+    try std.testing.expect(std.mem.find(u8, items, "\"currentValue\":\"high\"") != null);
+    const auto_index = std.mem.find(u8, items, "\"value\":\"auto\"").?;
+    const low_index = std.mem.find(u8, items, "\"value\":\"low\"").?;
+    try std.testing.expect(auto_index < low_index);
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, items, .{});
+    defer parsed.deinit();
+    try std.testing.expectEqualStrings("select", parsed.value.object.get("type").?.string);
+}
+
+test "effortSupportedBy accepts auto and advertised names only" {
+    const efforts = model_capabilities.ReasoningEffortOptions.fromSlice(&.{
+        types.ReasoningEffort.literal("low"),
+        types.ReasoningEffort.literal("high"),
+    });
+    try std.testing.expect(effortSupportedBy(efforts, .auto));
+    try std.testing.expect(effortSupportedBy(efforts, .literal("high")));
+    try std.testing.expect(!effortSupportedBy(efforts, .literal("max")));
 }
 
 test "formatIso8601 produces valid format" {

--- a/src/acp/sessions.zig
+++ b/src/acp/sessions.zig
@@ -1664,11 +1664,22 @@ pub fn writeEffortConfigOption(
     try w.writeAll("{\"id\":\"effort\",\"name\":\"Reasoning Effort\",\"description\":\"Controls how much the model thinks before responding\",\"category\":\"thought_level\",\"type\":\"select\",\"currentValue\":");
     try writeJsonStr(current.label(), w);
     try w.writeAll(",\"options\":[{\"value\":\"auto\",\"name\":\"default\"}");
+    var current_listed = current == .auto;
     for (efforts.slice()) |effort| {
+        if (effort.eql(current)) current_listed = true;
         try w.writeAll(",{\"value\":");
         try writeJsonStr(effort.label(), w);
         try w.writeAll(",\"name\":");
         try writeJsonStr(effort.displayLabel(), w);
+        try w.writeAll("}");
+    }
+    // A persisted effort the active model does not advertise still renders, so
+    // the select never shows a value outside its own option list.
+    if (!current_listed) {
+        try w.writeAll(",{\"value\":");
+        try writeJsonStr(current.label(), w);
+        try w.writeAll(",\"name\":");
+        try writeJsonStr(current.displayLabel(), w);
         try w.writeAll("}");
     }
     try w.writeAll("]}");
@@ -1703,6 +1714,21 @@ test "effortSupportedBy accepts auto and advertised names only" {
     try std.testing.expect(effortSupportedBy(efforts, .auto));
     try std.testing.expect(effortSupportedBy(efforts, .literal("high")));
     try std.testing.expect(!effortSupportedBy(efforts, .literal("max")));
+}
+
+test "writeEffortConfigOption appends an unadvertised current effort" {
+    const alloc = std.testing.allocator;
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    defer out.deinit();
+    const efforts = model_capabilities.ReasoningEffortOptions.fromSlice(&.{
+        types.ReasoningEffort.literal("low"),
+    });
+    try writeEffortConfigOption(&out.writer, efforts, .literal("max"));
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, out.writer.buffered(), .{});
+    defer parsed.deinit();
+    const options = parsed.value.object.get("options").?.array;
+    try std.testing.expectEqual(@as(usize, 3), options.items.len);
+    try std.testing.expectEqualStrings("max", options.items[2].object.get("value").?.string);
 }
 
 test "formatIso8601 produces valid format" {

--- a/tests/e2e/acp.test.ts
+++ b/tests/e2e/acp.test.ts
@@ -1861,6 +1861,86 @@ describe("acp: model-independent", () => {
   );
 
   test(
+    "ACP config options advertise and apply reasoning effort",
+    async () => {
+      const root = createIsolatedRoot("fx-acp-effort-");
+      const gateway = startFakeGateway(
+        [finalText("EFFORT_APPLIED")],
+        {
+          models: [{
+            id: FAKE_GATEWAY_MODEL,
+            type: "language",
+            tags: ["tool-use"],
+            context_window: 128_000,
+            reasoning_options: [{ type: "effort", values: ["low", "high"] }],
+          }],
+        },
+      );
+      let client: AcpClient | undefined;
+      try {
+        client = await AcpClient.create({
+          cwd: root.workspace,
+          env: fakeGatewayEnv(root, gateway),
+        });
+        await client.request("initialize", { protocolVersion: 1 }, 1);
+        const created = await client.request("session/new", { mcpServers: [] }, 2) as any;
+        await client.readLine(); // consume session/update notification
+        await client.request("session/set_mode", { modeId: "code" }, 3);
+        const sessionId = created.result.sessionId as string;
+
+        const advertised = created.result.configOptions.find((option: any) => option.id === "effort");
+        expect(advertised).toBeDefined();
+        expect(advertised.category).toBe("thought_level");
+        expect(advertised.type).toBe("select");
+        expect(advertised.currentValue).toBe("auto");
+        expect(advertised.options.map((option: any) => option.value)).toEqual(["auto", "low", "high"]);
+
+        const rejected = await client.request(
+          "session/set_config_option",
+          { sessionId, configId: "effort", value: "ultra" },
+          4,
+        ) as any;
+        expect(rejected.error).toBeDefined();
+        expect(rejected.error.message).toContain("not available");
+
+        const applied = await client.request(
+          "session/set_config_option",
+          { sessionId, configId: "effort", value: "high" },
+          5,
+        ) as any;
+        expect(applied.error).toBeUndefined();
+        expect(applied.result.configOptions.find((option: any) => option.id === "effort").currentValue)
+          .toBe("high");
+
+        const prompt = await runPrompt(client, "Say EFFORT_APPLIED.", TIMEOUT);
+        expect(prompt.promptResult.result.stopReason).toBe("end_turn");
+        expect(gateway.requests.at(-1)!.body).toContain("\"reasoning\":\"high\"");
+
+        await client.close();
+        client = await AcpClient.create({
+          cwd: root.workspace,
+          env: fakeGatewayEnv(root, gateway),
+        });
+        await client.request("initialize", { protocolVersion: 1 }, 6);
+        const loaded = await client.request(
+          "session/load",
+          { sessionId, cwd: root.workspace, mcpServers: [] },
+          7,
+        ) as any;
+        expect(loaded.error).toBeUndefined();
+        expect(loaded.result.configOptions.find((option: any) => option.id === "effort").currentValue)
+          .toBe("high");
+        expect(client.stderr).toBe("");
+      } finally {
+        await client?.close();
+        gateway.stop();
+        rmSync(root.root, { recursive: true, force: true });
+      }
+    },
+    TIMEOUT,
+  );
+
+  test(
     "ACP reload replays pending execution once and clears recovery after completion",
     async () => {
       const root = createIsolatedRoot("fx-acp-reload-model-recovery-");

--- a/tests/e2e/acp.test.ts
+++ b/tests/e2e/acp.test.ts
@@ -8819,6 +8819,17 @@ describe.skipIf(!HAS_API_KEY)("acp: model-backed protocol", () => {
 
         const notification = await client.readLine() as any;
         expect(notification.method).toBe("session/update");
+
+        // The fake model advertises no effort levels, so the selector is
+        // omitted and setting effort is rejected.
+        expect(resp.result.configOptions.find((o: any) => o.id === "effort")).toBeUndefined();
+        const rejected = await client.request(
+          "session/set_config_option",
+          { sessionId: resp.result.sessionId, configId: "effort", value: "high" },
+          3,
+        ) as any;
+        expect(rejected.error).toBeDefined();
+        expect(rejected.error.message).toContain("unavailable");
       } finally {
         await client?.close();
         gateway.stop();


### PR DESCRIPTION
## Summary

- ACP sessions advertise a Reasoning Effort selector (category `thought_level`) in `configOptions` whenever the active model offers effort levels, so clients such as Zed can render a native effort picker next to provider, model, and mode.
- Clients can change the effort through `session/set_config_option` with `configId: "effort"`; the value is validated against the levels the active model advertises, persisted with the session, and applied to subsequent prompts.
- The selector is omitted for models without advertised effort levels, matching the TUI picker's behavior.