### PR TITLE
Remove leftover helpers orphaned by the OS sandbox removal

### DIFF
--- a/src/core/agent/runtime/tool_admission.zig
+++ b/src/core/agent/runtime/tool_admission.zig
@@ -902,15 +902,6 @@ fn permissionDecisionName(decision: ToolPermissionDecision) []const u8 {
     return @tagName(decision);
 }
 
-pub fn retainSessionGrant(hooks: *const AgentRuntimeDeps, arena: Allocator, local_grants: *std.ArrayList(PermissionGrant), permission: []const u8, pattern: []const u8) !void {
-    const grant = PermissionGrant{
-        .tool_name = try arena.dupe(u8, permission),
-        .target_path = try arena.dupe(u8, pattern),
-    };
-    try appendLocalGrant(arena, local_grants, grant);
-    try propagateGrant(hooks, grant);
-}
-
 fn appendLocalGrant(arena: Allocator, grants: *std.ArrayList(PermissionGrant), grant: PermissionGrant) !void {
     if (permissions.sessionGrantAllowed(grants.items, grant.tool_name, grant.target_path)) return;
     try grants.append(arena, grant);

--- a/src/core/agent/runtime/tool_presentation.zig
+++ b/src/core/agent/runtime/tool_presentation.zig
@@ -837,34 +837,6 @@ fn finishDeferredToolStatus(
     } });
 }
 
-pub fn finishDeniedToolStatusWithResultMemory(
-    hooks: *const AgentRuntimeDeps,
-    arena: Allocator,
-    turn_id: u64,
-    call: ToolCall,
-    status_started: bool,
-    display_target: ?[]const u8,
-    label: []const u8,
-    advertised_dynamic_tool_names: []const []const u8,
-    result: ToolExecutionResult,
-    safe_result: []const u8,
-    result_memory: types.ToolResultMemory,
-) !void {
-    return finishDeniedToolStatusInternal(
-        hooks,
-        arena,
-        turn_id,
-        call,
-        status_started,
-        display_target,
-        label,
-        advertised_dynamic_tool_names,
-        safe_result,
-        result_memory,
-        result.command_result_json,
-    );
-}
-
 fn finishDeniedToolStatusInternal(
     hooks: *const AgentRuntimeDeps,
     arena: Allocator,

--- a/src/core/execution/command_runner.zig
+++ b/src/core/execution/command_runner.zig
@@ -1051,24 +1051,6 @@ fn executeProcess(scratch: Allocator, cfg: Config, argv: []const []const u8, cwd
     return executeProcessWithInput(scratch, cfg, argv, cwd, false, true);
 }
 
-fn executeProcessWithClosedInput(
-    scratch: Allocator,
-    cfg: Config,
-    argv: []const []const u8,
-    cwd: []const u8,
-) !CollectedProcess {
-    if (comptime supports_foreground_session) {
-        return executeProcessWithDetachedSession(
-            scratch,
-            cfg,
-            argv,
-            cwd,
-            "",
-        );
-    }
-    return executeProcessWithInput(scratch, cfg, argv, cwd, true, true);
-}
-
 fn executeProcessWithInput(
     scratch: Allocator,
     cfg: Config,
@@ -1772,19 +1754,6 @@ test "zsh user profile reports natural SIGTERM after alias-safe startup" {
     );
     try std.testing.expectEqual(@as(?i64, 42), trapped.command_result.?.exit_code);
     try std.testing.expectEqual(@as(?u32, null), trapped.command_result.?.signal);
-}
-
-fn formatExitOutput(alloc: Allocator, command: []const u8, cwd: []const u8, exit_code: i64, stdout_raw: []const u8, stderr_raw: []const u8, duration_ms: ?u64) !command_contract.RunCommandResult {
-    return command_contract.formatCommandResult(alloc, .{
-        .command = command,
-        .cwd = cwd,
-        .status = .{ .exit_code = exit_code },
-        .stdout_display = stdout_raw,
-        .stderr_display = stderr_raw,
-        .stdout_bytes = stdout_raw.len,
-        .stderr_bytes = stderr_raw.len,
-        .duration_ms = duration_ms,
-    });
 }
 
 fn formatOutput(alloc: Allocator, command: []const u8, cwd: []const u8, term: std.process.Child.Term, stdout_raw: []const u8, stderr_raw: []const u8, duration_ms: ?u64) !command_contract.RunCommandResult {


### PR DESCRIPTION
## Summary

- Remove four helpers whose last call sites were deleted by the OS command sandbox removal: `executeProcessWithClosedInput` and `formatExitOutput` from `core/execution/command_runner.zig` (sandbox execution path), `finishDeniedToolStatusWithResultMemory` from `core/agent/runtime/tool_presentation.zig` (sandbox widening-approval denial flow), and `retainSessionGrant` from `core/agent/runtime/tool_admission.zig` (same widening-approval flow). No user-facing behavior change: nothing references the removed declarations in production, tests, build roots, or docs, and their callees stay live through the remaining callers.