### PR TITLE
Send image file parts in the v4 language-model data shape

### DIFF
--- a/src/core/agent/runtime/prompt_context.zig
+++ b/src/core/agent/runtime/prompt_context.zig
@@ -263,11 +263,16 @@ pub const RequestTokenCalibration = struct {
     }
 };
 
+const ImagePartData = struct {
+    type: []const u8 = "",
+    data: ?[]const u8 = null,
+};
+
 const ImagePart = struct {
     type: []const u8 = "",
     mediaType: ?[]const u8 = null,
     detail: ?[]const u8 = null,
-    data: ?[]const u8 = null,
+    data: ?ImagePartData = null,
     image_url: ?[]const u8 = null,
 };
 
@@ -330,9 +335,11 @@ pub fn measureProviderRequest(alloc: Allocator, body: []const u8, request: strea
                 part.image_url orelse return error.InvalidRequestMeasurement
             else if (parsed.value.prompt != null and std.mem.eql(u8, part.type, "file") and
                 std.mem.startsWith(u8, part.mediaType orelse "", "image/"))
-                part.data orelse return error.InvalidRequestMeasurement
-            else
-                continue;
+            payload: {
+                const data = part.data orelse return error.InvalidRequestMeasurement;
+                if (!std.mem.eql(u8, data.type, "data")) return error.InvalidRequestMeasurement;
+                break :payload data.data orelse return error.InvalidRequestMeasurement;
+            } else continue;
             const address = @intFromPtr(payload.ptr);
             if (address < @intFromPtr(body.ptr)) return error.InvalidRequestMeasurement;
             const offset = address - @intFromPtr(body.ptr);
@@ -626,13 +633,14 @@ test "provider request measurement includes serialized structure" {
 }
 
 test "provider request image accounting excludes encoded payload length" {
-    const suffix = "\"}]}]}";
-    inline for (.{
-        "{\"input\":[{\"role\":\"user\",\"content\":[{\"type\":\"input_image\",\"image_url\":\"data:image/png;base64,",
-        "{\"prompt\":[{\"role\":\"user\",\"content\":[{\"type\":\"file\",\"mediaType\":\"image/png\",\"data\":\"",
-    }) |prefix| {
-        const small = try measureProviderRequest(std.testing.allocator, prefix ++ "AAAA" ++ suffix, measurement_test_request(true));
-        const large = try measureProviderRequest(std.testing.allocator, prefix ++ ("AAAA" ** 1000) ++ suffix, measurement_test_request(true));
+    const Case = struct { prefix: []const u8, suffix: []const u8 };
+    const cases = [_]Case{
+        .{ .prefix = "{\"input\":[{\"role\":\"user\",\"content\":[{\"type\":\"input_image\",\"image_url\":\"data:image/png;base64,", .suffix = "\"}]}]}" },
+        .{ .prefix = "{\"prompt\":[{\"role\":\"user\",\"content\":[{\"type\":\"file\",\"mediaType\":\"image/png\",\"data\":{\"type\":\"data\",\"data\":\"", .suffix = "\"}}]}]}" },
+    };
+    inline for (cases) |case| {
+        const small = try measureProviderRequest(std.testing.allocator, case.prefix ++ "AAAA" ++ case.suffix, measurement_test_request(true));
+        const large = try measureProviderRequest(std.testing.allocator, case.prefix ++ ("AAAA" ** 1000) ++ case.suffix, measurement_test_request(true));
         try std.testing.expect(large.serialized_bytes > small.serialized_bytes);
         try std.testing.expectEqual(small.text_tokens, large.text_tokens);
         try std.testing.expectEqual(small.estimated_input_tokens, large.estimated_input_tokens);
@@ -717,7 +725,7 @@ test "provider request image accounting preserves text and tool payloads" {
     ;
     try std.testing.expectEqual(textTokens(without_image_payload), measured.text_tokens);
 
-    const file_text = "{\"prompt\":[{\"role\":\"user\",\"content\":[{\"type\":\"file\",\"mediaType\":\"text/plain\",\"data\":\"AAAA\"}]}]}";
+    const file_text = "{\"prompt\":[{\"role\":\"user\",\"content\":[{\"type\":\"file\",\"mediaType\":\"text/plain\",\"data\":{\"type\":\"data\",\"data\":\"AAAA\"}}]}]}";
     const non_image = try measureProviderRequest(std.testing.allocator, file_text, measurement_test_request(true));
     try std.testing.expectEqual(textTokens(file_text), non_image.text_tokens);
     try std.testing.expectEqual(@as(?[32]u8, null), non_image.image_identity);

--- a/src/core/images/image_attachments.zig
+++ b/src/core/images/image_attachments.zig
@@ -1726,7 +1726,7 @@ pub fn writeVerifiedImageFilePartJsonWithBudget(
 
     try writer.writeAll("{\"type\":\"file\",\"mediaType\":\"");
     try writer.writeAll(snapshot.media_type);
-    try writer.writeAll("\",\"data\":\"");
+    try writer.writeAll("\",\"data\":{\"type\":\"data\",\"data\":\"");
 
     var offset: usize = 0;
     while (offset < snapshot.bytes.len) {
@@ -1736,7 +1736,7 @@ pub fn writeVerifiedImageFilePartJsonWithBudget(
         offset = end;
     }
 
-    try writer.writeAll("\"}");
+    try writer.writeAll("\"}}");
     try budget.check();
 }
 

--- a/src/gateway/vercel_protocol.zig
+++ b/src/gateway/vercel_protocol.zig
@@ -1276,7 +1276,7 @@ test "writeChatMessageJson serializes user text plus image file parts through co
     try std.testing.expect(std.mem.find(u8, json, "\"text\":\"look\"") != null);
     try std.testing.expect(std.mem.find(u8, json, "\"type\":\"file\"") != null);
     try std.testing.expect(std.mem.find(u8, json, "\"mediaType\":\"image/png\"") != null);
-    try std.testing.expect(std.mem.find(u8, json, "\"data\":\"iVBORw0KGgphYmM=\"") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"data\":{\"type\":\"data\",\"data\":\"iVBORw0KGgphYmM=\"}") != null);
 }
 
 test "writeChatMessageJson serializes assistant tool call input as raw json" {

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -5338,7 +5338,7 @@ test("provider context accounting is independent of image encoding size", async 
         const parts = (request.input ?? request.prompt).flatMap((message: { content: unknown }) => Array.isArray(message.content) ? message.content : []);
         const image = parts.find((part: { type?: string }) => part.type === (provider === "gateway" ? "file" : "input_image"));
         expect(image).toBeDefined();
-        expect(provider === "gateway" ? image.data : image.image_url).toBe((provider === "gateway" ? "" : "data:image/png;base64,") + bytes.toString("base64"));
+        expect(provider === "gateway" ? image.data.data : image.image_url).toBe((provider === "gateway" ? "" : "data:image/png;base64,") + bytes.toString("base64"));
         const decision = readFileSync(trace, "utf8");
         expect(decision).toContain("decision=no_op");
         expect(decision).toContain("has_images=true image_baseline=false");

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -3855,7 +3855,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       expect(continuedParts.filter((part) => part.type === "file")).toEqual([{
         type: "file",
         mediaType: "image/png",
-        data: expectedImageData,
+        data: { type: "data", data: expectedImageData },
       }]);
       expect(continuedBody).toContain("RICH_STEERING_TOOL_DONE");
       expect(continuedBody).toContain("<user_steering>");
@@ -4149,7 +4149,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       expect(steeringParts.filter((part) => part.type === "file")).toEqual([{
         type: "file",
         mediaType: "image/png",
-        data: expectedImageData,
+        data: { type: "data", data: expectedImageData },
       }]);
       expect(steeringBody).toContain("<user_steering>");
       expect(steeringBody).not.toContain("<turn_aborted>");

--- a/tests/e2e/vision-route-fake-gateway.test.ts
+++ b/tests/e2e/vision-route-fake-gateway.test.ts
@@ -118,10 +118,13 @@ function filePartCount(body: string) {
 
 function nativeFileParts(body: string) {
   return promptParts(body).filter(
-    (part): part is Record<string, unknown> & { data: string; mediaType: string } =>
+    (part): part is Record<string, unknown> & { data: { type: string; data: string }; mediaType: string } =>
       part.type === "file" &&
-      typeof part.data === "string" &&
-      typeof part.mediaType === "string",
+      typeof part.mediaType === "string" &&
+      typeof part.data === "object" &&
+      part.data !== null &&
+      (part.data as { type?: unknown }).type === "data" &&
+      typeof (part.data as { data?: unknown }).data === "string",
   );
 }
 
@@ -1157,7 +1160,7 @@ describe("Vision route fake Gateway", () => {
           const parts = nativeFileParts(gateway.chatRequests[0]!.body);
           expect(parts).toHaveLength(1);
           expect(parts[0]!.mediaType).toBe("image/jpeg");
-          expect(parts[0]!.data.length).toBeLessThanOrEqual(5 * 1024 * 1024);
+          expect(parts[0]!.data.data.length).toBeLessThanOrEqual(5 * 1024 * 1024);
           return;
         }
 
@@ -3168,7 +3171,7 @@ for (const sourceChange of ["removed", "changed", "saved snapshot missing", "sav
       expect(gateway.chatRequests).toHaveLength(4);
       const parts = nativeFileParts(gateway.chatRequests[2]!.body);
       expect(parts).toHaveLength(1);
-      expect(createHash("sha256").update(Buffer.from(parts[0]!.data, "base64")).digest("hex")).toBe(digest);
+      expect(createHash("sha256").update(Buffer.from(parts[0]!.data.data, "base64")).digest("hex")).toBe(digest);
       const history = readFileSync(join(sessions, id, "events.jsonl"), "utf8");
       expect(history).toContain(digest);
       expect(readFileSync(snapshot).toString("base64")).toBe(original);
@@ -3219,7 +3222,7 @@ test.skipIf(!tmuxAvailable())("TUI recovery retains images through failure and c
     await session.sendText("/continue");
     await session.waitForText("TUI_RECOVERY_IMAGE_COMPLETE", TIMEOUT);
     await session.waitForStableComposer(TIMEOUT);
-    expect(nativeFileParts(gateway.chatRequests[2]!.body)[0]!.data).toBe(original);
+    expect(nativeFileParts(gateway.chatRequests[2]!.body)[0]!.data.data).toBe(original);
     writeMarkedImage(input, "NEW_IMAGE_AFTER_RECOVERY");
     await session.sendText(`/image ${input}`);
     await session.waitForText("attached image:", TIMEOUT);


### PR DESCRIPTION
## Summary

- Attach images with the nested data object the v4 endpoint requires, so prompts carrying an image succeed instead of failing with HTTP 400 invalid_union.