### PR TITLE
Remove leftover entry points orphaned by the persistence cutover

### DIFF
--- a/src/core/session/session_display_metadata.zig
+++ b/src/core/session/session_display_metadata.zig
@@ -271,16 +271,6 @@ pub fn readSidecarOrFallback(
     return decodeSidecarOrFallback(alloc, bytes);
 }
 
-pub fn writeSidecar(
-    alloc: Allocator,
-    session_dir: *io_mod.VerifiedDir,
-    metadata: DisplayMetadata,
-) !void {
-    const bytes = try encodeSidecar(alloc, metadata);
-    defer alloc.free(bytes);
-    try io_mod.durableReplaceVerified(alloc, session_dir, sidecar_file, bytes);
-}
-
 fn requiredStringDup(alloc: Allocator, maybe_value: ?std.json.Value) ![]u8 {
     const value = maybe_value orelse return error.InvalidDisplayMetadata;
     if (value != .string) return error.InvalidDisplayMetadata;

--- a/src/core/session/session_replay.zig
+++ b/src/core/session/session_replay.zig
@@ -330,25 +330,6 @@ pub fn replayBoundary(
     };
 }
 
-/// Replays one caller-supplied durable boundary without consulting a commit
-/// watermark. It never searches for or selects a different prefix.
-pub fn replayExactBoundary(
-    alloc: Allocator,
-    file: std.Io.File,
-    expected_generation: Identifier,
-    expected_seq: u64,
-    expected_bytes: u64,
-) !session_codec.DurableSessionState {
-    var replayed = try replayExactPosition(
-        alloc,
-        file,
-        expected_generation,
-        expected_seq,
-        expected_bytes,
-    );
-    return replayed.takeState();
-}
-
 /// Owns `state`; callers must call `deinit` or transfer it with `takeState`.
 pub const ExactReplay = struct {
     state: session_codec.DurableSessionState,

--- a/src/core/subagent/resume_admission.zig
+++ b/src/core/subagent/resume_admission.zig
@@ -9,7 +9,6 @@ const catalog_cache = @import("../session/session_catalog_cache.zig");
 const session_summary_codec = @import("../session/session_summary_codec.zig");
 
 const Allocator = std.mem.Allocator;
-const max_page_limit: usize = 100;
 
 pub const ActionableContinuation = struct {
     updated_at_ms: i64,
@@ -22,19 +21,6 @@ pub const ActionableContinuation = struct {
 
     pub fn view(self: ActionableContinuation) session_store.ResumableSessionContinuation {
         return .{ .updated_at_ms = self.updated_at_ms, .id = self.id };
-    }
-};
-
-pub const ActionableSessionPage = struct {
-    summaries: std.ArrayList(session_store.SessionSummary) = .empty,
-    has_more: bool = false,
-    continuation: ?ActionableContinuation = null,
-
-    pub fn deinit(self: *ActionableSessionPage, alloc: Allocator) void {
-        for (self.summaries.items) |*summary| summary.deinit(alloc);
-        self.summaries.deinit(alloc);
-        if (self.continuation) |*continuation| continuation.deinit(alloc);
-        self.* = undefined;
     }
 };
 
@@ -308,80 +294,6 @@ pub fn loadVisibleReadOnlyDetail(
     errdefer detail.deinit(alloc);
     if (detail.state.subagent_child) return error.SessionNotFound;
     return detail;
-}
-
-pub fn listActionablePage(
-    store: session_store.Store,
-    alloc: Allocator,
-    scope: session_store.SessionListScope,
-    active_id: ?[]const u8,
-    continuation: ?session_store.ResumableSessionContinuation,
-    limit: usize,
-) !ActionableSessionPage {
-    if (limit == 0 or limit > max_page_limit) return error.InvalidSessionListLimit;
-
-    var result: ActionableSessionPage = .{};
-    errdefer result.deinit(alloc);
-    var position: ?ActionableContinuation = if (continuation) |value| .{
-        .updated_at_ms = value.updated_at_ms,
-        .id = try alloc.dupe(u8, value.id),
-    } else null;
-    defer if (position) |*value| value.deinit(alloc);
-
-    var scanned: usize = 0;
-    while (result.summaries.items.len < limit and scanned < max_page_limit) {
-        var scoped = store;
-        scoped.resume_page_limit = @min(
-            limit - result.summaries.items.len,
-            max_page_limit - scanned,
-        );
-        const next = if (position) |value| value.view() else null;
-        var page = switch (scope) {
-            .current_workspace => try scoped.listResumableWorkspacePage(
-                alloc,
-                active_id,
-                next,
-            ),
-            .all_workspaces => try scoped.listResumablePage(
-                alloc,
-                active_id,
-                next,
-            ),
-        };
-        defer page.deinit(alloc);
-        result.has_more = page.has_more;
-        if (page.summaries.items.len == 0) break;
-
-        for (page.summaries.items) |summary| {
-            scanned += 1;
-            if (position) |*value| value.deinit(alloc);
-            position = .{
-                .updated_at_ms = summary.updated_at_ms,
-                .id = try alloc.dupe(u8, summary.id),
-            };
-            const managed = child_state.isManagedChildSession(
-                store,
-                alloc,
-                summary.id,
-            ) catch |err| switch (err) {
-                error.OutOfMemory => return error.OutOfMemory,
-                else => true,
-            };
-            if (managed) continue;
-            var cloned = try session_summary_codec.cloneSessionSummary(alloc, summary);
-            result.summaries.append(alloc, cloned) catch |err| {
-                cloned.deinit(alloc);
-                return err;
-            };
-        }
-        if (!page.has_more) break;
-    }
-
-    if (position) |value| {
-        result.continuation = value;
-        position = null;
-    }
-    return result;
 }
 
 pub fn resumeForExternalPrompt(


### PR DESCRIPTION
## Summary

- Remove three entry points whose last callers were deleted by the conversation persistence cutover: `listActionablePage` from `core/subagent/resume_admission.zig` (the resume picker moved to `listActionableCatalog`), `replayExactBoundary` from `core/session/session_replay.zig` (recovery replays through the committed-prefix path), and `writeSidecar` from `core/session/session_display_metadata.zig` (display metadata sidecars are read-only legacy data now). Also removes `ActionableSessionPage` and `max_page_limit`, which only the removed paginator referenced. No user-facing behavior change: nothing references the removed declarations in production, tests, build roots, or docs, and their callees stay live through the remaining callers.