### PR TITLE
Pin rejection of non-v4 image file part shapes in request measurement

### DIFF
--- a/src/core/agent/runtime/prompt_context.zig
+++ b/src/core/agent/runtime/prompt_context.zig
@@ -804,6 +804,13 @@ test "provider request image accounting handles allocation and malformed input f
         "{\"input\":[],\"prompt\":[]}",
         "{\"input\":[{\"role\":\"user\",\"content\":[{\"type\":\"input_image\"}]}]}",
         "{\"input\":[{\"role\":\"user\",\"content\":[{\"type\":\"input_image\",\"image_url\":\"escaped\\nimage\"}]}]}",
+        // Prompt-shape file parts must carry the nested v4 data object; every
+        // other shape is rejected rather than mis-measured.
+        "{\"prompt\":[{\"role\":\"user\",\"content\":[{\"type\":\"file\",\"mediaType\":\"image/png\",\"data\":\"AAAA\"}]}]}",
+        "{\"prompt\":[{\"role\":\"user\",\"content\":[{\"type\":\"file\",\"mediaType\":\"image/png\"}]}]}",
+        "{\"prompt\":[{\"role\":\"user\",\"content\":[{\"type\":\"file\",\"mediaType\":\"image/png\",\"data\":{\"type\":\"url\",\"url\":\"https://x/y.png\"}}]}]}",
+        "{\"prompt\":[{\"role\":\"user\",\"content\":[{\"type\":\"file\",\"mediaType\":\"image/png\",\"data\":{\"type\":\"data\"}}]}]}",
+        "{\"prompt\":[{\"role\":\"user\",\"content\":[{\"type\":\"file\",\"mediaType\":\"image/png\",\"data\":{\"type\":\"data\",\"data\":\"escaped\\nimage\"}}]}]}",
     }) |body| {
         try std.testing.expectError(error.InvalidRequestMeasurement, measureProviderRequest(std.testing.allocator, body, measurement_test_request(true)));
     }


### PR DESCRIPTION
## Summary

- Cover the measurement parser's rejection of flat, missing, and URL-shaped image file data so only the nested v4 data object is measured as an image payload.