### PR TITLE
Remove leftover helpers orphaned by interaction simplifications

### DIFF
--- a/src/core/config/settings_catalog.zig
+++ b/src/core/config/settings_catalog.zig
@@ -309,13 +309,6 @@ pub fn itemAt(snapshot: Snapshot, category: Category, query: []const u8, display
     return null;
 }
 
-pub fn specFor(id: SettingId) *const Spec {
-    for (&specs) |*spec| {
-        if (spec.id == id) return spec;
-    }
-    unreachable;
-}
-
 pub fn optionCount(snapshot: *const Snapshot, id: SettingId) usize {
     return switch (id) {
         .effort => if (snapshot.reasoning_efforts.len > 0 or !std.ascii.eqlIgnoreCase(snapshot.effort, "default"))

--- a/src/core/skills/skill_runtime.zig
+++ b/src/core/skills/skill_runtime.zig
@@ -1146,10 +1146,6 @@ pub fn skillSourceMatchesFilter(source: SkillSource, filter: SkillMenuSourceFilt
     return filter == .all or skillMenuFilterForSource(source) == filter;
 }
 
-pub fn skill_matches_menu_query(skill: Skill, query: []const u8) bool {
-    return skillMatchRank(skill, query) != null;
-}
-
 pub fn skillDisplaySource(skills: []const Skill, selected: Skill) ?SkillSource {
     var matching_names: usize = 0;
     for (skills) |skill| {
@@ -1160,10 +1156,6 @@ pub fn skillDisplaySource(skills: []const Skill, selected: Skill) ?SkillSource {
     return null;
 }
 
-pub fn skillMenuFilterCount(skills: []const Skill, filter: SkillMenuSourceFilter) usize {
-    return skillMenuFilterQueryCount(skills, filter, "");
-}
-
 pub fn skillMenuFilterQueryCount(skills: []const Skill, filter: SkillMenuSourceFilter, query: []const u8) usize {
     var count: usize = 0;
     var it = SkillMenuView.init(skills, filter, query);
@@ -1171,10 +1163,6 @@ pub fn skillMenuFilterQueryCount(skills: []const Skill, filter: SkillMenuSourceF
         count += 1;
     }
     return count;
-}
-
-pub fn skillMenuActualIndexAt(skills: []const Skill, filter: SkillMenuSourceFilter, display_index: usize) ?usize {
-    return skillMenuActualIndexAtQuery(skills, filter, "", display_index);
 }
 
 pub fn skillMenuActualIndexAtQuery(skills: []const Skill, filter: SkillMenuSourceFilter, query: []const u8, display_index: usize) ?usize {

--- a/src/core/subagent/tool_host.zig
+++ b/src/core/subagent/tool_host.zig
@@ -1654,24 +1654,6 @@ pub const CapabilityPolicy = struct {
     mode: ModePolicy,
 };
 
-pub fn captureHostAuthority(
-    alloc: Allocator,
-    policy: CapabilityPolicy,
-    integration_names: []const []const u8,
-    rules: types.PermissionRuleSet,
-    grants: []const types.PermissionGrant,
-) !authority.HostAuthority {
-    return captureHostAuthorityWithMcpView(
-        alloc,
-        policy,
-        integration_names,
-        rules,
-        grants,
-        .{},
-        null,
-    );
-}
-
 pub fn captureHostAuthorityWithMcpView(
     alloc: Allocator,
     policy: CapabilityPolicy,

--- a/src/core/tooling/tool_dispatch.zig
+++ b/src/core/tooling/tool_dispatch.zig
@@ -323,7 +323,6 @@ pub const DispatchContext = struct {
     tool_result_memory_sink: ?*?core_types.ToolResultMemory = null,
     model_content_kind_sink: ?*ModelContentKind = null,
     command_result_json_sink: ?*?[]const u8 = null,
-    turn_control_sink: ?*?TurnControl = null,
     result_commit_sink: ?*?result_commit.Token = null,
 };
 
@@ -981,11 +980,6 @@ pub fn reportToolResultMemory(ctx: DispatchContext, memory: core_types.ToolResul
 pub fn reportCommandResultJson(ctx: DispatchContext, json: []const u8) void {
     const sink = ctx.command_result_json_sink orelse return;
     sink.* = json;
-}
-
-pub fn reportTurnControl(ctx: DispatchContext, control: TurnControl) void {
-    const sink = ctx.turn_control_sink orelse return;
-    sink.* = control;
 }
 
 pub fn reportResultCommit(ctx: DispatchContext, token: result_commit.Token) void {

--- a/src/core/tooling/tool_runtime.zig
+++ b/src/core/tooling/tool_runtime.zig
@@ -937,7 +937,6 @@ const DispatchMetadata = struct {
         ctx.web_fetch_completion_sink = &self.web_fetch_completion;
         ctx.tool_result_memory_sink = &self.tool_result_memory;
         ctx.command_result_json_sink = &self.command_result_json;
-        ctx.turn_control_sink = &self.turn_control;
     }
 };
 


### PR DESCRIPTION
## Summary

- Remove five helpers whose last call sites were deleted by completed simplifications: `specFor` from `core/config/settings_catalog.zig` (legacy terminal presentation retirement), the no-query skill menu wrappers `skill_matches_menu_query`, `skillMenuFilterCount`, and `skillMenuActualIndexAt` from `core/skills/skill_runtime.zig` (terminal menu speedup; their query variants serve the live menu), and `captureHostAuthority` from `core/subagent/tool_host.zig` (subagent delegation simplification; `captureHostAuthorityWithMcpView` is the live entry). Also removes the `reportTurnControl` sink channel from `core/tooling/tool_dispatch.zig` and its wiring in `core/tooling/tool_runtime.zig`: the managed shell interaction simplification deleted its only sender, and turn control still reaches the orchestrator through the metadata path. No user-facing behavior change: nothing references the removed declarations in production, tests, build roots, or docs.