### PR TITLE
Remove unwired helpers and orphaned render pieces

### DIFF
--- a/src/core/app/app_lifecycle.zig
+++ b/src/core/app/app_lifecycle.zig
@@ -344,21 +344,6 @@ pub fn loadLibfxStartupState(
     };
 }
 
-pub fn loadCatalogStartupState(
-    alloc: Allocator,
-    secret_store: host.SecretStore,
-    default_model: []const u8,
-    default_agent_step_limit: usize,
-) !StartupState {
-    return loadCatalogStartupStateWithAuthMode(
-        alloc,
-        secret_store,
-        default_model,
-        default_agent_step_limit,
-        .local,
-    );
-}
-
 pub fn loadCatalogStartupStateWithAuthMode(
     alloc: Allocator,
     secret_store: host.SecretStore,

--- a/src/core/auth/chatgpt_oauth.zig
+++ b/src/core/auth/chatgpt_oauth.zig
@@ -735,24 +735,6 @@ fn requestAcceptedWithBounds(
     return response.takeBody();
 }
 
-fn sessionFromToken(alloc: Allocator, token: *TokenSet, now_ms: i64) !chatgpt_session.Session {
-    const account_id = try extractAccountId(alloc, token.access_token);
-    errdefer alloc.free(account_id);
-    const duration_ms = std.math.mul(i64, token.expires_in, std.time.ms_per_s) catch
-        return error.InvalidChatGptOAuthResponse;
-    const expires_at_ms = std.math.add(i64, now_ms, duration_ms) catch
-        return error.InvalidChatGptOAuthResponse;
-    const session = chatgpt_session.Session{
-        .access_token = token.access_token,
-        .refresh_token = token.refresh_token,
-        .expires_at_ms = expires_at_ms,
-        .account_id = account_id,
-    };
-    token.access_token = &.{};
-    token.refresh_token = &.{};
-    return session;
-}
-
 pub fn extractAccountId(alloc: Allocator, token: []const u8) ![]u8 {
     var parts = std.mem.splitScalar(u8, token, '.');
     _ = parts.next() orelse return error.InvalidChatGptAccessToken;
@@ -787,18 +769,6 @@ fn requiredPositiveInteger(object: std.json.ObjectMap, key: []const u8) !i64 {
     const value = object.get(key) orelse return error.InvalidChatGptOAuthResponse;
     if (value != .integer or value.integer <= 0) return error.InvalidChatGptOAuthResponse;
     return value.integer;
-}
-
-fn flexiblePositiveInteger(object: std.json.ObjectMap, key: []const u8) !i64 {
-    const value = object.get(key) orelse return error.InvalidChatGptOAuthResponse;
-    const result = switch (value) {
-        .integer => value.integer,
-        .string => std.fmt.parseInt(i64, std.mem.trim(u8, value.string, " \t\r\n"), 10) catch
-            return error.InvalidChatGptOAuthResponse,
-        else => return error.InvalidChatGptOAuthResponse,
-    };
-    if (result < 0) return error.InvalidChatGptOAuthResponse;
-    return result;
 }
 
 const BrowserCallback = struct {

--- a/src/core/input/picker_state.zig
+++ b/src/core/input/picker_state.zig
@@ -56,12 +56,6 @@ pub const login_prefix = "/login ";
 const setup_prefix = "/setup ";
 pub const provider_picker_prefixes = [_][]const u8{ provider_prefix, login_prefix, setup_prefix };
 
-pub fn providerPickerPrefix(input: []const u8) ?[]const u8 {
-    const trimmed = std.mem.trimStart(u8, input, " \t\r\n");
-    const len = providerPickerPrefixLen(trimmed) orelse return null;
-    return trimmed[0..len];
-}
-
 pub const ModelPickerQuery = struct {
     stage: ModelPickerStage,
     query: []const u8,

--- a/src/ui/footer/paint_plan.zig
+++ b/src/ui/footer/paint_plan.zig
@@ -1224,10 +1224,6 @@ fn expectRowBackground(row_bytes: []const u8, width: u16, expected_bg: vt_emulat
     }
 }
 
-fn expectRowDefaultBackground(row_bytes: []const u8, width: u16) !void {
-    try expectRowBackground(row_bytes, width, .default);
-}
-
 fn expectFrameRowBackground(frame: *const footer_viewport.ComposedFooterFrame, row_number: u16, width: u16, expected_bg: vt_emulator.Color) !void {
     for (frame.rows.items) |row| {
         if (row.row == row_number) {

--- a/src/ui/full_transcript_screen.zig
+++ b/src/ui/full_transcript_screen.zig
@@ -5173,23 +5173,6 @@ fn appendStoredResultFallback(
     return true;
 }
 
-fn appendSavedResultUnavailable(
-    alloc: Allocator,
-    walker: *ProjectionRowWalker,
-    styles: transcript_blocks.Styles,
-    line_prefix: []const u8,
-) !bool {
-    var line: std.Io.Writer.Allocating = .init(alloc);
-    defer line.deinit();
-    try writeSecondaryPrefixedLine(
-        &line.writer,
-        styles,
-        line_prefix,
-        "Full saved result unavailable.",
-    );
-    return walker.append(line.written());
-}
-
 fn appendPermanentCommandUnavailable(
     walker: *ProjectionRowWalker,
     styles: transcript_blocks.Styles,


### PR DESCRIPTION
## Summary

- Remove six pieces with no reachable callers: `sessionFromToken` and `flexiblePositiveInteger` from `core/auth/chatgpt_oauth.zig` (added by the Codex subscription commit but never wired; the live token flow uses `extractAccountId` directly), `loadCatalogStartupState` from `core/app/app_lifecycle.zig` (both callers and its function type were removed when authentication stopped switching credential sources; the auth-mode variant is the only startup-state entry), `providerPickerPrefix` from `core/input/picker_state.zig` (`providerPickerPrefixLen` serves the live parsing paths), `appendSavedResultUnavailable` from `ui/full_transcript_screen.zig` (the Ctrl-O completeness pass deleted both call sites), and `expectRowDefaultBackground` from `ui/footer/paint_plan.zig` (its only test was retired with the legacy presentation modes). No user-facing behavior change: nothing references the removed declarations in production, tests, build roots, or docs, and every callee they had stays live through the remaining callers.