### PR TITLE
Remove persistence and shell leftovers orphaned by completed work

### DIFF
--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -5,7 +5,6 @@ const app_commands = @import("app_commands.zig");
 const app_lifecycle = @import("app_lifecycle.zig");
 const app_permission_runtime = @import("app_permission_runtime.zig");
 const app_session_runtime = @import("app_session_runtime.zig");
-const managed_execution = @import("../execution/managed_execution.zig");
 const terminal_ui_projection = @import("../terminal/ui_projection.zig");
 const worker_runtime = @import("../agent/worker_runtime.zig");
 const auth_runtime = @import("../auth/auth_runtime.zig");
@@ -1992,45 +1991,6 @@ pub fn Runtime(comptime App: type) type {
             };
         }
     };
-}
-
-fn managedExecutionProjection(
-    alloc: std.mem.Allocator,
-    runtime: *managed_execution.Runtime,
-) !terminal_ui_projection.Snapshot {
-    const executions = try runtime.list(alloc);
-    defer {
-        for (executions) |*execution| execution.deinit(alloc);
-        alloc.free(executions);
-    }
-    const rows = try alloc.alloc(terminal_ui_projection.Row, executions.len);
-    var initialized: usize = 0;
-    errdefer {
-        for (rows[0..initialized]) |*row| {
-            alloc.free(row.label);
-            alloc.free(row.session_id);
-        }
-        alloc.free(rows);
-    }
-    for (executions, rows) |execution, *row| {
-        const session_id = try alloc.dupe(u8, execution.execution_id);
-        errdefer alloc.free(session_id);
-        row.* = .{
-            .session_id = session_id,
-            .label = try alloc.dupe(u8, execution.command),
-            .lifecycle = switch (execution.state) {
-                .running => .running,
-                .completed => .exited,
-                .stopped => .closed,
-                .lost => .lost,
-            },
-            .attention = .{},
-            .backend = .native,
-            .attachable = execution.backend == .tty,
-        };
-        initialized += 1;
-    }
-    return .{ .alloc = alloc, .rows = rows };
 }
 
 fn renderReasonNames(
@@ -4039,20 +3999,6 @@ noinline fn coordinatorGridContains(grid: vt_emulator.Grid, needle: []const u8) 
         if (std.mem.find(u8, buf.items, needle) != null) return true;
     }
     return false;
-}
-
-noinline fn coordinatorGridOccurrenceCount(grid: vt_emulator.Grid, needle: []const u8) !usize {
-    var row: u16 = 1;
-    var count: usize = 0;
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(grid.alloc);
-
-    while (row <= grid.rows) : (row += 1) {
-        buf.clearRetainingCapacity();
-        try grid.rowTextTrimmed(row, &buf);
-        count += std.mem.count(u8, buf.items, needle);
-    }
-    return count;
 }
 
 test "core.app_render_runtime first requested startup frame commits through the ordinary coordinator" {

--- a/src/core/output/output_contracts.zig
+++ b/src/core/output/output_contracts.zig
@@ -1864,14 +1864,6 @@ fn writeSessionHistoryTurnJson(writer: *std.Io.Writer, turn: types.HistoryTurn) 
     }
 }
 
-fn writeHexBytes(writer: *std.Io.Writer, bytes: []const u8) !void {
-    const alphabet = "0123456789abcdef";
-    for (bytes) |byte| {
-        try writer.writeByte(alphabet[byte >> 4]);
-        try writer.writeByte(alphabet[byte & 0x0f]);
-    }
-}
-
 fn writeSessionUserTurnJson(writer: *std.Io.Writer, user: types.UserTurn) !void {
     try writer.writeAll("{\"text\":");
     try std.json.Stringify.value(user.text, .{}, writer);

--- a/src/core/session/session_event.zig
+++ b/src/core/session/session_event.zig
@@ -1481,26 +1481,6 @@ fn applyDelta(
     }
 }
 
-pub fn applyEventToState(
-    alloc: Allocator,
-    state: *session_codec.DurableSessionState,
-    event: Event,
-    timestamp_ms: i64,
-) !void {
-    const zero_id = [_]u8{0} ** 16;
-    const envelope = Envelope{
-        .log_generation = zero_id,
-        .seq = 1,
-        .event_id = zero_id,
-        .timestamp_ms = timestamp_ms,
-        .event = event,
-    };
-    try validateEnvelope(envelope);
-    var current: ?session_codec.DurableSessionState = state.*;
-    try applyDelta(alloc, &current, envelope);
-    state.* = current.?;
-}
-
 fn validateEnvelope(envelope: Envelope) !void {
     if (envelope.seq == 0 or envelope.timestamp_ms < 0) return error.InvalidEventFrame;
     switch (envelope.event) {

--- a/src/core/session/session_log.zig
+++ b/src/core/session/session_log.zig
@@ -2197,36 +2197,6 @@ fn restoreContextResultBodies(alloc: Allocator, dir: *io_mod.VerifiedDir, histor
     }
 }
 
-fn isCurrentConversationCheckpoint(turn: session.HistoryTurn) bool {
-    return switch (turn) {
-        .compacted_summary => |entry| std.mem.startsWith(
-            u8,
-            entry.summary,
-            types.context_handoff_open,
-        ),
-        else => false,
-    };
-}
-
-fn retainLatestCheckpointHistory(
-    alloc: Allocator,
-    state: *session_codec.DurableSessionState,
-) !void {
-    if (state.history.len == 0 or
-        !isCurrentConversationCheckpoint(state.history[state.history.len - 1]))
-    {
-        return error.InvalidConversationEvent;
-    }
-    const retained = try alloc.alloc(session.HistoryTurn, 1);
-    retained[0] = state.history[state.history.len - 1];
-    for (state.history[0 .. state.history.len - 1]) |turn| {
-        session.freeHistoryTurn(alloc, turn);
-    }
-    alloc.free(state.history);
-    state.history = retained;
-    state.context_history_start = 0;
-}
-
 fn projectConversationSnapshotLocators(
     alloc: Allocator,
     history: []session.HistoryTurn,

--- a/src/core/session/session_relationship_index_codec.zig
+++ b/src/core/session/session_relationship_index_codec.zig
@@ -190,22 +190,6 @@ pub fn decodeHeader(bytes: []const u8) Error!Header {
     return header;
 }
 
-pub fn encodePage(alloc: Allocator, page_data: PageData) Allocator.Error![]u8 {
-    var out: std.Io.Writer.Allocating = .init(alloc);
-    defer out.deinit();
-    out.writer.writeAll(page_magic) catch return error.OutOfMemory;
-    writeInt(&out.writer, u32, epoch_schema_version) catch return error.OutOfMemory;
-    writeInt(&out.writer, u64, page_data.number) catch return error.OutOfMemory;
-    writeInt(&out.writer, u64, page_data.storage_epoch) catch return error.OutOfMemory;
-    for (page_data.slots) |slot| {
-        out.writer.writeByte(if (slot.occupied) 1 else 0) catch return error.OutOfMemory;
-        writeInt(&out.writer, u64, slot.next_free) catch return error.OutOfMemory;
-        writeInt(&out.writer, u16, slot.child_len) catch return error.OutOfMemory;
-        out.writer.writeAll(slot.childId()) catch return error.OutOfMemory;
-    }
-    return out.toOwnedSlice();
-}
-
 pub fn decodePage(
     bytes: []const u8,
     expected_number: u64,

--- a/src/core/session/session_store.zig
+++ b/src/core/session/session_store.zig
@@ -4250,28 +4250,6 @@ fn resolveImageSnapshotLocators(
     }
 }
 
-fn deleteSnapshotFilesAddedByMigration(
-    candidate: []const session.HistoryTurn,
-    original: []const session.HistoryTurn,
-) void {
-    for (candidate, original) |candidate_turn, original_turn| {
-        const candidate_images = switch (candidate_turn) {
-            .compacted_summary => &.{},
-            .assistant => |entry| entry.user.images,
-            .interrupted => |entry| entry.user.images,
-        };
-        const original_images = switch (original_turn) {
-            .compacted_summary => &.{},
-            .assistant => |entry| entry.user.images,
-            .interrupted => |entry| entry.user.images,
-        };
-        image_attachments.deleteUnreferencedImageSnapshots(
-            candidate_images,
-            original_images,
-        );
-    }
-}
-
 test "session snapshot locators resolve through their owning store" {
     const alloc = std.testing.allocator;
     var history = try alloc.alloc(session.HistoryTurn, 1);

--- a/src/core/subagent/agent_adapter.zig
+++ b/src/core/subagent/agent_adapter.zig
@@ -881,4 +881,3 @@ fn pushLiveOutputChunk(
         .text = @constCast(text),
     } });
 }
-fn discardBackgroundUrl(_: *anyopaque, _: u64, _: []const u8) void {}

--- a/src/core/tooling/tool_runtime.zig
+++ b/src/core/tooling/tool_runtime.zig
@@ -2026,7 +2026,6 @@ fn executeSubagentProvider(
 }
 
 fn noopOutput(_: *anyopaque, _: ?types.ToolLifecycleId, _: command_contract.CommandOutputStream, _: []const u8) !void {}
-fn noopBackgroundReady(_: *anyopaque, _: u64, _: []const u8) void {}
 
 const TestCapturedShellInput = struct {
     command: []u8,


### PR DESCRIPTION
## Summary

- Remove nine declarations whose last callers were deleted by three finished changes. The subagent delegation simplification removed the only callers of `managedExecutionProjection` and the `coordinatorGridOccurrenceCount` test helper in app render, and dropped the `relationship_index` alias that was the sole caller of `encodePage`; the `managed_execution` import goes too since the projection was its only consumer. The command-execution unification under shell removed every assignment of `writeHexBytes`, `discardBackgroundUrl`, and `noopBackgroundReady`, and the `on_background_url_ready` callback field they fed no longer exists anywhere. The conversation persistence cutover removed the callers of `applyEventToState`, `retainLatestCheckpointHistory`, and `deleteSnapshotFilesAddedByMigration`; `isCurrentConversationCheckpoint` was only reachable through `retainLatestCheckpointHistory` and goes with it. No user-facing behavior change: nothing references the removed declarations in production, tests, build roots, or docs, and retained callees such as `validateEnvelope`, `applyDelta`, and `decodePage` keep live callers.