### PR TITLE
Remove leftover test and codec helpers orphaned by completed work

### DIFF
--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -4794,49 +4794,6 @@ fn testPermissionRuleSet(alloc: Allocator, permission: []const u8, pattern: []co
     return rules;
 }
 
-fn testPermissionRuleSetPair(
-    alloc: Allocator,
-    permission: []const u8,
-    first_pattern: []const u8,
-    first_action: types.PermissionAction,
-    second_pattern: []const u8,
-    second_action: types.PermissionAction,
-) !types.PermissionRuleSet {
-    const entries = [_]struct {
-        pattern: []const u8,
-        action: types.PermissionAction,
-    }{
-        .{ .pattern = first_pattern, .action = first_action },
-        .{ .pattern = second_pattern, .action = second_action },
-    };
-    var rules: types.PermissionRuleSet = .{
-        .rules = try alloc.alloc(types.PermissionRule, entries.len),
-    };
-    errdefer alloc.free(rules.rules);
-    var initialized: usize = 0;
-    errdefer {
-        for (rules.rules[0..initialized]) |rule| {
-            alloc.free(rule.permission);
-            alloc.free(rule.pattern);
-        }
-    }
-
-    for (entries, 0..) |entry, index| {
-        const owned_permission = try alloc.dupe(u8, permission);
-        const owned_pattern = alloc.dupe(u8, entry.pattern) catch |err| {
-            alloc.free(owned_permission);
-            return err;
-        };
-        rules.rules[index] = .{
-            .permission = owned_permission,
-            .pattern = owned_pattern,
-            .action = entry.action,
-        };
-        initialized += 1;
-    }
-    return rules;
-}
-
 test "CLI lifecycle action preserves dynamic MCP availability boundaries" {
     const Fixture = struct {
         calls: usize = 0,

--- a/src/core/session/session_codec.zig
+++ b/src/core/session/session_codec.zig
@@ -394,26 +394,6 @@ pub fn encodeRecoveryCheckpoint(
     return out.toOwnedSlice() catch return error.OutOfMemory;
 }
 
-pub fn decodeRecoveryCheckpoint(
-    alloc: Allocator,
-    bytes: []const u8,
-) !RecoveryCheckpoint {
-    if (bytes.len == 0 or bytes.len > max_recovery_checkpoint_bytes) {
-        return error.RecoveryCheckpointTooLarge;
-    }
-    var parsed = std.json.parseFromSlice(std.json.Value, alloc, bytes, .{
-        .max_value_len = max_recovery_checkpoint_bytes,
-    }) catch |err| switch (err) {
-        error.OutOfMemory => return error.OutOfMemory,
-        else => return error.InvalidRecoveryCheckpoint,
-    };
-    defer parsed.deinit();
-    return parseRecoveryCheckpoint(alloc, parsed.value) catch |err| switch (err) {
-        error.OutOfMemory => return error.OutOfMemory,
-        else => return error.InvalidRecoveryCheckpoint,
-    };
-}
-
 fn validateSessionMetadata(metadata: SessionMetadata) !void {
     if (metadata.schema_version != session_metadata_schema_version) {
         return error.UnsupportedSessionSchema;

--- a/src/core/session/session_log.zig
+++ b/src/core/session/session_log.zig
@@ -637,13 +637,6 @@ fn writeConversationMetadata(
     try io_mod.durableReplaceVerified(alloc, dir, manifest_file, bytes);
 }
 
-fn encodeConversationMetadata(
-    alloc: Allocator,
-    state: session_codec.DurableSessionState,
-) ![]u8 {
-    return encodeConversationMetadataWithTitle(alloc, state, null);
-}
-
 fn encodeConversationMetadataWithTitle(
     alloc: Allocator,
     state: session_codec.DurableSessionState,

--- a/src/core/tooling/tool_projection.zig
+++ b/src/core/tooling/tool_projection.zig
@@ -504,10 +504,6 @@ fn buildTestModelToolProjectionForRegistry(alloc: Allocator, tools: []const tool
     return buildModelToolProjectionForSet(alloc, testToolSetForRegistry(tools), options);
 }
 
-fn buildTestReadOnlyModelToolProjection(alloc: Allocator, options: Options) !EffectiveToolProjection {
-    return buildReadOnlyModelToolProjectionForSet(alloc, test_tool_set, options);
-}
-
 pub fn buildModelToolProjectionForSet(alloc: Allocator, tool_set: tool_set_contract.ToolSet, options: Options) !EffectiveToolProjection {
     return buildToolProjection(alloc, tool_set, .full, options);
 }

--- a/src/core/workspace/change_tracker.zig
+++ b/src/core/workspace/change_tracker.zig
@@ -168,12 +168,6 @@ fn expectSignalHandlerEqual(expected: std.posix.Sigaction, actual: std.posix.Sig
     try std.testing.expectEqual(expected.handler.handler, actual.handler.handler);
 }
 
-fn readUndoTrace(alloc: Allocator, tmp: std.testing.TmpDir, name: []const u8) ![]u8 {
-    const path = try tmpPath(alloc, tmp.dir, name);
-    defer alloc.free(path);
-    return readAbsolute(alloc, path);
-}
-
 test "file size limit guard restores SIGXFSZ after normal use" {
     if (builtin.os.tag != .linux and builtin.os.tag != .macos) return error.SkipZigTest;
 

--- a/src/ui/footer/picker_presentation.zig
+++ b/src/ui/footer/picker_presentation.zig
@@ -631,11 +631,6 @@ fn composeApiKeyPickerRow(
     return row;
 }
 
-pub fn pickerRowCount(completion_count: usize) u16 {
-    if (completion_count == 0) return 1;
-    return @intCast(@min(completion_count, input_presentation.max_model_picker_rows));
-}
-
 pub fn activeListPickerReservedRows(terminal_rows: u16, input_extra: u16, banner_rows: u16) u16 {
     const fixed_rows: u16 = 5 +| input_extra +| banner_rows;
     const available_rows = terminal_rows -| fixed_rows;


### PR DESCRIPTION
## Summary

- Remove six declarations whose callers are gone. The conversation persistence cutover deleted the migration caller of `encodeConversationMetadata` (the `WithTitle` variant is the only metadata encoder now). Preserving saved work across compaction and resume removed the `session_log` caller of `decodeRecoveryCheckpoint`. Removing redundant filesystem tools deleted the permission rule-pair test that used `testPermissionRuleSetPair` and the three undo-trace tests that used `readUndoTrace`. Hiding empty slash completion menus replaced the only `pickerRowCount` call with the reserved-rows computation. The provider boundary commit added `buildTestReadOnlyModelToolProjection` without ever wiring it; its sibling keeps `test_tool_set` live. No user-facing behavior change: nothing references the removed declarations in production, tests, build roots, or docs, and `parseRecoveryCheckpoint`, `encodeConversationMetadataWithTitle`, `tmpPath`, and `readAbsolute` all keep live callers.