### PR TITLE
Submit queued steering at compaction and terminal boundaries

### DIFF
--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -106,6 +106,70 @@ fn take_steering_boundary(
     return take(deps.ctx, arena, turn_id, kind);
 }
 
+/// A handoff ends the turn so the queued prompt can run as its own turn.
+/// Persist the interruption exactly once and report the finish reason.
+fn finish_steering_handoff(
+    deps: *const AgentRuntimeDeps,
+    finalization: *TurnFinalizationGuard,
+    job: QueuedPrompt,
+    completed_tool_names: [][]u8,
+    interrupted_persisted: *bool,
+    step_ctx: TraceContext,
+    within_turn_suffix: []const ChatMessage,
+    stop_state: *CommonStopState,
+    finish_trace: *PromptFinishTrace,
+) !void {
+    try runtime_interruption.persistInterruptedTurnOnce(
+        deps,
+        finalization,
+        job,
+        null,
+        null,
+        completed_tool_names,
+        interrupted_persisted,
+        step_ctx,
+        within_turn_suffix,
+        stop_state.retained_candidate,
+        &stop_state.terminal_materializing,
+    );
+    finish_trace.finish("steering_handoff");
+}
+
+const SteeringBoundaryAction = enum {
+    /// Nothing pending; the caller proceeds with its normal flow.
+    none,
+    /// Guidance was appended to the within-turn suffix; the caller must
+    /// continue the turn so the model receives it.
+    continued,
+    /// The queued prompt cannot join this turn; the caller decides the
+    /// outcome (mid-turn sites finish the turn for a handoff; terminal sites
+    /// finish normally and let the prompt run as the next turn).
+    handoff,
+};
+
+/// Observes one steering boundary and drains any guidance into the
+/// within-turn suffix. Handoff is only classified here; finishing the turn is
+/// the caller's decision.
+fn observe_steering_boundary(
+    deps: *const AgentRuntimeDeps,
+    arena: Allocator,
+    result_alloc: Allocator,
+    within_turn_suffix: *std.ArrayList(ChatMessage),
+    turn_id: u64,
+    origin: runtime_config.TurnOrigin,
+    kind: worker_runtime.SteeringBoundaryKind,
+) !SteeringBoundaryAction {
+    const boundary = try take_steering_boundary(deps, result_alloc, turn_id, kind);
+    switch (boundary) {
+        .continue_turn => |guidance| {
+            try append_steering_guidance(arena, within_turn_suffix, guidance, origin);
+            return .continued;
+        },
+        .handoff => return .handoff,
+        .none, .interrupt => return .none,
+    }
+}
+
 fn append_steering_guidance(
     arena: Allocator,
     within_turn_suffix: *std.ArrayList(ChatMessage),
@@ -6375,37 +6439,28 @@ fn processQueuedPromptLoop(
         }
         _ = overlay_arena_state.reset(.retain_capacity);
         const overlay_arena = overlay_arena_state.allocator();
-        const steering_boundary = try take_steering_boundary(
+        const steering_action = try observe_steering_boundary(
             deps,
+            arena,
             overlay_arena,
+            &within_turn_suffix,
             turn_id,
+            config.origin,
             .model,
         );
-        switch (steering_boundary) {
-            .handoff => {
-                try runtime_interruption.persistInterruptedTurnOnce(
-                    deps,
-                    finalization,
-                    job,
-                    null,
-                    null,
-                    completed_tool_names.items,
-                    &interrupted_persisted,
-                    step_ctx,
-                    within_turn_suffix.items,
-                    stop_state.retained_candidate,
-                    &stop_state.terminal_materializing,
-                );
-                finish_trace.finish("steering_handoff");
-                return;
-            },
-            .continue_turn => |guidance| try append_steering_guidance(
-                arena,
-                &within_turn_suffix,
-                guidance,
-                config.origin,
-            ),
-            .none, .interrupt => {},
+        if (steering_action == .handoff) {
+            try finish_steering_handoff(
+                deps,
+                finalization,
+                job,
+                completed_tool_names.items,
+                &interrupted_persisted,
+                step_ctx,
+                within_turn_suffix.items,
+                stop_state,
+                &finish_trace,
+            );
+            return;
         }
         var ephemeral_overlay: std.ArrayList(ChatMessage) = .empty;
         if (skills.explicit) |section| {
@@ -6996,7 +7051,34 @@ fn processQueuedPromptLoop(
                             installed_compaction = true;
                             break :compact_attempt;
                         }
-                        if (installed_compaction) continue;
+                        if (installed_compaction) {
+                            // A message queued while the compaction ran must ride the
+                            // rebuilt request, not wait for the reply after it.
+                            const post_compaction_action = try observe_steering_boundary(
+                                deps,
+                                arena,
+                                overlay_arena,
+                                &within_turn_suffix,
+                                turn_id,
+                                config.origin,
+                                .model,
+                            );
+                            if (post_compaction_action == .handoff) {
+                                try finish_steering_handoff(
+                                    deps,
+                                    finalization,
+                                    job,
+                                    completed_tool_names.items,
+                                    &interrupted_persisted,
+                                    step_ctx,
+                                    within_turn_suffix.items,
+                                    stop_state,
+                                    &finish_trace,
+                                );
+                                return;
+                            }
+                            continue;
+                        }
                     },
                 }
             }
@@ -8602,6 +8684,21 @@ fn processQueuedPromptLoop(
                 finish_reason.label(),
                 completion.tool_calls.len,
             });
+            if (agent_steps.allowsStep(config.agent_step_limit, step + 1) and
+                try append_pending_steering_after_assistant(
+                    deps,
+                    arena,
+                    &within_turn_suffix,
+                    turn_id,
+                    assistant_text,
+                    provider_replay,
+                    config.origin,
+                    .finalizing,
+                ))
+            {
+                try deps.push_text(deps.ctx, .{ .assistant_rendered = "\n" });
+                continue :agent_steps_loop;
+            }
             if (stop_state.retained_candidate != null) {
                 const persisted_text = try runtime_finalization.stopTerminalText(
                     arena,
@@ -11315,6 +11412,23 @@ fn processQueuedPromptLoop(
             &step_batch,
         );
         if (malformed_arguments_retry.finishBatch()) {
+            if (agent_steps.allowsStep(config.agent_step_limit, step + 1)) {
+                const terminal_action = try observe_steering_boundary(
+                    deps,
+                    arena,
+                    arena,
+                    &within_turn_suffix,
+                    turn_id,
+                    config.origin,
+                    .finalizing,
+                );
+                switch (terminal_action) {
+                    // The turn is already ending; an ineligible prompt runs as
+                    // the next turn after the normal terminal finish.
+                    .handoff, .none => {},
+                    .continued => continue :agent_steps_loop,
+                }
+            }
             debug_trace.eventf(
                 "agent",
                 "repeated_malformed_tool_arguments",
@@ -11337,6 +11451,21 @@ fn processQueuedPromptLoop(
             return;
         }
         if (terminal_validation_retry.finishBatch()) {
+            if (agent_steps.allowsStep(config.agent_step_limit, step + 1)) {
+                const terminal_action = try observe_steering_boundary(
+                    deps,
+                    arena,
+                    arena,
+                    &within_turn_suffix,
+                    turn_id,
+                    config.origin,
+                    .finalizing,
+                );
+                switch (terminal_action) {
+                    .handoff, .none => {},
+                    .continued => continue :agent_steps_loop,
+                }
+            }
             try deps.push_system_notice(
                 deps.ctx,
                 repeated_terminal_validation_notice,
@@ -11367,6 +11496,21 @@ fn processQueuedPromptLoop(
             return;
         }
         if (shell_execution_failure_retry.finishBatch()) {
+            if (agent_steps.allowsStep(config.agent_step_limit, step + 1)) {
+                const terminal_action = try observe_steering_boundary(
+                    deps,
+                    arena,
+                    arena,
+                    &within_turn_suffix,
+                    turn_id,
+                    config.origin,
+                    .finalizing,
+                );
+                switch (terminal_action) {
+                    .handoff, .none => {},
+                    .continued => continue :agent_steps_loop,
+                }
+            }
             debug_trace.eventf(
                 "agent",
                 "repeated_shell_execution_failure",

--- a/src/core/agent/runtime/tests/finalization_flow.zig
+++ b/src/core/agent/runtime/tests/finalization_flow.zig
@@ -32,6 +32,7 @@ const registerStopTestHandler = test_support.registerStopTestHandler;
 const testLifecycleContext = test_support.testLifecycleContext;
 const finishCommonAssistantTerminal = runtime_orchestrator.finishCommonAssistantTerminal;
 const expectBodyContains = test_support.expectBodyContains;
+const expectBodyContainsInOrder = test_support.expectBodyContainsInOrder;
 const expectBodyNotContains = test_support.expectBodyNotContains;
 const countText = test_support.countText;
 const countNeedle = test_support.countNeedle;
@@ -359,6 +360,86 @@ test "processQueuedPrompt stops repeated malformed calls before another provider
     }
     try std.testing.expectEqual(@as(usize, 0), hooks.permission_names.items.len);
     try std.testing.expectEqual(@as(usize, 0), hooks.executed_names.items.len);
+}
+
+test "processQueuedPrompt continues with steering queued before a repeated-malformed terminal" {
+    const alloc = std.testing.allocator;
+    const call_one = [_]ToolCall{.{
+        .id = "call_1",
+        .name = "read_file",
+        .arguments_json = "{}",
+        .argument_integrity = .malformed_json,
+    }};
+    const call_two = [_]ToolCall{.{
+        .id = "call_2",
+        .name = "read_file",
+        .arguments_json = "{}",
+        .argument_integrity = .malformed_json,
+    }};
+    const call_three = [_]ToolCall{.{
+        .id = "call_3",
+        .name = "read_file",
+        .arguments_json = "{}",
+        .argument_integrity = .malformed_json,
+    }};
+    const completions = [_]FakeCompletion{
+        .{ .tool_calls = &call_one },
+        .{ .tool_calls = &call_two },
+        .{ .tool_calls = &call_three },
+        .{ .content = "Steered recovery answer" },
+    };
+    var gateway = FakeGateway.init(alloc, &completions);
+    defer gateway.deinit();
+    const steering = [_][]const u8{"stop repeating the broken call"};
+    var hooks = FakeAgentRuntimeDeps.init(alloc);
+    // Step-top boundaries are takes 1-3; the terminal-exit boundary is take 4.
+    hooks.steering_messages = &steering;
+    hooks.steering_take_at = 4;
+    defer hooks.deinit();
+    var fixture = PromptFixture{};
+
+    try runFakePrompt(&gateway, &hooks, fixture.config(), fixture.job());
+
+    // The turn continued instead of ending: the fourth request carries the
+    // queued steering, and the malformed-stop notice never rendered.
+    try std.testing.expectEqual(@as(usize, 4), gateway.request_bodies.items.len);
+    try expectBodyContains(&gateway, 3, "user_steering");
+    try expectBodyContains(&gateway, 3, "stop repeating the broken call");
+    try std.testing.expect(!textContains(&hooks, "Repeated malformed tool arguments"));
+    try std.testing.expectEqualStrings("Steered recovery answer", hooks.finish_assistant_text.?);
+    try std.testing.expectEqual(types.TurnPresentationOutcome.completed, hooks.finalized_outcome.?);
+    const execution = hooks.history_turns.items[0].assistant.execution;
+    try std.testing.expectEqual(@as(usize, 1), execution.steering.len);
+    try std.testing.expectEqualStrings("stop repeating the broken call", execution.steering[0].text);
+}
+
+test "processQueuedPrompt continues with steering queued before a length-limited tool completion" {
+    const alloc = std.testing.allocator;
+    const truncated_calls = [_]ToolCall{toolCall("len_call_1", "read_file", "{\"path\":\"a.txt\"}")};
+    const completions = [_]FakeCompletion{
+        .{ .content = "partial draft", .tool_calls = &truncated_calls, .finish_reason = .length },
+        .{ .content = "Steered length recovery" },
+    };
+    var gateway = FakeGateway.init(alloc, &completions);
+    defer gateway.deinit();
+    const steering = [_][]const u8{"narrow the scope"};
+    var hooks = FakeAgentRuntimeDeps.init(alloc);
+    // Step-top boundary is take 1; the length-limited terminal boundary is take 2.
+    hooks.steering_messages = &steering;
+    hooks.steering_take_at = 2;
+    defer hooks.deinit();
+    var fixture = PromptFixture{};
+
+    try runFakePrompt(&gateway, &hooks, fixture.config(), fixture.job());
+
+    try std.testing.expectEqual(@as(usize, 2), gateway.request_bodies.items.len);
+    try expectBodyContainsInOrder(&gateway, 1, &.{
+        "partial draft",
+        "user_steering",
+        "narrow the scope",
+    });
+    try std.testing.expectEqualStrings("Steered length recovery", hooks.finish_assistant_text.?);
+    try std.testing.expectEqual(types.TurnPresentationOutcome.completed, hooks.finalized_outcome.?);
 }
 
 test "processQueuedPrompt returns a final response after a repeated tool-name cycle" {

--- a/src/core/agent/runtime/tests/gateway_flow.zig
+++ b/src/core/agent/runtime/tests/gateway_flow.zig
@@ -3055,6 +3055,97 @@ test "processQueuedPrompt semantically compacts history at eighty percent and co
     );
 }
 
+test "processQueuedPrompt delivers steering queued during in-turn compaction with the rebuilt request" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const result_dir = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(result_dir);
+
+    const first_calls = [_]ToolCall{toolCall(
+        "compact_steer_1",
+        "read_file",
+        "{\"path\":\"first.txt\"}",
+    )};
+    const completions = [_]FakeCompletion{
+        .{ .content = "Finish after the verified read and return the result." },
+        .{ .tool_calls = &first_calls },
+        .{ .content = "Steered answer after compaction." },
+    };
+    var gateway = FakeGateway.init(alloc, &completions);
+    defer gateway.deinit();
+    const model = "provider/compaction-steering";
+    const available_overrides = [_]ModelCapabilityOverride{.{
+        .model = model,
+        .capabilities = .{ .context_window = 45_000 },
+    }};
+    const steering = [_][]const u8{"STEER_DURING_COMPACT_SENTINEL"};
+    var hooks = FakeAgentRuntimeDeps.init(alloc);
+    hooks.available_capability_overrides = &available_overrides;
+    // Step-top boundary is take 1; the post-compaction boundary is take 2.
+    hooks.steering_messages = &steering;
+    hooks.steering_take_at = 2;
+    defer hooks.deinit();
+    hooks.permission_decisions = &.{.once};
+    hooks.exec_plans = &.{.{ .result = .{ .model_output = "COMPACT_STEER_RESULT" } }};
+    var fixture = PromptFixture{};
+    var config = fixture.config();
+    config.tool_result_dir = result_dir;
+    config.host_instructions = "COMPACT_STEER_HOST_INSTRUCTIONS";
+    config.skill_catalog = .{ .skills = &.{.{
+        .name = "compact-steer-workflow",
+        .description = "Keep the selected workflow available during compaction.",
+        .path = "/skills/compact-steer-workflow",
+        .source = .global_fx,
+    }} };
+    var job = fixture.job();
+    job.model = @constCast(model);
+    var restored_calls = [_]ToolCall{toolCall(
+        "compact_steer_restored_1",
+        "read_file",
+        "{\"path\":\"restored.txt\"}",
+    )};
+    var restored_results = [_]types.PersistedToolResult{.{
+        .tool_call_id = @constCast("compact_steer_restored_1"),
+        .tool_name = @constCast("read_file"),
+        .status = .success,
+        .output = @constCast("COMPACT_STEER_RESTORED_BYTES"),
+        .output_bytes = 100,
+        .stored_output_bytes = 26,
+        .truncated = true,
+    }};
+    var restored_steps = [_]types.ToolExecutionStep{.{
+        .tool_calls = &restored_calls,
+        .tool_results = &restored_results,
+    }};
+    var history = [_]HistoryTurn{
+        .{ .assistant = .{
+            .user = .{ .text = @constCast("COMPACT_STEER_HISTORY_USER") },
+            .assistant = @constCast("COMPACT_STEER_HISTORY_ASSISTANT\n" ++ ("h" ** 150_000)),
+            .execution = .{ .tool_steps = &restored_steps },
+        } },
+        .{ .assistant = .{
+            .user = .{ .text = @constCast("COMPACT_STEER_RECENT_USER") },
+            .assistant = @constCast("COMPACT_STEER_RECENT_ASSISTANT"),
+        } },
+    };
+    job.history = &history;
+    job.unversioned_history_count = history.len;
+
+    try runFakePrompt(&gateway, &hooks, config, job);
+
+    try std.testing.expectEqual(@as(usize, 3), gateway.request_bodies.items.len);
+    try expectBodyContains(&gateway, 0, "\"toolChoice\":{\"type\":\"none\"}");
+    // The first post-compaction request already carries the steering guidance.
+    // (Before the boundary fix it only appeared in the reply after it.)
+    try expectBodyContainsInOrder(&gateway, 1, &.{ "context_handoff", "user_steering", "STEER_DURING_COMPACT_SENTINEL" });
+    try expectBodyContains(&gateway, 2, "COMPACT_STEER_RESULT");
+    try std.testing.expectEqualStrings("Steered answer after compaction.", hooks.finish_assistant_text.?);
+    try std.testing.expectEqual(@as(usize, 2), hooks.history_turns.items.len);
+    try std.testing.expect(hooks.history_turns.items[0] == .compacted_summary);
+    try std.testing.expect(hooks.history_turns.items[1] == .assistant);
+}
+
 test "automatic compaction rejects fixed request overhead above its total target" {
     const alloc = std.testing.allocator;
     var gateway = FakeGateway.init(alloc, &.{

--- a/src/core/agent/worker_runtime.zig
+++ b/src/core/agent/worker_runtime.zig
@@ -1107,6 +1107,18 @@ pub const WorkerRuntime = struct {
         turn_id: u64,
         kind: SteeringBoundaryKind,
     ) !SteeringBoundaryResult {
+        const result = try self.takeSteeringBoundaryIntoInner(alloc, result_alloc, turn_id, kind);
+        debug_trace.eventf("worker", "steering_boundary_check", .{ .turn_id = turn_id }, "kind={s} outcome={s}", .{ @tagName(kind), @tagName(result) });
+        return result;
+    }
+
+    fn takeSteeringBoundaryIntoInner(
+        self: *WorkerRuntime,
+        alloc: std.mem.Allocator,
+        result_alloc: std.mem.Allocator,
+        turn_id: u64,
+        kind: SteeringBoundaryKind,
+    ) !SteeringBoundaryResult {
         self.worker_mutex.lockUncancelable(io_mod.getIo());
         defer self.worker_mutex.unlock(io_mod.getIo());
         const cancel_requested = self.worker_cancel_requested.load(.seq_cst);
@@ -1464,6 +1476,7 @@ pub const WorkerRuntime = struct {
         for (self.queued_prompts.items) |*prompt| {
             if (prompt.delivery.activeTurnId() == finished_turn_id) {
                 prompt.delivery = .continuation;
+                debug_trace.eventf("worker", "steering_deferred_to_next_turn", .{ .turn_id = finished_turn_id }, "queued_turn_id={d} prompt_bytes={d}", .{ prompt.turn_id, prompt.prompt.len });
             }
         }
         self.worker_processing = false;

--- a/tests/e2e/tui-compaction-activity.test.ts
+++ b/tests/e2e/tui-compaction-activity.test.ts
@@ -345,6 +345,37 @@ describe.skipIf(!tmuxAvailable())("tui: compaction activity", () => {
     }, 90_000);
   }
 
+  test("overflow: a message submitted during held in-turn compaction rides the rebuilt request", async () => {
+    const f = await fixture("overflow", "success");
+    let passed = false;
+    try {
+      const terminal = await f.launch();
+      await terminal.sendText("Continue the current turn.");
+      await until(() => f.counts().summaries === 1, "summary request in flight");
+      await terminal.waitForText(ACTIVITY, 10_000);
+      const steer = "STEER_DURING_OVERFLOW_5c1d";
+      await terminal.sendText(steer);
+      // While the summary is held, the message must neither start its own
+      // turn nor cancel the compaction.
+      await Bun.sleep(1500);
+      expect(f.counts()).toEqual({ summaries: 1, ordinary: f.seedTurns + 1, overflowSent: true });
+      await terminal.waitForText(ACTIVITY, 5000);
+      f.summaryHold.release(HANDOFF);
+      await until(() => f.durable() > 0, "acknowledged checkpoint");
+      // The rebuilt continuation is held by ordinaryHold; the steering must
+      // already ride it, as same-turn guidance, before any reply arrives.
+      await until(() => f.requestsContaining(steer).length > 0, "steering in the rebuilt request");
+      const steered = f.requestsContaining(steer);
+      expect(steered).toHaveLength(1);
+      expect(steered[0]).toContain("<user_steering>");
+      expect(steered[0]).toContain("INTERNAL_HANDOFF_4e12");
+      f.ordinaryHold.release("CURRENT_TURN_OK_OVERFLOW_STEER");
+      await terminal.waitForPane((pane) => pane.includes("CURRENT_TURN_OK_OVERFLOW_STEER") && hasEmptyComposer(pane), 20_000);
+      await f.close();
+      passed = true;
+    } finally { await f.cleanup(passed); }
+  }, 90_000);
+
   for (const outcome of ["cancel", "empty", "provider-error"] as const) {
     test(`manual ${outcome}: scoped feedback preserves history and permits later input and reopen`, async () => {
       const f = await fixture("manual", outcome);


### PR DESCRIPTION
## Summary

- Deliver a message typed during an in-turn compaction with the first request after the compaction commits, instead of after the next model reply.
- Deliver a message queued while a turn is ending through repeated malformed tool arguments, repeated terminal validation failures, repeated shell execution failures, or a length-limited tool completion, by continuing the turn with the guidance instead of ending first.
- Trace steering boundary checks and next-turn deferrals in the debug log.