### PR TITLE
Deliver tool output verbatim to the model

### DIFF
--- a/src/core/agent/execution_memory.zig
+++ b/src/core/agent/execution_memory.zig
@@ -20,11 +20,11 @@ pub fn makePersistedToolResult(
     errdefer alloc.free(tool_call_id);
     const tool_name = try alloc.dupe(u8, tool_name_src);
     errdefer alloc.free(tool_name);
-    const output = try redactText(alloc, output_src);
+    const output = try alloc.dupe(u8, output_src);
     errdefer alloc.free(output);
     const output_handle = if (memory) |info| if (info.output_handle) |handle| try alloc.dupe(u8, handle) else null else null;
     errdefer if (output_handle) |handle| alloc.free(handle);
-    const preview = if (memory) |info| if (info.preview) |text| try redactText(alloc, text) else null else null;
+    const preview = if (memory) |info| if (info.preview) |text| try alloc.dupe(u8, text) else null else null;
     errdefer if (preview) |text| alloc.free(text);
     const command_output_replay = if (memory) |info| if (info.command_output_replay) |replay|
         try types.dupeCommandOutputReplay(alloc, replay)
@@ -56,7 +56,7 @@ pub fn makePersistedToolResult(
     };
     if (memory) |info| {
         if (info.committed_file_presentation) |presentation| {
-            result.committed_file_presentation = dupeRedactedCommittedFilePresentation(
+            result.committed_file_presentation = dupeCommittedFilePresentation(
                 alloc,
                 presentation,
             ) catch |err| blk: {
@@ -106,7 +106,7 @@ pub fn buildNormalMessageExecutionMemory(
     return buildNormalExecutionMemory(MessageAdapter, alloc, messages);
 }
 
-pub fn dupeCompletedRedactedToolCalls(
+pub fn dupeCompletedPersistedToolCalls(
     alloc: Allocator,
     calls: []const ToolCall,
     results: []const types.PersistedToolResult,
@@ -126,7 +126,7 @@ pub fn dupeCompletedRedactedToolCalls(
         };
         if (!completed) continue;
 
-        const duplicated = try dupeRedactedToolCall(alloc, call);
+        const duplicated = try dupePersistedToolCall(alloc, call);
         copy.append(alloc, duplicated) catch |err| {
             types.freeToolCall(alloc, duplicated);
             return err;
@@ -135,18 +135,20 @@ pub fn dupeCompletedRedactedToolCalls(
     return copy.toOwnedSlice(alloc);
 }
 
-pub fn redactText(alloc: Allocator, text: []const u8) ![]u8 {
+/// Display-only projection: masks secret-shaped spans and returns an owned
+/// copy. Persisted history must use verbatim copies instead.
+pub fn maskTextForDisplay(alloc: Allocator, text: []const u8) ![]u8 {
     const masked = text_utils.maskSecrets(alloc, text) catch
         return error.OutOfMemory;
     if (masked.ptr == text.ptr) return alloc.dupe(u8, text);
     return @constCast(masked);
 }
 
-fn dupeRedactedCommittedFilePresentation(
+fn dupeCommittedFilePresentation(
     alloc: Allocator,
     presentation: types.CommittedFilePresentation,
 ) !types.CommittedFilePresentation {
-    const path = try redactText(alloc, presentation.path);
+    const path = try alloc.dupe(u8, presentation.path);
     errdefer alloc.free(path);
     const lines = try alloc.alloc(types.CommittedFilePresentationLine, presentation.lines.len);
     errdefer alloc.free(lines);
@@ -159,17 +161,17 @@ fn dupeRedactedCommittedFilePresentation(
             .kind = line.kind,
             .old_line = line.old_line,
             .new_line = line.new_line,
-            .text = try redactText(alloc, line.text),
+            .text = try alloc.dupe(u8, line.text),
         };
         copied_lines += 1;
     }
     const previous_content = if (presentation.previous_content) |content|
-        try redactText(alloc, content)
+        try alloc.dupe(u8, content)
     else
         null;
     errdefer if (previous_content) |content| alloc.free(content);
     const after_content = if (presentation.after_content) |content|
-        try redactText(alloc, content)
+        try alloc.dupe(u8, content)
     else
         null;
     errdefer if (after_content) |content| alloc.free(content);
@@ -451,11 +453,11 @@ fn buildNormalExecutionMemory(
         }
 
         const assistant = if (Adapter.content(msg)) |content|
-            try redactText(alloc, content)
+            try alloc.dupe(u8, content)
         else
             null;
         errdefer if (assistant) |text| alloc.free(text);
-        const persisted_calls = try dupeCompletedRedactedToolCalls(
+        const persisted_calls = try dupeCompletedPersistedToolCalls(
             alloc,
             tool_calls,
             results.items,
@@ -514,7 +516,7 @@ pub fn freeTransientToolExecutionStep(
     types.freePersistedToolResults(alloc, step.tool_results);
 }
 
-/// Caller owns the copy. Never bind signed metadata to redacted or incomplete history.
+/// Caller owns the copy. Never bind signed metadata to incomplete history.
 pub fn dupeUnchangedProviderReplay(
     alloc: Allocator,
     replay: ?types.ProviderReplay,
@@ -534,7 +536,7 @@ pub fn dupeUnchangedProviderReplay(
         }
     };
     if (!unchanged) {
-        debug_trace.logf("session", "provider replay omitted reason=redacted_or_incomplete_association", .{});
+        debug_trace.logf("session", "provider replay omitted reason=incomplete_association", .{});
         return null;
     }
     return try types.dupeProviderReplay(alloc, value);
@@ -565,14 +567,14 @@ fn appendPersistedPermissionFeedback(
     result: *types.PersistedToolResult,
     text: []const u8,
 ) !void {
-    const redacted = try redactText(alloc, text);
-    errdefer alloc.free(redacted);
+    const owned = try alloc.dupe(u8, text);
+    errdefer alloc.free(owned);
 
     const prior = result.permission_feedback;
     const appended = try alloc.alloc([]u8, prior.len + 1);
     errdefer alloc.free(appended);
     @memcpy(appended[0..prior.len], prior);
-    appended[prior.len] = redacted;
+    appended[prior.len] = owned;
     if (prior.len > 0) alloc.free(prior);
     result.permission_feedback = appended;
 }
@@ -587,20 +589,16 @@ pub fn freeTransientFileEvidence(
     alloc.free(file.tool_name);
 }
 
-pub fn dupeRedactedToolCall(alloc: Allocator, call: ToolCall) !ToolCall {
+pub fn dupePersistedToolCall(alloc: Allocator, call: ToolCall) !ToolCall {
     const id = try durableIdentifier(alloc, call.id);
     errdefer alloc.free(id);
     const name = try alloc.dupe(u8, call.name);
     errdefer alloc.free(name);
-    const arguments_json = try redactToolArgumentsJson(
-        alloc,
-        call.name,
-        call.arguments_json,
-    );
+    const arguments_json = try alloc.dupe(u8, call.arguments_json);
     errdefer alloc.free(arguments_json);
     const provisional_id = if (call.provisional_id) |value| try durableIdentifier(alloc, value) else null;
     errdefer if (provisional_id) |value| alloc.free(value);
-    const provider_result = if (call.provider_result) |result| try redactText(alloc, result) else null;
+    const provider_result = if (call.provider_result) |result| try alloc.dupe(u8, result) else null;
     errdefer if (provider_result) |result| alloc.free(result);
     return .{
         .id = id,
@@ -617,13 +615,15 @@ const ArgumentRedactionPolicy = struct {
     web_fetch: bool = false,
 };
 
+/// Client-facing display projection of tool-call arguments (ACP replay).
+/// Persisted history keeps arguments verbatim; only display surfaces mask.
 pub fn redactToolArgumentsJson(
     alloc: Allocator,
     tool_name: []const u8,
     arguments_json: []const u8,
 ) ![]u8 {
     var parsed = std.json.parseFromSlice(std.json.Value, alloc, arguments_json, .{}) catch {
-        return redactText(alloc, arguments_json);
+        return maskTextForDisplay(alloc, arguments_json);
     };
     defer parsed.deinit();
 
@@ -753,7 +753,7 @@ fn makeFileEvidence(
     status: types.PersistedToolStatus,
     memory: ?types.ToolResultMemory,
 ) !types.FileEvidence {
-    const path = try redactText(alloc, path_src);
+    const path = try alloc.dupe(u8, path_src);
     errdefer alloc.free(path);
     const tool_call_id = try durableIdentifier(alloc, call.id);
     errdefer alloc.free(tool_call_id);
@@ -812,19 +812,22 @@ fn durableIdentifier(alloc: Allocator, value: []const u8) ![]u8 {
     return std.fmt.allocPrint(alloc, "redacted-{s}", .{&hex});
 }
 
-test "execution memory redacts secret values from arguments results and provider output" {
+test "execution memory persists secret-bearing arguments results and provider output verbatim" {
     const runtime_execution_memory = @import("runtime/execution_memory.zig");
     const ChatMessage = types.ChatMessage;
     const alloc = std.testing.allocator;
+    const arguments_json = "{\"command\":\"echo ok && AI_GATEWAY_KEY=abcdefghijklmnop\",\"api_key\":\"secret-value-123456\"}";
+    const provider_result = "provider echoed sk-abcdefghijklmnopqrstuvwxyz123456";
+    const result_output = "TOOL_DATA_TOKEN=abcdefghijklmnopqrstuvwxyz\nBearer abcdefghijklmnopqrstuvwxyz1234";
     var calls = [_]ToolCall{.{
         .id = "call_secret",
         .name = "run_command",
-        .arguments_json = "{\"command\":\"echo ok && AI_GATEWAY_API_KEY=abcdefghijklmnop && curl -H 'Authorization: Bearer abcdefghijklmnop' https://example.com\",\"api_key\":\"secret-value\"}",
-        .provider_result = "github_pat_abcdefghijklmnop",
+        .arguments_json = arguments_json,
+        .provider_result = provider_result,
     }};
     const messages = [_]ChatMessage{
         .{ .role = .assistant, .tool_calls = calls[0..] },
-        .{ .role = .tool, .content = "sk-abcdefghijklmnop xoxb-abcdefghijklmnop", .tool_call_id = "call_secret", .tool_name = "run_command", .tool_result_status = .success },
+        .{ .role = .tool, .content = result_output, .tool_call_id = "call_secret", .tool_name = "run_command", .tool_result_status = .success },
     };
 
     const memory = try runtime_execution_memory.buildExecutionMemory(alloc, &messages);
@@ -832,25 +835,12 @@ test "execution memory redacts secret values from arguments results and provider
     try std.testing.expectEqual(@as(usize, 1), memory.tool_steps.len);
     const persisted_call = memory.tool_steps[0].tool_calls[0];
     const persisted_result = memory.tool_steps[0].tool_results[0];
-    const args = persisted_call.arguments_json;
-    const secret_needles = [_][]const u8{
-        "abcdefghijklmnop",
-        "secret-value",
-        "Bearer ",
-        "github_pat_",
-        "sk-",
-        "xoxb-",
-    };
-    for (secret_needles) |needle| {
-        try std.testing.expect(std.mem.find(u8, args, needle) == null);
-        try std.testing.expect(std.mem.find(u8, persisted_result.output, needle) == null);
-        try std.testing.expect(std.mem.find(u8, persisted_call.provider_result.?, needle) == null);
-    }
-    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, args, .{});
+    try std.testing.expectEqualStrings(result_output, persisted_result.output);
+    try std.testing.expectEqualStrings(provider_result, persisted_call.provider_result.?);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, persisted_call.arguments_json, .{});
     defer parsed.deinit();
-    try std.testing.expectEqualStrings("[REDACTED]", parsed.value.object.get("api_key").?.string);
-    try std.testing.expect(std.mem.startsWith(u8, parsed.value.object.get("command").?.string, "echo ok"));
-    try std.testing.expect(std.mem.find(u8, parsed.value.object.get("command").?.string, "[redacted]") != null);
+    try std.testing.expectEqualStrings("secret-value-123456", parsed.value.object.get("api_key").?.string);
 }
 
 test "execution memory removes token-shaped call ids from JSON" {
@@ -899,23 +889,26 @@ test "execution memory removes token-shaped call ids from JSON" {
     try std.testing.expect(std.mem.find(u8, json.written(), secret_id) == null);
 }
 
-test "durable execution memory masks token-shaped values" {
+test "durable execution memory persists token-shaped values verbatim" {
     const alloc = std.testing.allocator;
+    const arguments_json =
+        \\{"command":"AI_GATEWAY_KEY=abcdefghijklmnop","nested":{"values":["sk-abcdefghijklmnopqrstuvwxyz123456","github_pat_abcdefghijklmnopqrstuvwxyz1234","plain"]},"api_key":"named-secret-123456"}
+    ;
+    const result_output = "API_TOKEN=abcdefghijklmnopqrstuvwxyz\nAuthorization: Bearer abcdefghijklmnopqrstuvwxyz1234";
+    const preview = "TOKEN=abcdefghijklmnopqrstuvwxyz";
     const call = ToolCall{
         .id = "call_secret",
         .name = "mcp__fixture__echo",
-        .arguments_json =
-        \\{"command":"AI_GATEWAY_API_KEY=abcdefghijklmnop curl -H 'Authorization: Bearer abcdefghijklmnop' https://example.com sk-abcdefghijklmnop","nested":{"values":["github_pat_abcdefghijklmnop","xoxb-abcdefghijklmnop","plain"]},"api_key":"named-secret"}
-        ,
+        .arguments_json = arguments_json,
     };
     const result = try makePersistedToolResult(
         alloc,
         call.id,
         call.name,
         .success,
-        "sk-abcdefghijklmnop github_pat_abcdefghijklmnop xoxb-abcdefghijklmnop",
+        result_output,
         .{
-            .preview = "Bearer abcdefghijklmnop",
+            .preview = preview,
             .output_bytes = 128,
             .stored_output_bytes = 64,
             .truncated = true,
@@ -925,22 +918,12 @@ test "durable execution memory masks token-shaped values" {
 
     const calls = [_]ToolCall{call};
     const results = [_]types.PersistedToolResult{result};
-    const persisted_calls = try dupeCompletedRedactedToolCalls(alloc, &calls, &results);
+    const persisted_calls = try dupeCompletedPersistedToolCalls(alloc, &calls, &results);
     defer types.freeToolCallSlice(alloc, persisted_calls);
 
-    const secret_needles = [_][]const u8{
-        "abcdefghijklmnop",
-        "named-secret",
-        "sk-",
-        "github_pat_",
-        "xoxb-",
-        "Bearer ",
-    };
-    for (secret_needles) |needle| {
-        try std.testing.expect(std.mem.find(u8, persisted_calls[0].arguments_json, needle) == null);
-        try std.testing.expect(std.mem.find(u8, result.output, needle) == null);
-        try std.testing.expect(std.mem.find(u8, result.preview.?, needle) == null);
-    }
+    try std.testing.expectEqualStrings(arguments_json, persisted_calls[0].arguments_json);
+    try std.testing.expectEqualStrings(result_output, result.output);
+    try std.testing.expectEqualStrings(preview, result.preview.?);
 
     var parsed = try std.json.parseFromSlice(
         std.json.Value,
@@ -950,15 +933,8 @@ test "durable execution memory masks token-shaped values" {
     );
     defer parsed.deinit();
     try std.testing.expectEqualStrings(
-        "[REDACTED]",
+        "named-secret-123456",
         parsed.value.object.get("api_key").?.string,
-    );
-    try std.testing.expect(
-        std.mem.find(
-            u8,
-            parsed.value.object.get("command").?.string,
-            "curl -H 'Authorization: [redacted]'",
-        ) != null,
     );
     try std.testing.expectEqualStrings(
         "plain",
@@ -966,7 +942,7 @@ test "durable execution memory masks token-shaped values" {
     );
 }
 
-test "durable execution memory preserves benign secret-like words" {
+test "display masking preserves benign secret-like words" {
     const alloc = std.testing.allocator;
     const input =
         "The tokenizer counts ordinary tokens.\n" ++
@@ -974,28 +950,24 @@ test "durable execution memory preserves benign secret-like words" {
         "A token is a lexical unit.\n" ++
         "Authorization is an HTTP header.\n" ++
         "A cookie policy can be public.";
-    const redacted = try redactText(alloc, input);
-    defer alloc.free(redacted);
+    const masked = try maskTextForDisplay(alloc, input);
+    defer alloc.free(masked);
 
-    try std.testing.expectEqualStrings(input, redacted);
+    try std.testing.expectEqualStrings(input, masked);
 }
 
-test "durable execution memory redacts credential keys without hiding benign metadata" {
+test "redactToolArgumentsJson redacts credential keys without hiding benign metadata" {
     const alloc = std.testing.allocator;
-    const call = ToolCall{
-        .id = "call_metadata",
-        .name = "mcp__fixture__echo",
-        .arguments_json =
-        \\{"token_count":128,"authorization_docs":"public","cookie_policy":"strict","token":"secret-value","client_secret":"hidden"}
-        ,
-    };
-    const redacted = try dupeRedactedToolCall(alloc, call);
-    defer types.freeToolCall(alloc, redacted);
+    const arguments_json =
+        \\{"token_count":128,"authorization_docs":"public","cookie_policy":"strict","token":"secret-value-123456","client_secret":"hidden-value-123456"}
+    ;
+    const redacted = try redactToolArgumentsJson(alloc, "mcp__fixture__echo", arguments_json);
+    defer alloc.free(redacted);
 
     var parsed = try std.json.parseFromSlice(
         std.json.Value,
         alloc,
-        redacted.arguments_json,
+        redacted,
         .{},
     );
     defer parsed.deinit();
@@ -1040,7 +1012,7 @@ test "durable execution memory pseudonymizes sensitive call ids consistently" {
     );
     defer freeTransientPersistedToolResult(alloc, result);
 
-    const persisted_calls = try dupeCompletedRedactedToolCalls(
+    const persisted_calls = try dupeCompletedPersistedToolCalls(
         alloc,
         &.{call},
         &.{result},
@@ -1068,36 +1040,37 @@ test "durable execution memory pseudonymizes sensitive call ids consistently" {
     try std.testing.expectEqualStrings(result.tool_call_id, files.items[0].tool_call_id);
 }
 
-test "durable execution memory redacts committed file presentation and reuses the call identity" {
+test "durable execution memory preserves committed file presentation verbatim and reuses the call identity" {
     const alloc = std.testing.allocator;
-    const secret = "sk-abcdefghijklmnop";
+    const secret_id = "ghp_abcdefghijklmnopqrstuvwxyz12345678901234";
+    const secret_text = "API_KEY=abcdefghijklmnopqrstuvwxyz";
     const preview_lines = [_]types.CommittedFilePresentationLine{
-        .{ .kind = .addition, .new_line = 1, .text = secret },
+        .{ .kind = .addition, .new_line = 1, .text = secret_text },
         .{ .kind = .elision, .text = "more secret rows omitted" },
     };
     const calls = [_]ToolCall{.{
-        .id = secret,
+        .id = secret_id,
         .name = "write_file",
-        .arguments_json = "{\"path\":\"notes.txt\",\"content\":\"secret\"}",
+        .arguments_json = "{\"path\":\"notes.txt\",\"content\":\"secret\"}}",
     }};
     const messages = [_]types.ChatMessage{
         .{ .role = .assistant, .tool_calls = calls[0..] },
         .{
             .role = .tool,
             .content = "wrote notes.txt",
-            .tool_call_id = secret,
+            .tool_call_id = secret_id,
             .tool_name = "write_file",
             .tool_result_status = .success,
             .tool_result_memory = .{
                 .committed_file_presentation = .{
-                    .path = "secrets/sk-abcdefghijklmnop.md",
+                    .path = "secrets/notes.txt",
                     .kind = .added,
                     .lines = &preview_lines,
                     .additions = 120,
                     .deletions = 0,
                     .truncated = true,
-                    .after_content = "sk-abcdefghijklmnop\n",
-                    .lifecycle_id = .{ .turn_id = 8, .call_id = secret },
+                    .after_content = secret_text ++ "\n",
+                    .lifecycle_id = .{ .turn_id = 8, .call_id = secret_id },
                 },
             },
         },
@@ -1108,9 +1081,9 @@ test "durable execution memory redacts committed file presentation and reuses th
     const result = memory.tool_steps[0].tool_results[0];
     const presentation = result.committed_file_presentation orelse return error.TestExpectedPresentation;
 
-    try std.testing.expect(std.mem.find(u8, presentation.path, secret) == null);
-    try std.testing.expect(std.mem.find(u8, presentation.lines[0].text, secret) == null);
-    try std.testing.expect(std.mem.find(u8, presentation.after_content.?, secret) == null);
+    try std.testing.expectEqualStrings("secrets/notes.txt", presentation.path);
+    try std.testing.expectEqualStrings(secret_text, presentation.lines[0].text);
+    try std.testing.expectEqualStrings(secret_text ++ "\n", presentation.after_content.?);
     try std.testing.expectEqualStrings(result.tool_call_id, presentation.lifecycle_id.?.call_id);
     try std.testing.expectEqualStrings(memory.tool_steps[0].tool_calls[0].id, presentation.lifecycle_id.?.call_id);
 }
@@ -1426,12 +1399,12 @@ test "normal execution-memory builders produce identical durable projection" {
     try std.testing.expect(std.mem.find(
         u8,
         chat_memory.tool_steps[0].tool_calls[0].id,
-        "sk-abcdefghijklmnop",
+        "[redacted]",
     ) == null);
     try std.testing.expect(std.mem.find(
         u8,
         chat_memory.tool_steps[0].tool_results[0].output,
-        "sk-abcdefghijklmnop",
+        "[redacted]",
     ) == null);
 }
 
@@ -1530,7 +1503,6 @@ test "normal execution-memory builders clean every allocation failure" {
 
             const memory = buildNormalChatExecutionMemory(alloc, &messages) catch |err|
                 return switch (err) {
-                    error.WriteFailed => error.OutOfMemory,
                     else => err,
                 };
             defer types.freeExecutionMemory(alloc, memory);
@@ -1582,7 +1554,6 @@ test "normal execution-memory builders clean every allocation failure" {
 
             const memory = buildNormalMessageExecutionMemory(alloc, &messages) catch |err|
                 return switch (err) {
-                    error.WriteFailed => error.OutOfMemory,
                     else => err,
                 };
             defer types.freeExecutionMemory(alloc, memory);

--- a/src/core/agent/runtime/execution_memory.zig
+++ b/src/core/agent/runtime/execution_memory.zig
@@ -128,7 +128,7 @@ pub fn buildExecutionMemory(alloc: Allocator, within_turn_suffix: []const ChatMe
         };
         const copy = try alloc.dupe(u8, text);
         const prefix_copy = if (assistant_prefix) |prefix|
-            execution_memory_helpers.redactText(alloc, prefix) catch |err| {
+            alloc.dupe(u8, prefix) catch |err| {
                 alloc.free(copy);
                 return err;
             }
@@ -451,7 +451,7 @@ pub fn prepareToolExecutionOutput(
         return prepareCapturedToolModelOutput(arena, config, tool_call, execution.model_output, capture);
     }
     if (capture != null) return error.InvalidSkillContentResult;
-    const full = try tool_result_limits.prepareRedactedOutput(arena, execution.model_output);
+    const full = try tool_result_limits.prepareSanitizedOutput(arena, execution.model_output);
     errdefer arena.free(full);
     if (full.len > config.max_tool_result_bytes) return error.SkillContentLimitExceeded;
     var prepared = try prepareCapturedToolModelOutput(arena, config, tool_call, full, null);
@@ -484,7 +484,7 @@ pub fn prepareCapturedToolModelOutput(
     capture: ?*command_replay_store.Capture,
 ) !result_store.PreparedResult {
     if (std.mem.eql(u8, tool_call.name, "read_tool_result")) {
-        const prepared = try tool_result_limits.prepareUnmaskedModelOutputWithTruncation(
+        const prepared = try tool_result_limits.prepareModelOutputWithTruncation(
             arena,
             tool_call.name,
             raw_output,
@@ -519,7 +519,7 @@ pub fn prepareCapturedToolModelOutput(
     if (!required_command_replay and
         (config.session_child_capability != null or config.tool_result_dir != null))
     {
-        const redacted_output = try tool_result_limits.prepareRedactedOutput(
+        const sanitized_output = try tool_result_limits.prepareSanitizedOutput(
             arena,
             raw_output,
         );
@@ -530,7 +530,7 @@ pub fn prepareCapturedToolModelOutput(
                 tool_call.id,
                 tool_call.name,
                 raw_output.len,
-                redacted_output,
+                sanitized_output,
                 config.max_tool_result_bytes,
             );
         }
@@ -540,7 +540,7 @@ pub fn prepareCapturedToolModelOutput(
             tool_call.id,
             tool_call.name,
             raw_output.len,
-            redacted_output,
+            sanitized_output,
             config.max_tool_result_bytes,
         );
     }
@@ -745,7 +745,7 @@ fn selectedCommandSource(
         return source;
     }
     if (prepared.model_output.len > source_limit) return null;
-    const source = try execution_memory_helpers.redactText(arena, prepared.model_output);
+    const source = try arena.dupe(u8, prepared.model_output);
     if (source.len > source_limit) {
         arena.free(source);
         return null;
@@ -1193,7 +1193,7 @@ test "required terminal exec stores large output only as replay" {
     try std.testing.expectEqual(@as(usize, 0), tool_results.names.len);
 }
 
-test "saved preparation stores complete redacted output on sub-threshold cap loss" {
+test "saved preparation stores complete output verbatim on cap loss" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -1203,8 +1203,8 @@ test "saved preparation stores complete redacted output on sub-threshold cap los
     defer arena_state.deinit();
     const arena = arena_state.allocator();
     var cancel = std.atomic.Value(bool).init(false);
-    const raw = "CUSTOM_API_KEY=abc123\n" ** 46;
-    try std.testing.expectEqual(@as(usize, 1012), raw.len);
+    const raw = "MY_UNIT_TOKEN=abcdefgh" ** 47;
+    try std.testing.expect(raw.len > tool_result_limits.min_configured_tool_result_bytes);
 
     const prepared = try prepareToolModelOutput(
         arena,
@@ -1217,7 +1217,7 @@ test "saved preparation stores complete redacted output on sub-threshold cap los
             .cancel_flag = &cancel,
             .tool_result_dir = result_dir,
         },
-        toolCall("call_expanded_secret", "read_file", "{}"),
+        toolCall("call_expanded_output", "read_file", "{}"),
         raw,
     );
 
@@ -1232,17 +1232,17 @@ test "saved preparation stores complete redacted output on sub-threshold cap los
         result_store.read_max_bytes,
     );
     defer alloc.free(stored);
-    try std.testing.expect(std.mem.find(u8, stored, "CUSTOM_API_KEY=[redacted]") != null);
-    try std.testing.expect(std.mem.find(u8, stored, "abc123") == null);
+    try std.testing.expect(std.mem.find(u8, stored, "MY_UNIT_TOKEN=abcdefgh") != null);
+    try std.testing.expect(std.mem.find(u8, stored, "[redacted]") == null);
 }
 
-test "no-save preparation preserves capped success without a result handle" {
+test "no-save preparation preserves capped output verbatim without a result handle" {
     const alloc = std.testing.allocator;
     var arena_state = std.heap.ArenaAllocator.init(alloc);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
     var cancel = std.atomic.Value(bool).init(false);
-    const raw = "CUSTOM_API_KEY=abc123\n" ** 46;
+    const raw = "MY_UNIT_TOKEN=abcdefgh" ** 47;
 
     const prepared = try prepareToolModelOutput(
         arena,
@@ -1254,14 +1254,15 @@ test "no-save preparation preserves capped success without a result handle" {
             .max_tool_result_bytes = tool_result_limits.min_configured_tool_result_bytes,
             .cancel_flag = &cancel,
         },
-        toolCall("call_no_save_secret", "read_file", "{}"),
+        toolCall("call_no_save_output", "read_file", "{}"),
         raw,
     );
 
     try std.testing.expect(prepared.memory.output_handle == null);
     try std.testing.expect(prepared.memory.truncated);
     try std.testing.expect(std.mem.find(u8, prepared.model_output, "tool result truncated") != null);
-    try std.testing.expect(std.mem.find(u8, prepared.model_output, "abc123") == null);
+    try std.testing.expect(std.mem.find(u8, prepared.model_output, "MY_UNIT_TOKEN=abcdefgh") != null);
+    try std.testing.expect(std.mem.find(u8, prepared.model_output, "[redacted]") == null);
 }
 
 test "saved read_tool_result preparation preserves exact secret-like output" {
@@ -1417,7 +1418,7 @@ test "saved tool output preparation keeps builtins and dynamic tools compactable
     }
 }
 
-test "saved preparation externalizes complete redacted output without cap loss" {
+test "saved preparation externalizes complete output verbatim without cap loss" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -1427,7 +1428,7 @@ test "saved preparation externalizes complete redacted output without cap loss" 
     defer arena_state.deinit();
     const arena = arena_state.allocator();
     var cancel = std.atomic.Value(bool).init(false);
-    const raw = "AI_GATEWAY_API_KEY=abcdefghijklmnop end";
+    const raw = "AI_GATEWAY_API_KEY=abcdefghijklmnop";
 
     const prepared = try prepareToolModelOutput(
         arena,
@@ -1440,20 +1441,14 @@ test "saved preparation externalizes complete redacted output without cap loss" 
             .cancel_flag = &cancel,
             .tool_result_dir = result_dir,
         },
-        toolCall("call_redaction_shrink", "read_file", "{}"),
+        toolCall("call_external_output", "read_file", "{}"),
         raw,
     );
 
     try std.testing.expect(prepared.memory.output_handle != null);
-    try std.testing.expectEqualStrings(
-        "AI_GATEWAY_API_KEY=[redacted] end",
-        prepared.memory.preview.?,
-    );
+    try std.testing.expectEqualStrings(raw, prepared.memory.preview.?);
     try std.testing.expect(!prepared.memory.truncated);
-    try std.testing.expectEqualStrings(
-        "AI_GATEWAY_API_KEY=[redacted] end",
-        prepared.model_output,
-    );
+    try std.testing.expectEqualStrings(raw, prepared.model_output);
 }
 
 test "saved inline read retains full file evidence with its external copy" {
@@ -1563,12 +1558,13 @@ test "common execution memory does not mark stored read previews as full" {
     try std.testing.expect(std.mem.find(u8, replay, "model_view=full") == null);
 }
 
-test "execution memory redacts secret argument values without breaking JSON" {
+test "execution memory persists secret argument values verbatim" {
     const alloc = std.testing.allocator;
+    const arguments_json = "{\"command\":\"echo ok\",\"api_key\":\"secret-value-123456\"}";
     var calls = [_]ToolCall{.{
         .id = "call_secret",
         .name = "run_command",
-        .arguments_json = "{\"command\":\"echo ok\",\"api_key\":\"secret-value\"}",
+        .arguments_json = arguments_json,
     }};
     const messages = [_]ChatMessage{
         .{ .role = .assistant, .tool_calls = calls[0..] },
@@ -1579,19 +1575,21 @@ test "execution memory redacts secret argument values without breaking JSON" {
     defer types.freeExecutionMemory(alloc, memory);
     try std.testing.expectEqual(@as(usize, 1), memory.tool_steps.len);
     const args = memory.tool_steps[0].tool_calls[0].arguments_json;
-    try std.testing.expect(std.mem.find(u8, args, "secret-value") == null);
+    try std.testing.expectEqualStrings(arguments_json, args);
     var parsed = try std.json.parseFromSlice(std.json.Value, alloc, args, .{});
     defer parsed.deinit();
-    try std.testing.expectEqualStrings("[REDACTED]", parsed.value.object.get("api_key").?.string);
+    try std.testing.expectEqualStrings("secret-value-123456", parsed.value.object.get("api_key").?.string);
     try std.testing.expectEqualStrings("echo ok", parsed.value.object.get("command").?.string);
 }
 
-test "execution memory redacts credentialed web_fetch url arguments" {
+test "execution memory persists credentialed web_fetch url arguments verbatim" {
     const alloc = std.testing.allocator;
+    const url = "https://user:pass@example.com/docs?token=querytoken123";
+    const arguments_json = "{\"url\":\"https://user:pass@example.com/docs?token=querytoken123\"}";
     var calls = [_]ToolCall{.{
         .id = "call_fetch",
         .name = "web_fetch",
-        .arguments_json = "{\"url\":\"https://user:pass@example.com/docs?token=QUERY_SECRET_SHOULD_NOT_PERSIST\"}",
+        .arguments_json = arguments_json,
     }};
     const messages = [_]ChatMessage{
         .{ .role = .assistant, .tool_calls = calls[0..] },
@@ -1601,15 +1599,14 @@ test "execution memory redacts credentialed web_fetch url arguments" {
     const memory = try buildExecutionMemory(alloc, &messages);
     defer types.freeExecutionMemory(alloc, memory);
     const args = memory.tool_steps[0].tool_calls[0].arguments_json;
-    try std.testing.expect(std.mem.find(u8, args, "user:pass") == null);
-    try std.testing.expect(std.mem.find(u8, args, "QUERY_SECRET_SHOULD_NOT_PERSIST") == null);
+    try std.testing.expectEqualStrings(arguments_json, args);
     var parsed = try std.json.parseFromSlice(std.json.Value, alloc, args, .{});
     defer parsed.deinit();
     try std.testing.expect(parsed.value.object.get("prompt") == null);
-    try std.testing.expectEqualStrings("https://[redacted]@example.com/docs?token=[redacted]", parsed.value.object.get("url").?.string);
+    try std.testing.expectEqualStrings(url, parsed.value.object.get("url").?.string);
 }
 
-test "large result storage redacts secret-bearing output before preview and disk persistence" {
+test "large result storage persists secret-bearing output verbatim in preview and on disk" {
     const alloc = std.testing.allocator;
     var arena_state = std.heap.ArenaAllocator.init(alloc);
     defer arena_state.deinit();
@@ -1621,7 +1618,7 @@ test "large result storage redacts secret-bearing output before preview and disk
 
     var raw: std.ArrayList(u8) = .empty;
     defer raw.deinit(alloc);
-    try raw.appendSlice(alloc, "api_key=super-secret-value\n");
+    try raw.appendSlice(alloc, "api_key=super-secret-value" ++ "\n");
     try raw.appendNTimes(alloc, 'x', result_store.large_result_threshold_bytes + 64);
 
     var cancel_flag = std.atomic.Value(bool).init(false);
@@ -1630,18 +1627,19 @@ test "large result storage redacts secret-bearing output before preview and disk
         .gateway_retry_count = 0,
         .gateway_chat_url = "",
         .agent_step_limit = 1,
+        .max_tool_result_bytes = tool_result_limits.default_max_tool_result_bytes,
         .cancel_flag = &cancel_flag,
         .tool_result_dir = dir,
     }, toolCall("call_secret_large", "run_command", "{}"), raw.items);
 
     try std.testing.expect(prepared.memory.output_handle != null);
-    try std.testing.expect(std.mem.find(u8, prepared.model_output, "super-secret-value") == null);
-    try std.testing.expect(std.mem.find(u8, prepared.model_output, "api_key=[redacted]") != null);
+    try std.testing.expect(std.mem.find(u8, prepared.model_output, "api_key=super-secret-value") != null);
+    try std.testing.expect(std.mem.find(u8, prepared.model_output, "[redacted]") == null);
 
     const stored = try result_store.readByRange(alloc, dir, prepared.memory.output_handle.?, 1, 512);
     defer alloc.free(stored);
-    try std.testing.expect(std.mem.find(u8, stored, "super-secret-value") == null);
-    try std.testing.expect(std.mem.find(u8, stored, "api_key=[redacted]") != null);
+    try std.testing.expect(std.mem.find(u8, stored, "api_key=super-secret-value") != null);
+    try std.testing.expect(std.mem.find(u8, stored, "[redacted]") == null);
 }
 
 test "execution memory persists consumed steering without protocol wrappers" {

--- a/src/core/agent/runtime/interruption.zig
+++ b/src/core/agent/runtime/interruption.zig
@@ -125,7 +125,7 @@ fn persistInterruptedTurnWithPresentation(
     if (persisted.*) return;
 
     const durable_active_tool_call = if (active_tool_call) |call|
-        try execution_memory_helpers.dupeRedactedToolCall(
+        try execution_memory_helpers.dupePersistedToolCall(
             std.heap.c_allocator,
             call,
         )

--- a/src/core/agent/runtime/tests/tool_flow.zig
+++ b/src/core/agent/runtime/tests/tool_flow.zig
@@ -6225,14 +6225,14 @@ test "processQueuedPrompt pauses retryable failures and preserves execution on t
     }
 }
 
-test "processQueuedPrompt redacts interrupted active tool before history and replay" {
+test "processQueuedPrompt persists interrupted active tool verbatim before history and replay" {
     const alloc = std.testing.allocator;
-    const secret_id = "sk-abcdefghijklmnop";
-    const secret_path = "xoxb-abcdefghijklmnop";
+    const secret_id = "ghp_abcdefghijklmnopqrstuvwxyz1234567890";
+    const secret_path = "/secrets/TOKEN=path-secret-value";
     const calls = [_]ToolCall{toolCall(
         secret_id,
         "read_file",
-        "{\"path\":\"xoxb-abcdefghijklmnop\"}",
+        "{\"path\":\"/secrets/TOKEN=path-secret-value\"}",
     )};
     const completions = [_]FakeCompletion{.{ .tool_calls = &calls }};
     var gateway = FakeGateway.init(alloc, &completions);
@@ -6249,7 +6249,7 @@ test "processQueuedPrompt redacts interrupted active tool before history and rep
     const persisted_call = interrupted.tool_call.?;
     try std.testing.expect(!std.mem.eql(u8, secret_id, persisted_call.id));
     try std.testing.expect(
-        std.mem.find(u8, persisted_call.arguments_json, secret_path) == null,
+        std.mem.find(u8, persisted_call.arguments_json, secret_path) != null,
     );
 
     const follow_completions = [_]FakeCompletion{.{ .content = "Interrupted." }};
@@ -6270,7 +6270,7 @@ test "processQueuedPrompt redacts interrupted active tool before history and rep
     );
 
     try expectBodyNotContains(&follow_gateway, 0, secret_id);
-    try expectBodyNotContains(&follow_gateway, 0, secret_path);
+    try expectBodyContains(&follow_gateway, 0, secret_path);
     try expectBodyContains(&follow_gateway, 0, persisted_call.id);
 }
 

--- a/src/core/agent/runtime/tool_presentation.zig
+++ b/src/core/agent/runtime/tool_presentation.zig
@@ -1223,13 +1223,14 @@ fn failureStatusDetail(
                     std.mem.findScalar(u8, actionable, '\n') == null and
                     std.mem.findScalar(u8, actionable, '\r') == null)
                 {
-                    return actionable;
+                    return try text_utils.maskSecrets(arena, actionable);
                 }
             }
         }
 
         if (safe_result.len == 0) return detail;
-        const encoded = try text_utils.encodeTerminalSafe(arena, safe_result, 256);
+        const masked = try text_utils.maskSecrets(arena, safe_result);
+        const encoded = try text_utils.encodeTerminalSafe(arena, masked, 256);
         return if (encoded.bytes.len == 0) detail else encoded.bytes;
     }
 
@@ -1239,7 +1240,8 @@ fn failureStatusDetail(
         return null;
     }
     const detail = try mcpFailureEnvelopeText(arena, safe_result) orelse safe_result;
-    const encoded = try text_utils.encodeTerminalSafe(arena, detail, 256);
+    const masked_detail = try text_utils.maskSecrets(arena, detail);
+    const encoded = try text_utils.encodeTerminalSafe(arena, masked_detail, 256);
     return if (encoded.bytes.len == 0) null else encoded.bytes;
 }
 

--- a/src/core/app/app_callbacks.zig
+++ b/src/core/app/app_callbacks.zig
@@ -689,7 +689,7 @@ pub fn Bindings(comptime App: type) type {
                     result.work_id,
                     "subagent",
                     result.body.len,
-                    try tool_result_limits.prepareRedactedOutput(arena, result.body),
+                    try tool_result_limits.prepareSanitizedOutput(arena, result.body),
                     result.max_result_bytes,
                 );
                 debug_trace.eventf("subagent", "steering_context_prepared", .{ .turn_id = app.worker.activeTurnId() }, "child_id={s} work_id={s} already_delivered={} result_bytes={d} model_bytes={d} stored_handle={}", .{ result.child_id, result.work_id, result.delivered, result.body.len, prepared.model_output.len, prepared.memory.output_handle != null });

--- a/src/core/mcp/tool_result.zig
+++ b/src/core/mcp/tool_result.zig
@@ -265,11 +265,11 @@ fn write_protocol_diagnostic(
 ) !void {
     try writer.print("MCP protocol error {d}: ", .{code});
     const safe_message = try text_utils.sanitizeModelText(scratch, message);
-    try writer.writeAll(try text_utils.maskSecrets(scratch, safe_message));
+    try writer.writeAll(safe_message);
     if (data_json) |data| {
         const safe_data = try text_utils.sanitizeModelText(scratch, data);
         try writer.writeAll("; data=");
-        try writer.writeAll(try text_utils.maskSecrets(scratch, safe_data));
+        try writer.writeAll(safe_data);
     }
 }
 
@@ -385,8 +385,43 @@ fn write_envelope(
     try writer.writeAll(",\"tool\":");
     try std.json.Stringify.value(tool_name, .{}, writer);
     try writer.writeAll(",\"result\":");
-    try write_masked_json_value(alloc, writer, result);
+    try write_sanitized_json_value(alloc, writer, result);
     try writer.writeByte('}');
+}
+
+/// Sanitize-only projection for MCP tool results delivered to the model.
+fn write_sanitized_json_value(
+    alloc: Allocator,
+    writer: *std.Io.Writer,
+    value: std.json.Value,
+) !void {
+    switch (value) {
+        .null, .bool, .integer, .float, .number_string => try std.json.Stringify.value(value, .{}, writer),
+        .string => |text| {
+            const sanitized = try text_utils.sanitizeModelText(alloc, text);
+            try std.json.Stringify.value(sanitized, .{}, writer);
+        },
+        .array => |array| {
+            try writer.writeByte('[');
+            for (array.items, 0..) |item, index| {
+                if (index > 0) try writer.writeByte(',');
+                try write_sanitized_json_value(alloc, writer, item);
+            }
+            try writer.writeByte(']');
+        },
+        .object => |object| {
+            try writer.writeByte('{');
+            var it = object.iterator();
+            var index: usize = 0;
+            while (it.next()) |entry| : (index += 1) {
+                if (index > 0) try writer.writeByte(',');
+                try std.json.Stringify.value(entry.key_ptr.*, .{}, writer);
+                try writer.writeByte(':');
+                try write_sanitized_json_value(alloc, writer, entry.value_ptr.*);
+            }
+            try writer.writeByte('}');
+        },
+    }
 }
 
 fn write_masked_json_value(
@@ -443,9 +478,8 @@ fn append_text_strings(
     switch (value) {
         .string => |text| {
             const sanitized = try text_utils.sanitizeModelText(arena, text);
-            const masked = try text_utils.maskSecrets(arena, sanitized);
             if (needs_separator.*) try writer.writeByte('\n');
-            try writer.writeAll(masked);
+            try writer.writeAll(sanitized);
             needs_separator.* = true;
         },
         .array => |array| for (array.items) |item| {
@@ -652,9 +686,10 @@ test "invalid tool responses retain bounded protocol failures" {
     }
 }
 
-test "large tool results stay valid, bounded, and secret-masked" {
+test "large tool results stay valid, bounded, and verbatim" {
     const alloc = std.testing.allocator;
-    const large_text = "TOKEN=secret-value " ++ ("x" ** 1800);
+    const needle = "MY_NOTE_TOKEN=abcdefgh";
+    const large_text = needle ++ ("x" ** 1800);
     const response = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"" ++ large_text ++ "\"}]}}";
     var result = try extract(alloc, .{
         .server_name = "filesystem",
@@ -666,16 +701,8 @@ test "large tool results stay valid, bounded, and secret-masked" {
     defer result.deinit(alloc);
 
     try std.testing.expect(result.model_output.len <= 1024);
-    try std.testing.expect(std.mem.find(
-        u8,
-        result.model_output,
-        "TOKEN=secret-value",
-    ) == null);
-    try std.testing.expect(std.mem.find(
-        u8,
-        result.model_output,
-        "TOKEN=[redacted]",
-    ) != null);
+    try std.testing.expect(std.mem.find(u8, result.model_output, needle) != null);
+    try std.testing.expect(std.mem.find(u8, result.model_output, "[redacted]") == null);
     try std.testing.expect(std.mem.find(
         u8,
         result.model_output,

--- a/src/core/session/result_store.zig
+++ b/src/core/session/result_store.zig
@@ -333,7 +333,7 @@ pub fn formatStoredResultOutput(alloc: Allocator, handle: []const u8, preview: [
         alloc,
         "<tool_result_preview handle=\"{s}\" stored_bytes=\"{d}\">\n{s}\n</tool_result_preview>\n" ++
             "<tool_result_handle>{s}</tool_result_handle>\n" ++
-            "Full redacted result is stored outside session JSON. Use read_tool_result with this handle to inspect a byte range or literal query.",
+            "Full result is stored outside session JSON. Use read_tool_result with this handle to inspect a byte range or literal query.",
         .{ handle, stored_bytes, preview, handle },
     );
 }
@@ -449,7 +449,7 @@ pub fn statManaged(
     };
 }
 
-/// Opens a persisted redacted result for bounded read-only pages. This never
+/// Opens a persisted tool result for bounded read-only pages. This never
 /// materializes the full sidecar in memory.
 pub fn openReaderManaged(
     alloc: Allocator,

--- a/src/core/shared/text_utils.zig
+++ b/src/core/shared/text_utils.zig
@@ -448,60 +448,6 @@ pub fn maskSecrets(arena: std.mem.Allocator, text: []const u8) ![]const u8 {
     return try out.toOwnedSlice();
 }
 
-/// Returns true when a secret candidate begins before the retained suffix and
-/// cannot be classified until later bytes arrive on the same logical line.
-pub fn secretMayCrossBoundary(text: []const u8, retained_suffix_bytes: usize) bool {
-    const retained_start = text.len -| retained_suffix_bytes;
-
-    var assignment_end = text.len;
-    if (assignment_end > 0 and
-        (text[assignment_end - 1] == '"' or text[assignment_end - 1] == '\''))
-    {
-        assignment_end -= 1;
-    }
-    if (assignment_end > 0 and text[assignment_end - 1] == '=') {
-        const key_end = assignment_end - 1;
-        var unfinished_key_start = key_end;
-        while (unfinished_key_start > 0 and
-            isAssignmentKeyChar(text[unfinished_key_start - 1]))
-        {
-            unfinished_key_start -= 1;
-        }
-        if (unfinished_key_start < retained_start and
-            sensitiveAssignmentKey(text[unfinished_key_start..key_end]))
-        {
-            return true;
-        }
-    }
-
-    var key_start = text.len;
-    while (key_start > 0 and isAssignmentKeyChar(text[key_start - 1])) {
-        key_start -= 1;
-    }
-    if (key_start < retained_start and
-        sensitiveAssignmentKey(text[key_start..]))
-    {
-        return true;
-    }
-
-    const prefix = "https://";
-    var search_start: usize = 0;
-    while (std.mem.findPos(u8, text, search_start, prefix)) |url_start| {
-        const credential_start = url_start + prefix.len;
-        var end = credential_start;
-        while (end < text.len and
-            text[end] != '\n' and
-            text[end] != '\r' and
-            !std.ascii.isWhitespace(text[end])) : (end += 1)
-        {
-            if (text[end] == '/' or text[end] == '?' or text[end] == '#' or text[end] == '@') break;
-        }
-        if (end == text.len and url_start < retained_start) return true;
-        search_start = if (end < text.len) end + 1 else text.len;
-    }
-    return false;
-}
-
 pub fn redactUrlForDisplay(alloc: std.mem.Allocator, raw_url: []const u8) error{OutOfMemory}![]u8 {
     var out: std.Io.Writer.Allocating = .init(alloc);
     errdefer out.deinit();
@@ -1145,37 +1091,6 @@ test "maskSecrets masks expanded model-facing secret patterns" {
         masked,
     );
     try std.testing.expect(std.mem.find(u8, masked, "AKIA0123456789ABCDEF") == null);
-}
-
-test "secret boundary analysis preserves resolved URLs and catches unfinished candidates" {
-    try std.testing.expect(!secretMayCrossBoundary(
-        "prefix https://example.com suffix ",
-        64,
-    ));
-    try std.testing.expect(secretMayCrossBoundary(
-        "MY_VERY_LONG_TOKEN_KEY",
-        4,
-    ));
-    try std.testing.expect(secretMayCrossBoundary(
-        "MY_VERY_LONG_TOKEN_KEY=",
-        4,
-    ));
-    try std.testing.expect(secretMayCrossBoundary(
-        "MY_VERY_LONG_TOKEN_KEY=\"",
-        4,
-    ));
-    try std.testing.expect(secretMayCrossBoundary(
-        "MY_VERY_LONG_TOKEN_KEY='",
-        4,
-    ));
-    try std.testing.expect(secretMayCrossBoundary(
-        "prefix https://user:password",
-        4,
-    ));
-    try std.testing.expect(!secretMayCrossBoundary(
-        "prefix ORDINARY_KEY",
-        4,
-    ));
 }
 
 test "redactUrlForDisplay masks credential-like query values" {

--- a/src/core/skills/skill_invocation.zig
+++ b/src/core/skills/skill_invocation.zig
@@ -297,9 +297,9 @@ fn appendExplicitLoadRow(alloc: Allocator, out: *std.Io.Writer, name: []const u8
     else
         try std.fmt.allocPrint(alloc, "Loaded skill {s}", .{name});
     defer alloc.free(row);
-    const redacted = try tool_result_limits.prepareRedactedOutput(alloc, row);
-    defer alloc.free(redacted);
-    const safe = try text_utils.encodeTerminalSafe(alloc, redacted, context_limits.emergency_ceiling_bytes);
+    const sanitized = try tool_result_limits.prepareSanitizedOutput(alloc, row);
+    defer alloc.free(sanitized);
+    const safe = try text_utils.encodeTerminalSafe(alloc, sanitized, context_limits.emergency_ceiling_bytes);
     defer alloc.free(safe.bytes);
     try out.writeAll(safe.bytes);
 }
@@ -352,7 +352,7 @@ test "explicit skills include complete instructions beyond the default chunk" {
     try std.testing.expectError(error.Cancelled, buildExplicitPromptSection(alloc, .{ .skills = &skills }, "$workflow", &.{}, .{}, &cancelled));
 }
 
-test "explicit load rows keep untrusted names and diagnostics terminal safe" {
+test "explicit load rows keep untrusted names terminal safe and diagnostics verbatim" {
     const alloc = std.testing.allocator;
     var out: std.Io.Writer.Allocating = .init(alloc);
     defer out.deinit();
@@ -361,7 +361,7 @@ test "explicit load rows keep untrusted names and diagnostics terminal safe" {
     try std.testing.expect(text_utils.isTerminalSafe(out.written()));
     try expectNotContains(out.written(), "\n");
     try expectNotContains(out.written(), "\x1b");
-    try expectNotContains(out.written(), "private-skill-secret");
+    try expectContains(out.written(), "private-skill-secret");
 }
 
 test "explicit load summary reports a missing bound skill without success" {
@@ -898,7 +898,7 @@ fn loadByIdentityWithOptions(
         full.writer.writeAll("\" complete=\"true\">\n") catch return error.OutOfMemory;
         full.writer.writeAll(resource_read.bytes) catch return error.OutOfMemory;
         full.writer.writeAll("\n</skill_content>") catch return error.OutOfMemory;
-        const output = try tool_result_limits.prepareRedactedOutput(alloc, full.written());
+        const output = try tool_result_limits.prepareSanitizedOutput(alloc, full.written());
         if (output.len > primary_budget) {
             defer alloc.free(output);
             const message = try std.fmt.allocPrint(alloc, "Complete skill content exceeds max_tool_result_bytes ({d} bytes). No complete instructions were loaded.", .{primary_budget});
@@ -906,7 +906,7 @@ fn loadByIdentityWithOptions(
             return attachOwnedDiscoveryNotice(alloc, .{ .failure = .{ .model_output = try boundedSkillError(alloc, message, primary_budget) } }, &discovery_notice, max_tool_result_bytes);
         }
         const notice = if (!std.mem.eql(u8, output, full.written()))
-            alloc.dupe(u8, "[context] Skill content was sanitized or secret-masked before delivery.\n") catch |err| {
+            alloc.dupe(u8, "[context] Skill content was sanitized before delivery.\n") catch |err| {
                 alloc.free(output);
                 return err;
             }

--- a/src/core/skills/skill_runtime.zig
+++ b/src/core/skills/skill_runtime.zig
@@ -3120,7 +3120,7 @@ fn renderSkillPrompt(
 
         var description: std.Io.Writer.Allocating = .init(alloc);
         defer description.deinit();
-        const safe_description = try tool_result_limits.prepareRedactedOutput(alloc, skill.description);
+        const safe_description = try tool_result_limits.prepareSanitizedOutput(alloc, skill.description);
         defer alloc.free(safe_description);
         var description_limited = false;
         if (limits.skill_description_bytes.source == .compiled_default) {
@@ -4432,18 +4432,17 @@ test "skill catalog locations reject a changed identity mapping" {
     try std.testing.expectError(error.StaleSkillLocation, after.locations.resolve(alloc, location));
 }
 
-test "skill catalog does not expose sensitive descriptions or encoded locations" {
+test "skill catalog keeps secret-bearing descriptions and locations verbatim" {
     const alloc = std.testing.allocator;
     const skills = [_]Skill{
-        .{ .name = "safe", .description = "Release checks. API_KEY=description-secret", .path = "/root/safe", .source = .global_fx },
-        .{ .name = "hidden", .description = "Sensitive location", .path = "/root/TOKEN=location-secret", .source = .global_fx },
+        .{ .name = "safe", .description = "Release checks. API_KEY=description-secret-value", .path = "/root/safe", .source = .global_fx },
+        .{ .name = "hidden", .description = "Sensitive location", .path = "/root/TOKEN=location-secret-value", .source = .global_fx },
     };
     var section = try buildSkillPrompt(alloc, &skills, &.{}, .{}, 200_000);
     defer section.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, section.text, "- safe:") != null);
-    try std.testing.expect(std.mem.find(u8, section.text, "description-secret") == null);
-    try std.testing.expect(std.mem.find(u8, section.text, "location-secret") == null);
-    try std.testing.expect(std.mem.find(u8, section.text, "- hidden:") == null);
+    try std.testing.expect(std.mem.find(u8, section.text, "API_KEY=description-secret-value") != null);
+    try std.testing.expect(std.mem.find(u8, section.text, "- hidden:") != null);
 }
 
 fn checkSkillPromptAllocationFailures(alloc: Allocator) !void {

--- a/src/core/subagent/agent_adapter.zig
+++ b/src/core/subagent/agent_adapter.zig
@@ -857,9 +857,9 @@ fn captureHttpError(
         detail,
     );
     defer context.turn.alloc.free(formatted);
-    const redacted = try execution_memory.redactText(context.turn.alloc, formatted);
-    defer context.turn.alloc.free(redacted);
-    context.turn.setFailureDiagnostic("provider_http_error", redacted);
+    const masked = try execution_memory.maskTextForDisplay(context.turn.alloc, formatted);
+    defer context.turn.alloc.free(masked);
+    context.turn.setFailureDiagnostic("provider_http_error", masked);
 }
 
 fn pushLiveEvent(raw: *anyopaque, event: worker_runtime.WorkerEvent) !void {

--- a/src/core/tooling/tool_result_limits.zig
+++ b/src/core/tooling/tool_result_limits.zig
@@ -16,15 +16,15 @@ pub const PreparedModelOutput = struct {
     truncated: bool,
 };
 
-/// Returns an owned sanitized and secret-masked copy before any model cap.
-pub fn prepareRedactedOutput(
+/// Returns an owned sanitized copy before any model cap.
+pub fn prepareSanitizedOutput(
     alloc: Allocator,
     raw: []const u8,
 ) error{OutOfMemory}![]u8 {
     var scratch_impl = std.heap.ArenaAllocator.init(alloc);
     defer scratch_impl.deinit();
-    const redacted = try redactModelText(scratch_impl.allocator(), raw);
-    return alloc.dupe(u8, redacted);
+    const sanitized = try text_utils.sanitizeModelText(scratch_impl.allocator(), raw);
+    return alloc.dupe(u8, sanitized);
 }
 
 pub fn prepareModelOutput(
@@ -42,37 +42,6 @@ pub fn prepareModelOutput(
 }
 
 pub fn prepareModelOutputWithTruncation(
-    alloc: Allocator,
-    tool_name: []const u8,
-    raw: []const u8,
-    max_bytes: usize,
-) error{OutOfMemory}!PreparedModelOutput {
-    var scratch_impl = std.heap.ArenaAllocator.init(alloc);
-    defer scratch_impl.deinit();
-    const scratch = scratch_impl.allocator();
-
-    const redacted = try redactModelText(scratch, raw);
-    const capped = try truncateText(scratch, .{
-        .text = redacted,
-        .max_bytes = max_bytes,
-        .marker = try std.fmt.allocPrint(
-            scratch,
-            "\n... [tool result truncated for {s}: original {d} bytes; cap is {d} bytes]\n",
-            .{ tool_name, redacted.len, max_bytes },
-        ),
-        .trace_scope = "tool",
-        .trace_label = tool_name,
-    });
-    return .{
-        .model_output = try alloc.dupe(u8, capped),
-        .truncated = redacted.len > max_bytes,
-    };
-}
-
-/// Returns an owned, bounded model projection without replacing secret-like
-/// text. This is reserved for explicit `read_tool_result` retrieval, where the
-/// model requested exact bytes from an already bounded result page or query.
-pub fn prepareUnmaskedModelOutputWithTruncation(
     alloc: Allocator,
     tool_name: []const u8,
     raw: []const u8,
@@ -100,28 +69,15 @@ pub fn prepareUnmaskedModelOutputWithTruncation(
     };
 }
 
-fn redactModelText(
-    alloc: Allocator,
-    raw: []const u8,
-) error{OutOfMemory}![]const u8 {
-    const sanitized = try text_utils.sanitizeModelText(alloc, raw);
-    return text_utils.maskSecrets(alloc, sanitized) catch |err| switch (err) {
-        error.OutOfMemory, error.WriteFailed => error.OutOfMemory,
-    };
-}
-
 pub fn modelProjectionPreservesText(
     request_scratch: Allocator,
     raw: []const u8,
 ) error{OutOfMemory}!bool {
     const sanitized = try text_utils.sanitizeModelText(request_scratch, raw);
-    const masked = text_utils.maskSecrets(request_scratch, sanitized) catch |err| switch (err) {
-        error.OutOfMemory, error.WriteFailed => return error.OutOfMemory,
-    };
-    return std.mem.eql(u8, raw, masked);
+    return std.mem.eql(u8, raw, sanitized);
 }
 
-test "model projection stability rejects sanitized and secret-bearing identities" {
+test "model projection stability rejects non-utf8 identities" {
     var scratch_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer scratch_state.deinit();
     const scratch = scratch_state.allocator();
@@ -129,7 +85,6 @@ test "model projection stability rejects sanitized and secret-bearing identities
 
     try std.testing.expect(try modelProjectionPreservesText(scratch, "mcp_datadog_list_incidents"));
     try std.testing.expect(!try modelProjectionPreservesText(scratch, &invalid_utf8));
-    try std.testing.expect(!try modelProjectionPreservesText(scratch, "token=secret-value"));
 }
 
 pub const PreparedInlineResult = struct {
@@ -188,74 +143,39 @@ pub fn truncateText(arena: std.mem.Allocator, opts: TruncateOptions) ![]const u8
     return try std.mem.concat(arena, u8, &.{ opts.text[0..prefix_len], opts.marker });
 }
 
-test "prepareModelOutput masks secrets before applying cap" {
+test "prepareModelOutput preserves secret-shaped assignments verbatim" {
     const alloc = std.testing.allocator;
-    const output = try prepareModelOutput(alloc, "mcp__server__tool", "token=secret-value", default_max_tool_result_bytes);
+    const raw = "token=abcdefghijklmnopqrstuvwxyz";
+    const output = try prepareModelOutput(alloc, "mcp__server__tool", raw, default_max_tool_result_bytes);
     defer alloc.free(@constCast(output));
 
-    try std.testing.expectEqualStrings("token=[redacted]", output);
+    try std.testing.expectEqualStrings(raw, output);
 }
 
-test "prepareModelOutput masks quoted sensitive assignments" {
+test "prepareModelOutput preserves quoted sensitive assignments verbatim" {
     const alloc = std.testing.allocator;
-    const output = try prepareModelOutput(alloc, "run_command", "API_KEY=\"secret-value\"", default_max_tool_result_bytes);
+    const raw = "API_KEY=\"secret-value-123456\"";
+    const output = try prepareModelOutput(alloc, "run_command", raw, default_max_tool_result_bytes);
     defer alloc.free(@constCast(output));
 
-    try std.testing.expectEqualStrings("API_KEY=\"[redacted]\"", output);
+    try std.testing.expectEqualStrings(raw, output);
 }
 
-test "prepareUnmaskedModelOutput preserves secret-like text" {
+test "prepareInlineResult preserves assignments without reclassifying lengths" {
     const alloc = std.testing.allocator;
-    const raw = "TOOL_DATA_TOKEN=0123456789abcdef01234567";
-    const prepared = try prepareUnmaskedModelOutputWithTruncation(
+    const raw = "AI_GATEWAY_KEY=abcdefghijklmnop";
+    const prepared = try prepareInlineResult(
         alloc,
-        "read_tool_result",
+        "mcp__server__tool",
         raw,
         default_max_tool_result_bytes,
     );
     defer alloc.free(prepared.model_output);
 
     try std.testing.expectEqualStrings(raw, prepared.model_output);
-    try std.testing.expect(!prepared.truncated);
-}
-
-test "prepareInlineResult does not classify redaction shrink as cap loss" {
-    const alloc = std.testing.allocator;
-    const raw = "AI_GATEWAY_API_KEY=abcdefghijklmnop end";
-    const prepared = try prepareInlineResult(
-        alloc,
-        "mcp__server__tool",
-        raw,
-        default_max_tool_result_bytes,
-    );
-    defer alloc.free(prepared.model_output);
-
-    try std.testing.expectEqualStrings(
-        "AI_GATEWAY_API_KEY=[redacted] end",
-        prepared.model_output,
-    );
-    try std.testing.expect(prepared.model_output.len < raw.len);
     try std.testing.expect(!prepared.memory.truncated);
     try std.testing.expectEqual(raw.len, prepared.memory.output_bytes);
-}
-
-test "prepareInlineResult classifies cap loss after redaction expansion" {
-    const alloc = std.testing.allocator;
-    const raw = "CUSTOM_API_KEY=abc123\n" ** 46;
-    try std.testing.expectEqual(@as(usize, 1012), raw.len);
-
-    const prepared = try prepareInlineResult(
-        alloc,
-        "mcp__server__tool",
-        raw,
-        min_configured_tool_result_bytes,
-    );
-    defer alloc.free(prepared.model_output);
-
-    try std.testing.expectEqual(min_configured_tool_result_bytes, prepared.model_output.len);
-    try std.testing.expect(prepared.memory.truncated);
-    try std.testing.expect(std.mem.find(u8, prepared.model_output, "abc123") == null);
-    try std.testing.expect(std.mem.find(u8, prepared.model_output, "[redacted]") != null);
+    try std.testing.expectEqual(raw.len, prepared.memory.stored_output_bytes);
 }
 
 test "prepareModelOutput caps chatty output with explicit marker" {

--- a/src/tools/capabilities/capability_search.zig
+++ b/src/tools/capabilities/capability_search.zig
@@ -529,7 +529,7 @@ test "capability search combines bounded skill and MCP results" {
     try std.testing.expectEqual(@as(i64, 2), parsed.value.object.get("total_matches").?.object.get("skills").?.integer);
     try std.testing.expect(parsed.value.object.get("more_available") == null);
     try std.testing.expect(parsed.value.object.get("next_cursors") == null);
-    try std.testing.expect(parsed.value.object.get("authentication_required") == null);
+    try std.testing.expect(parsed.value.object.get("authentication_required") != null);
 }
 
 test "capability search combined projection releases every allocation failure" {

--- a/src/tools/skills/skill_search.zig
+++ b/src/tools/skills/skill_search.zig
@@ -258,11 +258,11 @@ test "skill search ranks metadata and returns final-projection-stable JSON" {
     try std.testing.expectEqualStrings(output, projected_again);
 }
 
-test "skill search omits projected identities and permits redacted descriptions" {
+test "skill search preserves projected identities and verbatim descriptions" {
     const alloc = std.testing.allocator;
     const skills = [_]skill_runtime.Skill{
-        .{ .name = "unsafe-location", .description = "Review files", .path = "/skills/TOKEN=runtime-location-secret/SKILL.md", .source = .workspace_fx },
-        .{ .name = "safe", .description = "API_KEY=runtime-description-secret", .path = "/skills/safe/SKILL.md", .source = .workspace_fx },
+        .{ .name = "unsafe-location", .description = "Review files", .path = "/skills/TOKEN=path-secret-value", .source = .workspace_fx },
+        .{ .name = "safe", .description = "API_KEY=description-secret-value", .path = "/skills/safe/SKILL.md", .source = .workspace_fx },
     };
     const query = try lexical_relevance.prepare("");
     const output = try renderProjectedSearch(
@@ -273,10 +273,10 @@ test "skill search omits projected identities and permits redacted descriptions"
         4096,
     );
     defer alloc.free(output);
-    try std.testing.expect(std.mem.find(u8, output, "unsafe-location") == null);
+    try std.testing.expect(std.mem.find(u8, output, "unsafe-location") != null);
     try std.testing.expect(std.mem.find(u8, output, "\"name\":\"safe\"") != null);
-    try std.testing.expect(std.mem.find(u8, output, "API_KEY=[redacted]") != null);
-    try std.testing.expect(std.mem.find(u8, output, "\"count\":1") != null);
+    try std.testing.expect(std.mem.find(u8, output, "API_KEY=description-secret-value") != null);
+    try std.testing.expect(std.mem.find(u8, output, "\"count\":2") != null);
     try std.testing.expect(std.mem.find(u8, output, "\"more_available\":false") != null);
 }
 

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -2227,7 +2227,7 @@ describe("gateway stream lifecycle", () => {
     }
   }, 45_000);
 
-  test("capability search ranks natural skill intent and keeps durable model-visible JSON exact after redaction", async () => {
+  test("capability search ranks natural skill intent and keeps durable model-visible JSON exact", async () => {
     const root = createFixtureRoot("skill-search-projection");
     const tracePath = join(root.root, "trace.log");
     const unsafeDirectory = join(
@@ -2332,7 +2332,7 @@ describe("gateway stream lifecycle", () => {
       expect(initialSkills).not.toContain("- mail-helper:");
       expect(projectedSearch?.skills[0]).toEqual({
         name: "mail-helper",
-        description: "Send email messages. API_KEY=[redacted]",
+        description: "Send email messages. API_KEY=runtime-description-secret",
         location: safeDirectory,
       });
       expect(projectedSearch?.counts.skills).toBe(1);

--- a/tests/e2e/web-fetch-fake-network.test.ts
+++ b/tests/e2e/web-fetch-fake-network.test.ts
@@ -351,7 +351,7 @@ describe("web_fetch Gateway fixture", () => {
   );
 
   test(
-    "invalid credentialed web_fetch persists no URL credentials",
+    "invalid credentialed web_fetch persists the URL verbatim",
     async () => {
       const root = createIsolatedRoot({ webFetchPermission: "allow" });
       const gateway = startFakeGateway([
@@ -384,8 +384,8 @@ describe("web_fetch Gateway fixture", () => {
           "utf8",
         );
         expect(sessionEvents).toContain("web_fetch");
-        expect(sessionEvents).not.toContain("user:pass");
-        expect(sessionEvents).toContain("https://[redacted]@example.com/docs");
+        expect(sessionEvents).toContain("https://user:pass@example.com/docs");
+        expect(sessionEvents).not.toContain("[redacted]");
       } finally {
         gateway.stop();
         rmSync(root.root, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Tool results, tool arguments, and saved session history now reach the model verbatim (still encoding-sanitized and capped). Previously, secret-shaped spans were replaced with a redaction marker at ingestion, and the masked copy was the only one kept — so when a task needed the value, the model could only pass the literal marker text and the receiving tool rejected it.

Human-facing surfaces keep masking: status lines, failure details, ACP client replay, URL display, diagnostics, and traces. `maskSecrets` and the credential-key argument projection remain in use for those display paths. The permission pipeline is unchanged.

This matches how other coding agents handle tool output: the model sees what the tool returned, display stays masked.

## Behavior change worth noting in review

This intentionally relaxes "secrets never persist in session state" to "secrets persist locally, display stays masked, provider sees tool output as-is" — the same posture as mainstream harnesses. Anything the pattern detector previously caught in tool output now flows like everything it never caught. The command-replay tape already stored raw output before this change.

## What was removed

- The model-path masking composition (`redactModelText`, `prepareRedactedOutput`)
- The `read_tool_result` unmasked special case (the general path is now unmasked, so the branch collapsed into it)
- History-write redaction of outputs, arguments, assistant text, previews, and committed-file presentations
- The secret-boundary analysis helper that only served replay-page masking
- Net −168 lines

## Verification

- `zig build test`: 8870 tests green (multiple runs)
- `zig fmt --check src/`: clean
- Deterministic harness (scripted fake gateway, no LLM): the follow-up tool call now receives the real key — the receiver file contains the raw value, gateway capture shows the secret in the tool-result message, exit 0, reproducible across two runs
- Live run against the real gateway: model read a fixture key from a file and wrote it into a target file as a value, exit 0
- e2e updated and green: `gateway-stream-lifecycle` (186 tests), `web-fetch-fake-network` + `auto-mode-reliability` (43), `session-recovery` + `ask-presentation` (50)

## Label

`type: bug` — the PR exists because masked placeholder text was being used as a value, breaking tool workflows.
