### PR TITLE
Remove never-wired helpers left over from the initial commit

### DIFF
--- a/src/acp/prompt.zig
+++ b/src/acp/prompt.zig
@@ -4170,17 +4170,6 @@ fn testPermissionRuleSet(alloc: Allocator, permission: []const u8, pattern: []co
     return rules;
 }
 
-fn writeArgsJson(alloc: Allocator, path: []const u8, content: []const u8) ![]u8 {
-    var out: std.Io.Writer.Allocating = .init(alloc);
-    defer out.deinit();
-    try out.writer.writeAll("{\"path\":");
-    try std.json.Stringify.value(path, .{}, &out.writer);
-    try out.writer.writeAll(",\"content\":");
-    try std.json.Stringify.value(content, .{}, &out.writer);
-    try out.writer.writeByte('}');
-    return try out.toOwnedSlice();
-}
-
 fn createSymlinkOrSkip(dir: std.Io.Dir, target_path: []const u8, link_path: []const u8) !void {
     if (comptime @import("builtin").os.tag == .windows) return error.SkipZigTest;
     dir.symLink(std.testing.io, target_path, link_path, .{ .is_directory = false }) catch |err| {

--- a/src/builtins/gateway.zig
+++ b/src/builtins/gateway.zig
@@ -1458,10 +1458,6 @@ fn writeParallelDomains(writer: *std.Io.Writer, name: []const u8, domains: []con
     try writer.writeAll("]}");
 }
 
-fn boundedDupe(alloc: Allocator, text: []const u8, max_len: usize) ![]u8 {
-    return try alloc.dupe(u8, text[0..@min(text.len, max_len)]);
-}
-
 fn hasValues(values: ?[]const []const u8) bool {
     return if (values) |actual| actual.len > 0 else false;
 }

--- a/src/builtins/tools.zig
+++ b/src/builtins/tools.zig
@@ -1777,12 +1777,6 @@ test "built-in registry uses executable web_fetch implementation" {
     try std.testing.expect(std.mem.find(u8, body, "UnsupportedScheme") != null);
 }
 
-fn expectRegisteredNames(names: []const []const u8) !void {
-    for (names) |name| {
-        try std.testing.expect(registry.lookup(name) != null);
-    }
-}
-
 test "built-in read-only tool set matches plan inspection tools" {
     const expected_names = [_][]const u8{
         "read_file",

--- a/src/core/agent/runtime/tests/gateway_flow.zig
+++ b/src/core/agent/runtime/tests/gateway_flow.zig
@@ -129,11 +129,6 @@ fn expectFailedLifecycleContains(
     return error.TestExpectedEqual;
 }
 
-fn expectNoticeContains(hooks: *const FakeAgentRuntimeDeps, index: usize, needle: []const u8) !void {
-    try std.testing.expect(index < hooks.system_notices.items.len);
-    try std.testing.expect(std.mem.find(u8, hooks.system_notices.items[index], needle) != null);
-}
-
 fn expectRouteStatus(
     hooks: *const FakeAgentRuntimeDeps,
     index: usize,

--- a/src/core/agent/runtime/tests/tool_flow.zig
+++ b/src/core/agent/runtime/tests/tool_flow.zig
@@ -157,19 +157,6 @@ fn expectGrantListsEqual(
     }
 }
 
-fn expectNoGrantPermission(
-    grants: []const PermissionGrant,
-    permission: []const u8,
-) !void {
-    for (grants) |grant| {
-        try std.testing.expect(!std.mem.eql(
-            u8,
-            grant.tool_name,
-            permission,
-        ));
-    }
-}
-
 fn logContains(hooks: *const FakeAgentRuntimeDeps, needle: []const u8) bool {
     for (hooks.log.items) |entry| {
         if (std.mem.find(u8, entry, needle) != null) return true;

--- a/src/core/agent/runtime/tool_presentation.zig
+++ b/src/core/agent/runtime/tool_presentation.zig
@@ -1322,17 +1322,6 @@ fn commandArtifactHandle(
     return owned;
 }
 
-pub fn malformedToolArgumentsResult(arena: Allocator, call: ToolCall) !ToolExecutionResult {
-    return .{
-        .status = .failure,
-        .model_output = if (call.argument_integrity == .non_object_json)
-            try tool_result_errors.nonObjectToolArgumentsJson(arena, call.name)
-        else
-            try tool_result_errors.malformedToolArgumentsJson(arena, call.name),
-        .status_detail = if (call.argument_integrity == .non_object_json) "non-object arguments" else "invalid JSON arguments",
-    };
-}
-
 pub fn finishCommittedFileStatus(
     hooks: *const AgentRuntimeDeps,
     arena: Allocator,

--- a/src/core/agent/worker_runtime.zig
+++ b/src/core/agent/worker_runtime.zig
@@ -2750,22 +2750,6 @@ fn appendGrantToQueuedPrompt(alloc: std.mem.Allocator, prompt: *QueuedPrompt, to
     prompt.grants = next;
 }
 
-fn dupeStringSlice(alloc: std.mem.Allocator, values: []const []const u8) ![][]u8 {
-    if (values.len == 0) return &.{};
-    const copy = try alloc.alloc([]u8, values.len);
-    errdefer alloc.free(copy);
-
-    var filled: usize = 0;
-    errdefer {
-        var i: usize = 0;
-        while (i < filled) : (i += 1) alloc.free(copy[i]);
-    }
-    while (filled < values.len) : (filled += 1) {
-        copy[filled] = try alloc.dupe(u8, values[filled]);
-    }
-    return copy;
-}
-
 fn freeStringSlice(alloc: std.mem.Allocator, values: [][]u8) void {
     for (values) |value| alloc.free(value);
     if (values.len > 0) alloc.free(values);

--- a/src/core/app/app_bootstrap_runtime.zig
+++ b/src/core/app/app_bootstrap_runtime.zig
@@ -850,21 +850,6 @@ fn runBootstrapForTest(app: *TestApp, capture: *TestCapture) !void {
     );
 }
 
-fn tracePathForTest(alloc: Allocator, tmp: std.testing.TmpDir, name: []const u8) ![]u8 {
-    const io_mod = @import("../shared/io.zig");
-    const root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
-    defer alloc.free(root);
-    return std.fs.path.join(alloc, &.{ root, name });
-}
-
-fn readTraceForTest(alloc: Allocator, path: []const u8) ![]u8 {
-    const io_mod = @import("../shared/io.zig");
-    debug_trace.shutdown();
-    var file = try std.Io.Dir.openFileAbsolute(io_mod.getIo(), path, .{});
-    defer file.close(io_mod.getIo());
-    return io_mod.readFileToEnd(alloc, &file, 8192);
-}
-
 fn resizeHandlerForTest(_: std.posix.SIG) callconv(.c) void {}
 
 test "app_bootstrap_runtime transfers startup state and starts a fresh session" {

--- a/src/core/app/app_entry_runtime.zig
+++ b/src/core/app/app_entry_runtime.zig
@@ -177,15 +177,6 @@ pub fn runBeforeInteractive(alloc: Allocator, args: []const [:0]const u8, cfg: C
     return beforeInteractiveResultFromRunResult(alloc, run_result, benchEnabled());
 }
 
-pub fn runNoConfigBeforeInteractive(
-    alloc: Allocator,
-    args: []const [:0]const u8,
-    version: []const u8,
-    command_catalog: command_specs.TopLevelRegistry,
-) !?RunOutcome {
-    return if (try cli_surface.runNoConfigIfRequested(alloc, args, version, command_catalog)) .returned else null;
-}
-
 fn runBeforeInteractiveWithDeps(alloc: Allocator, args: []const [:0]const u8, cfg: Config, deps: RunDeps) !BeforeInteractiveResult {
     const run_result = deps.run_if_requested(deps.cli_ctx, alloc, args, cliSurfaceConfig(cfg)) catch |err| switch (err) {
         error.UnknownCliCommand => return .{ .exit = 1 },

--- a/src/core/app/app_worker_runtime.zig
+++ b/src/core/app/app_worker_runtime.zig
@@ -37,13 +37,6 @@ test {
     _ = activity_runtime;
 }
 
-fn allocDimmedTranscriptLine(alloc: std.mem.Allocator, text: []const u8) ![]u8 {
-    if (std.mem.endsWith(u8, text, "\n")) {
-        return std.fmt.allocPrint(alloc, "{s}{s}{s}\n", .{ ui_render.dim_style, text[0 .. text.len - 1], reset_style });
-    }
-    return std.fmt.allocPrint(alloc, "{s}{s}{s}", .{ ui_render.dim_style, text, reset_style });
-}
-
 fn discardTable(_: *anyopaque, table: assistant_presentation.TablePayload) !void {
     var owned = table;
     owned.deinit(std.heap.c_allocator);

--- a/src/core/cli/cli_surface.zig
+++ b/src/core/cli/cli_surface.zig
@@ -2767,22 +2767,6 @@ fn permissionRulesForSnapshot(alloc: Allocator, active_rules: anytype) !types.Pe
     return .{ .rules = rules };
 }
 
-fn loadLatestWorkspaceSessionDetail(
-    alloc: Allocator,
-    store: session_store.Store,
-) !session_store.ReadOnlyDetail {
-    var summary = try store.latestReadOnlyWorkspaceSummary(alloc);
-    defer summary.deinit(alloc);
-    return store.loadReadOnlyDetail(alloc, summary.id, .{});
-}
-
-fn loadLatestWorkspaceSessionSummary(
-    alloc: Allocator,
-    store: session_store.Store,
-) !session_store.SessionSummary {
-    return store.latestReadOnlyWorkspaceSummary(alloc);
-}
-
 fn catalogFailureDetail(failure: model_catalog.Failure) []const u8 {
     return switch (failure.category) {
         .authentication => "AuthenticationRejected",

--- a/src/core/config/settings_catalog.zig
+++ b/src/core/config/settings_catalog.zig
@@ -282,15 +282,6 @@ pub fn filteredCount(snapshot: Snapshot, category: Category, query: []const u8) 
     return count;
 }
 
-pub fn categoryFilteredCount(snapshot: Snapshot, category: Category, query: []const u8) usize {
-    if (category == .all) return filteredCount(snapshot, .all, query);
-    var count: usize = 0;
-    for (specs) |spec| {
-        if (spec.category == category and matchesQuery(snapshot, spec, query)) count += 1;
-    }
-    return count;
-}
-
 pub fn itemAt(snapshot: Snapshot, category: Category, query: []const u8, display_index: usize) ?Item {
     var match_index: usize = 0;
     for (specs) |spec| {

--- a/src/core/mcp/mcp_auth.zig
+++ b/src/core/mcp/mcp_auth.zig
@@ -762,20 +762,6 @@ fn encodeBase64UrlNoPad(output: []u8, input: []const u8) []const u8 {
     return output[0..encoded_len];
 }
 
-pub fn generatePkce(
-    verifier_buf: *[64]u8,
-    challenge_buf: *[43]u8,
-    random: std.Random,
-) struct { verifier: []const u8, challenge: []const u8 } {
-    var entropy: [48]u8 = undefined;
-    random.bytes(&entropy);
-    const verifier = encodeBase64UrlNoPad(verifier_buf, &entropy);
-    var digest: [std.crypto.hash.sha2.Sha256.digest_length]u8 = undefined;
-    std.crypto.hash.sha2.Sha256.hash(verifier, &digest, .{});
-    const challenge = encodeBase64UrlNoPad(challenge_buf, &digest);
-    return .{ .verifier = verifier, .challenge = challenge };
-}
-
 test "PKCE base64url encoding covers complete and partial groups" {
     const cases = .{
         .{ "", "" },

--- a/src/core/permissions/permissions.zig
+++ b/src/core/permissions/permissions.zig
@@ -1430,10 +1430,6 @@ pub fn permissionNameForTool(tool_name: []const u8) []const u8 {
     return tool_name;
 }
 
-pub fn permissionRuleCategoryForGrant(permission_name: []const u8) ?[]const u8 {
-    return permissionNameForTool(permission_name);
-}
-
 /// Returns the persistent rule pattern for a session grant. Caller owns the returned slice.
 pub fn permissionRulePatternForGrant(alloc: std.mem.Allocator, workspace_root: []const u8, permission_name: []const u8, pattern: []const u8) ![]u8 {
     const permission = permissionNameForTool(permission_name);

--- a/src/core/tooling/tool_projection.zig
+++ b/src/core/tooling/tool_projection.zig
@@ -628,13 +628,6 @@ fn expectNotContainsName(names: []const []const u8, expected: []const u8) !void 
     }
 }
 
-fn indexOfName(names: []const []const u8, expected: []const u8) !usize {
-    for (names, 0..) |name, index| {
-        if (std.mem.eql(u8, name, expected)) return index;
-    }
-    return error.TestExpectedEqual;
-}
-
 test "provider-executed search follows settled advertisement permission" {
     const cases = [_]struct {
         action: ?types.PermissionAction,

--- a/src/gateway/client.zig
+++ b/src/gateway/client.zig
@@ -2950,10 +2950,6 @@ fn extractFirstJsonStringValue(args: []const u8) ?[]const u8 {
     return null;
 }
 
-fn isReasoningSseEvent(event_type: []const u8) bool {
-    return std.mem.startsWith(u8, event_type, "reasoning-");
-}
-
 fn finish_reason_label(finish_reason: ?types.ProviderFinishReason) []const u8 {
     return if (finish_reason) |reason| reason.label() else "(none)";
 }

--- a/src/gateway/vercel_protocol.zig
+++ b/src/gateway/vercel_protocol.zig
@@ -136,21 +136,6 @@ pub fn buildGatewayRequestBodyWithVerifiedImagesAndBudget(
     );
 }
 
-pub fn buildGatewayRequiredToolRequestBodyWithOptions(
-    alloc: std.mem.Allocator,
-    tools_json: []const u8,
-    messages: []const ChatMessage,
-    options: model_capabilities.ResolvedProviderOptions,
-) ![]u8 {
-    return buildGatewayRequiredToolRequestBodyWithOptionsAndOutputLimit(
-        alloc,
-        tools_json,
-        messages,
-        options,
-        null,
-    );
-}
-
 pub fn buildGatewayRequiredToolRequestBodyWithOptionsAndOutputLimit(
     alloc: std.mem.Allocator,
     tools_json: []const u8,

--- a/src/tools/filesystem/read_file.zig
+++ b/src/tools/filesystem/read_file.zig
@@ -485,42 +485,6 @@ fn allowDecision(_: *const tool_dispatch.Tool, _: tool_dispatch.ToolInput, _: to
     return .{ .action = .allow, .reason = "allowed by test" };
 }
 
-fn writeFileArgsJson(alloc: Allocator, path: []const u8, content: []const u8) ![]u8 {
-    var out: std.Io.Writer.Allocating = .init(alloc);
-    defer out.deinit();
-
-    try out.writer.writeAll("{\"path\":");
-    try std.json.Stringify.value(path, .{}, &out.writer);
-    try out.writer.writeAll(",\"content\":");
-    try std.json.Stringify.value(content, .{}, &out.writer);
-    try out.writer.writeByte('}');
-    return try out.toOwnedSlice();
-}
-
-fn dispatchWriteFileWithTracker(
-    alloc: Allocator,
-    workspace_root: []const u8,
-    path: []const u8,
-    content: []const u8,
-    tracker: *read_tracker.ReadTracker,
-) !tool_dispatch.DispatchResult {
-    const args_json = try writeFileArgsJson(alloc, path, content);
-    defer alloc.free(args_json);
-
-    const registry = tool_dispatch.Registry{ .tools = &.{write_file_dispatch_tool} };
-    return tool_dispatch.dispatchToolCall(.{
-        .allocator = alloc,
-        .permission_mode = .auto,
-        .permission_decider = allowDecision,
-        .workspace_root = workspace_root,
-        .read_tracker = tracker,
-    }, registry, .{
-        .id = "call_2",
-        .name = "write_file",
-        .arguments_json = args_json,
-    });
-}
-
 fn tmpPath(alloc: Allocator, tmp: std.testing.TmpDir, sub_path: []const u8) ![]u8 {
     return io_mod.dirRealpathAlloc(alloc, tmp.dir, sub_path);
 }

--- a/src/ui/footer/approval_ui.zig
+++ b/src/ui/footer/approval_ui.zig
@@ -127,10 +127,6 @@ pub fn composeFileApprovalScreenRow(
     };
 }
 
-pub fn approvalPanelRowsForLayout(shell: *const TranscriptRuntime) u16 {
-    return approvalPanelRowsForTerminalRows(shell.layout.rows);
-}
-
 pub fn inlineApprovalPanelRows(
     alloc: Allocator,
     label: []const u8,

--- a/src/ui/footer/paint_plan.zig
+++ b/src/ui/footer/paint_plan.zig
@@ -1109,29 +1109,6 @@ fn composeAndPushVisibleInputRows(
     return placement;
 }
 
-fn composeInputRowsSnapshot(
-    alloc: Allocator,
-    input: []const u8,
-    cursor: usize,
-    images: []const types.ImageAttachment,
-    width: u16,
-    row_limit: usize,
-) ![]u8 {
-    const source = visual_layout.Source{ .input = input, .cursor = cursor, .terminal_cols = width, .images = images };
-    const summary = visual_layout.summarize(source, null);
-    const window = visual_layout.visibleWindow(summary.cursor.row_index, summary.total_rows, row_limit);
-    var rows = try input_presentation.composeVisibleInputRows(alloc, source, window);
-    defer rows.deinit(alloc);
-
-    var out: std.ArrayList(u8) = .empty;
-    errdefer out.deinit(alloc);
-    for (rows.rows.items, 0..) |row, i| {
-        if (i > 0) try out.append(alloc, '\n');
-        try out.appendSlice(alloc, row.items);
-    }
-    return try out.toOwnedSlice(alloc);
-}
-
 fn pushFooterBandRow(
     alloc: Allocator,
     frame: *footer_viewport.ComposedFooterFrame,

--- a/src/ui/footer/viewport.zig
+++ b/src/ui/footer/viewport.zig
@@ -333,13 +333,6 @@ const FrameSink = struct {
     }
 };
 
-fn expectGridRow(grid: *vt_emulator.Grid, row: u16, expected: []const u8) !void {
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(std.testing.allocator);
-    try grid.rowTextTrimmed(row, &buf);
-    try std.testing.expectEqualStrings(expected, buf.items);
-}
-
 fn footerSurfaceTestPlan(cols: u16) paint_plan.PaintPlan {
     return .{
         .layout = .{

--- a/src/ui/render.zig
+++ b/src/ui/render.zig
@@ -547,10 +547,6 @@ fn appendSpacesToBuffer(out: []u8, len: *usize, count: usize) void {
     }
 }
 
-pub fn isPrintableAscii(byte: u8) bool {
-    return byte >= 32 and byte <= 126;
-}
-
 test "input line wraps to the cursor row" {
     var buf: [64]u8 = undefined;
     const view = buildInputLine("abcdefghijklmnopqrstuvwxyz", 26, 16, &buf);

--- a/src/ui/render_engine/transcript_blocks.zig
+++ b/src/ui/render_engine/transcript_blocks.zig
@@ -2683,14 +2683,6 @@ pub const RenderedBlock = struct {
     }
 };
 
-pub fn transcriptLineCount(text: []const u8) usize {
-    var total: usize = 1;
-    for (text) |byte| {
-        if (byte == '\n') total += 1;
-    }
-    return total;
-}
-
 fn deinitTestEntries(entries: *std.ArrayList(TranscriptEntry), alloc: Allocator) void {
     for (entries.items) |*entry| entry.deinit(alloc);
     entries.deinit(alloc);

--- a/src/ui/render_engine/viewport_selection.zig
+++ b/src/ui/render_engine/viewport_selection.zig
@@ -322,16 +322,6 @@ pub fn hardLineAt(bytes: []const u8, index: usize) []const u8 {
     return "";
 }
 
-pub fn unusedRowsBudget(line_visual_rows: []const u16, start_line: usize, total_lines: usize, visible_rows: u16) u16 {
-    var used: u32 = 0;
-    var line = start_line;
-    while (line < total_lines) : (line += 1) {
-        used += line_visual_rows[line];
-        if (used >= visible_rows) return 0;
-    }
-    return @intCast(@as(u32, visible_rows) - used);
-}
-
 pub fn sumVisualRows(line_visual_rows: []const u16, start_line: usize, end_line: usize) u16 {
     var total: u32 = 0;
     var line = start_line;

--- a/src/ui/resize_tests.zig
+++ b/src/ui/resize_tests.zig
@@ -7594,19 +7594,6 @@ fn readEmittedSince(h: *Harness, since_offset: u64) ![]u8 {
     return buf;
 }
 
-fn gridContains(grid: Grid, needle: []const u8) !void {
-    var row: u16 = 1;
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(grid.alloc);
-
-    while (row <= grid.rows) : (row += 1) {
-        buf.clearRetainingCapacity();
-        try grid.rowTextTrimmed(row, &buf);
-        if (std.mem.find(u8, buf.items, needle) != null) return;
-    }
-    return error.TestMissingMarker;
-}
-
 test "mid-drag resize does not emit scrollback wipe" {
     const alloc = std.testing.allocator;
     var h = try Harness.init(alloc, 80, 24, 4);


### PR DESCRIPTION
## Summary

- Remove 27 declarations across 25 files that have had exactly one reference since the initial commit: their own declaration. None are reachable from production code, tests, build roots, or docs, and none are reachable through comptime reflection or dynamic dispatch. The group spans dead test fixtures (`expectRegisteredNames`, `expectNoticeContains`, `expectNoGrantPermission`, `expectGridRow`, `gridContains`, `tracePathForTest`, `readTraceForTest`, `indexOfName`), dead JSON/dispatch wrappers (`writeArgsJson`, `dispatchWriteFileWithTracker` and its `writeFileArgsJson` helper, `malformedToolArgumentsResult`, `buildGatewayRequiredToolRequestBodyWithOptions` whose `WithOutputLimit` variant keeps the live path), dead UI helpers (`approvalPanelRowsForLayout`, `composeInputRowsSnapshot`, `isPrintableAscii`, `transcriptLineCount`, `unusedRowsBudget`, `allocDimmedTranscriptLine`), dead session/settings loaders (`loadLatestWorkspaceSessionDetail`, `loadLatestWorkspaceSessionSummary`, `categoryFilteredCount`, `permissionRuleCategoryForGrant`), and dead misc helpers (`boundedDupe`, `dupeStringSlice`, `runNoConfigBeforeInteractive`, `generatePkce`, `isReasoningSseEvent`). All referenced callees keep live callers. No user-facing behavior change.