### PR TITLE
Remove final unwired schema, auth, and test-dispatch leftovers

### DIFF
--- a/src/builtins/tools.zig
+++ b/src/builtins/tools.zig
@@ -972,22 +972,6 @@ fn schemaProperty(schema: model_tool_schema.ObjectSchema, name: []const u8) ?mod
     return null;
 }
 
-fn schemaEnumValues(property: model_tool_schema.Property) []const []const u8 {
-    const shape = property.shape orelse return &.{};
-    return switch (shape.*) {
-        .enum_values => |values| values,
-        else => &.{},
-    };
-}
-
-fn schemaObject(property: model_tool_schema.Property) ?*const model_tool_schema.ObjectSchema {
-    const shape = property.shape orelse return null;
-    return switch (shape.*) {
-        .object => |object| object,
-        else => null,
-    };
-}
-
 fn nameInSet(names: []const []const u8, wanted: []const u8) bool {
     for (names) |name| {
         if (std.mem.eql(u8, name, wanted)) return true;

--- a/src/core/shared/profile_paths.zig
+++ b/src/core/shared/profile_paths.zig
@@ -59,10 +59,6 @@ pub fn chatgptAuthPath(alloc: Allocator, home: []const u8) ![]u8 {
     return std.fs.path.join(alloc, &.{ home, root_dir_name, chatgpt_auth_file_name });
 }
 
-pub fn grokAuthPath(alloc: Allocator, home: []const u8) ![]u8 {
-    return std.fs.path.join(alloc, &.{ home, root_dir_name, grok_auth_file_name });
-}
-
 pub fn apiKeyPath(alloc: Allocator, home: []const u8) ![]u8 {
     return std.fs.path.join(alloc, &.{ home, root_dir_name, api_key_file_name });
 }

--- a/src/core/tooling/tool_runtime.zig
+++ b/src/core/tooling/tool_runtime.zig
@@ -2438,15 +2438,6 @@ fn runCommandArgsForTest(alloc: Allocator, command: []const u8) ![]u8 {
     return out.toOwnedSlice();
 }
 
-fn runCommandArgsWithCleanProfileForTest(alloc: Allocator, command: []const u8) ![]u8 {
-    var out: std.Io.Writer.Allocating = .init(alloc);
-    defer out.deinit();
-    try out.writer.writeAll("{\"action\":\"run\",\"command\":");
-    try std.json.Stringify.value(command, .{}, &out.writer);
-    try out.writer.writeAll(",\"profile\":\"clean\",\"timeout_ms\":600000}");
-    return out.toOwnedSlice();
-}
-
 fn executeTestRunCommand(
     ctx: Context,
     arena: Allocator,

--- a/src/tools/filesystem/read_file.zig
+++ b/src/tools/filesystem/read_file.zig
@@ -1,12 +1,10 @@
 const std = @import("std");
 const io_mod = @import("../../core/shared/io.zig");
 const pathing = @import("../../core/workspace/pathing.zig");
-const permission_gate = @import("../../core/permissions/permission_gate.zig");
 const read_tracker = @import("../../core/workspace/read_tracker.zig");
 const text_utils = @import("../../core/shared/text_utils.zig");
 const tool_dispatch = @import("../../core/tooling/tool_dispatch.zig");
 const tool_result_errors = @import("../../core/tooling/tool_result_errors.zig");
-const write_file_impl = @import("write_file.zig");
 
 const Allocator = std.mem.Allocator;
 
@@ -431,25 +429,6 @@ const read_file_dispatch_tool = tool_dispatch.Tool{
     .irreversible_fn = isIrreversible,
 };
 
-const write_file_dispatch_tool = tool_dispatch.Tool{
-    .name = "write_file",
-    .description = "Write file dispatch test fixture.",
-    .model_schema = .{
-        .name = "write_file",
-        .description = "Write file dispatch test fixture.",
-    },
-    .executor_kind = .write_file,
-    .activity_kind = .write,
-    .requires_approval = true,
-    .permission_target_kind = .path_create_parent,
-    .decode = write_file_impl.decode,
-    .validate = write_file_impl.validate,
-    .call = write_file_impl.call,
-    .take_file_mutation_input_fn = write_file_impl.takeFileMutationInput,
-    .reads_only_fn = write_file_impl.readsOnly,
-    .irreversible_fn = write_file_impl.isIrreversible,
-};
-
 fn dispatchReadFileInWorkspace(alloc: Allocator, workspace_root: []const u8, args_json: []const u8) !tool_dispatch.DispatchResult {
     const registry = tool_dispatch.Registry{ .tools = &.{read_file_dispatch_tool} };
     return tool_dispatch.dispatchToolCall(.{ .allocator = alloc, .permission_mode = .auto, .workspace_root = workspace_root }, registry, .{
@@ -479,10 +458,6 @@ fn dispatchReadFileWithTrackerInWorkspace(alloc: Allocator, workspace_root: []co
 
 fn dispatchReadFileWithTracker(alloc: Allocator, args_json: []const u8, tracker: *read_tracker.ReadTracker) !tool_dispatch.DispatchResult {
     return dispatchReadFileWithTrackerInWorkspace(alloc, "", args_json, tracker);
-}
-
-fn allowDecision(_: *const tool_dispatch.Tool, _: tool_dispatch.ToolInput, _: tool_dispatch.DispatchContext) permission_gate.Decision {
-    return .{ .action = .allow, .reason = "allowed by test" };
 }
 
 fn tmpPath(alloc: Allocator, tmp: std.testing.TmpDir, sub_path: []const u8) ![]u8 {


### PR DESCRIPTION
## Summary

- Remove the last never-called declarations. Unifying command execution under shell removed the terminal tool callers of `schemaEnumValues` and `schemaObject`, leaving both shape switches with only their declarations. Removing OS command sandboxing deleted the sandbox retry test that called `runCommandArgsWithCleanProfileForTest`. `grokAuthPath` has had no caller since Grok subscription support landed; the live auth stack uses `grok_auth_file_name` directly. The never-wired dispatcher removal orphaned its permission decider `allowDecision`, the `write_file` dispatch test fixture, and the fixture's `write_file_impl` and `permission_gate` imports; all are removed here so no orphan chain remains. No user-facing behavior change: nothing references the removed declarations in production, tests, build roots, or docs.