### PR TITLE
Remove unwired file-scope constants and aliases

### DIFF
--- a/src/builtins/tools.zig
+++ b/src/builtins/tools.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const std_builtin = @import("builtin");
 const builtin_gateway = @import("gateway.zig");
 const terminal_contracts = @import("../core/terminal/contracts.zig");
 const managed_execution_contract = @import("../core/execution/managed_execution_contract.zig");
@@ -30,14 +29,6 @@ const skill_impl = @import("../tools/skills/skill.zig");
 const capability_search_impl = @import("../tools/capabilities/capability_search.zig");
 const web_fetch_impl = @import("../tools/web/fetch.zig");
 const web_search_impl = @import("../tools/web/search.zig");
-const test_io_mod = if (std_builtin.is_test)
-    @import("../core/shared/io.zig")
-else
-    struct {};
-const test_session_child_store = if (std_builtin.is_test)
-    @import("../core/session/session_child_store.zig")
-else
-    struct {};
 
 const Allocator = std.mem.Allocator;
 

--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -87,7 +87,6 @@ const ToolPermissionDecision = types.ToolPermissionDecision;
 
 pub const file_picker_completion_cap = input_completion_runtime.file_picker_completion_cap;
 const ctrl_g_upgrade_byte: u8 = 7;
-const ctrl_x_manager_byte: u8 = 24;
 
 fn classifyResumeFailure(err: anyerror) session_catalog.ResumeFailure {
     return switch (err) {

--- a/src/core/hooks/hooks.zig
+++ b/src/core/hooks/hooks.zig
@@ -6,7 +6,6 @@ pub const tool = @import("tool.zig");
 
 pub const HookDefinition = definitions.HookDefinition;
 pub const HookKind = definitions.HookKind;
-pub const hook_definitions = definitions.all_hooks;
 pub const pre_tool_use = definitions.pre_tool_use;
 pub const stop = definitions.stop;
 pub const post_turn_end = definitions.post_turn_end;

--- a/src/core/subagent/domain.zig
+++ b/src/core/subagent/domain.zig
@@ -12,7 +12,6 @@ pub const max_prompt_bytes: usize = 64 * 1024;
 pub const max_message_bytes: usize = 64 * 1024;
 pub const max_agent_name_bytes: usize = 64;
 pub const max_instructions_bytes: usize = 64 * 1024;
-pub const max_cancellation_reason_bytes: usize = 512;
 pub const max_admission_items: usize = 256;
 pub const max_admission_item_bytes: usize = 4096;
 

--- a/src/core/terminal/native_session.zig
+++ b/src/core/terminal/native_session.zig
@@ -20,7 +20,6 @@ const io_mod = @import("../shared/io.zig");
 const self_exe = @import("../shared/self_exe.zig");
 const debug_trace = @import("../shared/debug_trace.zig");
 const types = @import("../shared/types.zig");
-const workspace_pathing = @import("../workspace/pathing.zig");
 
 const Allocator = std.mem.Allocator;
 

--- a/src/core/tooling/tool_dispatch.zig
+++ b/src/core/tooling/tool_dispatch.zig
@@ -51,7 +51,6 @@ pub const default_max_read_file_lines: usize = 400;
 pub const default_max_read_file_line_len: usize = 2000;
 
 pub const web_search_unavailable_message = "web_search is unavailable: no local runtime with a configured Gateway transport policy is installed";
-pub const web_fetch_unavailable_message = "web_fetch is unavailable: no local WebFetch runtime is installed";
 pub const terminal_unavailable_message =
     "{\"error\":{\"tool\":\"shell\",\"code\":\"unsupported_host\",\"retryable\":false}}";
 const terminal_saved_session_required_message =

--- a/src/core/tooling/tool_presentation.zig
+++ b/src/core/tooling/tool_presentation.zig
@@ -20,7 +20,6 @@ const ToolCall = types.ToolCall;
 const max_run_command_activity_bytes = 120;
 const max_run_command_activity_source_bytes = max_run_command_activity_bytes * max_run_command_activity_bytes;
 pub const max_run_command_reflow_bytes = max_run_command_activity_source_bytes;
-pub const max_auto_permission_reason_presentation_bytes: usize = 160;
 
 pub const ToolActionInput = struct {
     tool_registry: tool_dispatch.Registry,

--- a/src/core/tooling/tool_runtime.zig
+++ b/src/core/tooling/tool_runtime.zig
@@ -33,7 +33,6 @@ const subagent_tool_host = @import("../subagent/tool_host.zig");
 const subagent_tool_provider = @import("../subagent/tool_provider.zig");
 const session_runtime = @import("../session/session.zig");
 const session_permission_state = @import("../permissions/session_permission_state.zig");
-const session_codec_mod = @import("../session/session_codec.zig");
 const session_child_store = @import("../session/session_child_store.zig");
 const command_replay_store = @import("../session/command_replay_store.zig");
 const session_store = @import("../session/session_store.zig");
@@ -78,11 +77,6 @@ else
     struct {};
 const js_host_workspace = @import("../hosts/js_host_workspace.zig");
 
-const agent_test_support = if (builtin.is_test)
-    @import("../agent/runtime/tests/support.zig")
-else
-    struct {};
-
 const Allocator = std.mem.Allocator;
 const ToolCall = types.ToolCall;
 const ChatMessage = types.ChatMessage;
@@ -90,7 +84,6 @@ const ChatMessage = types.ChatMessage;
 const PermissionGrant = types.PermissionGrant;
 const PermissionMode = types.PermissionMode;
 const ToolPermissionDecision = types.ToolPermissionDecision;
-const subagent_tool_name = "subagent";
 const ToolExecutionResult = tool_contracts.ToolExecutionResult;
 const SessionRuntime = session_runtime.SessionRuntime;
 const WorkerRuntime = worker_runtime.WorkerRuntime;

--- a/src/ui/footer/interaction_state.zig
+++ b/src/ui/footer/interaction_state.zig
@@ -14,7 +14,6 @@ pub const approval_panel_rows_compact: u16 = 8;
 pub const approval_panel_rows_spacious: u16 = 11;
 pub const approval_spacious_min_terminal_rows: u16 = 34;
 pub const approval_once_label = "1. Yes";
-pub const approval_always_file_label = "2. Yes, and don't ask again for this request";
 pub const approval_deny_label = "3. No";
 pub const approval_hint = "1–3 choose now    ↑↓ or tab options    enter confirm    esc cancel";
 pub const approval_amendment_hint = "1–3 choose now    ↑↓ options    tab amend    enter confirm    esc cancel";

--- a/src/ui/footer/runtime.zig
+++ b/src/ui/footer/runtime.zig
@@ -7,7 +7,6 @@ const render_input = @import("render_input.zig");
 const surface_frame = @import("surface_frame.zig");
 
 pub const approval_once_label = interaction_state.approval_once_label;
-pub const approval_always_file_label = interaction_state.approval_always_file_label;
 pub const approval_deny_label = interaction_state.approval_deny_label;
 
 pub const FileApprovalScreenRowKind = approval_ui.FileApprovalScreenRowKind;

--- a/src/ui/input/runtime.zig
+++ b/src/ui/input/runtime.zig
@@ -55,8 +55,6 @@ const InputEscapeAction = input_action.Action;
 const MouseInput = escape_parser.MouseInput;
 
 pub const shortcutFromControlByte = shortcuts.fromControlByte;
-pub const shortcutFromFocusedEditorControlByte = shortcuts.fromFocusedEditorControlByte;
-pub const shortcutFromEscapeAction = shortcuts.fromEscapeAction;
 
 pub fn approvalActionFromByte(byte: u8) ?approval_decision.Action {
     return switch (byte) {

--- a/src/ui/render.zig
+++ b/src/ui/render.zig
@@ -13,12 +13,9 @@ const theme_protocol = @import("terminal/theme_protocol.zig");
 const visual_layout = @import("input/visual_layout.zig");
 const update_target = @import("../core/upgrade/update_target.zig");
 
-pub const input_prefix = "❯ ";
 pub const TerminalRgb = user_message_card.Rgb;
 pub const reset_style = "\x1b[0m";
 pub const bold_style = "\x1b[1m";
-pub const app_name = "fx";
-pub const right_tag = "/fx";
 pub const ask_activity_label = "⏺ Asking";
 
 const user_message_card = @import("assistant/user_message_card.zig");
@@ -125,7 +122,6 @@ pub fn themeNeedsUpdate(light: bool, terminal_bg: ?TerminalRgb) bool {
 }
 
 // Explicit theme overrides skip OSC 11, leaving `rgb` null for fallback shading.
-pub const ThemeDetection = theme_detection.Detection;
 pub const TerminalBackground = theme_protocol.Background;
 pub const explicitThemeOverride = theme_detection.explicitThemeOverride;
 pub const detectTheme = theme_detection.detectTheme;

--- a/src/ui/render_engine/viewport_selection.zig
+++ b/src/ui/render_engine/viewport_selection.zig
@@ -20,12 +20,6 @@ pub const LineRef = struct {
     }
 };
 
-pub const HardLinePolicy = enum {
-    eof_after_trailing_newline_is_cursor_only,
-};
-
-pub const hard_line_policy: HardLinePolicy = .eof_after_trailing_newline_is_cursor_only;
-
 pub const HardLineStarts = struct {
     starts: []usize,
     ends_with_newline: bool,


### PR DESCRIPTION
## Summary

- Extend the never-called sweep from functions to file-scope constants and remove nineteen declarations with no reference anywhere in the tree. `test_io_mod` and `test_session_child_store` (conditional test imports) lost their users when command execution was unified under shell, which also orphaned the `std_builtin` import. `ctrl_x_manager_byte`, `max_cancellation_reason_bytes`, `workspace_pathing`, `session_codec_mod`, `agent_test_support`, `subagent_tool_name`, and `shortcutFromEscapeAction` had callers at the initial commit that later work removed. `hook_definitions`, `web_fetch_unavailable_message`, `max_auto_permission_reason_presentation_bytes`, the duplicated `approval_always_file_label` pair, `shortcutFromFocusedEditorControlByte`, `input_prefix`, `app_name`, `right_tag`, `ThemeDetection`, and `hard_line_policy` have had exactly one reference since the initial commit: their own declaration. The one-member `HardLinePolicy` enum exists only as the type of `hard_line_policy` and is removed with it. All aliased targets keep live users. No user-facing behavior change.