### PR TITLE
Mask MCP protocol diagnostics on CLI command output

### DIFF
--- a/src/acp/sessions.zig
+++ b/src/acp/sessions.zig
@@ -1376,6 +1376,8 @@ fn planToolCallFrame(
         .kind = tool_call_presentation.mapToolKind(name),
         .status = replayStatus(result),
         .raw_input = if (parsed) |p| p.value else null,
+        // Result content replays verbatim, matching the live tool-update
+        // path; only arguments are masked for display (redactToolArgumentsJson).
         .content_text = if (result) |r| if (r.output.len > 0)
             tool_call_presentation.toolUpdateContentText(r.status == .failure, r.output)
         else

--- a/src/core/agent/execution_memory.zig
+++ b/src/core/agent/execution_memory.zig
@@ -1051,7 +1051,7 @@ test "durable execution memory preserves committed file presentation verbatim an
     const calls = [_]ToolCall{.{
         .id = secret_id,
         .name = "write_file",
-        .arguments_json = "{\"path\":\"notes.txt\",\"content\":\"secret\"}}",
+        .arguments_json = "{\"path\":\"notes.txt\",\"content\":\"secret\"}",
     }};
     const messages = [_]types.ChatMessage{
         .{ .role = .assistant, .tool_calls = calls[0..] },
@@ -1086,6 +1086,11 @@ test "durable execution memory preserves committed file presentation verbatim an
     try std.testing.expectEqualStrings(secret_text ++ "\n", presentation.after_content.?);
     try std.testing.expectEqualStrings(result.tool_call_id, presentation.lifecycle_id.?.call_id);
     try std.testing.expectEqualStrings(memory.tool_steps[0].tool_calls[0].id, presentation.lifecycle_id.?.call_id);
+
+    try std.testing.expectEqual(@as(usize, 1), memory.files.len);
+    try std.testing.expectEqualStrings("notes.txt", memory.files[0].path);
+    try std.testing.expectEqual(types.FileEvidenceAction.write, memory.files[0].action);
+    try std.testing.expectEqualStrings(result.tool_call_id, memory.files[0].tool_call_id);
 }
 
 test "file evidence does not parse unknown tool arguments" {
@@ -1396,16 +1401,19 @@ test "normal execution-memory builders produce identical durable projection" {
         chat_memory.tool_steps[0].tool_results[1].permission_feedback.len,
     );
     try std.testing.expectEqualStrings("", chat_memory.tool_steps[1].tool_results[0].output);
-    try std.testing.expect(std.mem.find(
-        u8,
-        chat_memory.tool_steps[0].tool_calls[0].id,
-        "[redacted]",
-    ) == null);
-    try std.testing.expect(std.mem.find(
-        u8,
+    try std.testing.expectEqualStrings(
+        chat_messages[2].content.?,
         chat_memory.tool_steps[0].tool_results[0].output,
-        "[redacted]",
-    ) == null);
+    );
+    try std.testing.expect(!std.mem.eql(
+        u8,
+        first_calls[0].id,
+        chat_memory.tool_steps[0].tool_calls[0].id,
+    ));
+    try std.testing.expectEqualStrings(
+        chat_memory.tool_steps[0].tool_results[0].tool_call_id,
+        chat_memory.tool_steps[0].tool_calls[0].id,
+    );
 }
 
 test "normal execution-memory builders reject missing tool result status identically" {

--- a/src/core/agent/runtime/tool_presentation.zig
+++ b/src/core/agent/runtime/tool_presentation.zig
@@ -2828,3 +2828,42 @@ test "cancelled shell wait names the observation instead of the process" {
         "Stopped waiting for",
     ) != null);
 }
+
+test "failure status detail masks secret-shaped failure output" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const call: ToolCall = .{
+        .id = "call_fail",
+        .name = "mcp__fixture__echo",
+        .arguments_json = "{}",
+    };
+    const result: ToolExecutionResult = .{
+        .model_output = "",
+        .status = .failure,
+        .status_detail = "preflight failed",
+    };
+    const failure_output = "MY_NOTE_" ++ "TOKEN=abcdefgh";
+    const detail = (try failureStatusDetail(arena, call, result, failure_output, &.{})).?;
+    try std.testing.expect(std.mem.find(u8, detail, "[redacted]") != null);
+    try std.testing.expect(std.mem.find(u8, detail, "abcdefgh") == null);
+}
+
+test "failure status detail masks the actionable edit failure reason" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const call: ToolCall = .{
+        .id = "call_edit_fail",
+        .name = "edit_file",
+        .arguments_json = "{}",
+    };
+    const result: ToolExecutionResult = .{
+        .model_output = "",
+        .status = .failure,
+        .status_detail = "preflight failed",
+    };
+    const failure_output = "edit_file failed: MY_NOTE_" ++ "TOKEN=abcdefgh";
+    const detail = (try failureStatusDetail(arena, call, result, failure_output, &.{})).?;
+    try std.testing.expectEqualStrings("MY_NOTE_" ++ "TOKEN=[redacted]", detail);
+}

--- a/src/core/app/app_commands.zig
+++ b/src/core/app/app_commands.zig
@@ -39,6 +39,7 @@ const usage_report = @import("../session/usage_report.zig");
 const types = @import("../shared/types.zig");
 const assistant_presentation = @import("../agent/assistant_presentation.zig");
 const worker_runtime = @import("../agent/worker_runtime.zig");
+const agent_execution_memory = @import("../agent/execution_memory.zig");
 const transcript_blocks = @import("../../ui/render_engine/transcript_blocks.zig");
 const transcript_runtime = @import("../../ui/transcript/runtime.zig");
 const test_builtin_skills = if (@import("builtin").is_test)
@@ -328,6 +329,19 @@ fn requestResumeExit(app: anytype) void {
     const App = @TypeOf(app.*);
     app_session_runtime.Runtime(App).requestResumeHandoff(app);
     app.should_exit = true;
+}
+
+/// Masks a retained MCP protocol diagnostic for terminal command output. The
+/// model-facing protocol-error path stays verbatim; this display boundary is
+/// the only place CLI command output sees the diagnostic. Takes ownership of
+/// `diagnostic` and returns an owned masked copy.
+fn maskedDisplayDiagnostic(alloc: std.mem.Allocator, diagnostic: []u8) ![]u8 {
+    const masked = agent_execution_memory.maskTextForDisplay(alloc, diagnostic) catch |err| {
+        alloc.free(diagnostic);
+        return err;
+    };
+    alloc.free(diagnostic);
+    return masked;
 }
 
 pub fn Handlers(comptime App: type) type {
@@ -1465,7 +1479,7 @@ pub fn Handlers(comptime App: type) type {
                 if (err == error.McpProtocolError) {
                     if (protocol_diagnostic) |diagnostic| {
                         protocol_diagnostic = null;
-                        return diagnostic;
+                        return try maskedDisplayDiagnostic(alloc, diagnostic);
                     }
                 }
                 return err;
@@ -1540,7 +1554,7 @@ pub fn Handlers(comptime App: type) type {
                 if (err == error.McpProtocolError) {
                     if (protocol_diagnostic) |diagnostic| {
                         protocol_diagnostic = null;
-                        return diagnostic;
+                        return try maskedDisplayDiagnostic(alloc, diagnostic);
                     }
                 }
                 return err;

--- a/src/core/mcp/mcp_runtime.zig
+++ b/src/core/mcp/mcp_runtime.zig
@@ -7992,7 +7992,8 @@ test "MCP server instructions are captured from initialize and exposed only when
     try server_transport.parseAndStoreServerInstructions(alloc, &server, init_response);
     try std.testing.expect(server.instructions != null);
     try std.testing.expect(std.mem.find(u8, server.instructions.?, "GitHub issue workflows") != null);
-    try std.testing.expect(std.mem.find(u8, server.instructions.?, "github_pat_1234567890abcdef") == null);
+    try std.testing.expect(std.mem.find(u8, server.instructions.?, "github_pat_1234567890abcdef") != null);
+    try std.testing.expect(std.mem.find(u8, server.instructions.?, "[redacted]") == null);
 
     const tools_response =
         \\{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"create_issue","description":"Create issue","inputSchema":{"type":"object","properties":{}}},{"name":"close_issue","description":"Close issue","inputSchema":{"type":"object","properties":{}}}]}}

--- a/src/core/mcp/server_transport.zig
+++ b/src/core/mcp/server_transport.zig
@@ -996,8 +996,7 @@ fn sanitizeServerInstructionsAlloc(alloc: Allocator, text: []const u8) ![]u8 {
     const arena = arena_state.allocator();
 
     const safe = try text_utils.sanitizeModelText(arena, text);
-    const masked = try text_utils.maskSecrets(arena, safe);
-    const trimmed = std.mem.trim(u8, masked, " \t\r\n");
+    const trimmed = std.mem.trim(u8, safe, " \t\r\n");
     return try alloc.dupe(u8, trimmed);
 }
 

--- a/src/core/mcp/tool_result.zig
+++ b/src/core/mcp/tool_result.zig
@@ -23,7 +23,7 @@ pub const ExtractOptions = struct {
     legacy_wire: ?elicitation.Wire = null,
 };
 
-/// Parses an MCP response into the bounded, secret-masked model result.
+/// Parses an MCP response into the bounded, sanitized model result.
 /// The caller owns every allocation in the returned result.
 pub fn extract(alloc: Allocator, options: ExtractOptions) !tool_mcp_runtime.CallResult {
     var outcome = tools_feature.parseCallOutcome(
@@ -169,7 +169,7 @@ pub fn format_protocol_error(
     try raw.writer.writeAll(try text_utils.maskSecrets(arena, safe_message));
     if (protocol_error.data) |data| {
         try raw.writer.writeAll("; data=");
-        try write_masked_json_value(arena, &raw.writer, data);
+        try writeJsonProjection(arena, &raw.writer, data, true);
     }
     return try alloc.dupe(u8, raw.writer.buffered());
 }
@@ -385,27 +385,34 @@ fn write_envelope(
     try writer.writeAll(",\"tool\":");
     try std.json.Stringify.value(tool_name, .{}, writer);
     try writer.writeAll(",\"result\":");
-    try write_sanitized_json_value(alloc, writer, result);
+    try writeJsonProjection(alloc, writer, result, false);
     try writer.writeByte('}');
 }
 
-/// Sanitize-only projection for MCP tool results delivered to the model.
-fn write_sanitized_json_value(
+/// JSON projection for MCP result envelopes. `mask_strings` selects the
+/// display projection (diagnostics); the model envelope uses the
+/// sanitize-only projection.
+fn writeJsonProjection(
     alloc: Allocator,
     writer: *std.Io.Writer,
     value: std.json.Value,
+    comptime mask_strings: bool,
 ) !void {
     switch (value) {
         .null, .bool, .integer, .float, .number_string => try std.json.Stringify.value(value, .{}, writer),
         .string => |text| {
             const sanitized = try text_utils.sanitizeModelText(alloc, text);
-            try std.json.Stringify.value(sanitized, .{}, writer);
+            const projected = if (mask_strings)
+                try text_utils.maskSecrets(alloc, sanitized)
+            else
+                sanitized;
+            try std.json.Stringify.value(projected, .{}, writer);
         },
         .array => |array| {
             try writer.writeByte('[');
             for (array.items, 0..) |item, index| {
                 if (index > 0) try writer.writeByte(',');
-                try write_sanitized_json_value(alloc, writer, item);
+                try writeJsonProjection(alloc, writer, item, mask_strings);
             }
             try writer.writeByte(']');
         },
@@ -417,45 +424,7 @@ fn write_sanitized_json_value(
                 if (index > 0) try writer.writeByte(',');
                 try std.json.Stringify.value(entry.key_ptr.*, .{}, writer);
                 try writer.writeByte(':');
-                try write_sanitized_json_value(alloc, writer, entry.value_ptr.*);
-            }
-            try writer.writeByte('}');
-        },
-    }
-}
-
-fn write_masked_json_value(
-    alloc: Allocator,
-    writer: *std.Io.Writer,
-    value: std.json.Value,
-) !void {
-    switch (value) {
-        .null, .bool, .integer, .float, .number_string => try std.json.Stringify.value(value, .{}, writer),
-        .string => |text| {
-            const sanitized = try text_utils.sanitizeModelText(alloc, text);
-            try std.json.Stringify.value(
-                try text_utils.maskSecrets(alloc, sanitized),
-                .{},
-                writer,
-            );
-        },
-        .array => |array| {
-            try writer.writeByte('[');
-            for (array.items, 0..) |item, index| {
-                if (index > 0) try writer.writeByte(',');
-                try write_masked_json_value(alloc, writer, item);
-            }
-            try writer.writeByte(']');
-        },
-        .object => |object| {
-            try writer.writeByte('{');
-            var it = object.iterator();
-            var index: usize = 0;
-            while (it.next()) |entry| : (index += 1) {
-                if (index > 0) try writer.writeByte(',');
-                try std.json.Stringify.value(entry.key_ptr.*, .{}, writer);
-                try writer.writeByte(':');
-                try write_masked_json_value(alloc, writer, entry.value_ptr.*);
+                try writeJsonProjection(alloc, writer, entry.value_ptr.*, mask_strings);
             }
             try writer.writeByte('}');
         },

--- a/src/core/shared/text_utils.zig
+++ b/src/core/shared/text_utils.zig
@@ -437,7 +437,7 @@ pub fn maskSecrets(arena: std.mem.Allocator, text: []const u8) ![]const u8 {
             modified = true;
             try out.writer.writeAll(text[i..span.prefix_end]);
             try out.writer.writeAll("[redacted]");
-            debug_trace.logf("core", "model-facing secret redacted kind={s} bytes={d}", .{ span.kind, span.value_len });
+            debug_trace.logf("core", "display secret redacted kind={s} bytes={d}", .{ span.kind, span.value_len });
             i = span.prefix_end + span.value_len;
         } else {
             try out.writer.writeByte(text[i]);

--- a/tests/e2e/fixtures/mcp-modern-stdio.mjs
+++ b/tests/e2e/fixtures/mcp-modern-stdio.mjs
@@ -367,7 +367,8 @@ function handle(message) {
         id: message.id,
         error: {
           code: -32602,
-          message: "Resource request rejected by fixture",
+          message: process.env.FX_MCP_PROTOCOL_ERROR_MESSAGE ??
+            "Resource request rejected by fixture",
           data: { method: message.method, retryable: false },
         },
       });

--- a/tests/e2e/mcp-stdio.test.ts
+++ b/tests/e2e/mcp-stdio.test.ts
@@ -112,6 +112,7 @@ type RootOptions = {
     | "crash_once"
     | "crash_always";
   startupTimeoutMs?: number;
+  protocolErrorMessage?: string;
   operationTimeoutMs?: number;
   restartLimit?: number;
   recoveredToolName?: string;
@@ -180,6 +181,7 @@ function createRoot(
             FX_MCP_PID_PATH: join(root, "mcp.pid"),
             FX_MCP_PROTOCOL_VERSION: "2026-07-28",
             FX_MCP_MODE: options.mode ?? "normal",
+            FX_MCP_PROTOCOL_ERROR_MESSAGE: options.protocolErrorMessage,
             FX_MCP_CRASH_MARKER: join(root, "mcp-crashed"),
             FX_MCP_RECOVERY_READY_PATH: join(root, "mcp-recovery-ready"),
             FX_MCP_INVALIDATION_RELEASE_PATH: invalidationReleasePath,
@@ -3097,6 +3099,42 @@ exec "$FX_MCP_FIXTURE_RUNTIME" "$FX_MCP_FIXTURE_PATH"
       await tui.kill();
       tui = null;
       await expectFixtureProcessesExited(wire);
+    },
+    35_000,
+  );
+
+  test.skipIf(!tmuxAvailable())(
+    "MCP resource read command masks secret-shaped protocol diagnostics",
+    async () => {
+      const secretNeedle = ["SERVICE_", "TOKEN=fixture-token-123456"].join("");
+      const root = createRoot("tui-feature-protocol-error-masked", MODERN_FIXTURE, {
+        mode: "feature_protocol_error",
+        protocolErrorMessage: secretNeedle,
+      });
+      gateway = startFakeGateway([fakeGatewayFinalText("unused")], {
+        models: [{ id: MODEL, type: "language", tags: ["tool-use"] }],
+      });
+      const stderrPath = join(root.root, "stderr.log");
+      tui = await TmuxSession.create({
+        isolated: true,
+        cwd: root.workspace,
+        width: 120,
+        height: 34,
+        stderrPath,
+        env: fixtureEnv(root, gateway),
+      });
+
+      await tui.waitForComposer(15_000);
+      await tui.sendText("/mcp resource read fixture custom://alpha");
+      await tui.waitForText("MCP protocol error -32602", 15_000);
+      const pane = await tui.capturePane();
+      expect(pane).toContain("[redacted]");
+      expect(pane).not.toContain(secretNeedle);
+
+      expect(readFileSync(stderrPath, "utf8")).toBe("");
+      await tui.kill();
+      tui = null;
+      await expectFixtureProcessesExited(readWire(root.wireLogPath));
     },
     35_000,
   );


### PR DESCRIPTION
## Summary

Follow-up to #825, fixing the two blockers the post-merge ship gate found plus the agreed advisories.

**MCP protocol diagnostics masked on CLI display.** `/mcp resource read` and `/mcp prompt get` returned protocol-error diagnostics verbatim once tool output became verbatim, so a server echoing secret-shaped text in an error printed unmasked to the terminal. Both handlers now mask the diagnostic at the display boundary through one ownership-safe helper (`maskedDisplayDiagnostic`); the model-facing protocol-error path stays verbatim. New e2e drives a server that echoes a token in its error and asserts the CLI shows the marker, not the raw value.

**MCP server instructions delivered verbatim.** Instructions are capability metadata the server author wrote — same class as skill descriptions, which #825 already unmasked. `sanitizeServerInstructionsAlloc` now sanitizes without masking; a token documented by a server reaches the model verbatim instead of as a marker. Verified deterministically (fake gateway capture: instructions text and token verbatim in the model request body, zero markers) and live (real model loaded the tool through the bridge and reported the documented value's exact length — 32, where the masked marker would read 9).

**Remaining items:** the duplicated recursive JSON projection walker is merged into one comptime-flagged function; a test fixture with a doubled closing brace (its parse failure was silently swallowed, skipping the file-evidence path) is repaired and now asserts the evidence entry; two marker-absence assertions are strengthened to verbatim equality; failure-status display masking (new in #825) gets secret-shaped tests so deleting the mask calls fails the suite; stale contract wording on the changed boundary is refreshed; the ACP replay decision (verbatim result content, matching the live path) is documented at the decision point.

## Verification

- `zig build test`: 8890 tests green
- `zig fmt --check src/`: clean
- e2e: 151 tests green across `mcp-stdio` + `mcp-http`, including the new masking test and the existing diagnostics test
- Deterministic schema proof: fake gateway + fixture MCP server; model request body carries instructions and token verbatim, no markers, exit 0
- Live: real model via the gateway — capability search, tool selection, tool call all succeeded; model answered the documented value's length correctly (32)

## Label

`type: bug` — fixes the unmasked CLI display path and the silently-skipped test coverage found by the post-merge gate.
