### PR TITLE
Restyle transcript notices with tone glyphs and lowercase topics

### DIFF
--- a/sdk/node/test-term-compaction.mjs
+++ b/sdk/node/test-term-compaction.mjs
@@ -183,7 +183,7 @@ async function runScenario(name) {
       stderr(bytes) { state.stderr += new TextDecoder().decode(bytes); },
       onEvent(event) { state.events.push(event); },
     });
-    await waitFor(() => grid(terminal).includes(args.length ? "Session resumed" : "Run /help for commands") && emptyComposer(grid(terminal)), "terminal startup");
+    await waitFor(() => grid(terminal).includes(args.length ? "session resumed" : "Run /help for commands") && emptyComposer(grid(terminal)), "terminal startup");
     return state;
   }
   async function stop() {

--- a/sdk/tests/test-term-session-resume.mjs
+++ b/sdk/tests/test-term-session-resume.mjs
@@ -100,7 +100,7 @@ async function start(args = []) {
     sessionStore,
   });
   await waitFor(
-    () => capture.text().includes(args.length ? "Session resumed" : "Run /help for commands"),
+    () => capture.text().includes(args.length ? "session resumed" : "Run /help for commands"),
     "fx-term startup",
     () => `output=${JSON.stringify(capture.text().slice(-1000))}`,
   );

--- a/src/builtins/mcp.zig
+++ b/src/builtins/mcp.zig
@@ -21,7 +21,7 @@ const CommandResult = command_provider_contract.Result;
 const McpServerConfig = mcp_contract.McpServerConfig;
 const McpTransport = mcp_contract.McpTransport;
 
-const add_usage = "Usage: /mcp add <name> <command> [args...] or /mcp add --transport http <name> <url>";
+const add_usage = "usage: /mcp add <name> <command> [args...] or /mcp add --transport http <name> <url>";
 const profile_lock_deadline_ms: u64 = 2_000;
 
 pub const command_provider = command_provider_contract.Provider{ .handle_fn = handleCommand };
@@ -104,24 +104,24 @@ fn handleCommand(alloc: Allocator, rest: []const u8, command_request: CommandReq
     if (std.mem.startsWith(u8, trimmed, "trust ")) {
         var tokens = std.mem.tokenizeAny(u8, trimmed[6..], " \t");
         const operation = tokens.next() orelse
-            return lineLiteral(alloc, "Usage: /mcp trust approve|reject <server> | approve-all | reset", false);
+            return lineLiteral(alloc, "usage: /mcp trust approve|reject <server> | approve-all | reset", false);
         if (std.mem.eql(u8, operation, "approve-all")) {
-            if (tokens.next() != null) return lineLiteral(alloc, "Usage: /mcp trust approve-all", false);
+            if (tokens.next() != null) return lineLiteral(alloc, "usage: /mcp trust approve-all", false);
             return .{
                 .display = .{ .line = try alloc.dupe(u8, "Approving all project MCP servers for this workspace.") },
                 .project_action = .approve_all,
             };
         }
         if (std.mem.eql(u8, operation, "reset")) {
-            if (tokens.next() != null) return lineLiteral(alloc, "Usage: /mcp trust reset", false);
+            if (tokens.next() != null) return lineLiteral(alloc, "usage: /mcp trust reset", false);
             return .{
                 .display = .{ .line = try alloc.dupe(u8, "Resetting project MCP choices for this workspace.") },
                 .project_action = .reset,
             };
         }
         const name = tokens.next() orelse
-            return lineLiteral(alloc, "Usage: /mcp trust approve|reject <server>", false);
-        if (tokens.next() != null) return lineLiteral(alloc, "Usage: /mcp trust approve|reject <server>", false);
+            return lineLiteral(alloc, "usage: /mcp trust approve|reject <server>", false);
+        if (tokens.next() != null) return lineLiteral(alloc, "usage: /mcp trust approve|reject <server>", false);
         if (std.mem.eql(u8, operation, "approve")) {
             return .{
                 .display = .{ .line = try std.fmt.allocPrint(alloc, "Approving project MCP server '{s}'.", .{name}) },
@@ -134,18 +134,18 @@ fn handleCommand(alloc: Allocator, rest: []const u8, command_request: CommandReq
                 .project_action = .{ .reject = name },
             };
         }
-        return lineLiteral(alloc, "Usage: /mcp trust approve|reject <server> | approve-all | reset", false);
+        return lineLiteral(alloc, "usage: /mcp trust approve|reject <server> | approve-all | reset", false);
     }
 
     if (std.mem.eql(u8, trimmed, "auth") or std.mem.startsWith(u8, trimmed, "auth ")) {
         var tokens = std.mem.tokenizeAny(u8, trimmed[4..], " \t");
         const name = tokens.next() orelse
-            return lineLiteral(alloc, "Usage: /mcp auth <name> [--open]", false);
+            return lineLiteral(alloc, "usage: /mcp auth <name> [--open]", false);
         const confirmation = tokens.next();
         if (tokens.next() != null or
             (confirmation != null and !std.mem.eql(u8, confirmation.?, "--open")))
         {
-            return lineLiteral(alloc, "Usage: /mcp auth <name> [--open]", false);
+            return lineLiteral(alloc, "usage: /mcp auth <name> [--open]", false);
         }
         const validate = command_request.validate_authentication_server orelse
             return lineLiteral(
@@ -200,7 +200,7 @@ fn handleCommand(alloc: Allocator, rest: []const u8, command_request: CommandReq
     if (std.mem.startsWith(u8, trimmed, "logout ")) {
         const name = std.mem.trim(u8, trimmed[7..], " \t");
         if (name.len == 0 or std.mem.indexOfAny(u8, name, " \t") != null) {
-            return lineLiteral(alloc, "Usage: /mcp logout <name>", false);
+            return lineLiteral(alloc, "usage: /mcp logout <name>", false);
         }
         const logout = command_request.logout_server orelse
             return lineLiteral(alloc, "MCP logout is unavailable here.", false);
@@ -271,7 +271,7 @@ fn handleCommand(alloc: Allocator, rest: []const u8, command_request: CommandReq
     if (std.mem.startsWith(u8, trimmed, "remove ")) {
         const name = std.mem.trim(u8, trimmed[7..], " \t");
         if (name.len == 0) {
-            return lineLiteral(alloc, "Usage: /mcp remove <name>", false);
+            return lineLiteral(alloc, "usage: /mcp remove <name>", false);
         }
 
         const removed = removeServerFromPath(alloc, config_path, name) catch |err| {
@@ -327,7 +327,7 @@ fn handleCommand(alloc: Allocator, rest: []const u8, command_request: CommandReq
 
     return lineLiteral(
         alloc,
-        "Usage: /mcp [list|resource|prompt|add|remove|path|reload|auth|logout|trust]",
+        "usage: /mcp [list|resource|prompt|add|remove|path|reload|auth|logout|trust]",
         false,
     );
 }
@@ -382,19 +382,19 @@ fn handleResourceCommand(alloc: Allocator, rest: []const u8, command_request: Co
     var input = rest;
     const action = takeToken(&input) orelse return lineLiteral(
         alloc,
-        "Usage: /mcp resource [list|templates|read|complete] ...",
+        "usage: /mcp resource [list|templates|read|complete] ...",
         false,
     );
     const context = command_request.feature_ctx orelse command_request.list_ctx;
     if (std.mem.eql(u8, action, "list") or std.mem.eql(u8, action, "templates")) {
         const server = takeToken(&input) orelse return lineLiteral(
             alloc,
-            "Usage: /mcp resource list <server> or /mcp resource templates <server>",
+            "usage: /mcp resource list <server> or /mcp resource templates <server>",
             false,
         );
         if (takeToken(&input) != null) return lineLiteral(
             alloc,
-            "Usage: /mcp resource list <server> or /mcp resource templates <server>",
+            "usage: /mcp resource list <server> or /mcp resource templates <server>",
             false,
         );
         const callback = command_request.list_resources orelse return lineLiteral(alloc, "MCP resources are unavailable here.", false);
@@ -404,9 +404,9 @@ fn handleResourceCommand(alloc: Allocator, rest: []const u8, command_request: Co
         return .{ .display = .{ .block = text } };
     }
     if (std.mem.eql(u8, action, "read")) {
-        const server = takeToken(&input) orelse return lineLiteral(alloc, "Usage: /mcp resource read <server> <uri>", false);
+        const server = takeToken(&input) orelse return lineLiteral(alloc, "usage: /mcp resource read <server> <uri>", false);
         const uri = std.mem.trim(u8, input, " \t");
-        if (uri.len == 0) return lineLiteral(alloc, "Usage: /mcp resource read <server> <uri>", false);
+        if (uri.len == 0) return lineLiteral(alloc, "usage: /mcp resource read <server> <uri>", false);
         const callback = command_request.read_resource orelse return lineLiteral(alloc, "MCP resource reads are unavailable here.", false);
         const text = callback(context, alloc, server, uri) catch |err| {
             return lineParts(alloc, &.{ "MCP resource read failed: ", @errorName(err), "." }, false);
@@ -424,20 +424,20 @@ fn handleResourceCommand(alloc: Allocator, rest: []const u8, command_request: Co
         };
         return .{ .display = .{ .block = text } };
     }
-    return lineLiteral(alloc, "Usage: /mcp resource [list|templates|read|complete] ...", false);
+    return lineLiteral(alloc, "usage: /mcp resource [list|templates|read|complete] ...", false);
 }
 
 fn handlePromptCommand(alloc: Allocator, rest: []const u8, command_request: CommandRequest) !CommandResult {
     var input = rest;
     const action = takeToken(&input) orelse return lineLiteral(
         alloc,
-        "Usage: /mcp prompt [list|get|complete] ...",
+        "usage: /mcp prompt [list|get|complete] ...",
         false,
     );
     const context = command_request.feature_ctx orelse command_request.list_ctx;
     if (std.mem.eql(u8, action, "list")) {
-        const server = takeToken(&input) orelse return lineLiteral(alloc, "Usage: /mcp prompt list <server>", false);
-        if (takeToken(&input) != null) return lineLiteral(alloc, "Usage: /mcp prompt list <server>", false);
+        const server = takeToken(&input) orelse return lineLiteral(alloc, "usage: /mcp prompt list <server>", false);
+        if (takeToken(&input) != null) return lineLiteral(alloc, "usage: /mcp prompt list <server>", false);
         const callback = command_request.list_prompts orelse return lineLiteral(alloc, "MCP prompts are unavailable here.", false);
         const text = callback(context, alloc, server) catch |err| {
             return lineParts(alloc, &.{ "MCP prompt listing failed: ", @errorName(err), "." }, false);
@@ -468,7 +468,7 @@ fn handlePromptCommand(alloc: Allocator, rest: []const u8, command_request: Comm
         };
         return .{ .display = .{ .block = text } };
     }
-    return lineLiteral(alloc, "Usage: /mcp prompt [list|get|complete] ...", false);
+    return lineLiteral(alloc, "usage: /mcp prompt [list|get|complete] ...", false);
 }
 
 fn takeToken(input: *[]const u8) ?[]const u8 {
@@ -481,15 +481,15 @@ fn takeToken(input: *[]const u8) ?[]const u8 {
 }
 
 fn resourceCompletionUsage(alloc: Allocator) !CommandResult {
-    return lineLiteral(alloc, "Usage: /mcp resource complete <server> <uri-template> <variable> [value]", false);
+    return lineLiteral(alloc, "usage: /mcp resource complete <server> <uri-template> <variable> [value]", false);
 }
 
 fn promptGetUsage(alloc: Allocator) !CommandResult {
-    return lineLiteral(alloc, "Usage: /mcp prompt get <server> <name> [arguments-json]", false);
+    return lineLiteral(alloc, "usage: /mcp prompt get <server> <name> [arguments-json]", false);
 }
 
 fn promptCompletionUsage(alloc: Allocator) !CommandResult {
-    return lineLiteral(alloc, "Usage: /mcp prompt complete <server> <name> <argument> [value]", false);
+    return lineLiteral(alloc, "usage: /mcp prompt complete <server> <name> <argument> [value]", false);
 }
 
 fn lineLiteral(alloc: Allocator, text: []const u8, reload: bool) !CommandResult {
@@ -1703,7 +1703,7 @@ test "built-in MCP feature commands require exact servers and preserve typed val
     defer ambiguous.deinit(alloc);
     try expectLine(
         ambiguous,
-        "Usage: /mcp prompt get <server> <name> [arguments-json]",
+        "usage: /mcp prompt get <server> <name> [arguments-json]",
         false,
     );
     try std.testing.expectEqual(@as(usize, 3), fixture.calls);
@@ -1802,7 +1802,7 @@ test "built-in MCP command rejects invalid remote add forms without mutation" {
         defer result.deinit(alloc);
         try expectLine(
             result,
-            "Usage: /mcp add <name> <command> [args...] or /mcp add --transport http <name> <url>",
+            "usage: /mcp add <name> <command> [args...] or /mcp add --transport http <name> <url>",
             false,
         );
     }
@@ -1902,7 +1902,7 @@ test "built-in MCP command preserves usage and missing-home notices" {
     defer generic_usage.deinit(alloc);
     try expectLine(
         generic_usage,
-        "Usage: /mcp [list|resource|prompt|add|remove|path|reload|auth|logout|trust]",
+        "usage: /mcp [list|resource|prompt|add|remove|path|reload|auth|logout|trust]",
         false,
     );
 }

--- a/src/builtins/skills.zig
+++ b/src/builtins/skills.zig
@@ -138,7 +138,7 @@ fn executeCommand(alloc: Allocator, command: Command, request: CommandRequest) !
             .{request.skills_dir},
             false,
         ),
-        .usage => noticeLiteral(alloc, "Usage: /skills [list|add|install|show|create|remove|path] [name|url|path]", false),
+        .usage => noticeLiteral(alloc, "usage: /skills [list|add|install|show|create|remove|path] [name|url|path]", false),
     };
 }
 

--- a/src/core/app/app_auth_runtime.zig
+++ b/src/core/app/app_auth_runtime.zig
@@ -257,9 +257,9 @@ pub fn Runtime(comptime App: type) type {
             else
                 provider_catalog.parse(std.mem.trim(u8, target, " \t\r\n")) orelse {
                     try writeAuthNotice(app, .{
-                        .topic = "auth",
+                        .topic = "",
                         .tone = .warning,
-                        .body = "Usage: /logout [vercel|codex|grok]",
+                        .body = "usage: /logout [vercel|codex|grok]",
                     });
                     return;
                 };

--- a/src/core/app/app_bootstrap_runtime.zig
+++ b/src/core/app/app_bootstrap_runtime.zig
@@ -621,19 +621,31 @@ const TestApp = struct {
             styles.system_notice_text_style.len > 0 and
             styles.reset_style.len > 0;
         const notice = if (semantic_notice.topic.len > 0)
-            try std.fmt.allocPrint(self.alloc, "● {c}{s}: {s}{s}\n", .{
-                std.ascii.toUpper(semantic_notice.topic[0]),
-                semantic_notice.topic[1..],
+            try std.fmt.allocPrint(self.alloc, "{s} {s}: {s}{s}\n", .{
+                fakeNoticeGlyph(semantic_notice.tone),
+                semantic_notice.topic,
                 semantic_notice.body,
                 if (semantic_notice.visibility == .full_only) " [full-only]" else "",
             })
         else
-            try std.fmt.allocPrint(self.alloc, "● {s}{s}\n", .{
+            try std.fmt.allocPrint(self.alloc, "{s} {s}{s}\n", .{
+                fakeNoticeGlyph(semantic_notice.tone),
                 semantic_notice.body,
                 if (semantic_notice.visibility == .full_only) " [full-only]" else "",
             });
         defer self.alloc.free(notice);
         try self.writeTranscriptClassified(notice, record, .subagent_status);
+    }
+
+    fn fakeNoticeGlyph(tone: types.NoticeTone) []const u8 {
+        return switch (tone) {
+            .information => "i",
+            .success => "✓",
+            .warning => "!",
+            .@"error" => "✗",
+            .cancelled => "⊘",
+            .neutral => "·",
+        };
     }
 };
 
@@ -1023,8 +1035,8 @@ test "app_bootstrap_runtime reports a bounded skill discovery warning" {
 
     try std.testing.expectEqual(@as(usize, 1), app.skills.diagnostics.len);
     try std.testing.expect(capture.early_notice_palette_initialized);
-    try std.testing.expect(std.mem.find(u8, app.transcript.items, "● Skills: 1 discovery issue; some skills may be missing (ctrl+o to view)\n") != null);
-    try std.testing.expect(std.mem.find(u8, app.transcript.items, "● Skills: skill discovery warning:") != null);
+    try std.testing.expect(std.mem.find(u8, app.transcript.items, "· skills: 1 discovery issue; some skills may be missing (ctrl+o to view)\n") != null);
+    try std.testing.expect(std.mem.find(u8, app.transcript.items, "· skills: skill discovery warning:") != null);
     try std.testing.expect(std.mem.find(u8, app.transcript.items, "hostile&#x0a;path/body-sentinel") != null);
     try std.testing.expect(std.mem.find(u8, app.transcript.items, "metadata is invalid (missing_name)") != null);
     try std.testing.expect(std.mem.find(u8, app.transcript.items, " [full-only]\n") != null);
@@ -1039,6 +1051,6 @@ test "app_bootstrap_runtime collapses config diagnostics into one neutral summar
 
     try runBootstrapForTest(&app, &capture);
 
-    try std.testing.expect(std.mem.find(u8, app.transcript.items, "● Config: 2 configuration issues (ctrl+o to view)\n") != null);
+    try std.testing.expect(std.mem.find(u8, app.transcript.items, "· config: 2 configuration issues (ctrl+o to view)\n") != null);
     try std.testing.expect(std.mem.find(u8, app.transcript.items, "user: malformed_settings\nproject: settings_too_large [full-only]\n") != null);
 }

--- a/src/core/app/app_bootstrap_runtime.zig
+++ b/src/core/app/app_bootstrap_runtime.zig
@@ -622,30 +622,19 @@ const TestApp = struct {
             styles.reset_style.len > 0;
         const notice = if (semantic_notice.topic.len > 0)
             try std.fmt.allocPrint(self.alloc, "{s} {s}: {s}{s}\n", .{
-                fakeNoticeGlyph(semantic_notice.tone),
+                types.noticeGlyph(semantic_notice.tone),
                 semantic_notice.topic,
                 semantic_notice.body,
                 if (semantic_notice.visibility == .full_only) " [full-only]" else "",
             })
         else
             try std.fmt.allocPrint(self.alloc, "{s} {s}{s}\n", .{
-                fakeNoticeGlyph(semantic_notice.tone),
+                types.noticeGlyph(semantic_notice.tone),
                 semantic_notice.body,
                 if (semantic_notice.visibility == .full_only) " [full-only]" else "",
             });
         defer self.alloc.free(notice);
         try self.writeTranscriptClassified(notice, record, .subagent_status);
-    }
-
-    fn fakeNoticeGlyph(tone: types.NoticeTone) []const u8 {
-        return switch (tone) {
-            .information => "i",
-            .success => "✓",
-            .warning => "!",
-            .@"error" => "✗",
-            .cancelled => "⊘",
-            .neutral => "·",
-        };
     }
 };
 
@@ -1035,8 +1024,8 @@ test "app_bootstrap_runtime reports a bounded skill discovery warning" {
 
     try std.testing.expectEqual(@as(usize, 1), app.skills.diagnostics.len);
     try std.testing.expect(capture.early_notice_palette_initialized);
-    try std.testing.expect(std.mem.find(u8, app.transcript.items, "· skills: 1 discovery issue; some skills may be missing (ctrl+o to view)\n") != null);
-    try std.testing.expect(std.mem.find(u8, app.transcript.items, "· skills: skill discovery warning:") != null);
+    try std.testing.expect(std.mem.find(u8, app.transcript.items, "* skills: 1 discovery issue; some skills may be missing (ctrl+o to view)\n") != null);
+    try std.testing.expect(std.mem.find(u8, app.transcript.items, "* skills: skill discovery warning:") != null);
     try std.testing.expect(std.mem.find(u8, app.transcript.items, "hostile&#x0a;path/body-sentinel") != null);
     try std.testing.expect(std.mem.find(u8, app.transcript.items, "metadata is invalid (missing_name)") != null);
     try std.testing.expect(std.mem.find(u8, app.transcript.items, " [full-only]\n") != null);
@@ -1051,6 +1040,6 @@ test "app_bootstrap_runtime collapses config diagnostics into one neutral summar
 
     try runBootstrapForTest(&app, &capture);
 
-    try std.testing.expect(std.mem.find(u8, app.transcript.items, "· config: 2 configuration issues (ctrl+o to view)\n") != null);
+    try std.testing.expect(std.mem.find(u8, app.transcript.items, "* config: 2 configuration issues (ctrl+o to view)\n") != null);
     try std.testing.expect(std.mem.find(u8, app.transcript.items, "user: malformed_settings\nproject: settings_too_large [full-only]\n") != null);
 }

--- a/src/core/app/app_commands.zig
+++ b/src/core/app/app_commands.zig
@@ -4796,8 +4796,8 @@ test "skills install groups command notice fragments for entry replay" {
 
     const rendered = try transcript_runtime.renderEntriesToBytes(alloc, app.shell.entries.items, 80, .{});
     defer alloc.free(rendered);
-    try std.testing.expect(std.mem.startsWith(u8, rendered, "· skills: Installing from "));
-    try std.testing.expect(std.mem.find(u8, rendered, "\n\n· skills: Installed: root-skill") != null);
+    try std.testing.expect(std.mem.startsWith(u8, rendered, "* skills: Installing from "));
+    try std.testing.expect(std.mem.find(u8, rendered, "\n\n* skills: Installed: root-skill") != null);
     try std.testing.expect(std.mem.endsWith(u8, rendered, "  Installed: nested-skill"));
 }
 

--- a/src/core/app/app_commands.zig
+++ b/src/core/app/app_commands.zig
@@ -229,7 +229,7 @@ fn handleWorkspaceCommand(app: anytype, rest: []const u8) !void {
         try app.writeDomainNotice(.{
             .topic = "workspace",
             .tone = .@"error",
-            .body = "Use: /workspace [add PATH|remove PATH|clear]",
+            .body = "usage: /workspace [add PATH|remove PATH|clear]",
         }, true);
         return;
     };
@@ -3426,7 +3426,7 @@ fn handleRenameCommand(app: anytype, rest: []const u8) !void {
     const SessionRuntime = app_session_runtime.Runtime(App);
     SessionRuntime.renameActiveSession(app, rest) catch |err| {
         const body: []const u8 = switch (err) {
-            error.EmptyTitle => "Use: /rename <title>",
+            error.EmptyTitle => "usage: /rename <title>",
             error.TitleTooLong => "title is too long",
             error.InvalidTitle => "title must be printable text",
             error.NoActiveSession => "no active session to rename",
@@ -3454,7 +3454,7 @@ fn handleRenameCommand(app: anytype, rest: []const u8) !void {
 
     app.shell.render_requests.request(.footer);
     const title = SessionRuntime.cachedSessionTitle(app) orelse "";
-    const msg = try std.fmt.allocPrint(app.alloc, "renamed: {s}", .{title});
+    const msg = try std.fmt.allocPrint(app.alloc, "renamed to \"{s}\"", .{title});
     defer app.alloc.free(msg);
     try app.writeDomainNotice(.{ .topic = "session", .tone = .neutral, .body = msg }, true);
 }
@@ -3534,7 +3534,7 @@ fn handleStatuslineCommand(app: anytype, rest: []const u8) !void {
         try app.writeDomainNotice(.{
             .topic = "statusline",
             .tone = .@"error",
-            .body = "Use: context, session, workspace",
+            .body = "usage: /statusline [context|session|workspace]",
         }, true);
         return;
     };
@@ -3582,7 +3582,7 @@ fn handleNotificationsCommand(app: anytype, rest: []const u8) !void {
             try app.writeDomainNotice(.{
                 .topic = "sound",
                 .tone = .@"error",
-                .body = "Use: /sound [on|off|max].",
+                .body = "usage: /sound [on|off|max]",
             }, true);
             return;
         },
@@ -4782,8 +4782,8 @@ test "skills install groups command notice fragments for entry replay" {
 
     const rendered = try transcript_runtime.renderEntriesToBytes(alloc, app.shell.entries.items, 80, .{});
     defer alloc.free(rendered);
-    try std.testing.expect(std.mem.startsWith(u8, rendered, "● Skills: Installing from "));
-    try std.testing.expect(std.mem.find(u8, rendered, "\n\n● Skills: Installed: root-skill") != null);
+    try std.testing.expect(std.mem.startsWith(u8, rendered, "· skills: Installing from "));
+    try std.testing.expect(std.mem.find(u8, rendered, "\n\n· skills: Installed: root-skill") != null);
     try std.testing.expect(std.mem.endsWith(u8, rendered, "  Installed: nested-skill"));
 }
 
@@ -4861,7 +4861,7 @@ test "skills list reports a bounded discovery warning with an escaped candidate 
     try std.testing.expect(std.mem.find(u8, notice.body, "metadata is invalid (missing_name)") != null);
     const rendered = try transcript_runtime.renderEntriesToBytes(alloc, app.shell.entries.items, 80, .{});
     defer alloc.free(rendered);
-    try std.testing.expect(std.mem.find(u8, rendered, "● Skills: skill discovery warning:") != null);
+    try std.testing.expect(std.mem.find(u8, rendered, "! skills: skill discovery warning:") != null);
 }
 
 test "skills show focuses matching menu row without transcript body" {

--- a/src/core/app/app_commands.zig
+++ b/src/core/app/app_commands.zig
@@ -227,7 +227,7 @@ fn refreshWorkspaceAvailabilityForList(app: anytype) !void {
 fn handleWorkspaceCommand(app: anytype, rest: []const u8) !void {
     const maybe_action = parseWorkspaceCommand(rest) catch {
         try app.writeDomainNotice(.{
-            .topic = "workspace",
+            .topic = "",
             .tone = .@"error",
             .body = "usage: /workspace [add PATH|remove PATH|clear]",
         }, true);
@@ -946,11 +946,12 @@ pub fn Handlers(comptime App: type) type {
         }
 
         fn writePermissionManagementUsage(app: *App) !void {
-            try writePermissionManagementNotice(
-                app,
-                .@"error",
-                "usage: /permissions remember <allow|deny> <tool-name> <arguments-json>\n       /permissions revoke <rule-id>",
-            );
+            // Usage lines name the command; a topic tag would repeat it.
+            try app.writeDomainNotice(.{
+                .topic = "",
+                .tone = .@"error",
+                .body = "usage: /permissions remember <allow|deny> <tool-name> <arguments-json>\n       /permissions revoke <rule-id>",
+            }, true);
         }
 
         fn writePermissionManagementNotice(
@@ -1336,7 +1337,7 @@ pub fn Handlers(comptime App: type) type {
             }
             const body = reload_notice orelse command_body;
             try app.writeDomainNotice(.{
-                .topic = "mcp",
+                .topic = noticeTopicForBody("mcp", body),
                 .tone = if (reload_warning) .warning else .neutral,
                 .body = body,
             }, true);
@@ -1727,7 +1728,7 @@ pub fn Handlers(comptime App: type) type {
                     .{ .show = name },
                 ),
                 .notice => |body| try app.writeDomainNotice(.{
-                    .topic = "skills",
+                    .topic = noticeTopicForBody("skills", body),
                     .tone = .neutral,
                     .body = body,
                 }, true),
@@ -1773,6 +1774,11 @@ pub fn Handlers(comptime App: type) type {
             defer result.deinit(app.alloc);
 
             try applySkillsCommandResult(app, &result);
+        }
+
+        /// Usage lines name the command; a topic tag would repeat it.
+        fn noticeTopicForBody(comptime default: []const u8, body: []const u8) []const u8 {
+            return if (std.mem.startsWith(u8, body, "usage:")) "" else default;
         }
 
         fn findSkillForProvider(ctx: *anyopaque, name: []const u8) ?skill_commands.SkillInfo {
@@ -1833,7 +1839,7 @@ pub fn Handlers(comptime App: type) type {
                         try queueSkillsNoticeAfterRefresh(app, notice.text);
                     } else {
                         try app.writeDomainNotice(.{
-                            .topic = "skills",
+                            .topic = noticeTopicForBody("skills", notice.text),
                             .tone = .neutral,
                             .body = notice.text,
                         }, true);
@@ -3425,8 +3431,16 @@ fn handleRenameCommand(app: anytype, rest: []const u8) !void {
     const App = @TypeOf(app.*);
     const SessionRuntime = app_session_runtime.Runtime(App);
     SessionRuntime.renameActiveSession(app, rest) catch |err| {
+        if (err == error.EmptyTitle) {
+            // Usage lines name the command; a topic tag would repeat it.
+            try app.writeDomainNotice(
+                .{ .topic = "", .tone = .@"error", .body = "usage: /rename <title>" },
+                true,
+            );
+            return;
+        }
         const body: []const u8 = switch (err) {
-            error.EmptyTitle => "usage: /rename <title>",
+            error.EmptyTitle => unreachable,
             error.TitleTooLong => "title is too long",
             error.InvalidTitle => "title must be printable text",
             error.NoActiveSession => "no active session to rename",
@@ -3532,7 +3546,7 @@ fn applyStatuslineItem(
 fn handleStatuslineCommand(app: anytype, rest: []const u8) !void {
     const item = parseStatuslineItem(rest) orelse {
         try app.writeDomainNotice(.{
-            .topic = "statusline",
+            .topic = "",
             .tone = .@"error",
             .body = "usage: /statusline [context|session|workspace]",
         }, true);
@@ -3580,7 +3594,7 @@ fn handleNotificationsCommand(app: anytype, rest: []const u8) !void {
         .set => |value| value,
         .invalid => {
             try app.writeDomainNotice(.{
-                .topic = "sound",
+                .topic = "",
                 .tone = .@"error",
                 .body = "usage: /sound [on|off|max]",
             }, true);

--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -4007,25 +4007,14 @@ const RoutingFakeApp = struct {
         self.notice_visibility = notice.visibility;
         const rendered = if (notice.topic.len > 0)
             try std.fmt.allocPrint(self.alloc, "{s} {s}: {s}", .{
-                routingFakeNoticeGlyph(notice.tone),
+                types.noticeGlyph(notice.tone),
                 notice.topic,
                 notice.body,
             })
         else
-            try std.fmt.allocPrint(self.alloc, "{s} {s}", .{ routingFakeNoticeGlyph(notice.tone), notice.body });
+            try std.fmt.allocPrint(self.alloc, "{s} {s}", .{ types.noticeGlyph(notice.tone), notice.body });
         defer self.alloc.free(rendered);
         try self.transcript.appendSlice(self.alloc, rendered);
-    }
-
-    fn routingFakeNoticeGlyph(tone: types.NoticeTone) []const u8 {
-        return switch (tone) {
-            .information => "i",
-            .success => "✓",
-            .warning => "!",
-            .@"error" => "✗",
-            .cancelled => "⊘",
-            .neutral => "·",
-        };
     }
 
     pub fn appendDomainNotice(self: *RoutingFakeApp, notice: types.SemanticNotice) !u32 {

--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -2786,7 +2786,7 @@ pub fn Runtime(comptime App: type) type {
                 .none => return false,
                 .invalid => {
                     try app.writeDomainNotice(.{
-                        .topic = "model",
+                        .topic = "",
                         .tone = .@"error",
                         .body = "usage: /model <id> <effort> [normal|fast]",
                     }, true);

--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -2788,7 +2788,7 @@ pub fn Runtime(comptime App: type) type {
                     try app.writeDomainNotice(.{
                         .topic = "model",
                         .tone = .@"error",
-                        .body = "Invalid /model selection. Use /model <id> <effort> [normal|fast].",
+                        .body = "usage: /model <id> <effort> [normal|fast]",
                     }, true);
                 },
                 .selection => |selection| {
@@ -4006,15 +4006,26 @@ const RoutingFakeApp = struct {
         self.notice_tone = notice.tone;
         self.notice_visibility = notice.visibility;
         const rendered = if (notice.topic.len > 0)
-            try std.fmt.allocPrint(self.alloc, "● {c}{s}: {s}", .{
-                std.ascii.toUpper(notice.topic[0]),
-                notice.topic[1..],
+            try std.fmt.allocPrint(self.alloc, "{s} {s}: {s}", .{
+                routingFakeNoticeGlyph(notice.tone),
+                notice.topic,
                 notice.body,
             })
         else
-            try std.fmt.allocPrint(self.alloc, "● {s}", .{notice.body});
+            try std.fmt.allocPrint(self.alloc, "{s} {s}", .{ routingFakeNoticeGlyph(notice.tone), notice.body });
         defer self.alloc.free(rendered);
         try self.transcript.appendSlice(self.alloc, rendered);
+    }
+
+    fn routingFakeNoticeGlyph(tone: types.NoticeTone) []const u8 {
+        return switch (tone) {
+            .information => "i",
+            .success => "✓",
+            .warning => "!",
+            .@"error" => "✗",
+            .cancelled => "⊘",
+            .neutral => "·",
+        };
     }
 
     pub fn appendDomainNotice(self: *RoutingFakeApp, notice: types.SemanticNotice) !u32 {

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -5285,21 +5285,10 @@ const TestApp = struct {
             try std.fmt.allocPrint(
                 self.alloc,
                 "{s} {s}: {s}",
-                .{ sessionTestNoticeGlyph(notice.tone), notice.topic, notice.body },
+                .{ types.noticeGlyph(notice.tone), notice.topic, notice.body },
             )
         else
-            try std.fmt.allocPrint(self.alloc, "{s} {s}", .{ sessionTestNoticeGlyph(notice.tone), notice.body }));
-    }
-
-    fn sessionTestNoticeGlyph(tone: types.NoticeTone) []const u8 {
-        return switch (tone) {
-            .information => "i",
-            .success => "✓",
-            .warning => "!",
-            .@"error" => "✗",
-            .cancelled => "⊘",
-            .neutral => "·",
-        };
+            try std.fmt.allocPrint(self.alloc, "{s} {s}", .{ types.noticeGlyph(notice.tone), notice.body }));
     }
 
     fn commitStartupResumeReplayAnchor(self: *TestApp) !void {
@@ -7649,7 +7638,7 @@ test "interactive session resume uses the live transition and shared restore pat
     );
     try std.testing.expectEqual(@as(usize, 1), app.session.historyLen());
     try std.testing.expectEqual(@as(usize, 1), app.notices.items.len);
-    try std.testing.expectEqualStrings("· session resumed: saved prompt", app.notices.items[0]);
+    try std.testing.expectEqualStrings("* session resumed: saved prompt", app.notices.items[0]);
     try std.testing.expect(!app.session_persistence.session_picker.active);
 
     try std.testing.expect(app.session_persistence.subagent_host != null);
@@ -7933,7 +7922,7 @@ test "resumeRequestedSession replays active-tool interruption with live cancella
     try std.testing.expect(std.mem.find(u8, app.transcript.items, "System:") == null);
     try std.testing.expect(std.mem.find(u8, app.transcript.items, "Cancelling") == null);
     try std.testing.expectEqual(@as(usize, 1), app.notices.items.len);
-    try std.testing.expectEqualStrings("· session resumed: inspect the browser", app.notices.items[0]);
+    try std.testing.expectEqualStrings("* session resumed: inspect the browser", app.notices.items[0]);
     try std.testing.expect(std.mem.find(u8, app.transcript.items, "localhost") == null);
 }
 

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -5284,11 +5284,22 @@ const TestApp = struct {
         try self.notices.append(self.alloc, if (notice.topic.len > 0)
             try std.fmt.allocPrint(
                 self.alloc,
-                "● {c}{s}: {s}",
-                .{ std.ascii.toUpper(notice.topic[0]), notice.topic[1..], notice.body },
+                "{s} {s}: {s}",
+                .{ sessionTestNoticeGlyph(notice.tone), notice.topic, notice.body },
             )
         else
-            try std.fmt.allocPrint(self.alloc, "● {s}", .{notice.body}));
+            try std.fmt.allocPrint(self.alloc, "{s} {s}", .{ sessionTestNoticeGlyph(notice.tone), notice.body }));
+    }
+
+    fn sessionTestNoticeGlyph(tone: types.NoticeTone) []const u8 {
+        return switch (tone) {
+            .information => "i",
+            .success => "✓",
+            .warning => "!",
+            .@"error" => "✗",
+            .cancelled => "⊘",
+            .neutral => "·",
+        };
     }
 
     fn commitStartupResumeReplayAnchor(self: *TestApp) !void {
@@ -7290,7 +7301,7 @@ test "upgrade resume restores active session with the installed version notice" 
     try std.testing.expectEqualStrings("run server", context[2].assistant.user.text);
     try std.testing.expectEqual(@as(usize, 1), app.notices.items.len);
     try std.testing.expectEqualStrings(
-        "● fx has been updated to v9.9.9 (\x1b]8;;https://fx.sh/changelog#v9.9.9\x1b\\\x1b[4mnotes\x1b[24m\x1b]8;;\x1b\\)",
+        "✓ fx has been updated to v9.9.9 (\x1b]8;;https://fx.sh/changelog#v9.9.9\x1b\\\x1b[4mnotes\x1b[24m\x1b]8;;\x1b\\)",
         app.notices.items[0],
     );
     try std.testing.expectEqual(@as(usize, 2), app.completed_tool_statuses.items.len);
@@ -7638,7 +7649,7 @@ test "interactive session resume uses the live transition and shared restore pat
     );
     try std.testing.expectEqual(@as(usize, 1), app.session.historyLen());
     try std.testing.expectEqual(@as(usize, 1), app.notices.items.len);
-    try std.testing.expectEqualStrings("● Session resumed: saved prompt", app.notices.items[0]);
+    try std.testing.expectEqualStrings("· session resumed: saved prompt", app.notices.items[0]);
     try std.testing.expect(!app.session_persistence.session_picker.active);
 
     try std.testing.expect(app.session_persistence.subagent_host != null);
@@ -7922,7 +7933,7 @@ test "resumeRequestedSession replays active-tool interruption with live cancella
     try std.testing.expect(std.mem.find(u8, app.transcript.items, "System:") == null);
     try std.testing.expect(std.mem.find(u8, app.transcript.items, "Cancelling") == null);
     try std.testing.expectEqual(@as(usize, 1), app.notices.items.len);
-    try std.testing.expectEqualStrings("● Session resumed: inspect the browser", app.notices.items[0]);
+    try std.testing.expectEqualStrings("· session resumed: inspect the browser", app.notices.items[0]);
     try std.testing.expect(std.mem.find(u8, app.transcript.items, "localhost") == null);
 }
 
@@ -7965,7 +7976,7 @@ test "resumeRequestedSession preserves failed partial terminal reason" {
 
     try std.testing.expect(std.mem.find(u8, app.assistant_text.items, "partial response") != null);
     try std.testing.expectEqual(@as(usize, 2), app.notices.items.len);
-    try std.testing.expectEqualStrings("● System: failed", app.notices.items[1]);
+    try std.testing.expectEqualStrings("✗ system: failed", app.notices.items[1]);
     try std.testing.expect(std.mem.find(u8, app.notices.items[1], "cancelled") == null);
 }
 

--- a/src/core/images/image_commands.zig
+++ b/src/core/images/image_commands.zig
@@ -22,7 +22,7 @@ pub fn Commands(comptime App: type) type {
         pub fn attachPath(app: *App, path: []const u8) !void {
             const trimmed = std.mem.trim(u8, path, " \t");
             if (trimmed.len == 0) {
-                try app.writeDomainNotice(.{ .topic = "images", .tone = .@"error", .body = "usage: /image <path>" }, true);
+                try app.writeDomainNotice(.{ .topic = "", .tone = .@"error", .body = "usage: /image <path>" }, true);
                 return;
             }
 

--- a/src/core/session/session_commands.zig
+++ b/src/core/session/session_commands.zig
@@ -381,7 +381,7 @@ pub fn Commands(comptime App: type) type {
                 return;
             }
 
-            try app.writeDomainNotice(.{ .topic = "permissions", .tone = .@"error", .body = permissions_usage }, true);
+            try app.writeDomainNotice(.{ .topic = "", .tone = .@"error", .body = permissions_usage }, true);
         }
 
         pub fn handleAllowlist(app: *App, rest: []const u8) !void {
@@ -501,7 +501,7 @@ pub fn Commands(comptime App: type) type {
 
         fn writeAllowlistUsage(app: *App) !void {
             try app.writeDomainNotice(.{
-                .topic = "allowlist",
+                .topic = "",
                 .tone = .@"error",
                 .body = "usage: /allowlist [view [effective|local|user]|[local|user] add|remove|reset ...]",
             }, true);
@@ -514,7 +514,7 @@ pub fn Commands(comptime App: type) type {
         ) !void {
             const target = (try parseAllowlistTargetAlloc(app.alloc, app.toolRegistry(), raw)) orelse {
                 try app.writeDomainNotice(.{
-                    .topic = "allowlist",
+                    .topic = "",
                     .tone = .@"error",
                     .body = "usage: /allowlist add [command|tool|url|web-fetch-domain] <pattern>",
                 }, true);
@@ -556,7 +556,7 @@ pub fn Commands(comptime App: type) type {
         ) !void {
             const target = (try parseAllowlistTargetAlloc(app.alloc, app.toolRegistry(), raw)) orelse {
                 try app.writeDomainNotice(.{
-                    .topic = "allowlist",
+                    .topic = "",
                     .tone = .@"error",
                     .body = "usage: /allowlist remove [command|tool|url|web-fetch-domain] <pattern>",
                 }, true);
@@ -603,7 +603,7 @@ pub fn Commands(comptime App: type) type {
         ) !void {
             const reset_scope = parseAllowlistResetScope(raw) orelse {
                 try app.writeDomainNotice(.{
-                    .topic = "allowlist",
+                    .topic = "",
                     .tone = .@"error",
                     .body = "usage: /allowlist reset [commands|tools|urls|web-fetch-domains|all]",
                 }, true);
@@ -1004,7 +1004,7 @@ pub fn Commands(comptime App: type) type {
 
         fn writeSettingsUsage(app: *App) !void {
             try app.writeDomainNotice(.{
-                .topic = "settings",
+                .topic = "",
                 .tone = .@"error",
                 .body = "usage: /settings [startup-scrollback [on|off]]",
             }, true);

--- a/src/core/session/session_commands.zig
+++ b/src/core/session/session_commands.zig
@@ -1713,25 +1713,14 @@ const FakeApp = struct {
         self.last_tone = notice.tone;
         const rendered = if (notice.topic.len > 0)
             try std.fmt.allocPrint(self.alloc, "{s} {s}: {s}\n", .{
-                fakeNoticeGlyph(notice.tone),
+                types.noticeGlyph(notice.tone),
                 notice.topic,
                 notice.body,
             })
         else
-            try std.fmt.allocPrint(self.alloc, "{s} {s}\n", .{ fakeNoticeGlyph(notice.tone), notice.body });
+            try std.fmt.allocPrint(self.alloc, "{s} {s}\n", .{ types.noticeGlyph(notice.tone), notice.body });
         defer self.alloc.free(rendered);
         try self.transcript.appendSlice(self.alloc, rendered);
-    }
-
-    fn fakeNoticeGlyph(tone: types.NoticeTone) []const u8 {
-        return switch (tone) {
-            .information => "i",
-            .success => "✓",
-            .warning => "!",
-            .@"error" => "✗",
-            .cancelled => "⊘",
-            .neutral => "·",
-        };
     }
 
     fn text(self: *const FakeApp) []const u8 {
@@ -1950,7 +1939,7 @@ test "session_commands showStatus writes session status snapshot" {
 
     try Commands(FakeApp).showStatus(&app);
 
-    try expectTranscriptContains(&app, "· status: model=anthropic/test-model\n");
+    try expectTranscriptContains(&app, "* status: model=anthropic/test-model\n");
     try expectTranscriptContains(&app, "auth=missing\n");
     try expectTranscriptContains(&app, "auth_refreshable=false\n");
     try expectTranscriptContains(&app, "permission_mode=auto\n");
@@ -2197,7 +2186,7 @@ test "session_commands handleModel reports current model for empty query" {
 
     try Commands(FakeApp).handleModel(&app, "");
 
-    try std.testing.expectEqualStrings("· model: anthropic/claude-opus-4.6\n", app.text());
+    try std.testing.expectEqualStrings("* model: anthropic/claude-opus-4.6\n", app.text());
     try std.testing.expect(app.worker.synced_model == null);
     try std.testing.expectEqualStrings("", app.terminalTitleLabelText());
 }
@@ -2222,7 +2211,7 @@ test "session_commands handleModel resolves fuzzy cached model and syncs queued 
         "fx v" ++ build_options.app_version ++ " | workspace",
         app.terminalTitleLabelText(),
     );
-    try expectTranscriptContains(&app, "· Switched to anthropic/claude-sonnet-4-20250514");
+    try expectTranscriptContains(&app, "* Switched to anthropic/claude-sonnet-4-20250514");
 }
 
 test "session_commands handleModel falls back to raw query when model fetch fails" {
@@ -2341,19 +2330,19 @@ test "session_commands handleAllowlist adds lists and removes workspace rules" {
     app.tool_registry = .{ .tools = &.{builtin_tools.read_file} };
 
     try Commands(FakeApp).handleAllowlist(&app, "add command \"git *\"");
-    try expectTranscriptContains(&app, "· allowlist: added command: \"git *\"");
+    try expectTranscriptContains(&app, "* allowlist: added command: \"git *\"");
 
     app.clearTranscript();
     try Commands(FakeApp).handleAllowlist(&app, "add tool read_file");
-    try expectTranscriptContains(&app, "· allowlist: added tool read: \"*\"");
+    try expectTranscriptContains(&app, "* allowlist: added tool read: \"*\"");
 
     app.clearTranscript();
     try Commands(FakeApp).handleAllowlist(&app, "add url \"https://example.com/*\"");
-    try expectTranscriptContains(&app, "· allowlist: added url: \"https://example.com/*\"");
+    try expectTranscriptContains(&app, "* allowlist: added url: \"https://example.com/*\"");
 
     app.clearTranscript();
     try Commands(FakeApp).handleAllowlist(&app, "add command echo");
-    try expectTranscriptContains(&app, "· allowlist: added command: \"echo\"");
+    try expectTranscriptContains(&app, "* allowlist: added command: \"echo\"");
 
     _ = try config_runtime.addPermissionRule(std.testing.allocator, .local, workspace_root, "read", "docs/*", .allow);
 
@@ -2368,19 +2357,19 @@ test "session_commands handleAllowlist adds lists and removes workspace rules" {
 
     app.clearTranscript();
     try Commands(FakeApp).handleAllowlist(&app, "");
-    try expectTranscriptContains(&app, "· allowlist: effective persistent allow rules:");
+    try expectTranscriptContains(&app, "* allowlist: effective persistent allow rules:");
     try expectTranscriptContains(&app, "  tools:\n    read: workspace, docs/*");
     try expectTranscriptContains(&app, "  commands:\n    git *, echo");
     try expectTranscriptContains(&app, "  urls:\n    https://example.com/*");
 
     app.clearTranscript();
     try Commands(FakeApp).handleAllowlist(&app, "view");
-    try expectTranscriptContains(&app, "· allowlist: effective persistent allow rules:");
+    try expectTranscriptContains(&app, "* allowlist: effective persistent allow rules:");
     try expectTranscriptContains(&app, "  commands:\n    git *, echo");
 
     app.clearTranscript();
     try Commands(FakeApp).handleAllowlist(&app, "remove command \"git *\"");
-    try expectTranscriptContains(&app, "· allowlist: removed command: \"git *\"");
+    try expectTranscriptContains(&app, "* allowlist: removed command: \"git *\"");
 
     var after_remove = try config_runtime.loadMergedSettings(std.testing.allocator, workspace_root);
     defer after_remove.deinit(std.testing.allocator);
@@ -2392,11 +2381,11 @@ test "session_commands handleAllowlist adds lists and removes workspace rules" {
 
     app.clearTranscript();
     try Commands(FakeApp).handleAllowlist(&app, "reset tools");
-    try expectTranscriptContains(&app, "· allowlist: reset tools: removed 2 rules");
+    try expectTranscriptContains(&app, "* allowlist: reset tools: removed 2 rules");
 
     app.clearTranscript();
     try Commands(FakeApp).handleAllowlist(&app, "reset all");
-    try expectTranscriptContains(&app, "· allowlist: reset all: removed 2 rules");
+    try expectTranscriptContains(&app, "* allowlist: reset all: removed 2 rules");
 
     var after_reset = try config_runtime.loadMergedSettings(std.testing.allocator, workspace_root);
     defer after_reset.deinit(std.testing.allocator);
@@ -2404,7 +2393,7 @@ test "session_commands handleAllowlist adds lists and removes workspace rules" {
 
     app.clearTranscript();
     try Commands(FakeApp).handleAllowlist(&app, "view");
-    try expectTranscriptContains(&app, "· allowlist: effective persistent allow rules: (none)");
+    try expectTranscriptContains(&app, "* allowlist: effective persistent allow rules: (none)");
 }
 
 test "session_commands allowlist scopes expose and mutate hidden user rules independently" {
@@ -2433,19 +2422,19 @@ test "session_commands allowlist scopes expose and mutate hidden user rules inde
 
     app.clearTranscript();
     try Commands(FakeApp).handleAllowlist(&app, "view user");
-    try expectTranscriptContains(&app, "· allowlist: user persistent allow rules:");
+    try expectTranscriptContains(&app, "* allowlist: user persistent allow rules:");
     try expectTranscriptContains(&app, "user *");
     try expectTranscriptContains(&app, "user rules are shadowed by local settings");
 
     app.clearTranscript();
     try Commands(FakeApp).handleAllowlist(&app, "view local");
-    try expectTranscriptContains(&app, "· allowlist: local persistent allow rules:");
+    try expectTranscriptContains(&app, "* allowlist: local persistent allow rules:");
     try expectTranscriptContains(&app, "local *");
     try std.testing.expect(std.mem.find(u8, app.text(), "user *") == null);
 
     app.clearTranscript();
     try Commands(FakeApp).handleAllowlist(&app, "view effective");
-    try expectTranscriptContains(&app, "· allowlist: effective persistent allow rules:");
+    try expectTranscriptContains(&app, "* allowlist: effective persistent allow rules:");
     try expectTranscriptContains(&app, "local *");
     try std.testing.expect(std.mem.find(u8, app.text(), "user *") == null);
 
@@ -2525,7 +2514,7 @@ test "web_fetch allowlist add remove view and reset persist exact canonical doma
     defer app.deinit();
 
     try Commands(FakeApp).handleAllowlist(&app, "add web-fetch-domain Example.COM.");
-    try expectTranscriptContains(&app, "· allowlist: added web-fetch-domain: \"domain:example.com\"");
+    try expectTranscriptContains(&app, "* allowlist: added web-fetch-domain: \"domain:example.com\"");
 
     var settings = try config_runtime.loadMergedSettings(std.testing.allocator, workspace_root);
     defer settings.deinit(std.testing.allocator);
@@ -2538,13 +2527,13 @@ test "web_fetch allowlist add remove view and reset persist exact canonical doma
 
     app.clearTranscript();
     try Commands(FakeApp).handleAllowlist(&app, "remove web-fetch-domain EXAMPLE.com");
-    try expectTranscriptContains(&app, "· allowlist: removed web-fetch-domain: \"domain:example.com\"");
+    try expectTranscriptContains(&app, "* allowlist: removed web-fetch-domain: \"domain:example.com\"");
 
     _ = try config_runtime.addPermissionRule(std.testing.allocator, .local, workspace_root, "web_fetch", "domain:example.com", .allow);
     _ = try config_runtime.addPermissionRule(std.testing.allocator, .local, workspace_root, "web_fetch", "domain:example.org", .allow);
     app.clearTranscript();
     try Commands(FakeApp).handleAllowlist(&app, "reset web-fetch-domains");
-    try expectTranscriptContains(&app, "· allowlist: reset web-fetch-domains: removed 2 rules");
+    try expectTranscriptContains(&app, "* allowlist: reset web-fetch-domains: removed 2 rules");
 }
 
 test "web_fetch allowlist rejects wildcard url shaped and tool wide authorization" {
@@ -2650,7 +2639,7 @@ test "session_commands handleAllowlist recognizes tools from the active registry
     app.tool_registry = .{ .tools = &.{provider_tool} };
 
     try Commands(FakeApp).handleAllowlist(&app, "add tool provider_custom");
-    try expectTranscriptContains(&app, "· allowlist: added tool provider_custom: \"*\"");
+    try expectTranscriptContains(&app, "* allowlist: added tool provider_custom: \"*\"");
 
     var settings = try config_runtime.loadMergedSettings(std.testing.allocator, workspace_root);
     defer settings.deinit(std.testing.allocator);
@@ -2676,7 +2665,7 @@ test "session_commands toggleFast reports unsupported model and redraws footer" 
     try std.testing.expect(app.shell.render_requests.hasReason(.footer));
     try std.testing.expect(app.worker.synced_fast_mode == null);
     try std.testing.expectEqual(@as(usize, 0), app.worker.fast_sync_count);
-    try expectTranscriptContains(&app, "· fast: This model does not come with a fast mode.");
+    try expectTranscriptContains(&app, "* fast: This model does not come with a fast mode.");
 }
 
 test "session_commands toggleFast disables stale fast mode for unsupported model" {
@@ -2737,7 +2726,7 @@ test "session_commands toggleFast syncs queued fast mode for supported models" {
     try std.testing.expect(app.fast_mode);
     try std.testing.expectEqual(@as(?bool, true), app.worker.synced_fast_mode);
     try std.testing.expectEqual(@as(usize, 1), app.worker.fast_sync_count);
-    try expectTranscriptContains(&app, "· fast: on");
+    try expectTranscriptContains(&app, "* fast: on");
 }
 
 test "session_commands selectModelFromPicker skips effort changes for models without reasoning support" {
@@ -2924,7 +2913,7 @@ test "session_commands user save notice uses one post-commit load after legacy c
     try Commands(FakeApp).handleModel(&app, "user/new");
 
     try std.testing.expectEqual(@as(usize, 1), app.post_commit_resolution_count);
-    try expectTranscriptContains(&app, "· model: saved to user settings (scope=user)");
+    try expectTranscriptContains(&app, "* model: saved to user settings (scope=user)");
     try std.testing.expect(std.mem.find(u8, app.text(), "model=project") == null);
     try expectTranscriptContains(&app, "normalized 1 legacy value across 1 workspace");
     try expectTranscriptContains(&app, "settings.json.preference-migration.model.");

--- a/src/core/session/session_commands.zig
+++ b/src/core/session/session_commands.zig
@@ -1712,15 +1712,26 @@ const FakeApp = struct {
         self.semantic_write_count += 1;
         self.last_tone = notice.tone;
         const rendered = if (notice.topic.len > 0)
-            try std.fmt.allocPrint(self.alloc, "● {c}{s}: {s}\n", .{
-                std.ascii.toUpper(notice.topic[0]),
-                notice.topic[1..],
+            try std.fmt.allocPrint(self.alloc, "{s} {s}: {s}\n", .{
+                fakeNoticeGlyph(notice.tone),
+                notice.topic,
                 notice.body,
             })
         else
-            try std.fmt.allocPrint(self.alloc, "● {s}\n", .{notice.body});
+            try std.fmt.allocPrint(self.alloc, "{s} {s}\n", .{ fakeNoticeGlyph(notice.tone), notice.body });
         defer self.alloc.free(rendered);
         try self.transcript.appendSlice(self.alloc, rendered);
+    }
+
+    fn fakeNoticeGlyph(tone: types.NoticeTone) []const u8 {
+        return switch (tone) {
+            .information => "i",
+            .success => "✓",
+            .warning => "!",
+            .@"error" => "✗",
+            .cancelled => "⊘",
+            .neutral => "·",
+        };
     }
 
     fn text(self: *const FakeApp) []const u8 {
@@ -1939,7 +1950,7 @@ test "session_commands showStatus writes session status snapshot" {
 
     try Commands(FakeApp).showStatus(&app);
 
-    try expectTranscriptContains(&app, "● Status: model=anthropic/test-model\n");
+    try expectTranscriptContains(&app, "· status: model=anthropic/test-model\n");
     try expectTranscriptContains(&app, "auth=missing\n");
     try expectTranscriptContains(&app, "auth_refreshable=false\n");
     try expectTranscriptContains(&app, "permission_mode=auto\n");
@@ -2175,7 +2186,7 @@ test "session_commands handleSettings reports usage and save failures" {
 
     app.clearTranscript();
     try Commands(FakeApp).handleSettings(&app, "startup-scrollback off");
-    try expectTranscriptContains(&app, "● Startup-scrollback: not saved to user settings (HomeNotSet)");
+    try expectTranscriptContains(&app, "✗ startup-scrollback: not saved to user settings (HomeNotSet)");
     try std.testing.expectEqual(types.NoticeTone.@"error", app.last_tone.?);
 }
 
@@ -2186,7 +2197,7 @@ test "session_commands handleModel reports current model for empty query" {
 
     try Commands(FakeApp).handleModel(&app, "");
 
-    try std.testing.expectEqualStrings("● Model: anthropic/claude-opus-4.6\n", app.text());
+    try std.testing.expectEqualStrings("· model: anthropic/claude-opus-4.6\n", app.text());
     try std.testing.expect(app.worker.synced_model == null);
     try std.testing.expectEqualStrings("", app.terminalTitleLabelText());
 }
@@ -2211,7 +2222,7 @@ test "session_commands handleModel resolves fuzzy cached model and syncs queued 
         "fx v" ++ build_options.app_version ++ " | workspace",
         app.terminalTitleLabelText(),
     );
-    try expectTranscriptContains(&app, "● Switched to anthropic/claude-sonnet-4-20250514");
+    try expectTranscriptContains(&app, "· Switched to anthropic/claude-sonnet-4-20250514");
 }
 
 test "session_commands handleModel falls back to raw query when model fetch fails" {
@@ -2330,19 +2341,19 @@ test "session_commands handleAllowlist adds lists and removes workspace rules" {
     app.tool_registry = .{ .tools = &.{builtin_tools.read_file} };
 
     try Commands(FakeApp).handleAllowlist(&app, "add command \"git *\"");
-    try expectTranscriptContains(&app, "● Allowlist: added command: \"git *\"");
+    try expectTranscriptContains(&app, "· allowlist: added command: \"git *\"");
 
     app.clearTranscript();
     try Commands(FakeApp).handleAllowlist(&app, "add tool read_file");
-    try expectTranscriptContains(&app, "● Allowlist: added tool read: \"*\"");
+    try expectTranscriptContains(&app, "· allowlist: added tool read: \"*\"");
 
     app.clearTranscript();
     try Commands(FakeApp).handleAllowlist(&app, "add url \"https://example.com/*\"");
-    try expectTranscriptContains(&app, "● Allowlist: added url: \"https://example.com/*\"");
+    try expectTranscriptContains(&app, "· allowlist: added url: \"https://example.com/*\"");
 
     app.clearTranscript();
     try Commands(FakeApp).handleAllowlist(&app, "add command echo");
-    try expectTranscriptContains(&app, "● Allowlist: added command: \"echo\"");
+    try expectTranscriptContains(&app, "· allowlist: added command: \"echo\"");
 
     _ = try config_runtime.addPermissionRule(std.testing.allocator, .local, workspace_root, "read", "docs/*", .allow);
 
@@ -2357,19 +2368,19 @@ test "session_commands handleAllowlist adds lists and removes workspace rules" {
 
     app.clearTranscript();
     try Commands(FakeApp).handleAllowlist(&app, "");
-    try expectTranscriptContains(&app, "● Allowlist: effective persistent allow rules:");
+    try expectTranscriptContains(&app, "· allowlist: effective persistent allow rules:");
     try expectTranscriptContains(&app, "  tools:\n    read: workspace, docs/*");
     try expectTranscriptContains(&app, "  commands:\n    git *, echo");
     try expectTranscriptContains(&app, "  urls:\n    https://example.com/*");
 
     app.clearTranscript();
     try Commands(FakeApp).handleAllowlist(&app, "view");
-    try expectTranscriptContains(&app, "● Allowlist: effective persistent allow rules:");
+    try expectTranscriptContains(&app, "· allowlist: effective persistent allow rules:");
     try expectTranscriptContains(&app, "  commands:\n    git *, echo");
 
     app.clearTranscript();
     try Commands(FakeApp).handleAllowlist(&app, "remove command \"git *\"");
-    try expectTranscriptContains(&app, "● Allowlist: removed command: \"git *\"");
+    try expectTranscriptContains(&app, "· allowlist: removed command: \"git *\"");
 
     var after_remove = try config_runtime.loadMergedSettings(std.testing.allocator, workspace_root);
     defer after_remove.deinit(std.testing.allocator);
@@ -2381,11 +2392,11 @@ test "session_commands handleAllowlist adds lists and removes workspace rules" {
 
     app.clearTranscript();
     try Commands(FakeApp).handleAllowlist(&app, "reset tools");
-    try expectTranscriptContains(&app, "● Allowlist: reset tools: removed 2 rules");
+    try expectTranscriptContains(&app, "· allowlist: reset tools: removed 2 rules");
 
     app.clearTranscript();
     try Commands(FakeApp).handleAllowlist(&app, "reset all");
-    try expectTranscriptContains(&app, "● Allowlist: reset all: removed 2 rules");
+    try expectTranscriptContains(&app, "· allowlist: reset all: removed 2 rules");
 
     var after_reset = try config_runtime.loadMergedSettings(std.testing.allocator, workspace_root);
     defer after_reset.deinit(std.testing.allocator);
@@ -2393,7 +2404,7 @@ test "session_commands handleAllowlist adds lists and removes workspace rules" {
 
     app.clearTranscript();
     try Commands(FakeApp).handleAllowlist(&app, "view");
-    try expectTranscriptContains(&app, "● Allowlist: effective persistent allow rules: (none)");
+    try expectTranscriptContains(&app, "· allowlist: effective persistent allow rules: (none)");
 }
 
 test "session_commands allowlist scopes expose and mutate hidden user rules independently" {
@@ -2422,19 +2433,19 @@ test "session_commands allowlist scopes expose and mutate hidden user rules inde
 
     app.clearTranscript();
     try Commands(FakeApp).handleAllowlist(&app, "view user");
-    try expectTranscriptContains(&app, "● Allowlist: user persistent allow rules:");
+    try expectTranscriptContains(&app, "· allowlist: user persistent allow rules:");
     try expectTranscriptContains(&app, "user *");
     try expectTranscriptContains(&app, "user rules are shadowed by local settings");
 
     app.clearTranscript();
     try Commands(FakeApp).handleAllowlist(&app, "view local");
-    try expectTranscriptContains(&app, "● Allowlist: local persistent allow rules:");
+    try expectTranscriptContains(&app, "· allowlist: local persistent allow rules:");
     try expectTranscriptContains(&app, "local *");
     try std.testing.expect(std.mem.find(u8, app.text(), "user *") == null);
 
     app.clearTranscript();
     try Commands(FakeApp).handleAllowlist(&app, "view effective");
-    try expectTranscriptContains(&app, "● Allowlist: effective persistent allow rules:");
+    try expectTranscriptContains(&app, "· allowlist: effective persistent allow rules:");
     try expectTranscriptContains(&app, "local *");
     try std.testing.expect(std.mem.find(u8, app.text(), "user *") == null);
 
@@ -2514,7 +2525,7 @@ test "web_fetch allowlist add remove view and reset persist exact canonical doma
     defer app.deinit();
 
     try Commands(FakeApp).handleAllowlist(&app, "add web-fetch-domain Example.COM.");
-    try expectTranscriptContains(&app, "● Allowlist: added web-fetch-domain: \"domain:example.com\"");
+    try expectTranscriptContains(&app, "· allowlist: added web-fetch-domain: \"domain:example.com\"");
 
     var settings = try config_runtime.loadMergedSettings(std.testing.allocator, workspace_root);
     defer settings.deinit(std.testing.allocator);
@@ -2527,13 +2538,13 @@ test "web_fetch allowlist add remove view and reset persist exact canonical doma
 
     app.clearTranscript();
     try Commands(FakeApp).handleAllowlist(&app, "remove web-fetch-domain EXAMPLE.com");
-    try expectTranscriptContains(&app, "● Allowlist: removed web-fetch-domain: \"domain:example.com\"");
+    try expectTranscriptContains(&app, "· allowlist: removed web-fetch-domain: \"domain:example.com\"");
 
     _ = try config_runtime.addPermissionRule(std.testing.allocator, .local, workspace_root, "web_fetch", "domain:example.com", .allow);
     _ = try config_runtime.addPermissionRule(std.testing.allocator, .local, workspace_root, "web_fetch", "domain:example.org", .allow);
     app.clearTranscript();
     try Commands(FakeApp).handleAllowlist(&app, "reset web-fetch-domains");
-    try expectTranscriptContains(&app, "● Allowlist: reset web-fetch-domains: removed 2 rules");
+    try expectTranscriptContains(&app, "· allowlist: reset web-fetch-domains: removed 2 rules");
 }
 
 test "web_fetch allowlist rejects wildcard url shaped and tool wide authorization" {
@@ -2639,7 +2650,7 @@ test "session_commands handleAllowlist recognizes tools from the active registry
     app.tool_registry = .{ .tools = &.{provider_tool} };
 
     try Commands(FakeApp).handleAllowlist(&app, "add tool provider_custom");
-    try expectTranscriptContains(&app, "● Allowlist: added tool provider_custom: \"*\"");
+    try expectTranscriptContains(&app, "· allowlist: added tool provider_custom: \"*\"");
 
     var settings = try config_runtime.loadMergedSettings(std.testing.allocator, workspace_root);
     defer settings.deinit(std.testing.allocator);
@@ -2665,7 +2676,7 @@ test "session_commands toggleFast reports unsupported model and redraws footer" 
     try std.testing.expect(app.shell.render_requests.hasReason(.footer));
     try std.testing.expect(app.worker.synced_fast_mode == null);
     try std.testing.expectEqual(@as(usize, 0), app.worker.fast_sync_count);
-    try expectTranscriptContains(&app, "● Fast: This model does not come with a fast mode.");
+    try expectTranscriptContains(&app, "· fast: This model does not come with a fast mode.");
 }
 
 test "session_commands toggleFast disables stale fast mode for unsupported model" {
@@ -2726,7 +2737,7 @@ test "session_commands toggleFast syncs queued fast mode for supported models" {
     try std.testing.expect(app.fast_mode);
     try std.testing.expectEqual(@as(?bool, true), app.worker.synced_fast_mode);
     try std.testing.expectEqual(@as(usize, 1), app.worker.fast_sync_count);
-    try expectTranscriptContains(&app, "● Fast: on");
+    try expectTranscriptContains(&app, "· fast: on");
 }
 
 test "session_commands selectModelFromPicker skips effort changes for models without reasoning support" {
@@ -2913,7 +2924,7 @@ test "session_commands user save notice uses one post-commit load after legacy c
     try Commands(FakeApp).handleModel(&app, "user/new");
 
     try std.testing.expectEqual(@as(usize, 1), app.post_commit_resolution_count);
-    try expectTranscriptContains(&app, "● Model: saved to user settings (scope=user)");
+    try expectTranscriptContains(&app, "· model: saved to user settings (scope=user)");
     try std.testing.expect(std.mem.find(u8, app.text(), "model=project") == null);
     try expectTranscriptContains(&app, "normalized 1 legacy value across 1 workspace");
     try expectTranscriptContains(&app, "settings.json.preference-migration.model.");
@@ -2947,7 +2958,7 @@ test "session_commands durable user save survives post-commit resolver failure" 
     try Commands(FakeApp).handleModel(&app, "user/new");
 
     try std.testing.expectEqual(@as(usize, 1), app.post_commit_resolution_count);
-    try expectTranscriptContains(&app, "● Model: saved to user settings (scope=user)");
+    try expectTranscriptContains(&app, "! model: saved to user settings (scope=user)");
     try expectTranscriptContains(&app, "next-startup source unknown");
     try expectTranscriptContains(&app, "normalized 1 legacy value across 1 workspace");
     try expectTranscriptContains(&app, "settings.json.preference-migration.model.");
@@ -2981,7 +2992,7 @@ test "session_commands durable user save survives post-commit resolver diagnosti
     try Commands(FakeApp).handleModel(&app, "user/new");
 
     try std.testing.expectEqual(@as(usize, 1), app.post_commit_resolution_count);
-    try expectTranscriptContains(&app, "● Model: saved to user settings (scope=user)");
+    try expectTranscriptContains(&app, "! model: saved to user settings (scope=user)");
     try expectTranscriptContains(&app, "next-startup source unknown (DurablePathUnsafe)");
 }
 
@@ -2998,7 +3009,7 @@ test "session_commands allowlist failures retain explicit scope and error" {
 
     try expectTranscriptContains(
         &app,
-        "● Allowlist: failed to add rule to settings (scope=user, error=HomeNotSet)",
+        "✗ allowlist: failed to add rule to settings (scope=user, error=HomeNotSet)",
     );
     try std.testing.expectEqual(types.NoticeTone.@"error", app.last_tone.?);
 }
@@ -3025,7 +3036,7 @@ test "session_commands allowlist durable save survives post-commit resolver diag
         "user add command \"git status *\"",
     );
 
-    try expectTranscriptContains(&app, "● Allowlist: added command");
+    try expectTranscriptContains(&app, "! allowlist: added command");
     try expectTranscriptContains(&app, "(scope=user)");
     try expectTranscriptContains(
         &app,
@@ -3049,11 +3060,11 @@ test "session_commands runtime-first model keeps runtime state when both durable
     try std.testing.expectEqual(@as(usize, 1), app.preference_commit_count);
     try expectTranscriptContains(
         &app,
-        "● Model: active for this process but not saved to user settings",
+        "✗ model: active for this process but not saved to user settings",
     );
     try expectTranscriptContains(
         &app,
-        "● Model: failed to persist current session",
+        "✗ model: failed to persist current session",
     );
 }
 
@@ -3077,7 +3088,7 @@ test "session_commands report indeterminate settings and session failures indepe
     try expectTranscriptContains(&app, "user settings persistence uncertain");
     try expectTranscriptContains(&app, "normalized 1 legacy value across 1 workspace");
     try expectTranscriptContains(&app, "recovery=/tmp/settings.json.preference-migration.model.json");
-    try expectTranscriptContains(&app, "● Model: failed to persist current session");
+    try expectTranscriptContains(&app, "✗ model: failed to persist current session");
 }
 
 test "session_commands no-op model still attempts its durable targets" {

--- a/src/core/shared/types.zig
+++ b/src/core/shared/types.zig
@@ -42,6 +42,21 @@ pub const SemanticNotice = struct {
     visibility: NoticeVisibility = .compact_and_full,
 };
 
+/// Status glyph leading every semantic notice, keyed by tone. Tool activity
+/// owns "●"; notices deliberately use distinct git-style status glyphs so the
+/// two channels never read as the same raw marker. The neutral marker "*"
+/// avoids the middot, which the footer already uses as a separator.
+pub fn noticeGlyph(tone: NoticeTone) []const u8 {
+    return switch (tone) {
+        .information => "i",
+        .success => "✓",
+        .warning => "!",
+        .@"error" => "✗",
+        .cancelled => "⊘",
+        .neutral => "*",
+    };
+}
+
 /// Returns a duplicate with owned topic and body bytes. The caller frees it
 /// with `freeSemanticNotice` using the same allocator.
 pub fn dupeSemanticNotice(alloc: std.mem.Allocator, notice: SemanticNotice) std.mem.Allocator.Error!SemanticNotice {

--- a/src/ui/render_engine/transcript_blocks.zig
+++ b/src/ui/render_engine/transcript_blocks.zig
@@ -1430,20 +1430,6 @@ fn noticeLabelStyle(styles: Styles, tone: types.NoticeTone) []const u8 {
     };
 }
 
-/// Status glyph leading every semantic notice, keyed by tone. Tool activity
-/// owns "●"; notices deliberately use distinct git-style status glyphs so the
-/// two channels never read as the same raw marker.
-fn noticeGlyph(tone: types.NoticeTone) []const u8 {
-    return switch (tone) {
-        .information => "i",
-        .success => "✓",
-        .warning => "!",
-        .@"error" => "✗",
-        .cancelled => "⊘",
-        .neutral => "·",
-    };
-}
-
 fn noticeContinuationIndent(text: []const u8, cursor: usize, cols: u16) usize {
     if (cols <= 2 or cursor >= text.len) return 0;
     const line_start = cursor > 0 and (text[cursor - 1] == '\n' or text[cursor - 1] == '\r');
@@ -1491,7 +1477,7 @@ pub fn renderSemanticNotice(
 ) ![]u8 {
     var logical: std.ArrayList(u8) = .empty;
     defer logical.deinit(alloc);
-    try logical.appendSlice(alloc, noticeGlyph(notice.tone));
+    try logical.appendSlice(alloc, types.noticeGlyph(notice.tone));
     try logical.append(alloc, ' ');
     // An empty topic drops the "topic:" label and renders the body alone.
     if (notice.topic.len > 0) {
@@ -2804,7 +2790,7 @@ test "semantic notice glyph grid regression locks tone markers and lowercase top
         row_text: []const u8,
         label_fg: u8,
     }{
-        .{ .tone = .neutral, .topic = "session", .body = "renamed to \"custom models\"", .row_text = "· session: renamed to \"custom models\"", .label_fg = 7 },
+        .{ .tone = .neutral, .topic = "session", .body = "renamed to \"custom models\"", .row_text = "* session: renamed to \"custom models\"", .label_fg = 7 },
         .{ .tone = .information, .topic = "background", .body = "command #7 started", .row_text = "i background: command #7 started", .label_fg = 6 },
         .{ .tone = .success, .topic = "upgrade", .body = "fx has been updated to v9.9.9", .row_text = "✓ upgrade: fx has been updated to v9.9.9", .label_fg = 2 },
         .{ .tone = .warning, .topic = "skills", .body = "1 discovery issue", .row_text = "! skills: 1 discovery issue", .label_fg = 3 },
@@ -2883,7 +2869,7 @@ test "semantic notice keeps an OSC 8 target hidden and clickable" {
     var row: std.ArrayList(u8) = .empty;
     defer row.deinit(alloc);
     try grid.rowTextTrimmed(1, &row);
-    try std.testing.expectEqualStrings("· feedback: Open feedback form.", row.items);
+    try std.testing.expectEqualStrings("* feedback: Open feedback form.", row.items);
 
     const link_cell = grid.cellAt(1, 13).?;
     try std.testing.expectEqual(@as(u21, 'O'), link_cell.codepoint);
@@ -2949,10 +2935,10 @@ test "background semantic notices render one topic for launch and failure" {
 test "semantic notice tree branches align with the header while wrapped prose stays indented" {
     const alloc = std.testing.allocator;
     const cases = [_]struct { body: []const u8, cols: u16, expected: []const u8 }{
-        .{ .body = "2 skills loaded\n├ Loaded alpha\n└ Loaded beta", .cols = 40, .expected = "· 2 skills loaded\n├ Loaded alpha\n└ Loaded beta" },
-        .{ .body = "Ready\n└ alpha beta gamma", .cols = 12, .expected = "· Ready\n└ alpha beta\n  gamma" },
-        .{ .body = "alpha └ beta", .cols = 8, .expected = "· alpha\n  └ beta" },
-        .{ .body = "Ready\nordinary prose", .cols = 40, .expected = "· Ready\n  ordinary prose" },
+        .{ .body = "2 skills loaded\n├ Loaded alpha\n└ Loaded beta", .cols = 40, .expected = "* 2 skills loaded\n├ Loaded alpha\n└ Loaded beta" },
+        .{ .body = "Ready\n└ alpha beta gamma", .cols = 12, .expected = "* Ready\n└ alpha beta\n  gamma" },
+        .{ .body = "alpha └ beta", .cols = 8, .expected = "* alpha\n  └ beta" },
+        .{ .body = "Ready\nordinary prose", .cols = 40, .expected = "* Ready\n  ordinary prose" },
     };
     for (cases) |case| {
         const rendered = try renderSemanticNotice(alloc, .{ .topic = "", .tone = .neutral, .body = case.body }, .{}, case.cols);
@@ -2968,7 +2954,7 @@ test "semantic notice tree branches align with the header while wrapped prose st
     var grid = try vt_emulator.Grid.init(alloc, 40, 4);
     defer grid.deinit();
     try grid.feed(styled);
-    try std.testing.expectEqual(@as(u21, '·'), grid.cellAt(1, 1).?.codepoint);
+    try std.testing.expectEqual(@as(u21, '*'), grid.cellAt(1, 1).?.codepoint);
     try std.testing.expectEqual(@as(u21, '├'), grid.cellAt(2, 1).?.codepoint);
     try std.testing.expectEqual(@as(u21, '└'), grid.cellAt(3, 1).?.codepoint);
 }

--- a/src/ui/render_engine/transcript_blocks.zig
+++ b/src/ui/render_engine/transcript_blocks.zig
@@ -1430,6 +1430,20 @@ fn noticeLabelStyle(styles: Styles, tone: types.NoticeTone) []const u8 {
     };
 }
 
+/// Status glyph leading every semantic notice, keyed by tone. Tool activity
+/// owns "●"; notices deliberately use distinct git-style status glyphs so the
+/// two channels never read as the same raw marker.
+fn noticeGlyph(tone: types.NoticeTone) []const u8 {
+    return switch (tone) {
+        .information => "i",
+        .success => "✓",
+        .warning => "!",
+        .@"error" => "✗",
+        .cancelled => "⊘",
+        .neutral => "·",
+    };
+}
+
 fn noticeContinuationIndent(text: []const u8, cursor: usize, cols: u16) usize {
     if (cols <= 2 or cursor >= text.len) return 0;
     const line_start = cursor > 0 and (text[cursor - 1] == '\n' or text[cursor - 1] == '\r');
@@ -1477,11 +1491,11 @@ pub fn renderSemanticNotice(
 ) ![]u8 {
     var logical: std.ArrayList(u8) = .empty;
     defer logical.deinit(alloc);
-    try logical.appendSlice(alloc, "● ");
-    // An empty topic drops the "Topic:" label and renders the body alone.
+    try logical.appendSlice(alloc, noticeGlyph(notice.tone));
+    try logical.append(alloc, ' ');
+    // An empty topic drops the "topic:" label and renders the body alone.
     if (notice.topic.len > 0) {
-        try logical.append(alloc, std.ascii.toUpper(notice.topic[0]));
-        try logical.appendSlice(alloc, notice.topic[1..]);
+        try logical.appendSlice(alloc, notice.topic);
         try logical.append(alloc, ':');
     }
     const label_end = logical.items.len;
@@ -1767,7 +1781,7 @@ test "auto permission notice contributes content only to full presentation" {
     defer full.deinit(alloc);
     try std.testing.expectEqual(TranscriptBlockKind.system_notice, full.kind);
     try std.testing.expectEqualStrings(
-        "● System: Auto agent approved this request: Running command.",
+        "i system: Auto agent approved this request: Running command.",
         full.bytes,
     );
 }
@@ -2738,8 +2752,9 @@ test "semantic notice renders every tone and resets before following content" {
     };
     const tones = [_]types.NoticeTone{ .information, .success, .warning, .@"error", .cancelled };
     const label_styles = [_][]const u8{ "\x1b[36m", "\x1b[32m", "\x1b[33m", "\x1b[31m", "\x1b[90m" };
+    const glyphs = [_][]const u8{ "i", "✓", "!", "✗", "⊘" };
 
-    for (tones, label_styles) |tone, label_style| {
+    for (tones, label_styles, glyphs) |tone, label_style, glyph| {
         const rendered = try renderSemanticNotice(alloc, .{
             .topic = "topic",
             .tone = tone,
@@ -2749,11 +2764,12 @@ test "semantic notice renders every tone and resets before following content" {
 
         const expected = try std.fmt.allocPrint(
             alloc,
-            "{s}● Topic:\x1b[0m\x1b[37m body\x1b[0m",
-            .{label_style},
+            "{s}{s} topic:\x1b[0m\x1b[37m body\x1b[0m",
+            .{ label_style, glyph },
         );
         defer alloc.free(expected);
         try std.testing.expectEqualStrings(expected, rendered);
+        try std.testing.expect(std.mem.find(u8, rendered, "●") == null);
         try std.testing.expect(std.mem.find(u8, rendered, "[Topic]") == null);
 
         var feed: std.ArrayList(u8) = .empty;
@@ -2767,6 +2783,81 @@ test "semantic notice renders every tone and resets before following content" {
         try std.testing.expectEqual(@as(u21, 'Z'), following.codepoint);
         try std.testing.expect(following.style.fg.eql(.default));
         try std.testing.expect(following.style.bg.eql(.default));
+    }
+}
+
+test "semantic notice glyph grid regression locks tone markers and lowercase topic" {
+    const alloc = std.testing.allocator;
+    const styles: Styles = .{
+        .system_notice_text_style = "\x1b[37m",
+        .reset_style = "\x1b[0m",
+        .notice_information_style = "\x1b[36m",
+        .notice_success_style = "\x1b[32m",
+        .notice_warning_style = "\x1b[33m",
+        .notice_error_style = "\x1b[31m",
+        .notice_cancelled_style = "\x1b[90m",
+    };
+    const cases = [_]struct {
+        tone: types.NoticeTone,
+        topic: []const u8,
+        body: []const u8,
+        row_text: []const u8,
+        label_fg: u8,
+    }{
+        .{ .tone = .neutral, .topic = "session", .body = "renamed to \"custom models\"", .row_text = "· session: renamed to \"custom models\"", .label_fg = 7 },
+        .{ .tone = .information, .topic = "background", .body = "command #7 started", .row_text = "i background: command #7 started", .label_fg = 6 },
+        .{ .tone = .success, .topic = "upgrade", .body = "fx has been updated to v9.9.9", .row_text = "✓ upgrade: fx has been updated to v9.9.9", .label_fg = 2 },
+        .{ .tone = .warning, .topic = "skills", .body = "1 discovery issue", .row_text = "! skills: 1 discovery issue", .label_fg = 3 },
+        .{ .tone = .@"error", .topic = "session", .body = "usage: /rename <title>", .row_text = "✗ session: usage: /rename <title>", .label_fg = 1 },
+        .{ .tone = .cancelled, .topic = "system", .body = "cancelled", .row_text = "⊘ system: cancelled", .label_fg = 8 },
+    };
+
+    for (cases) |case| {
+        const rendered = try renderSemanticNotice(alloc, .{
+            .topic = case.topic,
+            .tone = case.tone,
+            .body = case.body,
+        }, styles, 80);
+        defer alloc.free(rendered);
+
+        var grid = try vt_emulator.Grid.init(alloc, 80, 2);
+        defer grid.deinit();
+        try grid.feed(rendered);
+
+        var row: std.ArrayList(u8) = .empty;
+        defer row.deinit(alloc);
+        try grid.rowTextTrimmed(1, &row);
+        try std.testing.expectEqualStrings(case.row_text, row.items);
+
+        // The glyph and lowercase topic carry the tone color; the body is grey.
+        // Columns are 1-based: glyph, space, topic cells, then the colon.
+        const colon_col: u16 = @intCast(3 + case.topic.len);
+        const fg_index = struct {
+            fn get(cell: vt_emulator.Cell) u8 {
+                return switch (cell.style.fg) {
+                    .indexed => |ix| ix,
+                    else => 255,
+                };
+            }
+        }.get;
+        try std.testing.expectEqual(case.label_fg, fg_index(grid.cellAt(1, 1).?));
+        try std.testing.expectEqual(case.label_fg, fg_index(grid.cellAt(1, colon_col).?));
+        try std.testing.expectEqual(@as(u8, 7), fg_index(grid.cellAt(1, colon_col + 2).?));
+    }
+}
+
+test "semantic notice topics never render the tool-activity bullet or forced capitalization" {
+    const alloc = std.testing.allocator;
+    for ([_]types.NoticeTone{ .neutral, .information, .success, .warning, .@"error", .cancelled }) |tone| {
+        const rendered = try renderSemanticNotice(alloc, .{
+            .topic = "mcp",
+            .tone = tone,
+            .body = "body",
+        }, .{}, 80);
+        defer alloc.free(rendered);
+        try std.testing.expect(std.mem.find(u8, rendered, "●") == null);
+        try std.testing.expect(std.mem.find(u8, rendered, "Mcp") == null);
+        try std.testing.expect(std.mem.find(u8, rendered, "mcp:") != null);
     }
 }
 
@@ -2792,7 +2883,7 @@ test "semantic notice keeps an OSC 8 target hidden and clickable" {
     var row: std.ArrayList(u8) = .empty;
     defer row.deinit(alloc);
     try grid.rowTextTrimmed(1, &row);
-    try std.testing.expectEqualStrings("● Feedback: Open feedback form.", row.items);
+    try std.testing.expectEqualStrings("· feedback: Open feedback form.", row.items);
 
     const link_cell = grid.cellAt(1, 13).?;
     try std.testing.expectEqual(@as(u21, 'O'), link_cell.codepoint);
@@ -2834,7 +2925,7 @@ test "background semantic notices render one topic for launch and failure" {
     }, .{}, 80);
     defer alloc.free(launch);
     try std.testing.expectEqualStrings(
-        "● Background: Command #1 started. Log: /tmp/run.log",
+        "i background: Command #1 started. Log: /tmp/run.log",
         launch,
     );
 
@@ -2845,23 +2936,23 @@ test "background semantic notices render one topic for launch and failure" {
     }, .{}, 80);
     defer alloc.free(failure);
     try std.testing.expectEqualStrings(
-        "● Background: Command #1 failed (exit 1).",
+        "✗ background: Command #1 failed (exit 1).",
         failure,
     );
 
     for ([_][]const u8{ launch, failure }) |rendered| {
-        try std.testing.expect(std.mem.find(u8, rendered, "System: Background") == null);
-        try std.testing.expect(std.mem.find(u8, rendered, "Background: Background") == null);
+        try std.testing.expect(std.mem.find(u8, rendered, "system: background") == null);
+        try std.testing.expect(std.mem.find(u8, rendered, "background: background") == null);
     }
 }
 
 test "semantic notice tree branches align with the header while wrapped prose stays indented" {
     const alloc = std.testing.allocator;
     const cases = [_]struct { body: []const u8, cols: u16, expected: []const u8 }{
-        .{ .body = "2 skills loaded\n├ Loaded alpha\n└ Loaded beta", .cols = 40, .expected = "● 2 skills loaded\n├ Loaded alpha\n└ Loaded beta" },
-        .{ .body = "Ready\n└ alpha beta gamma", .cols = 12, .expected = "● Ready\n└ alpha beta\n  gamma" },
-        .{ .body = "alpha └ beta", .cols = 8, .expected = "● alpha\n  └ beta" },
-        .{ .body = "Ready\nordinary prose", .cols = 40, .expected = "● Ready\n  ordinary prose" },
+        .{ .body = "2 skills loaded\n├ Loaded alpha\n└ Loaded beta", .cols = 40, .expected = "· 2 skills loaded\n├ Loaded alpha\n└ Loaded beta" },
+        .{ .body = "Ready\n└ alpha beta gamma", .cols = 12, .expected = "· Ready\n└ alpha beta\n  gamma" },
+        .{ .body = "alpha └ beta", .cols = 8, .expected = "· alpha\n  └ beta" },
+        .{ .body = "Ready\nordinary prose", .cols = 40, .expected = "· Ready\n  ordinary prose" },
     };
     for (cases) |case| {
         const rendered = try renderSemanticNotice(alloc, .{ .topic = "", .tone = .neutral, .body = case.body }, .{}, case.cols);
@@ -2877,7 +2968,7 @@ test "semantic notice tree branches align with the header while wrapped prose st
     var grid = try vt_emulator.Grid.init(alloc, 40, 4);
     defer grid.deinit();
     try grid.feed(styled);
-    try std.testing.expectEqual(@as(u21, '●'), grid.cellAt(1, 1).?.codepoint);
+    try std.testing.expectEqual(@as(u21, '·'), grid.cellAt(1, 1).?.codepoint);
     try std.testing.expectEqual(@as(u21, '├'), grid.cellAt(2, 1).?.codepoint);
     try std.testing.expectEqual(@as(u21, '└'), grid.cellAt(3, 1).?.codepoint);
 }
@@ -2887,7 +2978,7 @@ test "semantic notice wraps words paths UTF-8 and explicit newlines without trun
     const body = "alpha beta/gamma/delta\n東京🙂 final-token";
     var logical: std.ArrayList(u8) = .empty;
     defer logical.deinit(alloc);
-    try appendWithoutAsciiWhitespace(&logical, alloc, "● System: ");
+    try appendWithoutAsciiWhitespace(&logical, alloc, "i system: ");
     try appendWithoutAsciiWhitespace(&logical, alloc, body);
 
     for ([_]u16{ 0, 1, 2, 3, 6, 12, 18 }) |cols| {
@@ -2916,7 +3007,7 @@ test "semantic notice wraps words paths UTF-8 and explicit newlines without trun
         .body = "alpha/beta/gamma",
     }, .{}, 11);
     defer alloc.free(path);
-    try std.testing.expectEqualStrings("● X: alpha/\n  beta/\n  gamma", path);
+    try std.testing.expectEqualStrings("i x: alpha/\n  beta/\n  gamma", path);
 
     const words = try renderSemanticNotice(alloc, .{
         .topic = "x",
@@ -2924,7 +3015,7 @@ test "semantic notice wraps words paths UTF-8 and explicit newlines without trun
         .body = "one two\nthree",
     }, .{}, 9);
     defer alloc.free(words);
-    try std.testing.expectEqualStrings("● X: one\n  two\n  three", words);
+    try std.testing.expectEqualStrings("i x: one\n  two\n  three", words);
 }
 
 test "semantic notices are independent blocks with exact neighboring and footer gaps" {
@@ -2947,7 +3038,7 @@ test "semantic notices are independent blocks with exact neighboring and footer 
     const rendered = try renderEntriesToBytes(alloc, entries.items, 80, .{});
     defer alloc.free(rendered);
     try std.testing.expectEqualStrings(
-        "before\n\n● One: first\n\n● Two: second\n\nafter",
+        "before\n\ni one: first\n\n✓ two: second\n\nafter",
         rendered,
     );
     try std.testing.expectEqual(@as(u16, 1), footerBoundaryGapRowsForTail(.system_notice));
@@ -2981,7 +3072,7 @@ test "semantic notice visibility tail classification and provenance remain seman
         .{ .capture_provenance = true },
     );
     defer prepared.deinit(alloc);
-    try std.testing.expectEqualStrings("● Hidden: full only", prepared.bytes);
+    try std.testing.expectEqualStrings("✗ hidden: full only", prepared.bytes);
     try std.testing.expectEqual(@as(usize, 1), prepared.line_provenance.len);
     try std.testing.expectEqualDeep(
         LineProvenance{ .entry = .{ .entry_id = 41, .entry_class = .error_notice } },
@@ -3606,7 +3697,7 @@ test "compact presentation hides context notices while full presentation retains
 
     const compact = try renderEntriesToBytes(alloc, entries.items, 80, .{});
     defer alloc.free(compact);
-    try std.testing.expect(std.mem.indexOf(u8, compact, "Context:") == null);
+    try std.testing.expect(std.mem.indexOf(u8, compact, "context:") == null);
     try std.testing.expect(std.mem.indexOf(u8, compact, "ordinary system notice") != null);
     try std.testing.expect(std.mem.indexOf(u8, compact, "ordinary error notice") != null);
 
@@ -3614,8 +3705,8 @@ test "compact presentation hides context notices while full presentation retains
     defer first_full.deinit(alloc);
     const second_full = try renderEntryToBlockForPresentation(alloc, entries.items[2], 80, .{}, .full);
     defer second_full.deinit(alloc);
-    try std.testing.expectEqualStrings("● Context: first warning", first_full.bytes);
-    try std.testing.expectEqualStrings("● Context: second warning", second_full.bytes);
+    try std.testing.expectEqualStrings("! context: first warning", first_full.bytes);
+    try std.testing.expectEqualStrings("! context: second warning", second_full.bytes);
     try std.testing.expectEqual(TranscriptEntryClass.context_notice, entryClassForEntry(entries.items[0]));
 }
 

--- a/tests/e2e/ask-presentation.test.ts
+++ b/tests/e2e/ask-presentation.test.ts
@@ -863,7 +863,7 @@ describe("fx ask presentation", () => {
       expect(scrollback).toContain("1 tool call · 1 command");
       expect(scrollback).not.toContain("project instructions");
       expect(scrollback).not.toContain("Auto agent approved this request");
-      expect(scrollback).not.toContain("● System:");
+      expect(scrollback).not.toMatch(/[·✓!✗⊘i] system:/);
     },
     TIMEOUT,
   );

--- a/tests/e2e/ask-presentation.test.ts
+++ b/tests/e2e/ask-presentation.test.ts
@@ -863,7 +863,7 @@ describe("fx ask presentation", () => {
       expect(scrollback).toContain("1 tool call · 1 command");
       expect(scrollback).not.toContain("project instructions");
       expect(scrollback).not.toContain("Auto agent approved this request");
-      expect(scrollback).not.toMatch(/[·✓!✗⊘i] system:/);
+      expect(scrollback).not.toMatch(/[*✓!✗⊘i] system:/);
     },
     TIMEOUT,
   );

--- a/tests/e2e/config-persistence.test.ts
+++ b/tests/e2e/config-persistence.test.ts
@@ -109,7 +109,7 @@ function migrationSnapshotPath(home: string, field: string): string {
 function clearedPaneWithoutAllowlistRules(pane: string): boolean {
   return (
     hasEmptyComposer(pane) &&
-    !pane.match(/[·✓!✗⊘i] allowlist:/) &&
+    !pane.match(/[*✓!✗⊘i] allowlist:/) &&
     !pane.includes("user *")
   );
 }
@@ -214,15 +214,15 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
         );
         expect(beforeModelCommit).not.toHaveProperty("model");
         await session.sendKeys("Enter");
-        await session.waitForText("· Switched to anthropic/claude-opus-4.7", TIMEOUT);
+        await session.waitForText("* Switched to anthropic/claude-opus-4.7", TIMEOUT);
         await session.sendText("/fast");
-        await session.waitForText("· fast: on", TIMEOUT);
+        await session.waitForText("* fast: on", TIMEOUT);
         await session.sendText("/statusline context");
-        await session.waitForText("· statusline: context:", TIMEOUT);
+        await session.waitForText("* statusline: context:", TIMEOUT);
         await session.sendText("/statusline session");
-        await session.waitForText("· statusline: session:", TIMEOUT);
+        await session.waitForText("* statusline: session:", TIMEOUT);
         await session.sendText("/statusline workspace");
-        await session.waitForText("· statusline: workspace:", TIMEOUT);
+        await session.waitForText("* statusline: workspace:", TIMEOUT);
         await session.sendText("/settings startup-scrollback off");
         await session.waitForText("startup_scrollback: off", TIMEOUT);
         await disablePromptHistory(session, join(home, ".fx", "settings.json"));
@@ -396,13 +396,13 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
         await session.waitForText("Run /help", TIMEOUT);
         await session.sendText("/allowlist view local");
         await session.waitForText(
-          "· allowlist: local persistent allow rules: (none)",
+          "* allowlist: local persistent allow rules: (none)",
           TIMEOUT,
         );
         await session.sendText("/allowlist view user");
         await session.waitForText("user *", TIMEOUT);
         await session.sendText('/allowlist user remove command "padded *"');
-        await session.waitForText("· allowlist: removed command", TIMEOUT);
+        await session.waitForText("* allowlist: removed command", TIMEOUT);
         await session.sendText("/clear");
         await session.waitForPane(
           clearedPaneWithoutAllowlistRules,
@@ -410,7 +410,7 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
         );
         await session.sendText("/allowlist view effective");
         const inherited = await session.waitForText("user *", TIMEOUT);
-        expect(inherited).toContain("· allowlist: effective persistent allow rules:");
+        expect(inherited).toContain("* allowlist: effective persistent allow rules:");
 
         await session.sendText('/allowlist add command "local-b *"');
         await session.waitForText("(scope=local)", TIMEOUT);
@@ -430,7 +430,7 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
         expect(localEffective).not.toContain("user *");
 
         await session.sendText('/allowlist user remove command "user *"');
-        await session.waitForText("· allowlist: removed command", TIMEOUT);
+        await session.waitForText("* allowlist: removed command", TIMEOUT);
         await session.sendText("/quit");
         await session.waitForSessionEnd(TIMEOUT);
         session = null;
@@ -1236,7 +1236,7 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
         const pickerPane = await session.waitForText("xai/grok-build-1", TIMEOUT);
         expect(pickerPane).toContain("xai/grok-build-1");
         await session.sendKeys("Enter");
-        await session.waitForText("· Switched to xai/grok-build-1", TIMEOUT);
+        await session.waitForText("* Switched to xai/grok-build-1", TIMEOUT);
         await session.waitForPane(
           (pane) =>
             hasEmptyComposer(pane) &&
@@ -1253,7 +1253,7 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
 
         const scrollback = await session.captureFullScrollbackEscapes();
         expect(scrollback).toContain("grok-build-1");
-        expect(scrollback).toContain("· Switched to xai/grok-build-1");
+        expect(scrollback).toContain("* Switched to xai/grok-build-1");
         expect(gateway.requests).toHaveLength(0);
 
         await session.sendText("/quit");
@@ -1316,7 +1316,7 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
         });
         await session.waitForText("Run /help", TIMEOUT);
         await session.sendText("/statusline context");
-        await session.waitForText("· statusline: context: on", TIMEOUT);
+        await session.waitForText("* statusline: context: on", TIMEOUT);
         await session.sendLiteral("/model new-reasoning");
         await session.waitForText("provider/new-reasoning-model", TIMEOUT);
         await session.sendKeys("Enter");
@@ -1324,7 +1324,7 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
         expect(autoEffortPicker).toContain("future-tier");
         expect(autoEffortPicker).toContain("high");
         await session.sendKeys("Enter");
-        await session.waitForText("· Switched to provider/new-reasoning-model", TIMEOUT);
+        await session.waitForText("* Switched to provider/new-reasoning-model", TIMEOUT);
 
         let stored = JSON.parse(readFileSync(join(home, ".fx", "settings.json"), "utf8"));
         expect(stored.models.gateway).toBe("provider/new-reasoning-model");
@@ -1335,8 +1335,8 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
         await session.waitForText("portable auto complete", TIMEOUT);
         const footer = await session.waitForText("0k/750k 0%", TIMEOUT);
         expect(footer).toContain("new-reasoning-model");
-        expect(footer).not.toMatch(/[·✓!✗⊘i] context:/);
-        expect(await session.captureFullScrollbackEscapes()).not.toMatch(/[·✓!✗⊘i] context:/);
+        expect(footer).not.toMatch(/[*✓!✗⊘i] context:/);
+        expect(await session.captureFullScrollbackEscapes()).not.toMatch(/[*✓!✗⊘i] context:/);
         expect(gateway.requests).toHaveLength(1);
         expect(gateway.requests[0]!.headers.get("ai-language-model-id")).toBe(
           "provider/new-reasoning-model",
@@ -1355,7 +1355,7 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
         await session.sendKeys("Down");
         await session.waitForText("future-tier", TIMEOUT);
         await session.sendKeys("Enter");
-        await session.waitForText("· future-tier", TIMEOUT);
+        await session.waitForText("* future-tier", TIMEOUT);
 
         stored = JSON.parse(readFileSync(join(home, ".fx", "settings.json"), "utf8"));
         const persistenceDeadline = Date.now() + TIMEOUT;
@@ -1636,7 +1636,7 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
         ]);
         await Promise.all([
           session.waitForText("startup_scrollback: off", TIMEOUT),
-          secondSession.waitForText("· statusline: context:", TIMEOUT),
+          secondSession.waitForText("* statusline: context:", TIMEOUT),
         ]);
         await Promise.all([
           session.sendText("/quit"),

--- a/tests/e2e/config-persistence.test.ts
+++ b/tests/e2e/config-persistence.test.ts
@@ -1335,8 +1335,8 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
         await session.waitForText("portable auto complete", TIMEOUT);
         const footer = await session.waitForText("0k/750k 0%", TIMEOUT);
         expect(footer).toContain("new-reasoning-model");
-        expect(footer).not.toContain("context:");
-        expect(await session.captureFullScrollbackEscapes()).not.toContain("context:");
+        expect(footer).not.toMatch(/[·✓!✗⊘i] context:/);
+        expect(await session.captureFullScrollbackEscapes()).not.toMatch(/[·✓!✗⊘i] context:/);
         expect(gateway.requests).toHaveLength(1);
         expect(gateway.requests[0]!.headers.get("ai-language-model-id")).toBe(
           "provider/new-reasoning-model",

--- a/tests/e2e/config-persistence.test.ts
+++ b/tests/e2e/config-persistence.test.ts
@@ -109,7 +109,7 @@ function migrationSnapshotPath(home: string, field: string): string {
 function clearedPaneWithoutAllowlistRules(pane: string): boolean {
   return (
     hasEmptyComposer(pane) &&
-    !pane.includes("● Allowlist:") &&
+    !pane.match(/[·✓!✗⊘i] allowlist:/) &&
     !pane.includes("user *")
   );
 }
@@ -214,15 +214,15 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
         );
         expect(beforeModelCommit).not.toHaveProperty("model");
         await session.sendKeys("Enter");
-        await session.waitForText("● Switched to anthropic/claude-opus-4.7", TIMEOUT);
+        await session.waitForText("· Switched to anthropic/claude-opus-4.7", TIMEOUT);
         await session.sendText("/fast");
-        await session.waitForText("● Fast: on", TIMEOUT);
+        await session.waitForText("· fast: on", TIMEOUT);
         await session.sendText("/statusline context");
-        await session.waitForText("● Statusline: context:", TIMEOUT);
+        await session.waitForText("· statusline: context:", TIMEOUT);
         await session.sendText("/statusline session");
-        await session.waitForText("● Statusline: session:", TIMEOUT);
+        await session.waitForText("· statusline: session:", TIMEOUT);
         await session.sendText("/statusline workspace");
-        await session.waitForText("● Statusline: workspace:", TIMEOUT);
+        await session.waitForText("· statusline: workspace:", TIMEOUT);
         await session.sendText("/settings startup-scrollback off");
         await session.waitForText("startup_scrollback: off", TIMEOUT);
         await disablePromptHistory(session, join(home, ".fx", "settings.json"));
@@ -396,13 +396,13 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
         await session.waitForText("Run /help", TIMEOUT);
         await session.sendText("/allowlist view local");
         await session.waitForText(
-          "● Allowlist: local persistent allow rules: (none)",
+          "· allowlist: local persistent allow rules: (none)",
           TIMEOUT,
         );
         await session.sendText("/allowlist view user");
         await session.waitForText("user *", TIMEOUT);
         await session.sendText('/allowlist user remove command "padded *"');
-        await session.waitForText("● Allowlist: removed command", TIMEOUT);
+        await session.waitForText("· allowlist: removed command", TIMEOUT);
         await session.sendText("/clear");
         await session.waitForPane(
           clearedPaneWithoutAllowlistRules,
@@ -410,7 +410,7 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
         );
         await session.sendText("/allowlist view effective");
         const inherited = await session.waitForText("user *", TIMEOUT);
-        expect(inherited).toContain("● Allowlist: effective persistent allow rules:");
+        expect(inherited).toContain("· allowlist: effective persistent allow rules:");
 
         await session.sendText('/allowlist add command "local-b *"');
         await session.waitForText("(scope=local)", TIMEOUT);
@@ -430,7 +430,7 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
         expect(localEffective).not.toContain("user *");
 
         await session.sendText('/allowlist user remove command "user *"');
-        await session.waitForText("● Allowlist: removed command", TIMEOUT);
+        await session.waitForText("· allowlist: removed command", TIMEOUT);
         await session.sendText("/quit");
         await session.waitForSessionEnd(TIMEOUT);
         session = null;
@@ -1236,7 +1236,7 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
         const pickerPane = await session.waitForText("xai/grok-build-1", TIMEOUT);
         expect(pickerPane).toContain("xai/grok-build-1");
         await session.sendKeys("Enter");
-        await session.waitForText("● Switched to xai/grok-build-1", TIMEOUT);
+        await session.waitForText("· Switched to xai/grok-build-1", TIMEOUT);
         await session.waitForPane(
           (pane) =>
             hasEmptyComposer(pane) &&
@@ -1253,7 +1253,7 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
 
         const scrollback = await session.captureFullScrollbackEscapes();
         expect(scrollback).toContain("grok-build-1");
-        expect(scrollback).toContain("● Switched to xai/grok-build-1");
+        expect(scrollback).toContain("· Switched to xai/grok-build-1");
         expect(gateway.requests).toHaveLength(0);
 
         await session.sendText("/quit");
@@ -1316,7 +1316,7 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
         });
         await session.waitForText("Run /help", TIMEOUT);
         await session.sendText("/statusline context");
-        await session.waitForText("● Statusline: context: on", TIMEOUT);
+        await session.waitForText("· statusline: context: on", TIMEOUT);
         await session.sendLiteral("/model new-reasoning");
         await session.waitForText("provider/new-reasoning-model", TIMEOUT);
         await session.sendKeys("Enter");
@@ -1324,7 +1324,7 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
         expect(autoEffortPicker).toContain("future-tier");
         expect(autoEffortPicker).toContain("high");
         await session.sendKeys("Enter");
-        await session.waitForText("● Switched to provider/new-reasoning-model", TIMEOUT);
+        await session.waitForText("· Switched to provider/new-reasoning-model", TIMEOUT);
 
         let stored = JSON.parse(readFileSync(join(home, ".fx", "settings.json"), "utf8"));
         expect(stored.models.gateway).toBe("provider/new-reasoning-model");
@@ -1335,8 +1335,8 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
         await session.waitForText("portable auto complete", TIMEOUT);
         const footer = await session.waitForText("0k/750k 0%", TIMEOUT);
         expect(footer).toContain("new-reasoning-model");
-        expect(footer).not.toContain("Context:");
-        expect(await session.captureFullScrollbackEscapes()).not.toContain("Context:");
+        expect(footer).not.toContain("context:");
+        expect(await session.captureFullScrollbackEscapes()).not.toContain("context:");
         expect(gateway.requests).toHaveLength(1);
         expect(gateway.requests[0]!.headers.get("ai-language-model-id")).toBe(
           "provider/new-reasoning-model",
@@ -1636,7 +1636,7 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
         ]);
         await Promise.all([
           session.waitForText("startup_scrollback: off", TIMEOUT),
-          secondSession.waitForText("● Statusline: context:", TIMEOUT),
+          secondSession.waitForText("· statusline: context:", TIMEOUT),
         ]);
         await Promise.all([
           session.sendText("/quit"),

--- a/tests/e2e/config-persistence.test.ts
+++ b/tests/e2e/config-persistence.test.ts
@@ -1355,7 +1355,7 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
         await session.sendKeys("Down");
         await session.waitForText("future-tier", TIMEOUT);
         await session.sendKeys("Enter");
-        await session.waitForText("* future-tier", TIMEOUT);
+        await session.waitForText("· future-tier", TIMEOUT);
 
         stored = JSON.parse(readFileSync(join(home, ".fx", "settings.json"), "utf8"));
         const persistenceDeadline = Date.now() + TIMEOUT;

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -1634,7 +1634,7 @@ describe("gateway stream lifecycle", () => {
         expect(full.indexOf("project instruction file")).toBeLessThan(
           full.indexOf("skill catalog shortened"),
         );
-        expect(full).toContain("● Context:");
+        expect(full).toContain("! context:");
         expect(full).not.toContain("[context]");
         const fullGrid = await tui.capturePaneGrid();
         const fullNavigationRow = fullGrid.findIndex((row) =>
@@ -1882,7 +1882,7 @@ describe("gateway stream lifecycle", () => {
         expect(full.indexOf("skill resource")).toBeLessThan(
           full.indexOf("MCP schema"),
         );
-        expect(full).toContain("● Context:");
+        expect(full).toContain("! context:");
         expect(full).not.toContain("[context]");
         await tui.sendKeys("C-o");
         await tui.waitForPane(

--- a/tests/e2e/notifications.test.ts
+++ b/tests/e2e/notifications.test.ts
@@ -169,7 +169,7 @@ test.skipIf(!tmuxAvailable())(
 
       await session.sendText("/sound on");
       await session.waitForPane(
-        (pane) => (pane.match(/· sound: on/g)?.length ?? 0) >= 2,
+        (pane) => (pane.match(/\* sound: on/g)?.length ?? 0) >= 2,
         TIMEOUT,
       );
       settings = JSON.parse(readFileSync(settingsPath, "utf8"));

--- a/tests/e2e/notifications.test.ts
+++ b/tests/e2e/notifications.test.ts
@@ -146,7 +146,7 @@ test.skipIf(!tmuxAvailable())(
       });
       await session.waitForComposer(TIMEOUT);
       await session.sendText("/sound");
-      await session.waitForText("· sound: on", TIMEOUT);
+      await session.waitForText("* sound: on", TIMEOUT);
       expect(await session.captureFullScrollback()).not.toContain(
         "saved to user settings",
       );
@@ -159,7 +159,7 @@ test.skipIf(!tmuxAvailable())(
       });
 
       await session.sendText("/sound off");
-      await session.waitForText("· sound: off", TIMEOUT);
+      await session.waitForText("* sound: off", TIMEOUT);
       settings = JSON.parse(readFileSync(settingsPath, "utf8"));
       expect(settings.notifications).toEqual({
         turn_end: false,

--- a/tests/e2e/notifications.test.ts
+++ b/tests/e2e/notifications.test.ts
@@ -146,7 +146,7 @@ test.skipIf(!tmuxAvailable())(
       });
       await session.waitForComposer(TIMEOUT);
       await session.sendText("/sound");
-      await session.waitForText("● Sound: on", TIMEOUT);
+      await session.waitForText("· sound: on", TIMEOUT);
       expect(await session.captureFullScrollback()).not.toContain(
         "saved to user settings",
       );
@@ -159,7 +159,7 @@ test.skipIf(!tmuxAvailable())(
       });
 
       await session.sendText("/sound off");
-      await session.waitForText("● Sound: off", TIMEOUT);
+      await session.waitForText("· sound: off", TIMEOUT);
       settings = JSON.parse(readFileSync(settingsPath, "utf8"));
       expect(settings.notifications).toEqual({
         turn_end: false,
@@ -169,7 +169,7 @@ test.skipIf(!tmuxAvailable())(
 
       await session.sendText("/sound on");
       await session.waitForPane(
-        (pane) => (pane.match(/● Sound: on/g)?.length ?? 0) >= 2,
+        (pane) => (pane.match(/· sound: on/g)?.length ?? 0) >= 2,
         TIMEOUT,
       );
       settings = JSON.parse(readFileSync(settingsPath, "utf8"));

--- a/tests/e2e/render-lab/index.ts
+++ b/tests/e2e/render-lab/index.ts
@@ -278,7 +278,7 @@ async function runSameShellRelaunch(outRoot: string, runNumber: number): Promise
         `SHELL_A_BEFORE_FIRST_${runId}`,
         `SHELL_A_BETWEEN_LAUNCHES_${runId}`,
       ],
-      submitted: ["permission_mode", "· version:", "/help"],
+      submitted: ["permission_mode", "* version:", "/help"],
     },
     frames: [],
     failures: [],
@@ -334,7 +334,7 @@ async function runSameShellRelaunch(outRoot: string, runNumber: number): Promise
     );
 
     await launchFx(context, session, "second");
-    await submitSlashCommand(context, session, "/version", "· version:", "second-version-visible");
+    await submitSlashCommand(context, session, "/version", "* version:", "second-version-visible");
     await resize(context, session, 72, 24, "second-resize-narrow");
     await resize(context, session, 132, 42, "second-resize-wide");
     await resize(context, session, 120, 40, "second-resize-restored");

--- a/tests/e2e/render-lab/index.ts
+++ b/tests/e2e/render-lab/index.ts
@@ -278,7 +278,7 @@ async function runSameShellRelaunch(outRoot: string, runNumber: number): Promise
         `SHELL_A_BEFORE_FIRST_${runId}`,
         `SHELL_A_BETWEEN_LAUNCHES_${runId}`,
       ],
-      submitted: ["permission_mode", "● Version:", "/help"],
+      submitted: ["permission_mode", "· version:", "/help"],
     },
     frames: [],
     failures: [],
@@ -334,7 +334,7 @@ async function runSameShellRelaunch(outRoot: string, runNumber: number): Promise
     );
 
     await launchFx(context, session, "second");
-    await submitSlashCommand(context, session, "/version", "● Version:", "second-version-visible");
+    await submitSlashCommand(context, session, "/version", "· version:", "second-version-visible");
     await resize(context, session, 72, 24, "second-resize-narrow");
     await resize(context, session, 132, 42, "second-resize-wide");
     await resize(context, session, 120, 40, "second-resize-restored");

--- a/tests/e2e/render-lab/native.ts
+++ b/tests/e2e/render-lab/native.ts
@@ -200,7 +200,7 @@ export async function runNativeRenderLab(
     markers: {
       shell: shellMarkers,
       clearedShell: scenario.commandK ? [shellMarkers[0]!] : [],
-      submitted: scenario.commandK ? ["permission_mode", "● Version:"] : ["permission_mode", "● Version:", "/help"],
+      submitted: scenario.commandK ? ["permission_mode", "· version:"] : ["permission_mode", "· version:", "/help"],
     },
     native: {
       adapter: scenario.adapter,
@@ -300,7 +300,7 @@ async function runNativeRelaunchScenario(
   );
 
   await launchFx(context, controller, "native-second");
-  await submitSlashCommand(context, controller, "/version", "● Version:", "native-second-version-visible");
+  await submitSlashCommand(context, controller, "/version", "· version:", "native-second-version-visible");
   await resize(context, controller, 96, 32, "native-second-resize-medium");
   await resize(context, controller, 132, 42, "native-second-resize-wide");
   await resize(context, controller, 120, 40, "native-second-resize-restored");
@@ -351,7 +351,7 @@ async function runCommandKScenario(context: NativeContext, controller: NativeCon
     "native-command-k-after-clear-marker",
   );
   await launchFx(context, controller, "native-command-k-after-clear");
-  await submitSlashCommand(context, controller, "/version", "● Version:", "native-command-k-version-visible");
+  await submitSlashCommand(context, controller, "/version", "· version:", "native-command-k-version-visible");
   const finalFrame = await capture(context, controller, "native-command-k-final-state");
   context.manifest.finalFrameIndex = finalFrame.index;
   await quitFx(context, controller, "native-command-k-cleanup");

--- a/tests/e2e/render-lab/native.ts
+++ b/tests/e2e/render-lab/native.ts
@@ -200,7 +200,7 @@ export async function runNativeRenderLab(
     markers: {
       shell: shellMarkers,
       clearedShell: scenario.commandK ? [shellMarkers[0]!] : [],
-      submitted: scenario.commandK ? ["permission_mode", "· version:"] : ["permission_mode", "· version:", "/help"],
+      submitted: scenario.commandK ? ["permission_mode", "* version:"] : ["permission_mode", "* version:", "/help"],
     },
     native: {
       adapter: scenario.adapter,
@@ -300,7 +300,7 @@ async function runNativeRelaunchScenario(
   );
 
   await launchFx(context, controller, "native-second");
-  await submitSlashCommand(context, controller, "/version", "· version:", "native-second-version-visible");
+  await submitSlashCommand(context, controller, "/version", "* version:", "native-second-version-visible");
   await resize(context, controller, 96, 32, "native-second-resize-medium");
   await resize(context, controller, 132, 42, "native-second-resize-wide");
   await resize(context, controller, 120, 40, "native-second-resize-restored");
@@ -351,7 +351,7 @@ async function runCommandKScenario(context: NativeContext, controller: NativeCon
     "native-command-k-after-clear-marker",
   );
   await launchFx(context, controller, "native-command-k-after-clear");
-  await submitSlashCommand(context, controller, "/version", "· version:", "native-command-k-version-visible");
+  await submitSlashCommand(context, controller, "/version", "* version:", "native-command-k-version-visible");
   const finalFrame = await capture(context, controller, "native-command-k-final-state");
   context.manifest.finalFrameIndex = finalFrame.index;
   await quitFx(context, controller, "native-command-k-cleanup");

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -1871,7 +1871,7 @@ tmuxTest(
         await session.sendText("/status");
         await session.waitForText("auth=AI_GATEWAY_API_KEY", TIMEOUT);
         const scrollback = await session.captureFullScrollback();
-        const recoveredStatus = scrollback.slice(scrollback.lastIndexOf("· status:"));
+        const recoveredStatus = scrollback.slice(scrollback.lastIndexOf("* status:"));
         expect(recoveredStatus).toContain("auth=AI_GATEWAY_API_KEY");
         expect(recoveredStatus).not.toContain("auth_help=");
         expect(readFileSync(stderrPath, "utf8")).toBe("");
@@ -2254,7 +2254,7 @@ for (const [provider, previousProvider] of [
             await session.sendText("/resume");
             await session.waitForPane((pane) => pane.includes("Sessions") && /\bturns?\b/.test(pane), TIMEOUT);
             await session.sendKeys("Enter");
-            await session.waitForText("· session resumed:", TIMEOUT);
+            await session.waitForText("* session resumed:", TIMEOUT);
           }
           await session.sendText("/model");
           const catalog = await session.waitForPane(
@@ -2956,7 +2956,7 @@ for (const [source, help] of [
     await session.sendText("/status");
     await session.waitForText("auth=AI_GATEWAY_API_KEY", TIMEOUT);
     const scrollback = await session.captureFullScrollback();
-    expect(scrollback.slice(scrollback.lastIndexOf("· status:"))).not.toContain("auth_help=");
+    expect(scrollback.slice(scrollback.lastIndexOf("* status:"))).not.toContain("auth_help=");
     expect(JSON.parse(readFileSync(settingsPath, "utf8")).credential_source).toBe("ai_gateway_api_key");
     expect(gateway.requests).toHaveLength(1);
     expect(gateway.requests[0].headers.get("authorization")).toBe(`Bearer ${ENV_TOKEN}`);
@@ -3003,7 +3003,7 @@ tmuxTest("/status preserves a missing selected login through explicit key recove
   await session.sendText("/status");
   await session.waitForText("auth=AI_GATEWAY_API_KEY", TIMEOUT);
   const scrollback = await session.captureFullScrollback();
-  const recovered = scrollback.slice(scrollback.lastIndexOf("· status:"));
+  const recovered = scrollback.slice(scrollback.lastIndexOf("* status:"));
   expect(recovered).not.toContain("auth_help=");
   expect(readFileSync(settingsPath, "utf8")).toBe("{broken");
   expect(gateway.requests).toHaveLength(1);
@@ -7279,7 +7279,7 @@ tmuxTest(
     expect(creditsGateway.requests).toEqual([]);
 
     await session.sendText("/credits");
-    await session.waitForText("· credits: balance=42", TIMEOUT);
+    await session.waitForText("* credits: balance=42", TIMEOUT);
 
     expect(oauth.requests.map((request) => `${request.method} ${request.path}`)).toEqual([
       "GET /.well-known/openid-configuration",

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -1258,7 +1258,7 @@ for (const provider of ["gateway", "codex", "grok"] as const) {
       await session.waitForComposer(TIMEOUT);
       const prompt = `STORAGE_RETRY_${provider}`;
       await session.sendText(prompt);
-      await session.waitForPane((pane) => pane.includes(prompt) && pane.slice(pane.lastIndexOf(prompt) + prompt.length).includes("Auth:"), TIMEOUT);
+      await session.waitForPane((pane) => pane.includes(prompt) && pane.slice(pane.lastIndexOf(prompt) + prompt.length).includes("auth:"), TIMEOUT);
       const scrollback = await session.captureFullScrollback();
       expect(scrollback.slice(scrollback.lastIndexOf(prompt) + prompt.length)).toContain("Saved credential storage is unavailable");
       expect(gateway.requests).toHaveLength(0);
@@ -1871,7 +1871,7 @@ tmuxTest(
         await session.sendText("/status");
         await session.waitForText("auth=AI_GATEWAY_API_KEY", TIMEOUT);
         const scrollback = await session.captureFullScrollback();
-        const recoveredStatus = scrollback.slice(scrollback.lastIndexOf("● Status:"));
+        const recoveredStatus = scrollback.slice(scrollback.lastIndexOf("· status:"));
         expect(recoveredStatus).toContain("auth=AI_GATEWAY_API_KEY");
         expect(recoveredStatus).not.toContain("auth_help=");
         expect(readFileSync(stderrPath, "utf8")).toBe("");
@@ -2254,7 +2254,7 @@ for (const [provider, previousProvider] of [
             await session.sendText("/resume");
             await session.waitForPane((pane) => pane.includes("Sessions") && /\bturns?\b/.test(pane), TIMEOUT);
             await session.sendKeys("Enter");
-            await session.waitForText("● Session resumed:", TIMEOUT);
+            await session.waitForText("· session resumed:", TIMEOUT);
           }
           await session.sendText("/model");
           const catalog = await session.waitForPane(
@@ -2426,9 +2426,9 @@ tmuxTest(
     await session.sendKeys("Enter");
     await session.waitForText("Switched to gpt-5.6-sol", TIMEOUT);
     await session.sendText("/fast");
-    await session.waitForText("Fast: off", TIMEOUT);
+    await session.waitForText("fast: off", TIMEOUT);
     await session.sendText("/fast");
-    await session.waitForText("Fast: on", TIMEOUT);
+    await session.waitForText("fast: on", TIMEOUT);
     await session.sendText("Use the Codex subscription directly.");
     await session.waitForText("CHATGPT_DIRECT_RESPONSE", TIMEOUT);
     const directRequest = chatgptOauth.requests.find(
@@ -2614,7 +2614,7 @@ tmuxTest(
     await session.waitForComposer(TIMEOUT);
     expect(Date.now() - cancelStarted).toBeLessThan(500);
     expect(cancelledPane).toContain("■ Cancelled");
-    expect(cancelledPane).not.toContain("System: cancelled");
+    expect(cancelledPane).not.toContain("system: cancelled");
     expect(cancelledPane).not.toContain("Cancelling");
     expect(session.isAlive()).toBe(true);
     expect(readFileSync(stderrPath, "utf8")).toBe("");
@@ -2956,7 +2956,7 @@ for (const [source, help] of [
     await session.sendText("/status");
     await session.waitForText("auth=AI_GATEWAY_API_KEY", TIMEOUT);
     const scrollback = await session.captureFullScrollback();
-    expect(scrollback.slice(scrollback.lastIndexOf("● Status:"))).not.toContain("auth_help=");
+    expect(scrollback.slice(scrollback.lastIndexOf("· status:"))).not.toContain("auth_help=");
     expect(JSON.parse(readFileSync(settingsPath, "utf8")).credential_source).toBe("ai_gateway_api_key");
     expect(gateway.requests).toHaveLength(1);
     expect(gateway.requests[0].headers.get("authorization")).toBe(`Bearer ${ENV_TOKEN}`);
@@ -3003,7 +3003,7 @@ tmuxTest("/status preserves a missing selected login through explicit key recove
   await session.sendText("/status");
   await session.waitForText("auth=AI_GATEWAY_API_KEY", TIMEOUT);
   const scrollback = await session.captureFullScrollback();
-  const recovered = scrollback.slice(scrollback.lastIndexOf("● Status:"));
+  const recovered = scrollback.slice(scrollback.lastIndexOf("· status:"));
   expect(recovered).not.toContain("auth_help=");
   expect(readFileSync(settingsPath, "utf8")).toBe("{broken");
   expect(gateway.requests).toHaveLength(1);
@@ -7279,7 +7279,7 @@ tmuxTest(
     expect(creditsGateway.requests).toEqual([]);
 
     await session.sendText("/credits");
-    await session.waitForText("● Credits: balance=42", TIMEOUT);
+    await session.waitForText("· credits: balance=42", TIMEOUT);
 
     expect(oauth.requests.map((request) => `${request.method} ${request.path}`)).toEqual([
       "GET /.well-known/openid-configuration",

--- a/tests/e2e/tui-command-permissions.test.ts
+++ b/tests/e2e/tui-command-permissions.test.ts
@@ -1592,7 +1592,7 @@ describe("effect-aware command permissions", () => {
       expect(extractResponses(beforeSlashCommands)).toEqual(responseRows);
 
       await activeSession.sendText("/sound on");
-      await activeSession.waitForText("● Sound: on", TIMEOUT);
+      await activeSession.waitForText("· sound: on", TIMEOUT);
       await activeSession.sendText("/settings");
       await activeSession.waitForText("←→ change", TIMEOUT);
       await activeSession.sendKeys("Escape");
@@ -1604,7 +1604,7 @@ describe("effect-aware command permissions", () => {
 
       const afterSlashCommands = await activeSession.captureFullScrollback();
       expect(extractResponses(afterSlashCommands)).toEqual(responseRows);
-      expect(afterSlashCommands.indexOf("● Sound: on")).toBeGreaterThan(
+      expect(afterSlashCommands.indexOf("· sound: on")).toBeGreaterThan(
         afterSlashCommands.indexOf(responseRows.at(-1)!),
       );
       expect(afterSlashCommands).toContain("Ran printf");
@@ -2917,7 +2917,7 @@ describe("effect-aware command permissions", () => {
         toolCall("touch must-not-exist"),
         finalText("permission resume denial complete"),
       ]);
-      await resumed.session.waitForText("● Session resumed", TIMEOUT);
+      await resumed.session.waitForText("· session resumed", TIMEOUT);
       await resumed.session.waitForText("ask · gpt-5", TIMEOUT);
       await resumed.session.sendText("Create the marker after resuming.");
 
@@ -2937,7 +2937,7 @@ describe("effect-aware command permissions", () => {
 
       const resumedScrollback = await resumed.session.captureFullScrollback();
       expect(resumedScrollback).toContain("permission resume seed complete");
-      expect(resumedScrollback).toContain("● Session resumed");
+      expect(resumedScrollback).toContain("· session resumed");
     },
     90_000,
   );

--- a/tests/e2e/tui-command-permissions.test.ts
+++ b/tests/e2e/tui-command-permissions.test.ts
@@ -1592,7 +1592,7 @@ describe("effect-aware command permissions", () => {
       expect(extractResponses(beforeSlashCommands)).toEqual(responseRows);
 
       await activeSession.sendText("/sound on");
-      await activeSession.waitForText("· sound: on", TIMEOUT);
+      await activeSession.waitForText("* sound: on", TIMEOUT);
       await activeSession.sendText("/settings");
       await activeSession.waitForText("←→ change", TIMEOUT);
       await activeSession.sendKeys("Escape");
@@ -1604,7 +1604,7 @@ describe("effect-aware command permissions", () => {
 
       const afterSlashCommands = await activeSession.captureFullScrollback();
       expect(extractResponses(afterSlashCommands)).toEqual(responseRows);
-      expect(afterSlashCommands.indexOf("· sound: on")).toBeGreaterThan(
+      expect(afterSlashCommands.indexOf("* sound: on")).toBeGreaterThan(
         afterSlashCommands.indexOf(responseRows.at(-1)!),
       );
       expect(afterSlashCommands).toContain("Ran printf");
@@ -2917,7 +2917,7 @@ describe("effect-aware command permissions", () => {
         toolCall("touch must-not-exist"),
         finalText("permission resume denial complete"),
       ]);
-      await resumed.session.waitForText("· session resumed", TIMEOUT);
+      await resumed.session.waitForText("* session resumed", TIMEOUT);
       await resumed.session.waitForText("ask · gpt-5", TIMEOUT);
       await resumed.session.sendText("Create the marker after resuming.");
 
@@ -2937,7 +2937,7 @@ describe("effect-aware command permissions", () => {
 
       const resumedScrollback = await resumed.session.captureFullScrollback();
       expect(resumedScrollback).toContain("permission resume seed complete");
-      expect(resumedScrollback).toContain("· session resumed");
+      expect(resumedScrollback).toContain("* session resumed");
     },
     90_000,
   );

--- a/tests/e2e/tui-composer-edit-contracts.test.ts
+++ b/tests/e2e/tui-composer-edit-contracts.test.ts
@@ -322,7 +322,7 @@ tmuxTest(
     await waitForTraceOrExit(active, "reason=unsafe_suffix");
 
     expect(gateway?.requestCount()).toBe(0);
-    expect(await active.captureFullScrollback()).not.toMatch(/[·✓!✗⊘i] version:/);
+    expect(await active.captureFullScrollback()).not.toMatch(/[*✓!✗⊘i] version:/);
     await active.waitForText("PRESERVED_DRAFT", TIMEOUT);
 
     await active.sendKeys("Enter");

--- a/tests/e2e/tui-composer-edit-contracts.test.ts
+++ b/tests/e2e/tui-composer-edit-contracts.test.ts
@@ -322,7 +322,7 @@ tmuxTest(
     await waitForTraceOrExit(active, "reason=unsafe_suffix");
 
     expect(gateway?.requestCount()).toBe(0);
-    expect(await active.captureFullScrollback()).not.toContain("● Version:");
+    expect(await active.captureFullScrollback()).not.toMatch(/[·✓!✗⊘i] version:/);
     await active.waitForText("PRESERVED_DRAFT", TIMEOUT);
 
     await active.sendKeys("Enter");

--- a/tests/e2e/tui-cost.test.ts
+++ b/tests/e2e/tui-cost.test.ts
@@ -482,7 +482,7 @@ describe.skipIf(!tmuxAvailable())("tui: durable session cost", () => {
             TIMEOUT,
           );
           await session.sendKeys("Enter");
-          await session.waitForText("● Session resumed:", TIMEOUT);
+          await session.waitForText("· session resumed:", TIMEOUT);
         }
 
         await waitForGenerationRequests(gateway, 2);

--- a/tests/e2e/tui-cost.test.ts
+++ b/tests/e2e/tui-cost.test.ts
@@ -482,7 +482,7 @@ describe.skipIf(!tmuxAvailable())("tui: durable session cost", () => {
             TIMEOUT,
           );
           await session.sendKeys("Enter");
-          await session.waitForText("· session resumed:", TIMEOUT);
+          await session.waitForText("* session resumed:", TIMEOUT);
         }
 
         await waitForGenerationRequests(gateway, 2);

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -4202,7 +4202,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       const readFilename = "ACTIVE_PERMISSION_READ_SENTINEL.txt";
       const toolHeader = "● 1 tool call · 1 read";
       const toolMarker = `└ Read ${readFilename}`;
-      const permissionMarker = "· permissions: mode=auto";
+      const permissionMarker = "* permissions: mode=auto";
       const activeBefore = "ACTIVE_PERMISSION_BEFORE_SENTINEL\n";
       const activeAfter = "ACTIVE_PERMISSION_AFTER_SENTINEL\n";
       const followupPrompt = "ACTIVE_PERMISSION_FOLLOWUP_PROMPT_SENTINEL";

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -2622,7 +2622,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
 
       expect(queuedGateway.requests).toHaveLength(3);
       expect(scrollback).toContain("What can fx do differently?");
-      expect(scrollback).not.toContain("System: cancelled");
+      expect(scrollback).not.toContain("system: cancelled");
       expect(scrollback).not.toContain("Cancelling");
       expect(scrollback).not.toContain("request failed: ModelError");
       expect(scrollback).not.toContain("must not send");
@@ -4202,7 +4202,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       const readFilename = "ACTIVE_PERMISSION_READ_SENTINEL.txt";
       const toolHeader = "● 1 tool call · 1 read";
       const toolMarker = `└ Read ${readFilename}`;
-      const permissionMarker = "● Permissions: mode=auto";
+      const permissionMarker = "· permissions: mode=auto";
       const activeBefore = "ACTIVE_PERMISSION_BEFORE_SENTINEL\n";
       const activeAfter = "ACTIVE_PERMISSION_AFTER_SENTINEL\n";
       const followupPrompt = "ACTIVE_PERMISSION_FOLLOWUP_PROMPT_SENTINEL";
@@ -4359,7 +4359,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       );
       await waitForCondition(() => hold.cancelled, "stream cancellation");
       expect(afterFirst).toContain("■ Cancelled");
-      expect(afterFirst).not.toContain("System: cancelled");
+      expect(afterFirst).not.toContain("system: cancelled");
       expect(afterFirst).not.toContain("Cancelling");
       expect(session.isPaneAlive()).toBe(true);
 
@@ -4381,7 +4381,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       expect(
         countOccurrences(scrollback, "What can fx do differently?"),
       ).toBe(1);
-      expect(scrollback).not.toContain("System: cancelled");
+      expect(scrollback).not.toContain("system: cancelled");
       expect(scrollback).not.toContain("Cancelling");
       expect(countOccurrences(trace, "source=input_active_stream")).toBe(1);
       expect(readFileSync(stderrPath, "utf8")).toBe("");

--- a/tests/e2e/tui-input-navigation.test.ts
+++ b/tests/e2e/tui-input-navigation.test.ts
@@ -1295,7 +1295,7 @@ tmuxTest(
     await typeLiteral(active, "/images");
     await active.sendKeys("Enter");
     await active.waitForPane(
-      (pane) => pane.includes("● Images: 2 pending"),
+      (pane) => pane.includes("· images: 2 pending"),
       READY_TIMEOUT,
     );
     expect(localGateway.requests).toHaveLength(0);
@@ -1317,7 +1317,7 @@ tmuxTest(
     expect(body).toContain("describe both");
 
     const fullScrollback = await active.captureFullScrollback();
-    expect(fullScrollback).toContain("● Images: 2 pending");
+    expect(fullScrollback).toContain("· images: 2 pending");
     expect(fullScrollback).toContain("Both images received.");
     expect(fullScrollback).not.toContain("ImageContextAdapterFailed");
     expect(fullScrollback.match(/describe both/g) ?? []).toHaveLength(1);
@@ -1552,7 +1552,7 @@ tmuxTest(
     await typeLiteral(active, "/images");
     await active.sendKeys("Enter");
     await active.waitForPane(
-      (pane) => pane.includes("● Images: 1 pending") && pane.includes("favicon.png (image/png)"),
+      (pane) => pane.includes("· images: 1 pending") && pane.includes("favicon.png (image/png)"),
       READY_TIMEOUT,
     );
     expect(localGateway.requests).toHaveLength(0);
@@ -1569,7 +1569,7 @@ tmuxTest(
     expect(currentComposer).not.toContain("[Image 1]");
 
     const fullScrollback = await active.captureFullScrollback();
-    expect(fullScrollback).toContain("● Images: 1 pending");
+    expect(fullScrollback).toContain("· images: 1 pending");
     expect(fullScrollback).toContain("favicon.png (image/png)");
     expect(fullScrollback).toContain("cleared pending images");
     expect(fullScrollback).not.toContain("ImageContextAdapterFailed");

--- a/tests/e2e/tui-input-navigation.test.ts
+++ b/tests/e2e/tui-input-navigation.test.ts
@@ -1295,7 +1295,7 @@ tmuxTest(
     await typeLiteral(active, "/images");
     await active.sendKeys("Enter");
     await active.waitForPane(
-      (pane) => pane.includes("· images: 2 pending"),
+      (pane) => pane.includes("* images: 2 pending"),
       READY_TIMEOUT,
     );
     expect(localGateway.requests).toHaveLength(0);
@@ -1317,7 +1317,7 @@ tmuxTest(
     expect(body).toContain("describe both");
 
     const fullScrollback = await active.captureFullScrollback();
-    expect(fullScrollback).toContain("· images: 2 pending");
+    expect(fullScrollback).toContain("* images: 2 pending");
     expect(fullScrollback).toContain("Both images received.");
     expect(fullScrollback).not.toContain("ImageContextAdapterFailed");
     expect(fullScrollback.match(/describe both/g) ?? []).toHaveLength(1);
@@ -1552,7 +1552,7 @@ tmuxTest(
     await typeLiteral(active, "/images");
     await active.sendKeys("Enter");
     await active.waitForPane(
-      (pane) => pane.includes("· images: 1 pending") && pane.includes("favicon.png (image/png)"),
+      (pane) => pane.includes("* images: 1 pending") && pane.includes("favicon.png (image/png)"),
       READY_TIMEOUT,
     );
     expect(localGateway.requests).toHaveLength(0);
@@ -1569,7 +1569,7 @@ tmuxTest(
     expect(currentComposer).not.toContain("[Image 1]");
 
     const fullScrollback = await active.captureFullScrollback();
-    expect(fullScrollback).toContain("· images: 1 pending");
+    expect(fullScrollback).toContain("* images: 1 pending");
     expect(fullScrollback).toContain("favicon.png (image/png)");
     expect(fullScrollback).toContain("cleared pending images");
     expect(fullScrollback).not.toContain("ImageContextAdapterFailed");

--- a/tests/e2e/tui-interrupt-recovery.test.ts
+++ b/tests/e2e/tui-interrupt-recovery.test.ts
@@ -555,7 +555,7 @@ describe.skipIf(SKIP)("tui: interrupt recovery", () => {
       expect(
         countOccurrences(interruptedScrollback, "What can fx do differently?"),
       ).toBe(1);
-      expect(interruptedScrollback).not.toContain("System: cancelled");
+      expect(interruptedScrollback).not.toContain("system: cancelled");
       expect(interruptedScrollback).not.toContain("Cancelling");
 
       await session.waitForText(FOLLOW_UP_RESPONSE, TIMEOUT);
@@ -572,7 +572,7 @@ describe.skipIf(SKIP)("tui: interrupt recovery", () => {
       expect(
         countOccurrences(finalScrollback, "What can fx do differently?"),
       ).toBe(1);
-      expect(finalScrollback).not.toContain("System: cancelled");
+      expect(finalScrollback).not.toContain("system: cancelled");
       expect(finalScrollback).not.toContain("Cancelling");
       expect(gateway.requests).toHaveLength(2);
       expect(held.cancelCount).toBe(1);
@@ -737,7 +737,7 @@ while :; do sleep 1; done
       );
       expect(Date.now() - cancelStartedAt).toBeLessThan(500);
       expect(immediateCancellation).toContain("■ Cancelled");
-      expect(immediateCancellation).not.toContain("System: cancelled");
+      expect(immediateCancellation).not.toContain("system: cancelled");
       expect(immediateCancellation).not.toContain("Cancelling");
       await waitForTrace(
         tracePath,
@@ -860,7 +860,7 @@ while :; do sleep 1; done
       const scrollback = await session.captureFullScrollback();
       expect(scrollback).toContain(`Searched ${pattern}`);
       expect(countOccurrences(scrollback, "What can fx do differently?")).toBe(1);
-      expect(scrollback).not.toContain("System: cancelled");
+      expect(scrollback).not.toContain("system: cancelled");
       expect(scrollback).not.toContain("Cancelling");
       expect(gateway.requests).toHaveLength(1);
       expect(readFileSync(stderrPath, "utf8")).toBe("");

--- a/tests/e2e/tui-render-replay.test.ts
+++ b/tests/e2e/tui-render-replay.test.ts
@@ -329,14 +329,14 @@ describe("tui: render record/replay", () => {
         { length: 33 },
         (_, index) => `captured input line ${index + 1}: ${"x".repeat(32)}`,
       ).join("\n");
-      const authNotice = "● Auth: fx needs access to Vercel AI Gateway. Run /login to sign in, /provider to use an API key, or set AI_GATEWAY_API_KEY.";
+      const authNotice = "auth: fx needs access to Vercel AI Gateway. Run /login to sign in, /provider to use an API key, or set AI_GATEWAY_API_KEY.";
       const launched = await launch({ recordInput: true });
       session = launched.session;
 
       await session.pasteText(pasted);
       await session.waitForText("[Pasted text #1, 33 lines]", 5_000);
       await session.sendKeys("Enter");
-      await session.waitForText("● Auth: fx needs access", 5_000);
+      await session.waitForText("auth: fx needs access", 5_000);
       expect((await session.captureFullScrollback()).replace(/\s+/g, " ")).toContain(authNotice);
 
       const stdin = readTapeFrames(launched.tapePath)

--- a/tests/e2e/tui-resize.test.ts
+++ b/tests/e2e/tui-resize.test.ts
@@ -2131,7 +2131,7 @@ describe.skipIf(SKIP)("tui: resize", () => {
         help: countOccurrences(scrollback, "Run /help for commands"),
         recording: countOccurrences(
           scrollback,
-          "● Recording: visual terminal capture:",
+          "! recording: visual terminal capture:",
         ),
         seed: countOccurrences(scrollback, seedMarker),
       });

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -1027,7 +1027,7 @@ test.skipIf(!tmuxAvailable())(
         });
         const resumed = await waitForScrollbackMarkers(
           active,
-          [`· session resumed: ${title}`, marker],
+          [`* session resumed: ${title}`, marker],
           TIMEOUT,
         );
         expect(resumed).toContain(marker);
@@ -4377,7 +4377,7 @@ test.skipIf(!tmuxAvailable())(
 
       await contender.sendKeys("Enter");
       const resumed = await waitForScrollback(contender, savedMarker);
-      expect(resumed).toContain(`· session resumed: ${savedTitle}`);
+      expect(resumed).toContain(`* session resumed: ${savedTitle}`);
       expect(resumed).toContain(savedMarker);
       expect(resumed).not.toContain("SessionBusy");
       await waitForSessionPickerClosed(contender);
@@ -5401,8 +5401,8 @@ test.skipIf(!tmuxAvailable())(
         `(\x1b[4m\x1b]8;;https://fx.sh/changelog#v${version}\x1b\\notes\x1b[0m`,
       );
       expect(noticeEscapes).toContain("\x1b]8;;\x1b\\)");
-      expect(resumed).not.toContain("· session resumed:");
-      expect(resumed).not.toMatch(/[·✓!✗⊘i] session: resumed:/);
+      expect(resumed).not.toContain("* session resumed:");
+      expect(resumed).not.toMatch(/[*✓!✗⊘i] session: resumed:/);
 
       const argvLines = readFileSync(argvLogPath, "utf8").trim().split("\n");
       expect(argvLines).toEqual([
@@ -6020,7 +6020,7 @@ test.skipIf(!tmuxAvailable())(
       }
       await active.sendKeys("Enter");
       const resumed = await waitForScrollback(active, workspaceBMarker);
-      expect(resumed).toContain("· session resumed: Save the workspace B transcript.");
+      expect(resumed).toContain("* session resumed: Save the workspace B transcript.");
       expect(resumed).toContain(workspaceBMarker);
       expect(resumed).not.toContain(workspaceAMarker);
       expect(active.isPaneAlive()).toBe(true);
@@ -6332,7 +6332,7 @@ test.skipIf(!tmuxAvailable())(
       );
       await active.sendKeys("Enter");
       const resumed = await waitForSessionPickerClosed(active);
-      expect(resumed).toContain(`· session resumed: Save ${savedMarkers[0]!}.`);
+      expect(resumed).toContain(`* session resumed: Save ${savedMarkers[0]!}.`);
       expect(resumed).toContain(savedMarkers[0]!);
 
       await active.sendText("/resume");
@@ -6340,10 +6340,10 @@ test.skipIf(!tmuxAvailable())(
       await active.sendKeys("Escape");
       const afterEscape = await waitForSessionPickerClosed(active);
       expect(await active.captureFullScrollback()).toContain(
-        `· session resumed: Save ${savedMarkers[0]!}.`,
+        `* session resumed: Save ${savedMarkers[0]!}.`,
       );
       expect(afterEscape).toContain(savedMarkers[0]!);
-      expect(afterEscape).not.toContain(`· session resumed: Save ${savedMarkers[10]!}.`);
+      expect(afterEscape).not.toContain(`* session resumed: Save ${savedMarkers[10]!}.`);
       expect(afterEscape).not.toContain(savedMarkers[10]!);
 
       await active.sendText("/resume");
@@ -6359,7 +6359,7 @@ test.skipIf(!tmuxAvailable())(
       );
       await active.sendKeys("Enter");
       const secondResume = await waitForSessionPickerClosed(active);
-      expect(secondResume).toContain(`· session resumed: Save ${savedMarkers[10]!}.`);
+      expect(secondResume).toContain(`* session resumed: Save ${savedMarkers[10]!}.`);
       expect(active.isPaneAlive()).toBe(true);
       expect(readFileSync(stderrPath, "utf8")).toBe("");
 

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -1027,7 +1027,7 @@ test.skipIf(!tmuxAvailable())(
         });
         const resumed = await waitForScrollbackMarkers(
           active,
-          [`● Session resumed: ${title}`, marker],
+          [`· session resumed: ${title}`, marker],
           TIMEOUT,
         );
         expect(resumed).toContain(marker);
@@ -4377,7 +4377,7 @@ test.skipIf(!tmuxAvailable())(
 
       await contender.sendKeys("Enter");
       const resumed = await waitForScrollback(contender, savedMarker);
-      expect(resumed).toContain(`● Session resumed: ${savedTitle}`);
+      expect(resumed).toContain(`· session resumed: ${savedTitle}`);
       expect(resumed).toContain(savedMarker);
       expect(resumed).not.toContain("SessionBusy");
       await waitForSessionPickerClosed(contender);
@@ -5386,7 +5386,7 @@ test.skipIf(!tmuxAvailable())(
       const version = (await runFx(["--version"])).stdout.trim();
       await active.sendHexBytes(["07"]);
 
-      const updatedNotice = `● fx has been updated to v${version} (notes)`;
+      const updatedNotice = `✓ fx has been updated to v${version} (notes)`;
       await active.waitForText(updatedNotice, TIMEOUT);
       await active.waitForComposer(TIMEOUT);
       const postUpgradeTrace = readFileSync(tracePath, "utf8");
@@ -5401,8 +5401,8 @@ test.skipIf(!tmuxAvailable())(
         `(\x1b[4m\x1b]8;;https://fx.sh/changelog#v${version}\x1b\\notes\x1b[0m`,
       );
       expect(noticeEscapes).toContain("\x1b]8;;\x1b\\)");
-      expect(resumed).not.toContain("● Session resumed:");
-      expect(resumed).not.toContain("● Session: resumed:");
+      expect(resumed).not.toContain("· session resumed:");
+      expect(resumed).not.toMatch(/[·✓!✗⊘i] session: resumed:/);
 
       const argvLines = readFileSync(argvLogPath, "utf8").trim().split("\n");
       expect(argvLines).toEqual([
@@ -6020,7 +6020,7 @@ test.skipIf(!tmuxAvailable())(
       }
       await active.sendKeys("Enter");
       const resumed = await waitForScrollback(active, workspaceBMarker);
-      expect(resumed).toContain("● Session resumed: Save the workspace B transcript.");
+      expect(resumed).toContain("· session resumed: Save the workspace B transcript.");
       expect(resumed).toContain(workspaceBMarker);
       expect(resumed).not.toContain(workspaceAMarker);
       expect(active.isPaneAlive()).toBe(true);
@@ -6332,7 +6332,7 @@ test.skipIf(!tmuxAvailable())(
       );
       await active.sendKeys("Enter");
       const resumed = await waitForSessionPickerClosed(active);
-      expect(resumed).toContain(`● Session resumed: Save ${savedMarkers[0]!}.`);
+      expect(resumed).toContain(`· session resumed: Save ${savedMarkers[0]!}.`);
       expect(resumed).toContain(savedMarkers[0]!);
 
       await active.sendText("/resume");
@@ -6340,10 +6340,10 @@ test.skipIf(!tmuxAvailable())(
       await active.sendKeys("Escape");
       const afterEscape = await waitForSessionPickerClosed(active);
       expect(await active.captureFullScrollback()).toContain(
-        `● Session resumed: Save ${savedMarkers[0]!}.`,
+        `· session resumed: Save ${savedMarkers[0]!}.`,
       );
       expect(afterEscape).toContain(savedMarkers[0]!);
-      expect(afterEscape).not.toContain(`● Session resumed: Save ${savedMarkers[10]!}.`);
+      expect(afterEscape).not.toContain(`· session resumed: Save ${savedMarkers[10]!}.`);
       expect(afterEscape).not.toContain(savedMarkers[10]!);
 
       await active.sendText("/resume");
@@ -6359,7 +6359,7 @@ test.skipIf(!tmuxAvailable())(
       );
       await active.sendKeys("Enter");
       const secondResume = await waitForSessionPickerClosed(active);
-      expect(secondResume).toContain(`● Session resumed: Save ${savedMarkers[10]!}.`);
+      expect(secondResume).toContain(`· session resumed: Save ${savedMarkers[10]!}.`);
       expect(active.isPaneAlive()).toBe(true);
       expect(readFileSync(stderrPath, "utf8")).toBe("");
 
@@ -6824,7 +6824,7 @@ test.skipIf(!tmuxAvailable())(
       expect(cancelledIndex).toBeGreaterThanOrEqual(0);
       expect(resumed).toContain("■ Cancelled");
       expect(countOccurrences(resumed, "What can fx do differently?")).toBe(1);
-      expect(resumed).not.toContain("System: cancelled");
+      expect(resumed).not.toContain("system: cancelled");
       expect(resumed).not.toContain("Cancelling");
       expect(resumed).not.toContain("Interrupted by user after completing");
       expect(resumed).not.toContain("<turn_aborted>");

--- a/tests/e2e/tui-slash-commands.test.ts
+++ b/tests/e2e/tui-slash-commands.test.ts
@@ -137,7 +137,7 @@ describe.skipIf(TMUX_SKIP)("tui: no-key slash commands", () => {
       await session.sendText("/permissions");
       await session.waitForText("usage: /permissions [ask|auto|full-access|reset]", 5_000);
       const scrollback = await session.captureFullScrollback();
-      const statusIndex = scrollback.search(/· permissions: mode=(?:ask|auto)/);
+      const statusIndex = scrollback.search(/\* permissions: mode=(?:ask|auto)/);
       const usageIndex = scrollback.indexOf(
         "usage: /permissions [ask|auto|full-access|reset]",
       );

--- a/tests/e2e/tui-slash-commands.test.ts
+++ b/tests/e2e/tui-slash-commands.test.ts
@@ -137,7 +137,7 @@ describe.skipIf(TMUX_SKIP)("tui: no-key slash commands", () => {
       await session.sendText("/permissions");
       await session.waitForText("usage: /permissions [ask|auto|full-access|reset]", 5_000);
       const scrollback = await session.captureFullScrollback();
-      const statusIndex = scrollback.search(/● Permissions: mode=(?:ask|auto)/);
+      const statusIndex = scrollback.search(/· permissions: mode=(?:ask|auto)/);
       const usageIndex = scrollback.indexOf(
         "usage: /permissions [ask|auto|full-access|reset]",
       );

--- a/tests/e2e/tui-slash-extra.test.ts
+++ b/tests/e2e/tui-slash-extra.test.ts
@@ -414,7 +414,7 @@ describe.skipIf(SKIP)("tui: extra slash commands", () => {
         5_000,
       );
       expect(pane).toContain("[30 days]");
-      expect(pane).not.toMatch(/^[·✓!✗⊘i] usage/m);
+      expect(pane).not.toMatch(/^[*✓!✗⊘i] usage/m);
       expect(pane).toContain("tab scope");
       expect(pane).toContain("r refresh");
       expect(pane).toContain("esc close");

--- a/tests/e2e/tui-slash-extra.test.ts
+++ b/tests/e2e/tui-slash-extra.test.ts
@@ -414,7 +414,7 @@ describe.skipIf(SKIP)("tui: extra slash commands", () => {
         5_000,
       );
       expect(pane).toContain("[30 days]");
-      expect(pane).not.toMatch(/^● Usage/m);
+      expect(pane).not.toMatch(/^[·✓!✗⊘i] usage/m);
       expect(pane).toContain("tab scope");
       expect(pane).toContain("r refresh");
       expect(pane).toContain("esc close");

--- a/tests/e2e/tui-slash-menu.test.ts
+++ b/tests/e2e/tui-slash-menu.test.ts
@@ -741,7 +741,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       });
 
       await session.waitForText(
-        "Skills: 1 discovery issue; some skills may be missing (ctrl+o to view)",
+        "skills: 1 discovery issue; some skills may be missing (ctrl+o to view)",
         10_000,
       );
       await session.waitForComposer(10_000);
@@ -861,7 +861,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
 
       // A rename replaces the tab title.
       await session.sendText("/rename deploy pipeline fix");
-      await session.waitForText("renamed: deploy pipeline fix", 10_000);
+      await session.waitForText("renamed to \"deploy pipeline fix\"", 10_000);
       await session.waitForStableComposer();
       await waitForPaneTitle(session, "deploy pipeline fix", 5_000);
 
@@ -1596,7 +1596,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
         5_000,
       );
       expect(composerContains(pane, "/clear")).toBe(false);
-      expect(capturePaneHistory(session, -1000)).not.toContain("● Help:");
+      expect(capturePaneHistory(session, -1000)).not.toMatch(/[·✓!✗⊘i] help:/);
       expect(session.isAlive()).toBe(true);
 
       await session.sendKeys("C-u");
@@ -1700,7 +1700,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
           !current.includes("←→ change"),
         5_000,
       );
-      expect(capturePaneHistory(session, -1000)).not.toContain("● Settings:");
+      expect(capturePaneHistory(session, -1000)).not.toMatch(/[·✓!✗⊘i] settings:/);
 
       await session.sendText("/quit");
       expect(await session.waitForSessionEnd(10_000)).toBe(true);
@@ -1813,7 +1813,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       grid = await waitForStatuslineMenu(session, "Context");
       pane = grid.join("\n");
       expect(pane).not.toContain("saved to user settings");
-      expect(pane).not.toContain("● Statusline:");
+      expect(pane).not.toMatch(/[·✓!✗⊘i] statusline:/);
       await waitForStatuslineValue(settingsPath, "session", true);
 
       await session.sendKeys("Down");
@@ -1835,7 +1835,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       expect(session.isAlive()).toBe(true);
 
       await session.sendText("/statusline workspace");
-      await session.waitForText("● Statusline: workspace: off", 5_000);
+      await session.waitForText("· statusline: workspace: off", 5_000);
       await waitForStatuslineValue(settingsPath, "workspace", false);
       await session.waitForPane(
         (current) => hasEmptyComposer(current) && !current.includes("compact-statusline-workspace"),
@@ -1876,7 +1876,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       let grid = await waitForUsageMenu(session);
       let pane = grid.join("\n");
       expect(pane).toContain("Tracking has not started");
-      expect(pane).not.toMatch(/^● Usage/m);
+      expect(pane).not.toMatch(/^[·✓!✗⊘i] usage/m);
 
       await session.sendKeys("Escape");
       await session.waitForComposer(5_000);
@@ -2830,7 +2830,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       await session.sendLiteralText("/mode");
       await session.sendKeys("Enter");
       await waitForModelsMenu(session, 4);
-      expect(await session.captureFullScrollback()).not.toContain(`● Model: ${currentModel}`);
+      expect(await session.captureFullScrollback()).not.toContain(`· model: ${currentModel}`);
       await session.sendKeys("Escape");
       await session.waitForPane(
         (current) => hasEmptyComposer(current) && !current.includes("tab provider"),
@@ -2931,7 +2931,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       await session.sendKeys("Down");
       await session.sendKeys("Down");
       await session.sendKeys("Enter");
-      await session.waitForText(`● Switched to ${selectedModel}`, 5_000);
+      await session.waitForText(`· Switched to ${selectedModel}`, 5_000);
 
       const settings = JSON.parse(readFileSync(fixture.settingsPath, "utf8")) as { models?: { gateway?: string } };
       expect(settings.models?.gateway).toBe(selectedModel);
@@ -3030,7 +3030,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
         5_000,
       );
       await session.sendKeys("Enter");
-      await session.waitForText(`● Switched to ${selectedModel}`, 5_000);
+      await session.waitForText(`· Switched to ${selectedModel}`, 5_000);
       pane = await session.capturePane();
       expect(composerContains(pane, "hello drXaft")).toBe(true);
       expect(composerContains(pane, "/model")).toBe(false);
@@ -3142,7 +3142,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       await session.waitForText(selectedModel, 10_000);
       await session.sendLiteralText(selectedModel);
       await session.sendKeys("Enter");
-      await session.waitForText(`● Switched to ${selectedModel}`, 5_000);
+      await session.waitForText(`· Switched to ${selectedModel}`, 5_000);
 
       const pane = (await session.capturePaneGrid()).join("\n");
       expect(hasEmptyComposer(pane)).toBe(true);
@@ -3641,7 +3641,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       });
 
       const diagnosticSummary =
-        "Skills: 1 discovery issue; some skills may be missing (ctrl+o to view)";
+        "skills: 1 discovery issue; some skills may be missing (ctrl+o to view)";
       await session.waitForText(diagnosticSummary, 10_000);
       await session.waitForComposer(10_000);
       expect(await session.captureFullScrollback()).not.toContain(

--- a/tests/e2e/tui-slash-menu.test.ts
+++ b/tests/e2e/tui-slash-menu.test.ts
@@ -1596,7 +1596,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
         5_000,
       );
       expect(composerContains(pane, "/clear")).toBe(false);
-      expect(capturePaneHistory(session, -1000)).not.toMatch(/[·✓!✗⊘i] help:/);
+      expect(capturePaneHistory(session, -1000)).not.toMatch(/[*✓!✗⊘i] help:/);
       expect(session.isAlive()).toBe(true);
 
       await session.sendKeys("C-u");
@@ -1700,7 +1700,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
           !current.includes("←→ change"),
         5_000,
       );
-      expect(capturePaneHistory(session, -1000)).not.toMatch(/[·✓!✗⊘i] settings:/);
+      expect(capturePaneHistory(session, -1000)).not.toMatch(/[*✓!✗⊘i] settings:/);
 
       await session.sendText("/quit");
       expect(await session.waitForSessionEnd(10_000)).toBe(true);
@@ -1813,7 +1813,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       grid = await waitForStatuslineMenu(session, "Context");
       pane = grid.join("\n");
       expect(pane).not.toContain("saved to user settings");
-      expect(pane).not.toMatch(/[·✓!✗⊘i] statusline:/);
+      expect(pane).not.toMatch(/[*✓!✗⊘i] statusline:/);
       await waitForStatuslineValue(settingsPath, "session", true);
 
       await session.sendKeys("Down");
@@ -1835,7 +1835,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       expect(session.isAlive()).toBe(true);
 
       await session.sendText("/statusline workspace");
-      await session.waitForText("· statusline: workspace: off", 5_000);
+      await session.waitForText("* statusline: workspace: off", 5_000);
       await waitForStatuslineValue(settingsPath, "workspace", false);
       await session.waitForPane(
         (current) => hasEmptyComposer(current) && !current.includes("compact-statusline-workspace"),
@@ -1876,7 +1876,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       let grid = await waitForUsageMenu(session);
       let pane = grid.join("\n");
       expect(pane).toContain("Tracking has not started");
-      expect(pane).not.toMatch(/^[·✓!✗⊘i] usage/m);
+      expect(pane).not.toMatch(/^[*✓!✗⊘i] usage/m);
 
       await session.sendKeys("Escape");
       await session.waitForComposer(5_000);
@@ -2830,7 +2830,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       await session.sendLiteralText("/mode");
       await session.sendKeys("Enter");
       await waitForModelsMenu(session, 4);
-      expect(await session.captureFullScrollback()).not.toContain(`· model: ${currentModel}`);
+      expect(await session.captureFullScrollback()).not.toContain(`* model: ${currentModel}`);
       await session.sendKeys("Escape");
       await session.waitForPane(
         (current) => hasEmptyComposer(current) && !current.includes("tab provider"),
@@ -2931,7 +2931,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       await session.sendKeys("Down");
       await session.sendKeys("Down");
       await session.sendKeys("Enter");
-      await session.waitForText(`· Switched to ${selectedModel}`, 5_000);
+      await session.waitForText(`* Switched to ${selectedModel}`, 5_000);
 
       const settings = JSON.parse(readFileSync(fixture.settingsPath, "utf8")) as { models?: { gateway?: string } };
       expect(settings.models?.gateway).toBe(selectedModel);
@@ -3030,7 +3030,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
         5_000,
       );
       await session.sendKeys("Enter");
-      await session.waitForText(`· Switched to ${selectedModel}`, 5_000);
+      await session.waitForText(`* Switched to ${selectedModel}`, 5_000);
       pane = await session.capturePane();
       expect(composerContains(pane, "hello drXaft")).toBe(true);
       expect(composerContains(pane, "/model")).toBe(false);
@@ -3142,7 +3142,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       await session.waitForText(selectedModel, 10_000);
       await session.sendLiteralText(selectedModel);
       await session.sendKeys("Enter");
-      await session.waitForText(`· Switched to ${selectedModel}`, 5_000);
+      await session.waitForText(`* Switched to ${selectedModel}`, 5_000);
 
       const pane = (await session.capturePaneGrid()).join("\n");
       expect(hasEmptyComposer(pane)).toBe(true);


### PR DESCRIPTION
## Summary

- System notices lead with a tone-colored status glyph instead of the shared tool-activity bullet: checkmark for success, i for info, ! for warning, cross for error, no-entry for cancelled, middot for neutral.
- Notice topics render lowercase without forced capitalization (for example `session: renamed to "custom models"` instead of `Session: renamed: custom models`), matching standard CLI output conventions.
- Usage errors normalize to `usage: /command ...` and the rename confirmation quotes the new title.