### PR TITLE
Preserve resume publication row ordering

### DIFF
--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -4001,6 +4001,141 @@ noinline fn coordinatorGridContains(grid: vt_emulator.Grid, needle: []const u8) 
     return false;
 }
 
+test "core.app_render_runtime resume publication preserves the pre-scroll origin through the coordinator" {
+    const alloc = std.testing.allocator;
+    const cases = [_]struct { origin: u16, rows: u16, post_top: u16 }{
+        .{ .origin = 1, .rows = 3, .post_top = 1 },
+        .{ .origin = 5, .rows = 3, .post_top = 5 },
+        .{ .origin = 5, .rows = 6, .post_top = 4 },
+        .{ .origin = 8, .rows = 6, .post_top = 4 },
+        .{ .origin = 1, .rows = 12, .post_top = 1 },
+        .{ .origin = 5, .rows = 12, .post_top = 1 },
+        .{ .origin = 1, .rows = 80, .post_top = 1 },
+        .{ .origin = 5, .rows = 80, .post_top = 1 },
+    };
+    for (cases) |case| {
+        errdefer std.debug.print("resume origin={d} rows={d}\n", .{ case.origin, case.rows });
+        var tmp = std.testing.tmpDir(.{});
+        defer tmp.cleanup();
+        var file = try tmp.dir.createFile(std.testing.io, "resume-origin.log", .{ .read = true });
+        defer file.close(std.testing.io);
+        var app = try initCoordinatorProjectionTestApp(alloc, file);
+        defer app.deinit();
+        app.terminal_client.source_running = false;
+        try app.shell.initViewport(&app.metrics, case.origin);
+
+        var projection = try resume_projection.ResumeProjection.initEmpty(alloc, &app.shell, 0, 1);
+        defer projection.deinit();
+        var flow: std.ArrayList(u8) = .empty;
+        defer flow.deinit(alloc);
+        for (0..case.rows) |i| {
+            var buf: [32]u8 = undefined;
+            try flow.appendSlice(alloc, try std.fmt.bufPrint(
+                &buf,
+                "{s}ORIGIN_ROW_{d:0>3}",
+                .{ if (i == 0) "" else "\n", i },
+            ));
+        }
+        _ = try projection.appendRawClassified(flow.items, .unknown_raw);
+        try projection.finalize();
+        projection.install(&app.shell);
+        try std.testing.expectEqual(.invalid, app.shell.transcriptCommitDiagnostic().state);
+        var read_offset = try file.length(std.testing.io);
+
+        // Interrupt actual preparation, not the coordinator's synthetic receipt stub.
+        app.terminal_input_runtime.terminal_action_decoder.stage = 2;
+        app.shell.render_requests.request(.first_frame);
+        try Runtime(CoordinatorTestApp).flushRequestedFrame(&app);
+        try std.testing.expectEqual(read_offset, try file.length(std.testing.io));
+        try std.testing.expectEqual(case.origin, app.shell.owned_top_row);
+        try std.testing.expectEqual(.invalid, app.shell.transcriptCommitDiagnostic().state);
+        try std.testing.expect(app.shell.pending_resume_source != null);
+        try std.testing.expect(app.shell.render_requests.hasPending());
+        app.terminal_input_runtime.resetEscapeDecoder();
+
+        // A unit-test stdin can be closed; suppress that unrelated poll on retries.
+        app.shell.render_requests.consecutive_input_pending_aborts = render_request.max_consecutive_input_pending_aborts;
+        try Runtime(CoordinatorTestApp).flushRequestedFrame(&app);
+        const first = try readCoordinatorFrameBytes(alloc, file, &read_offset);
+        defer alloc.free(first);
+        const document_start = std.mem.find(u8, first, "ORIGIN_ROW_000") orelse return error.MissingResumeDocument;
+        var physical = try vt_emulator.Grid.init(alloc, 80, 12);
+        defer physical.deinit();
+        if (case.rows > 9) {
+            var origin_buf: [32]u8 = undefined;
+            const origin = try std.fmt.bufPrint(&origin_buf, "\x1b[{d};1H", .{case.origin});
+            try std.testing.expect(std.mem.find(u8, first[0..document_start], origin) != null);
+        }
+        var first_stats: vt_emulator.FeedStats = .{};
+        try physical.feedWithStats(first, &first_stats);
+        var physical_scroll_rows = first_stats.scroll_rows;
+        try std.testing.expectEqual(case.post_top, app.shell.owned_top_row);
+        try std.testing.expectEqual(case.post_top, app.shell.committed_frame_layout.transcript_area.top);
+
+        const history_rows: u32 = case.rows -| 9;
+        const first_history = @min(history_rows, 64);
+        const diagnostic = app.shell.transcriptCommitDiagnostic();
+        if (history_rows > 64) {
+            try std.testing.expectEqual(first_history, diagnostic.history_visual_offset);
+            try std.testing.expectEqual(history_rows - first_history, diagnostic.remaining_inline_rows);
+        }
+        try std.testing.expectEqual(@as(u16, 0), diagnostic.remaining_unplanned_scroll_rows);
+        var row: std.ArrayList(u8) = .empty;
+        defer row.deinit(alloc);
+        try physical.rowTextTrimmed(case.post_top, &row);
+        var expected_buf: [32]u8 = undefined;
+        try std.testing.expectEqualStrings(try std.fmt.bufPrint(&expected_buf, "ORIGIN_ROW_{d:0>3}", .{first_history}), row.items);
+
+        if (history_rows > 64) {
+            try std.testing.expectEqual(.recovering, diagnostic.state);
+            const receipt = app.shell.transcript_commit_state.recovering;
+            try std.testing.expect(receipt.materialized_flow_len != null);
+            app.shell.render_requests.consecutive_input_pending_aborts = render_request.max_consecutive_input_pending_aborts;
+            try Runtime(CoordinatorTestApp).flushRequestedFrame(&app);
+            const next = try readCoordinatorFrameBytes(alloc, file, &read_offset);
+            defer alloc.free(next);
+            // Recovery continues the materialized suffix instead of replaying row zero.
+            try std.testing.expect(std.mem.find(u8, next, "ORIGIN_ROW_000") == null);
+            const suffix_start = std.mem.find(u8, next, "ORIGIN_ROW_") orelse return error.MissingResumeSuffix;
+            var receipt_cursor_buf: [32]u8 = undefined;
+            const receipt_cursor = try std.fmt.bufPrint(&receipt_cursor_buf, "\x1b[{d};{d}H", .{ receipt.cursor_row, receipt.cursor_col });
+            try std.testing.expect(std.mem.find(u8, next[0..suffix_start], receipt_cursor) != null);
+            var next_stats: vt_emulator.FeedStats = .{};
+            try physical.feedWithStats(next, &next_stats);
+            physical_scroll_rows += next_stats.scroll_rows;
+            row.clearRetainingCapacity();
+            try physical.rowTextTrimmed(case.post_top, &row);
+            try std.testing.expectEqualStrings(try std.fmt.bufPrint(&expected_buf, "ORIGIN_ROW_{d:0>3}", .{history_rows}), row.items);
+            try std.testing.expectEqual(@as(u32, 0), app.shell.transcriptCommitDiagnostic().remaining_inline_rows);
+        }
+        for (0..3) |_| {
+            app.shell.render_requests.consecutive_input_pending_aborts = render_request.max_consecutive_input_pending_aborts;
+            try Runtime(CoordinatorTestApp).flushRequestedFrame(&app);
+        }
+        try std.testing.expectEqual(.stable, app.shell.transcriptCommitDiagnostic().state);
+        try std.testing.expectEqual(history_rows, app.shell.transcriptCommitDiagnostic().history_visual_offset);
+        try std.testing.expectEqual(history_rows + case.origin - case.post_top, physical_scroll_rows);
+        try std.testing.expect(app.shell.pending_resume_source == null);
+        try std.testing.expect(try coordinatorGridContains(app.shell.shadow_vt.?.*, try std.fmt.bufPrint(&expected_buf, "ORIGIN_ROW_{d:0>3}", .{case.rows - 1})));
+
+        const anchor = app.shell.transcript_commit_state.stable;
+        read_offset = try file.length(std.testing.io);
+        try app.shell.writeTranscript(alloc, &app.metrics, "\nAFTER_RESUME", true);
+        app.shell.render_requests.request(.transcript);
+        app.shell.render_requests.consecutive_input_pending_aborts = render_request.max_consecutive_input_pending_aborts;
+        try Runtime(CoordinatorTestApp).flushRequestedFrame(&app);
+        const appended = try readCoordinatorFrameBytes(alloc, file, &read_offset);
+        defer alloc.free(appended);
+        var cursor_buf: [32]u8 = undefined;
+        const append_cursor = try std.fmt.bufPrint(&cursor_buf, "\x1b[{d};{d}H", .{ anchor.cursor_row, anchor.cursor_col });
+        if (history_rows > 0) {
+            const suffix_start = std.mem.find(u8, appended, "AFTER_RESUME") orelse return error.MissingAppend;
+            try std.testing.expect(std.mem.find(u8, appended[0..suffix_start], append_cursor) != null);
+        }
+        try std.testing.expect(try coordinatorGridContains(app.shell.shadow_vt.?.*, "AFTER_RESUME"));
+    }
+}
+
 test "core.app_render_runtime first requested startup frame commits through the ordinary coordinator" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});

--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -4014,7 +4014,7 @@ test "core.app_render_runtime resume publication preserves the pre-scroll origin
         .{ .origin = 5, .rows = 80, .post_top = 1 },
     };
     for (cases) |case| {
-        errdefer std.debug.print("resume origin={d} rows={d}\n", .{ case.origin, case.rows });
+        errdefer std.debug.panic("resume origin={d} rows={d}", .{ case.origin, case.rows });
         var tmp = std.testing.tmpDir(.{});
         defer tmp.cleanup();
         var file = try tmp.dir.createFile(std.testing.io, "resume-origin.log", .{ .read = true });

--- a/src/ui/transcript/runtime.zig
+++ b/src/ui/transcript/runtime.zig
@@ -8256,6 +8256,7 @@ pub const TranscriptRuntime = struct {
     fn resolveTransitionAppendBase(
         self: *const TranscriptRuntime,
         prepared: *const transcript_painter.PreparedTranscriptSurfacePaint,
+        prior_owned_top: u16,
         scroll_facts: TranscriptScrollFacts,
         destructive_invalidation: bool,
         target_flow: []const u8,
@@ -8341,7 +8342,7 @@ pub const TranscriptRuntime = struct {
                     .flow_len = 0,
                     .visual_offset = 0,
                     .visual_rows = 0,
-                    .cursor_row = prepared.projectionArea().top,
+                    .cursor_row = prior_owned_top,
                     .cursor_col = 1,
                 };
             },
@@ -8834,6 +8835,7 @@ pub const TranscriptRuntime = struct {
 
         const append_base = try self.resolveTransitionAppendBase(
             prepared,
+            scroll_plan.prior_owned_top,
             scroll_facts,
             destructive_invalidation,
             target_flow,
@@ -12181,6 +12183,7 @@ test "oversized resume publication starts without a prior committed frame" {
 
     const append_base = (try runtime.resolveTransitionAppendBase(
         &prepared,
+        scroll_plan.prior_owned_top,
         facts,
         false,
         source.bytes,
@@ -13223,7 +13226,7 @@ fn expectHistoryReplayBoundary(target_flow: []const u8, source_pending_wrap: boo
     try std.testing.expect(!transition.document_append.isEmpty());
     try std.testing.expect(!transition.document_append.start_pending_wrap);
     try std.testing.expectEqual(@as(u16, 1), transition.document_append.start_col);
-    const base = (try runtime.resolveTransitionAppendBase(&prepared, facts, false, transition.target_flow, facts.target_visual_offset)).?;
+    const base = (try runtime.resolveTransitionAppendBase(&prepared, scroll_plan.prior_owned_top, facts, false, transition.target_flow, facts.target_visual_offset)).?;
     var boundary = try transcript_painter.prepareTranscriptDocumentAppend(alloc, transition.target_flow, layout.cols, base.flow_len, base.flow_len, false);
     defer boundary.deinit(alloc);
     try std.testing.expectEqual(source_pending_wrap, boundary.start_pending_wrap);
@@ -13331,6 +13334,7 @@ test "history replay starts at committed source top and follows resize eligibili
 
     const append_base = (try runtime.resolveTransitionAppendBase(
         &prepared,
+        runtime.owned_top_row,
         facts,
         false,
         source.bytes,
@@ -13356,6 +13360,7 @@ test "history replay starts at committed source top and follows resize eligibili
     const resize_facts = runtime.planTranscriptScroll(&prepared);
     const resize_append_base = (try runtime.resolveTransitionAppendBase(
         &prepared,
+        scroll_plan.prior_owned_top,
         resize_facts,
         false,
         source.bytes,

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -348,6 +348,95 @@ test.skipIf(!tmuxAvailable())("suspended sessions retain exclusive writer owners
   }
 }, TIMEOUT * 3);
 
+test.skipIf(!tmuxAvailable())(
+  "resume publication preserves history from a low native cursor",
+  async () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "fx-resume-origin-")));
+    const home = join(root, "home");
+    const workspace = join(root, "workspace");
+    const launchReady = join(root, "launch-ready");
+    const launchGate = join(root, "launch-gate");
+    const stderrPath = join(root, "stderr.log");
+    const tapePath = join(root, "resume.fxtape");
+    mkdirSync(join(home, ".fx"), { recursive: true });
+    mkdirSync(workspace);
+    writeFileSync(join(home, ".fx", "settings.json"), JSON.stringify({ startup_scrollback: false }));
+    const labels = Array.from({ length: 67 }, (_, i) => `RESUME_ROW_${String(i).padStart(3, "0")}`);
+    const gateway = startFakeGateway([
+      fakeGatewayFinalText(labels.join("\n\n")),
+      fakeGatewayFinalText("AFTER_RESUME_INTERACTION"),
+    ]);
+    const env = {
+      ...gatewayEnv(home, gateway),
+      FX_SOUND: "0",
+      FX_DISABLE_KEYCHAIN: "1",
+      FX_E2E_DISABLE_DOTENV: "1",
+    };
+    let active: TmuxSession | undefined;
+    const expectPublishedRows = (capture: string) => {
+      const rows = stripAnsi(capture).split("\n");
+      const published = rows.flatMap((text, row) =>
+        [...text.matchAll(/RESUME_ROW_\d{3}/g)].map(([label]) => ({ label, row }))
+      );
+      expect(published.map(({ label }) => label)).toEqual(labels);
+      const prior = rows.flatMap(text => [...text.matchAll(/PRIOR_\d{3}/g)].map(([label]) => label));
+      expect(prior).toEqual(Array.from({ length: 66 }, (_, i) => `PRIOR_${String(i + 1).padStart(3, "0")}`));
+      expect(rows.findIndex(text => text.includes("PRIOR_066"))).toBeLessThan(published[0]!.row);
+      for (let i = 1; i < published.length; i++) {
+        expect(published[i]!.row - published[i - 1]!.row).toBe(2);
+        expect(rows[published[i]!.row - 1]!.trim()).toBe("");
+      }
+    };
+    try {
+      const seeded = await runFx(["ask", "--json", "Seed the prepared transcript without tools."], {
+        cwd: workspace, env, timeoutMs: TIMEOUT,
+      });
+      expect(seeded.code).toBe(0);
+      expect(seeded.stderr).toBe("");
+      const id = sessionIdFromHome(home);
+      const eventsPath = join(home, ".fx", "sessions", id, "events.jsonl");
+      const events = readFileSync(eventsPath, "utf8");
+      for (const label of labels) expect(events).toContain(label);
+
+      // Pause after real terminal output, with no synthetic cursor response.
+      const launch = `printf '\\033[2J\\033[H'; i=1; while [ "$i" -le 66 ]; do printf 'PRIOR_%03d\\n' "$i"; i=$((i+1)); done; : > ${shellQuote(launchReady)}; while [ ! -f ${shellQuote(launchGate)} ]; do sleep 0.02; done; exec ${shellQuote(FX_BIN)} --resume ${shellQuote(id)}`;
+      active = await TmuxSession.create({
+        cmd: `/bin/sh -c ${shellQuote(launch)}`,
+        cwd: workspace,
+        env: { ...env, FX_RECORD: tapePath },
+        width: 168, height: 75, isolated: true, remainOnExit: true,
+        stderrPath,
+      });
+      await waitForCondition(() => existsSync(launchReady), "native resume launch gate");
+      expect(active.cursorPosition()).toEqual({ row: 66, col: 0 });
+      writeFileSync(launchGate, "");
+      await waitForScrollbackMarkers(active, labels);
+      await active.waitForStableComposer(TIMEOUT);
+      expectPublishedRows(await active.captureFullScrollbackEscapes());
+      expect(await active.capturePane()).not.toContain(labels[0]!);
+
+      await active.sendText("Continue with the prepared follow-up.");
+      await active.waitForText("AFTER_RESUME_INTERACTION", TIMEOUT);
+      await active.waitForStableComposer(TIMEOUT);
+      expectPublishedRows(await active.captureFullScrollbackEscapes());
+      await waitForPersistedSessionMarker(home, "AFTER_RESUME_INTERACTION");
+      expect(gateway.requests).toHaveLength(2);
+      await active.sendText("/quit");
+      await waitForCondition(() => !active!.isPaneAlive(), "clean resume exit");
+      expect(active.paneStatus()).toEqual({ dead: true, status: 0 });
+      expect(readFileSync(stderrPath, "utf8")).toBe("");
+      const replay = await runFx(["replay", tapePath, "--json"], { cwd: workspace, env, timeoutMs: TIMEOUT });
+      expect(replay.code).toBe(0);
+      expect(replay.stderr).toBe("");
+    } finally {
+      await active?.kill();
+      gateway.stop();
+      rmSync(root, { recursive: true, force: true });
+    }
+  },
+  TIMEOUT * 2,
+);
+
 async function waitForSessionPicker(session: TmuxSession): Promise<string> {
   return session.waitForPane(
     (pane) => {


### PR DESCRIPTION
## Summary

- Publish resumed transcripts from the current pre-scroll row.
- Preserve native scrollback order when a resumed transcript needs several publication batches.
- Add regression coverage for low native cursor resumes and later interactions.