### PR TITLE
Replace PGSO artifacts when jobs are rerun

### DIFF
--- a/.github/workflows/pgso-macos-arm64.yml
+++ b/.github/workflows/pgso-macos-arm64.yml
@@ -85,6 +85,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: pgso-seed-${{ github.sha }}
+          overwrite: true
           path: |
             ${{ runner.temp }}/fx-pgso-seed/manifest.json
             ${{ runner.temp }}/fx-pgso-seed/control/bin/fx
@@ -147,6 +148,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: pgso-training-${{ github.sha }}-${{ matrix.id }}
+          overwrite: true
           path: |
             ${{ runner.temp }}/fx-pgso-training-${{ matrix.id }}/manifest.json
             ${{ runner.temp }}/fx-pgso-training-${{ matrix.id }}/failure.json
@@ -202,6 +204,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: pgso-candidate-${{ github.sha }}
+          overwrite: true
           path: |
             ${{ runner.temp }}/fx-pgso-candidate/manifest.json
             ${{ runner.temp }}/fx-pgso-candidate/failure.json
@@ -279,6 +282,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: pgso-behavior-${{ github.sha }}-${{ matrix.id }}
+          overwrite: true
           path: |
             ${{ runner.temp }}/fx-pgso-behavior-${{ matrix.id }}/manifest.json
             ${{ runner.temp }}/fx-pgso-behavior-${{ matrix.id }}/failure.json
@@ -335,6 +339,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: pgso-startup-${{ github.sha }}-${{ matrix.name }}
+          overwrite: true
           path: |
             ${{ runner.temp }}/fx-pgso-startup-${{ matrix.name }}/manifest.json
             ${{ runner.temp }}/fx-pgso-startup-${{ matrix.name }}/failure.json
@@ -392,6 +397,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: pgso-heavy-${{ github.sha }}-${{ matrix.name }}
+          overwrite: true
           path: |
             ${{ runner.temp }}/fx-pgso-heavy-${{ matrix.name }}/manifest.json
             ${{ runner.temp }}/fx-pgso-heavy-${{ matrix.name }}/failure.json
@@ -454,6 +460,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: pgso-evidence-macos-arm64-${{ github.sha }}
+          overwrite: true
           path: ${{ runner.temp }}/fx-pgso-aggregate
           if-no-files-found: error
           retention-days: 14

--- a/scripts/pgso/README.md
+++ b/scripts/pgso/README.md
@@ -61,6 +61,11 @@ binary, candidate, assignment, or shard identity mismatch. The aggregate
 command requires all 36 training scenarios, all 53 behavior scenarios, and all
 12 performance gates exactly once before it emits `eligible: true`.
 
+Rerunning a workflow job replaces its previous named artifact, including
+failed evidence. Consumers therefore read the latest result for each shard;
+a failed retry cannot fall back to an earlier pass. Source and artifact hashes
+must still match before aggregation can qualify a release.
+
 ## Corpus
 
 [`corpus.json`](corpus.json) references existing test owners instead of copying their behavior. Training contains six direct CLI commands and thirty deterministic E2E files covering CLI, configuration, tools, Gateway lifecycle, fake web and vision routes, ACP, modern and legacy MCP, sessions, terminal hosting, TUI startup, resizing, rendering, permissions, interruption, subagents, and recovery. A bounded `profile_runs` count can weight a direct training command without duplicating manifest entries or final behavior checks. Seventeen additional deterministic E2E files verify the final candidate without influencing LLVM's hot and cold classification.

--- a/scripts/pgso/tests/test_distributed.py
+++ b/scripts/pgso/tests/test_distributed.py
@@ -4,6 +4,7 @@ import unittest
 
 import pathlib
 import dataclasses
+import re
 
 from scripts.pgso.corpus import Corpus, Scenario
 from scripts.pgso.distributed import (
@@ -34,6 +35,17 @@ def scenario(name: str, timeout_seconds: float) -> Scenario:
 
 
 class WorkflowContractTests(unittest.TestCase):
+    def test_reruns_replace_each_producer_artifact(self) -> None:
+        repo_root = pathlib.Path(__file__).resolve().parents[3]
+        workflow = (repo_root / ".github/workflows/pgso-macos-arm64.yml").read_text()
+        for job in ("seed", "train", "candidate", "behavior", "startup", "heavy", "aggregate"):
+            with self.subTest(job=job):
+                job_body = re.split(
+                    r"\n  (?=\S)", workflow.split(f"\n  {job}:\n", 1)[1], maxsplit=1
+                )[0]
+                upload = job_body.split("uses: actions/upload-artifact@", 1)[1]
+                self.assertIn("          overwrite: true\n", upload)
+
     def test_behavior_workers_install_pinned_zig_without_llvm(self) -> None:
         repo_root = pathlib.Path(__file__).resolve().parents[3]
         action = (repo_root / ".github/actions/setup-pgso/action.yml").read_text()


### PR DESCRIPTION
## Summary

- Replace previous PGSO artifacts when a job is rerun so release checks use the current result.
