### PR TITLE
Remove born-dead enum artifacts

### DIFF
--- a/src/core/auth/auth_runtime.zig
+++ b/src/core/auth/auth_runtime.zig
@@ -1135,7 +1135,6 @@ const InventoryRefreshTask = struct {
 const ApiKeyExitReason = enum {
     cancel,
     saved,
-    save_failed,
     screen_replacement,
     runtime_deinit,
 };

--- a/src/ui/render_engine/paint_plan.zig
+++ b/src/ui/render_engine/paint_plan.zig
@@ -321,7 +321,6 @@ pub const FooterReservationSource = enum {
     footer_layout,
     transient_activity,
     idle_footer_gap,
-    resize_reflow,
 };
 
 pub const FooterPaintResult = struct {

--- a/src/ui/transcript/painter.zig
+++ b/src/ui/transcript/painter.zig
@@ -3420,11 +3420,6 @@ fn paintTranscriptIntoSurfaceWithLimit(
     };
 }
 
-const TestFullRepaintMode = enum {
-    enabled,
-    diagnostic_wipe_only,
-};
-
 const TestFooterGeometry = struct {
     top: u16 = 0,
 };


### PR DESCRIPTION
## Summary

- Remove three enum artifacts that have had exactly one reference since the initial commit: their own declaration. `ApiKeyExitReason.save_failed` is never passed to `exitApiKeyStage` (`cancel`, `saved`, `screen_replacement`, and `runtime_deinit` remain). The `TestFullRepaintMode` enum in the transcript painter is referenced nowhere, including its own module. The `FooterReservationSource.resize_reflow` member is never constructed by the reservation-reason mapping. Persistence-decoded members were deliberately excluded: `AuthoritySource.legacy_migration` stays because `session_authority` decodes it from session.json via `std.meta.stringToEnum`, and `EventFileKind.symbolic_link` stays because it models stat kinds in the fingerprint contract with explicit u8 values. No user-facing behavior change.