### PR TITLE
Remove never-referenced struct fields and their orphan chains

### DIFF
--- a/src/core/agent/runtime/deps.zig
+++ b/src/core/agent/runtime/deps.zig
@@ -141,8 +141,6 @@ pub const ParentTurnDeliveryAck = struct {
     start_offset: u64,
     end_offset: u64,
     total_bytes: u64,
-    discovery_start_offset: ?u64 = null,
-    discovery_next_offset: ?u64 = null,
 };
 
 /// Slices are owned by the allocator passed to `prepare_parent_turn_context`

--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -3432,10 +3432,6 @@ const RoutingSubagents = struct {
     active: bool = false,
     main_approval_presented: bool = false,
     handled_keys: usize = 0,
-    handled_raw_keys: usize = 0,
-    handled_actions: usize = 0,
-    last_handled_key: ?u8 = null,
-    last_main_approval_id: ?u64 = null,
     toggle_view_calls: usize = 0,
     manager_paste: core_input_runtime.Runtime = .{},
 

--- a/src/core/cli/cli_surface.zig
+++ b/src/core/cli/cli_surface.zig
@@ -311,14 +311,12 @@ const LoadCatalogStartupStateWithAuthModeFn = *const fn (Allocator, host.SecretS
 const LoadStartupStatusWithAuthModeFn = *const fn (Allocator, host.SecretStore, []const u8, usize, credentials.AuthMode) anyerror!app_lifecycle.StartupStatus;
 const GetenvFn = *const fn (?*anyopaque, []const u8) ?[]const u8;
 const EnvironMapFn = *const fn (?*anyopaque) ?*const std.process.Environ.Map;
-const SelfExePathFn = *const fn (?*anyopaque, Allocator) anyerror![]u8;
 const ReadMaskedKeyFn = *const fn (?*anyopaque, Allocator, WriteFn, ?*anyopaque) anyerror![]u8;
 const SetupTerminalAvailableFn = *const fn (?*anyopaque) bool;
 const RunDeps = struct {
     stdout_ctx: ?*anyopaque = null,
     stderr_ctx: ?*anyopaque = null,
     env_ctx: ?*anyopaque = null,
-    self_exe_ctx: ?*anyopaque = null,
     setup_ctx: ?*anyopaque = null,
     write_stdout: WriteFn = writeRealStdout,
     write_stderr: WriteFn = writeRealStderr,
@@ -330,7 +328,6 @@ const RunDeps = struct {
     load_startup_status_with_auth_mode: LoadStartupStatusWithAuthModeFn = app_lifecycle.loadStartupStatusWithAuthMode,
     getenv: GetenvFn = getenvDefault,
     environ_map: EnvironMapFn = environMapDefault,
-    self_exe_path: SelfExePathFn = selfExePathDefault,
     read_masked_key: ReadMaskedKeyFn = readMaskedKeyDefault,
     setup_terminal_available: SetupTerminalAvailableFn = setupTerminalAvailableDefault,
 };
@@ -2159,12 +2156,6 @@ fn getenvDefault(_: ?*anyopaque, key: []const u8) ?[]const u8 {
 
 fn environMapDefault(_: ?*anyopaque) ?*const std.process.Environ.Map {
     return io_mod.environMap();
-}
-
-fn selfExePathDefault(_: ?*anyopaque, alloc: Allocator) ![]u8 {
-    const path_z = try std.process.executablePathAlloc(io_mod.getIo(), alloc);
-    defer alloc.free(path_z);
-    return alloc.dupe(u8, path_z);
 }
 
 fn writeTopLevelUsage(command_catalog: CommandCatalog, deps: RunDeps, kind: TopLevelKind) !void {

--- a/src/core/terminal/ui_projection.zig
+++ b/src/core/terminal/ui_projection.zig
@@ -9,7 +9,6 @@ pub const Row = struct {
     lifecycle: contracts.Lifecycle,
     attention: contracts.AttentionState,
     backend: contracts.Backend,
-    attachable: bool = true,
 
     fn deinit(self: *Row, alloc: Allocator) void {
         alloc.free(self.label);

--- a/src/core/tooling/tool_dispatch.zig
+++ b/src/core/tooling/tool_dispatch.zig
@@ -266,7 +266,6 @@ pub const DispatchContext = struct {
     skill_locations: ?*const skill_contract.Locations = null,
     resolved_skill: ?*const skill_contract.PreparedSkill = null,
     context_limits: context_limits.Values = .{},
-    permission_ctx: ?*const PermissionContext = null,
     read_tracker: ?*read_tracker_mod.ReadTracker = null,
     change_tracker: ?*change_tracker.ChangeTracker = null,
     cancel_flag: ?*std.atomic.Value(bool) = null,
@@ -334,22 +333,6 @@ pub const AskQuestionBatchFn = *const fn (
 
 /// Function pointer used to override permission decisions in tests and callers.
 pub const PermissionDecider = *const fn (*const Tool, ToolInput, DispatchContext) permission_gate.Decision;
-
-/// Rule-engine lookup function carried through dispatch for test injection.
-pub const PermissionRuleLookup = *const fn (
-    Allocator,
-    core_types.PermissionRuleSet,
-    []const u8,
-    []const u8,
-    []const u8,
-    PermissionTargetKind,
-) anyerror!core_permissions.RuleDecision;
-
-/// Permission state shared by a noninteractive turn.
-pub const PermissionContext = struct {
-    rules: ?*const core_types.PermissionRuleSet = null,
-    rule_lookup: PermissionRuleLookup = core_permissions.ruleDecisionFor,
-};
 
 /// Function pointer that decodes JSON arguments into a concrete input.
 pub const DecodeFn = *const fn (DispatchContext, []const u8) DispatchError!DecodeResult;

--- a/src/ui/render_engine/frame_layout.zig
+++ b/src/ui/render_engine/frame_layout.zig
@@ -58,7 +58,6 @@ pub const TranscriptFlowPreview = struct {
     replaceable_row: u16 = 1,
     tail_kind: ?transcript_blocks.TranscriptBlockKind = null,
     replaceable_active: bool = false,
-    welcome_split_active: bool = false,
     split_prefix_lines: usize = 0,
     split_suffix_start_line: usize = 0,
 };


### PR DESCRIPTION
## Summary

- Remove thirteen struct fields that each have exactly one textual reference: their own declaration. The `DispatchContext.permission_ctx` pointer was never set or read, so the `PermissionContext` struct and its `PermissionRuleLookup` alias exist only for that field and are removed with it; the live rule path goes through permissions.zig directly. The `RunDeps` `self_exe_ctx` and `self_exe_path` fields were never read, orphaning the `SelfExePathFn` alias and `selfExePathDefault`, removed together. Four `RoutingSubagents` test counters are never written or asserted. The `Row.attachable`, `ParentTurnDeliveryAck` discovery offsets, and frame-layout `welcome_split_active` fields are never read. Load-bearing padding and extern call parameter names were excluded: `StyleFlags._pad` keeps the packed u8 width the bitCast equality relies on, and getpeereid/sysctlbyname parameter names are documentation, not fields. No user-facing behavior change.