### PR TITLE
Remove never-constructed enum members and the unwired turn-control channel

### DIFF
--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -6342,7 +6342,6 @@ fn processQueuedPromptLoop(
     }
     var pending_image_ids: []const usize = initial_pending_image_ids;
     var configured_first_tool_choice_pending = true;
-    var return_to_user_pending = false;
     var active_presentation_group_id: ?types.ToolPresentationGroupId = null;
     const restored_attempts = if (job.recovery_checkpoint) |checkpoint|
         restoredConsumedAttempts(checkpoint)
@@ -6802,8 +6801,6 @@ fn processQueuedPromptLoop(
             provider_opts.prompt_caching = true;
             runtime_telemetry.traceGatewayProviderOptions(step_ctx, gateway_model, route_fast_mode, config.effort, provider_opts);
             const tool_choice: types.ToolChoice = if (recovery_strategy == .reconcile_tool)
-                .none
-            else if (return_to_user_pending)
                 .none
             else if (configured_first_tool_choice_pending and vision_mode != .required)
                 config.first_call_tool_choice
@@ -8330,7 +8327,6 @@ fn processQueuedPromptLoop(
             successful_recovery_strategy = recovery_strategy;
             retainCompletedResultInTurnArena(&stream_result);
             if (vision_mode != .required) configured_first_tool_choice_pending = false;
-            return_to_user_pending = false;
             break;
         }
         defer if (stream_result_set) stream_result.deinit(arena);
@@ -11363,9 +11359,6 @@ fn processQueuedPromptLoop(
                 try commit.commit();
                 result_commit_pending = false;
             }
-            if (execution.turn_control) |control| switch (control) {
-                .return_to_user => return_to_user_pending = true,
-            };
             replay_handed_off = true;
             if (execution.system_notice) |notice| {
                 try within_turn_suffix.append(arena, .{

--- a/src/core/agent/runtime/tool_contracts.zig
+++ b/src/core/agent/runtime/tool_contracts.zig
@@ -85,7 +85,6 @@ pub const ToolExecutionResult = struct {
     interactive_notice: ?types.SemanticNotice = null,
     context_notices: []const []const u8 = &.{},
     command_result_json: ?[]const u8 = null,
-    turn_control: ?tool_dispatch.TurnControl = null,
     web_search_completion: ?types.WebSearchCompletion = null,
     web_fetch_completion: ?types.WebFetchCompletion = null,
     inner_usage: ?types.ToolUsage = null,

--- a/src/core/app/app_commands.zig
+++ b/src/core/app/app_commands.zig
@@ -3891,7 +3891,6 @@ const McpCommandFakeApp = struct {
         published_healthy,
         published_degraded,
         retained,
-        completion_failed,
         begin_failed,
     };
 
@@ -3995,7 +3994,6 @@ const McpCommandFakeApp = struct {
                     "Required MCP server 'fixture' failed to start.",
                 ),
             } },
-            .completion_failed => .{ .failed = error.TestReloadFailed },
             .begin_failed => unreachable,
         };
     }

--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -432,7 +432,7 @@ pub fn Runtime(comptime App: type) type {
                 finished.*,
             )) {
                 .uncommitted => .uncommitted,
-                .committed, .committed_degraded => .committed,
+                .committed => .committed,
             };
         }
 

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -245,7 +245,6 @@ pub const SessionPickerScope = session_catalog.Scope;
 pub const HistoryAppendOutcome = enum {
     uncommitted,
     committed,
-    committed_degraded,
 };
 
 pub const ResumeHandoffIntent = enum {

--- a/src/core/tooling/tool_dispatch.zig
+++ b/src/core/tooling/tool_dispatch.zig
@@ -121,10 +121,6 @@ pub const SelectedDynamicToolSinkFn = *const fn (
 
 pub const ContextNoticeSinkFn = *const fn (?*anyopaque, []const u8) error{OutOfMemory}!void;
 
-pub const TurnControl = enum {
-    return_to_user,
-};
-
 /// Erased, owned typed input decoded by a concrete tool.
 pub const ToolInput = struct {
     ptr: *anyopaque,

--- a/src/core/tooling/tool_runtime.zig
+++ b/src/core/tooling/tool_runtime.zig
@@ -921,7 +921,6 @@ const DispatchMetadata = struct {
     web_fetch_completion: ?types.WebFetchCompletion = null,
     tool_result_memory: ?types.ToolResultMemory = null,
     command_result_json: ?[]const u8 = null,
-    turn_control: ?tool_dispatch.TurnControl = null,
 
     fn attach(self: *DispatchMetadata, ctx: *tool_dispatch.DispatchContext) void {
         ctx.model_content_kind_sink = &self.model_content_kind;
@@ -953,7 +952,6 @@ fn toolExecutionResultFromDispatch(
             .web_fetch_completion = metadata.web_fetch_completion,
             .tool_result_memory = memory,
             .command_result_json = metadata.command_result_json,
-            .turn_control = metadata.turn_control,
         },
         .failure => .{
             .status = .failure,
@@ -964,7 +962,6 @@ fn toolExecutionResultFromDispatch(
             .web_fetch_completion = metadata.web_fetch_completion,
             .tool_result_memory = memory,
             .command_result_json = metadata.command_result_json,
-            .turn_control = metadata.turn_control,
         },
     };
 }

--- a/src/core/workspace/context_contract.zig
+++ b/src/core/workspace/context_contract.zig
@@ -437,13 +437,11 @@ pub const EntryPoint = enum {
 pub const DriftStatus = enum {
     intentional,
     temporary,
-    phase12_follow_up,
 
     fn label(self: DriftStatus) []const u8 {
         return switch (self) {
             .intentional => "intentional",
             .temporary => "temporary",
-            .phase12_follow_up => "phase12_follow_up",
         };
     }
 };


### PR DESCRIPTION
## Summary

- Remove four enum members that are matched in switch prongs or serialized in label mappings but never constructed anywhere. `TurnControl.return_to_user` is the only member of an enum whose channel was never wired: nothing sets the dispatch or execution metadata `turn_control` fields to a non-null value since the shell turn handoff that introduced them lost its producer. The enum, both optional fields, both passthrough copies, the orchestrator prong, and the always-false `return_to_user_pending` flag with its tool-choice arm are removed together. `HistoryAppendOutcome.committed_degraded`, `ReloadBehavior.completion_failed`, and `DriftStatus.phase12_follow_up` are never returned or assigned; their prongs are removed with the members. Enums decoded from persisted strings or constructed by reflection keep their members: `AuthoritySource.native_create` is stringToEnum-decoded from session.json, ACP `StopReason` and `ToolCallKind` members are wire vocabulary, `Signal.hangup` stays in the terminal signal contract, and `BoundedProbeStage` members are exercised through `std.meta.tags` in tests. No user-facing behavior change.